### PR TITLE
Refactor: introducing CommittedVote, NonCommittedVote, and RefVote types

### DIFF
--- a/openraft/src/core/heartbeat/worker.rs
+++ b/openraft/src/core/heartbeat/worker.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -83,7 +82,7 @@ where
             let option = RPCOption::new(timeout);
 
             let payload = AppendEntriesRequest {
-                vote: *heartbeat.session_id.leader_vote.deref(),
+                vote: heartbeat.session_id.leader_vote.into_vote(),
                 prev_log_id: None,
                 leader_commit: heartbeat.committed,
                 entries: vec![],

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -1,4 +1,3 @@
-use std::ops::Deref;
 use std::time::Duration;
 
 use validit::Valid;
@@ -645,10 +644,10 @@ where C: RaftTypeConfig
         // Before sending any log, update the vote.
         // This could not fail because `internal_server_state` will be cleared
         // once `state.vote` is changed to a value of other node.
-        let _res = self.vote_handler().update_vote(&vote);
+        let _res = self.vote_handler().update_vote(&vote.into_vote());
         debug_assert!(_res.is_ok(), "commit vote can not fail but: {:?}", _res);
 
-        self.state.accept_io(IOId::new_log_io(vote.into_committed(), last_log_id));
+        self.state.accept_io(IOId::new_log_io(vote, last_log_id));
 
         // No need to submit UpdateIOProgress command,
         // IO progress is updated by the new blank log
@@ -752,7 +751,7 @@ where C: RaftTypeConfig
         };
 
         debug_assert!(
-            leader.committed_vote_ref().deref() >= self.state.vote_ref(),
+            leader.committed_vote_ref().into_vote() >= *self.state.vote_ref(),
             "leader.vote({}) >= state.vote({})",
             leader.committed_vote_ref(),
             self.state.vote_ref()

--- a/openraft/src/engine/handler/establish_handler/mod.rs
+++ b/openraft/src/engine/handler/establish_handler/mod.rs
@@ -31,7 +31,7 @@ where C: RaftTypeConfig
 
         if let Some(l) = self.leader.as_ref() {
             #[allow(clippy::neg_cmp_op_on_partial_ord)]
-            if !(&vote > l.committed_vote_ref()) {
+            if !(vote > l.committed_vote_ref().into_vote()) {
                 tracing::warn!(
                     "vote is not greater than current existing leader vote. Do not establish new leader and quit"
                 );

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -121,7 +121,11 @@ where C: RaftTypeConfig
         self.state.vote.disable_lease();
 
         self.output.push_command(Command::BroadcastTransferLeader {
-            req: TransferLeaderRequest::new(*self.leader.committed_vote, to, self.leader.last_log_id().copied()),
+            req: TransferLeaderRequest::new(
+                self.leader.committed_vote.into_vote(),
+                to,
+                self.leader.last_log_id().copied(),
+            ),
         });
     }
 

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -167,7 +167,7 @@ where C: RaftTypeConfig
         if let Some(l) = self.leader.as_mut() {
             tracing::debug!("leading vote: {}", l.committed_vote,);
 
-            if l.committed_vote.leader_id() == self.state.vote_ref().leader_id() {
+            if l.committed_vote.into_vote().leader_id() == self.state.vote_ref().leader_id() {
                 tracing::debug!(
                     "vote still belongs to the same leader. Just updating vote is enough: node-{}, {}",
                     self.config.id,

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -200,7 +200,7 @@ where
         // Thus vote.voted_for() is this node.
 
         // Safe unwrap: voted_for() is always non-None in Openraft
-        let node_id = self.committed_vote.leader_id().voted_for().unwrap();
+        let node_id = self.committed_vote.into_vote().leader_id().voted_for().unwrap();
         let now = C::now();
 
         tracing::debug!(

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -232,8 +232,8 @@ where C: RaftTypeConfig
         );
 
         if cfg!(debug_assertions) {
-            let new_vote = *accepted.vote_ref();
-            let current_vote = curr_accepted.map(|x| *x.vote_ref());
+            let new_vote = accepted.to_vote();
+            let current_vote = curr_accepted.map(|io_id| io_id.to_vote());
             assert!(
                 Some(new_vote) >= current_vote,
                 "new accepted.committed_vote {} must be >= current accepted.committed_vote: {}",

--- a/openraft/src/replication/replication_session_id.rs
+++ b/openraft/src/replication/replication_session_id.rs
@@ -64,7 +64,11 @@ where C: RaftTypeConfig
         }
     }
 
-    pub(crate) fn vote_ref(&self) -> &Vote<C::NodeId> {
-        &self.leader_vote
+    pub(crate) fn committed_vote(&self) -> CommittedVote<C> {
+        self.leader_vote
+    }
+
+    pub(crate) fn vote(&self) -> Vote<C::NodeId> {
+        self.leader_vote.into_vote()
     }
 }

--- a/openraft/src/vote/committed.rs
+++ b/openraft/src/vote/committed.rs
@@ -1,8 +1,8 @@
 use std::cmp::Ordering;
 use std::fmt;
-use std::ops::Deref;
 
 use crate::type_config::alias::NodeIdOf;
+use crate::vote::ref_vote::RefVote;
 use crate::CommittedLeaderId;
 use crate::RaftTypeConfig;
 use crate::Vote;
@@ -41,18 +41,17 @@ where C: RaftTypeConfig
         vote.committed = true;
         Self { vote }
     }
+
     pub(crate) fn committed_leader_id(&self) -> CommittedLeaderId<C::NodeId> {
-        self.leader_id().to_committed()
+        self.vote.leader_id().to_committed()
     }
-}
 
-impl<C> Deref for CommittedVote<C>
-where C: RaftTypeConfig
-{
-    type Target = Vote<NodeIdOf<C>>;
+    pub(crate) fn into_vote(self) -> Vote<NodeIdOf<C>> {
+        self.vote
+    }
 
-    fn deref(&self) -> &Self::Target {
-        &self.vote
+    pub(crate) fn as_ref_vote(&self) -> RefVote<'_, C::NodeId> {
+        RefVote::new(&self.vote.leader_id, true)
     }
 }
 

--- a/openraft/src/vote/mod.rs
+++ b/openraft/src/vote/mod.rs
@@ -1,8 +1,10 @@
 pub(crate) mod committed;
 mod leader_id;
 pub(crate) mod non_committed;
+pub(crate) mod ref_vote;
 #[allow(clippy::module_inception)]
 mod vote;
+pub(crate) mod vote_status;
 
 pub(crate) use committed::CommittedVote;
 pub use leader_id::CommittedLeaderId;

--- a/openraft/src/vote/non_committed.rs
+++ b/openraft/src/vote/non_committed.rs
@@ -1,7 +1,8 @@
 use std::fmt;
-use std::ops::Deref;
 
+use crate::type_config::alias::LeaderIdOf;
 use crate::type_config::alias::NodeIdOf;
+use crate::vote::ref_vote::RefVote;
 use crate::RaftTypeConfig;
 use crate::Vote;
 
@@ -24,15 +25,17 @@ where C: RaftTypeConfig
         debug_assert!(!vote.committed);
         Self { vote }
     }
-}
 
-impl<C> Deref for NonCommittedVote<C>
-where C: RaftTypeConfig
-{
-    type Target = Vote<NodeIdOf<C>>;
+    pub(crate) fn leader_id(&self) -> &LeaderIdOf<C> {
+        &self.vote.leader_id
+    }
 
-    fn deref(&self) -> &Self::Target {
-        &self.vote
+    pub(crate) fn into_vote(self) -> Vote<NodeIdOf<C>> {
+        self.vote
+    }
+
+    pub(crate) fn as_ref_vote(&self) -> RefVote<'_, C::NodeId> {
+        RefVote::new(&self.vote.leader_id, false)
     }
 }
 

--- a/openraft/src/vote/ref_vote.rs
+++ b/openraft/src/vote/ref_vote.rs
@@ -1,0 +1,61 @@
+use std::cmp::Ordering;
+use std::fmt::Formatter;
+
+use crate::LeaderId;
+use crate::NodeId;
+
+/// Same as [`Vote`] but with a reference to the [`LeaderId`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RefVote<'a, NID: NodeId> {
+    pub(crate) leader_id: &'a LeaderId<NID>,
+    pub(crate) committed: bool,
+}
+
+impl<'a, NID> RefVote<'a, NID>
+where NID: NodeId
+{
+    pub(crate) fn new(leader_id: &'a LeaderId<NID>, committed: bool) -> Self {
+        Self { leader_id, committed }
+    }
+
+    pub(crate) fn is_committed(&self) -> bool {
+        self.committed
+    }
+}
+
+// Commit vote have a total order relation with all other votes
+impl<'a, NID> PartialOrd for RefVote<'a, NID>
+where NID: NodeId
+{
+    #[inline]
+    fn partial_cmp(&self, other: &RefVote<'a, NID>) -> Option<Ordering> {
+        match PartialOrd::partial_cmp(self.leader_id, other.leader_id) {
+            Some(Ordering::Equal) => PartialOrd::partial_cmp(&self.committed, &other.committed),
+            None => {
+                // If two leader_id are not comparable, they won't both be granted(committed).
+                // Therefore use `committed` to determine greatness to minimize election conflict.
+                match (self.committed, other.committed) {
+                    (false, false) => None,
+                    (true, false) => Some(Ordering::Greater),
+                    (false, true) => Some(Ordering::Less),
+                    (true, true) => {
+                        unreachable!("two incomparable leaders can not be both committed: {} {}", self, other)
+                    }
+                }
+            }
+            // Some(non-equal)
+            cmp => cmp,
+        }
+    }
+}
+
+impl<'a, NID: NodeId> std::fmt::Display for RefVote<'a, NID> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "<{}:{}>",
+            self.leader_id,
+            if self.is_committed() { "Q" } else { "-" }
+        )
+    }
+}

--- a/openraft/src/vote/vote_status.rs
+++ b/openraft/src/vote/vote_status.rs
@@ -1,0 +1,9 @@
+use crate::vote::CommittedVote;
+use crate::vote::NonCommittedVote;
+use crate::RaftTypeConfig;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum VoteStatus<C: RaftTypeConfig> {
+    Committed(CommittedVote<C>),
+    Pending(NonCommittedVote<C>),
+}


### PR DESCRIPTION

## Changelog

##### Refactor: introducing CommittedVote, NonCommittedVote, and RefVote types

- **Introduce Specialized Vote Types:**
  - Added `CommittedVote` and `NonCommittedVote` to distinguish between votes that have been
    accepted by a quorum and those that have not.
  - Introduced `RefVote` to provide a reference-based representation of votes, facilitating safer
    and more efficient comparisons.

- **Update Vote Management Logic:**
  - Replaced direct usage of `Vote` with `CommittedVote` and `NonCommittedVote` across various
    modules (`heartbeat/worker.rs`, `notification.rs`, `raft_core.rs`, etc.) to enhance type
    safety and clarity.
  - Modified comparison logic to leverage the new vote types, ensuring accurate and meaningful
    ordering based on vote status.

- **Enhance Notification Mechanisms:**
  - Updated notification structures to use the new vote types, improving the accuracy of messages
    related to vote responses and higher votes observed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1254)
<!-- Reviewable:end -->
