### PR TITLE
Refactor: remvoe `Copy` bound from `NodeId`

### DIFF
--- a/examples/memstore/src/log_store.rs
+++ b/examples/memstore/src/log_store.rs
@@ -60,12 +60,12 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
     }
 
     async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C>> {
-        let last = self.log.iter().next_back().map(|(_, ent)| *ent.get_log_id());
+        let last = self.log.iter().next_back().map(|(_, ent)| ent.get_log_id().clone());
 
-        let last_purged = self.last_purged_log_id;
+        let last_purged = self.last_purged_log_id.clone();
 
         let last = match last {
-            None => last_purged,
+            None => last_purged.clone(),
             Some(x) => Some(x),
         };
 
@@ -81,16 +81,16 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
     }
 
     async fn read_committed(&mut self) -> Result<Option<LogId<C::NodeId>>, StorageError<C>> {
-        Ok(self.committed)
+        Ok(self.committed.clone())
     }
 
     async fn save_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), StorageError<C>> {
-        self.vote = Some(*vote);
+        self.vote = Some(vote.clone());
         Ok(())
     }
 
     async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C>> {
-        Ok(self.vote)
+        Ok(self.vote.clone())
     }
 
     async fn append<I>(&mut self, entries: I, callback: IOFlushed<C>) -> Result<(), StorageError<C>>
@@ -116,8 +116,8 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
     async fn purge(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C>> {
         {
             let ld = &mut self.last_purged_log_id;
-            assert!(*ld <= Some(log_id));
-            *ld = Some(log_id);
+            assert!(ld.as_ref() <= Some(&log_id));
+            *ld = Some(log_id.clone());
         }
 
         {

--- a/openraft/src/core/heartbeat/event.rs
+++ b/openraft/src/core/heartbeat/event.rs
@@ -8,9 +8,9 @@ use crate::LogId;
 use crate::RaftTypeConfig;
 
 /// The information for broadcasting a heartbeat.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
-pub struct HeartbeatEvent<C>
+pub(crate) struct HeartbeatEvent<C>
 where C: RaftTypeConfig
 {
     /// The timestamp when this heartbeat is sent.

--- a/openraft/src/core/heartbeat/handle.rs
+++ b/openraft/src/core/heartbeat/handle.rs
@@ -69,19 +69,19 @@ where C: RaftTypeConfig
     {
         for (target, node) in targets {
             tracing::debug!("id={} spawn HeartbeatWorker target={}", self.id, target);
-            let network = network_factory.new_client(target, &node).await;
+            let network = network_factory.new_client(target.clone(), &node).await;
 
             let worker = HeartbeatWorker {
-                id: self.id,
+                id: self.id.clone(),
                 rx: self.rx.clone(),
                 network,
-                target,
+                target: target.clone(),
                 node,
                 config: self.config.clone(),
                 tx_notification: tx_notification.clone(),
             };
 
-            let span = tracing::span!(parent: &Span::current(), Level::DEBUG, "heartbeat", id=display(self.id), target=display(target));
+            let span = tracing::span!(parent: &Span::current(), Level::DEBUG, "heartbeat", id=display(&self.id), target=display(&target));
 
             let (tx_shutdown, rx_shutdown) = C::oneshot();
 

--- a/openraft/src/core/heartbeat/worker.rs
+++ b/openraft/src/core/heartbeat/worker.rs
@@ -71,7 +71,7 @@ where
                 _ = self.rx.changed().fuse() => {},
             }
 
-            let heartbeat: Option<HeartbeatEvent<C>> = *self.rx.borrow_watched();
+            let heartbeat: Option<HeartbeatEvent<C>> = self.rx.borrow_watched().clone();
 
             // None is the initial value of the WatchReceiver, ignore it.
             let Some(heartbeat) = heartbeat else {
@@ -82,9 +82,9 @@ where
             let option = RPCOption::new(timeout);
 
             let payload = AppendEntriesRequest {
-                vote: heartbeat.session_id.leader_vote.into_vote(),
+                vote: heartbeat.session_id.leader_vote.clone().into_vote(),
                 prev_log_id: None,
-                leader_commit: heartbeat.committed,
+                leader_commit: heartbeat.committed.clone(),
                 entries: vec![],
             };
 
@@ -94,9 +94,9 @@ where
             match res {
                 Ok(Ok(_)) => {
                     let res = self.tx_notification.send(Notification::HeartbeatProgress {
-                        session_id: heartbeat.session_id,
+                        session_id: heartbeat.session_id.clone(),
                         sending_time: heartbeat.time,
-                        target: self.target,
+                        target: self.target.clone(),
                     });
 
                     if res.is_err() {

--- a/openraft/src/core/sm/command.rs
+++ b/openraft/src/core/sm/command.rs
@@ -85,7 +85,7 @@ where C: RaftTypeConfig
             Command::BuildSnapshot => None,
             Command::GetSnapshot { .. } => None,
             Command::BeginReceivingSnapshot { .. } => None,
-            Command::InstallFullSnapshot { io_id, .. } => Some(*io_id),
+            Command::InstallFullSnapshot { io_id, .. } => Some(io_id.clone()),
             Command::Apply { .. } => None,
             Command::Func { .. } => None,
         }

--- a/openraft/src/core/sm/worker.rs
+++ b/openraft/src/core/sm/worker.rs
@@ -186,7 +186,7 @@ where
         #[allow(clippy::needless_collect)]
         let applying_entries = entries
             .iter()
-            .map(|e| ApplyingEntry::new(*e.get_log_id(), e.get_membership().cloned()))
+            .map(|e| ApplyingEntry::new(e.get_log_id().clone(), e.get_membership().cloned()))
             .collect::<Vec<_>>();
 
         let n_entries = end - since;

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -257,15 +257,15 @@ where C: RaftTypeConfig
     pub(crate) fn condition(&self) -> Option<Condition<C>> {
         match self {
             Command::RebuildReplicationStreams { .. } => None,
-            Command::Respond { when, .. }             => *when,
+            Command::Respond { when, .. }             => when.clone(),
 
-            Command::UpdateIOProgress { when, .. }    => *when,
+            Command::UpdateIOProgress { when, .. }    => when.clone(),
             Command::AppendInputEntries { .. }        => None,
             Command::SaveVote { .. }                  => None,
             Command::TruncateLog { .. }               => None,
             Command::SaveCommitted { .. }             => None,
 
-            Command::PurgeLog { upto }                => Some(Condition::Snapshot { log_id: Some(*upto) }),
+            Command::PurgeLog { upto }                => Some(Condition::Snapshot { log_id: Some(upto.clone()) }),
 
             Command::ReplicateCommitted { .. }        => None,
             Command::BroadcastHeartbeat { .. }        => None,
@@ -280,7 +280,7 @@ where C: RaftTypeConfig
 }
 
 /// A condition to wait for before running a command.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
 pub(crate) enum Condition<C>
 where C: RaftTypeConfig

--- a/openraft/src/engine/handler/establish_handler/mod.rs
+++ b/openraft/src/engine/handler/establish_handler/mod.rs
@@ -21,17 +21,17 @@ where C: RaftTypeConfig
         self,
         candidate: Candidate<C, LeaderQuorumSet<C>>,
     ) -> Option<&'x mut Leader<C, LeaderQuorumSet<C>>> {
-        let vote = *candidate.vote_ref();
+        let vote = candidate.vote_ref().clone();
 
         debug_assert_eq!(
             vote.leader_id().voted_for(),
-            Some(self.config.id),
+            Some(self.config.id.clone()),
             "it can only commit its own vote"
         );
 
         if let Some(l) = self.leader.as_ref() {
             #[allow(clippy::neg_cmp_op_on_partial_ord)]
-            if !(vote > l.committed_vote_ref().into_vote()) {
+            if !(vote > l.committed_vote_ref().clone().into_vote()) {
                 tracing::warn!(
                     "vote is not greater than current existing leader vote. Do not establish new leader and quit"
                 );

--- a/openraft/src/engine/handler/log_handler/mod.rs
+++ b/openraft/src/engine/handler/log_handler/mod.rs
@@ -41,7 +41,7 @@ where C: RaftTypeConfig
             return;
         }
 
-        let upto = *purge_upto.unwrap();
+        let upto = purge_upto.unwrap().clone();
 
         st.purge_log(&upto);
         self.output.push_command(Command::PurgeLog { upto });
@@ -82,7 +82,7 @@ where C: RaftTypeConfig
         let purge_end = self.state.snapshot_meta.last_log_id.next_index().saturating_sub(max_keep);
 
         tracing::debug!(
-            snapshot_last_log_id = debug(self.state.snapshot_meta.last_log_id),
+            snapshot_last_log_id = debug(self.state.snapshot_meta.last_log_id.clone()),
             max_keep,
             "try purge: (-oo, {})",
             purge_end
@@ -90,7 +90,7 @@ where C: RaftTypeConfig
 
         if st.last_purged_log_id().next_index() + batch_size > purge_end {
             tracing::debug!(
-                snapshot_last_log_id = debug(self.state.snapshot_meta.last_log_id),
+                snapshot_last_log_id = debug(self.state.snapshot_meta.last_log_id.clone()),
                 max_keep,
                 last_purged_log_id = display(st.last_purged_log_id().display()),
                 batch_size,

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -128,15 +128,15 @@ fn test_leader_append_membership_update_learner_process() -> anyhow::Result<()> 
         assert_eq!(&ProgressEntry::empty(11), l.progress.get(&5));
 
         let p = ProgressEntry::new(Some(log_id(1, 1, 4)));
-        let _ = l.progress.update(&4, p);
+        let _ = l.progress.update(&4, p.clone());
         assert_eq!(&p, l.progress.get(&4));
 
         let p = ProgressEntry::new(Some(log_id(1, 1, 5)));
-        let _ = l.progress.update(&5, p);
+        let _ = l.progress.update(&5, p.clone());
         assert_eq!(&p, l.progress.get(&5));
 
         let p = ProgressEntry::new(Some(log_id(1, 1, 3)));
-        let _ = l.progress.update(&3, p);
+        let _ = l.progress.update(&3, p.clone());
         assert_eq!(&p, l.progress.get(&3));
     } else {
         unreachable!("leader should not be None");

--- a/openraft/src/engine/handler/server_state_handler/mod.rs
+++ b/openraft/src/engine/handler/server_state_handler/mod.rs
@@ -23,7 +23,7 @@ where C: RaftTypeConfig
         let server_state = self.state.calc_server_state(&self.config.id);
 
         tracing::debug!(
-            id = display(self.config.id),
+            id = display(&self.config.id),
             prev_server_state = debug(self.state.server_state),
             server_state = debug(server_state),
             "update_server_state_if_changed"
@@ -37,9 +37,9 @@ where C: RaftTypeConfig
         let is_leader = server_state == ServerState::Leader;
 
         if !was_leader && is_leader {
-            tracing::info!(id = display(self.config.id), "become leader");
+            tracing::info!(id = display(&self.config.id), "become leader");
         } else if was_leader && !is_leader {
-            tracing::info!(id = display(self.config.id), "quit leader");
+            tracing::info!(id = display(&self.config.id), "quit leader");
         } else {
             // nothing to do
         }

--- a/openraft/src/engine/handler/snapshot_handler/mod.rs
+++ b/openraft/src/engine/handler/snapshot_handler/mod.rs
@@ -53,7 +53,7 @@ where C: RaftTypeConfig
     pub(crate) fn update_snapshot(&mut self, meta: SnapshotMeta<C>) -> bool {
         tracing::info!("update_snapshot: {:?}", meta);
 
-        if meta.last_log_id <= self.state.snapshot_last_log_id().copied() {
+        if meta.last_log_id <= self.state.snapshot_last_log_id().cloned() {
             tracing::info!(
                 "No need to install a smaller snapshot: current snapshot last_log_id({}), new snapshot last_log_id({})",
                 self.state.snapshot_last_log_id().display(),

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -60,7 +60,7 @@ fn test_accept_vote_reject_smaller_vote() -> anyhow::Result<()> {
             //
             Command::Respond {
                 when: Some(Condition::IOFlushed {
-                    io_id: IOId::new(Vote::new(2, 1))
+                    io_id: IOId::new(&Vote::new(2, 1))
                 }),
                 resp: Respond::new(mk_res(false), tx)
             },

--- a/openraft/src/engine/log_id_list.rs
+++ b/openraft/src/engine/log_id_list.rs
@@ -63,7 +63,7 @@ where C: RaftTypeConfig
         };
 
         // Recursion stack
-        let mut stack = vec![(first, last)];
+        let mut stack = vec![(first, last.clone())];
 
         loop {
             let (first, last) = match stack.pop() {
@@ -75,7 +75,7 @@ where C: RaftTypeConfig
 
             // Case AA
             if first.leader_id == last.leader_id {
-                if res.last().map(|x| x.leader_id) < Some(first.leader_id) {
+                if res.last().map(|x| &x.leader_id) < Some(&first.leader_id) {
                     res.push(first);
                 }
                 continue;
@@ -83,7 +83,7 @@ where C: RaftTypeConfig
 
             // Two adjacent logs with different leader_id, no need to binary search
             if first.index + 1 == last.index {
-                if res.last().map(|x| x.leader_id) < Some(first.leader_id) {
+                if res.last().map(|x| &x.leader_id) < Some(&first.leader_id) {
                     res.push(first);
                 }
                 res.push(last);
@@ -94,7 +94,7 @@ where C: RaftTypeConfig
 
             if first.leader_id == mid.leader_id {
                 // Case AAC
-                if res.last().map(|x| x.leader_id) < Some(first.leader_id) {
+                if res.last().map(|x| &x.leader_id) < Some(&first.leader_id) {
                     res.push(first);
                 }
                 stack.push((mid, last));
@@ -105,7 +105,7 @@ where C: RaftTypeConfig
                 // Case ABC
                 // first.leader_id < mid_log_id.leader_id < last.leader_id
                 // Deal with (first, mid) then (mid, last)
-                stack.push((mid, last));
+                stack.push((mid.clone(), last));
                 stack.push((first, mid));
             }
         }
@@ -133,14 +133,14 @@ where C: RaftTypeConfig
     pub(crate) fn extend_from_same_leader<'a, LID: RaftLogId<C::NodeId> + 'a>(&mut self, new_ids: &[LID]) {
         if let Some(first) = new_ids.first() {
             let first_id = first.get_log_id();
-            self.append(*first_id);
+            self.append(first_id.clone());
 
             if let Some(last) = new_ids.last() {
                 let last_id = last.get_log_id();
                 assert_eq!(last_id.leader_id, first_id.leader_id);
 
                 if last_id != first_id {
-                    self.append(*last_id);
+                    self.append(last_id.clone());
                 }
             }
         }
@@ -149,15 +149,15 @@ where C: RaftTypeConfig
     /// Extends a list of `log_id`.
     #[allow(dead_code)]
     pub(crate) fn extend<'a, LID: RaftLogId<C::NodeId> + 'a>(&mut self, new_ids: &[LID]) {
-        let mut prev = self.last().map(|x| x.leader_id);
+        let mut prev = self.last().map(|x| x.leader_id.clone());
 
         for x in new_ids.iter() {
             let log_id = x.get_log_id();
 
-            if prev != Some(log_id.leader_id) {
-                self.append(*log_id);
+            if prev.as_ref() != Some(&log_id.leader_id) {
+                self.append(log_id.clone());
 
-                prev = Some(log_id.leader_id);
+                prev = Some(log_id.leader_id.clone());
             }
         }
 
@@ -165,7 +165,7 @@ where C: RaftTypeConfig
             let log_id = last.get_log_id();
 
             if self.last() != Some(log_id) {
-                self.append(*log_id);
+                self.append(log_id.clone());
             }
         }
     }
@@ -201,9 +201,9 @@ where C: RaftTypeConfig
 
         // l >= 2
 
-        let last = self.key_log_ids[l - 1];
+        let last = &self.key_log_ids[l - 1];
 
-        if self.key_log_ids.get(l - 2).map(|x| x.leader_id) == Some(last.leader_id) {
+        if self.key_log_ids.get(l - 2).map(|x| &x.leader_id) == Some(&last.leader_id) {
             // Replace the **last log id**.
             self.key_log_ids[l - 1] = new_log_id;
             return;
@@ -235,7 +235,7 @@ where C: RaftTypeConfig
         // Add key log id if there is a gap between last.index and at - 1.
         let last = self.key_log_ids.last();
         if let Some(last) = last {
-            let (last_leader_id, last_index) = (last.leader_id, last.index);
+            let (last_leader_id, last_index) = (last.leader_id.clone(), last.index);
             if last_index < at - 1 {
                 self.append(LogId::new(last_leader_id, at - 1));
             }
@@ -250,7 +250,7 @@ where C: RaftTypeConfig
         // When installing  snapshot it may need to purge across the `last_log_id`.
         if upto.index >= last.next_index() {
             debug_assert!(Some(upto) > self.last());
-            self.key_log_ids = vec![*upto];
+            self.key_log_ids = vec![upto.clone()];
             return;
         }
 
@@ -280,12 +280,12 @@ where C: RaftTypeConfig
         let res = self.key_log_ids.binary_search_by(|log_id| log_id.index.cmp(&index));
 
         match res {
-            Ok(i) => Some(LogId::new(self.key_log_ids[i].leader_id, index)),
+            Ok(i) => Some(LogId::new(self.key_log_ids[i].leader_id.clone(), index)),
             Err(i) => {
                 if i == 0 || i == self.key_log_ids.len() {
                     None
                 } else {
-                    Some(LogId::new(self.key_log_ids[i - 1].leader_id, index))
+                    Some(LogId::new(self.key_log_ids[i - 1].leader_id.clone(), index))
                 }
             }
         }

--- a/openraft/src/entry/mod.rs
+++ b/openraft/src/entry/mod.rs
@@ -34,7 +34,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            log_id: self.log_id,
+            log_id: self.log_id.clone(),
             payload: self.payload.clone(),
         }
     }
@@ -105,7 +105,7 @@ where C: RaftTypeConfig
     }
 
     fn set_log_id(&mut self, log_id: &LogId<C::NodeId>) {
-        self.log_id = *log_id;
+        self.log_id = log_id.clone();
     }
 }
 

--- a/openraft/src/log_id/log_id_option_ext.rs
+++ b/openraft/src/log_id/log_id_option_ext.rs
@@ -14,7 +14,7 @@ pub trait LogIdOptionExt {
 
 impl<NID: NodeId> LogIdOptionExt for Option<LogId<NID>> {
     fn index(&self) -> Option<u64> {
-        self.map(|x| x.index)
+        self.as_ref().map(|x| x.index)
     }
 
     fn next_index(&self) -> u64 {

--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -19,7 +19,7 @@ use crate::NodeId;
 ///
 /// The log id serves as unique identifier for a log entry across the system. It is composed of two
 /// parts: a leader id, which refers to the leader that proposed this log, and an integer index.
-#[derive(Debug, Default, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialOrd, Ord, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct LogId<NID: NodeId> {
     /// The id of the leader that proposed this log
@@ -30,13 +30,15 @@ pub struct LogId<NID: NodeId> {
     pub index: u64,
 }
 
+impl<NID> Copy for LogId<NID> where NID: NodeId + Copy {}
+
 impl<NID: NodeId> RaftLogId<NID> for LogId<NID> {
     fn get_log_id(&self) -> &LogId<NID> {
         self
     }
 
     fn set_log_id(&mut self, log_id: &LogId<NID>) {
-        *self = *log_id
+        *self = log_id.clone()
     }
 }
 

--- a/openraft/src/log_id_range.rs
+++ b/openraft/src/log_id_range.rs
@@ -38,7 +38,7 @@ impl<C> Validate for LogIdRange<C>
 where C: RaftTypeConfig
 {
     fn validate(&self) -> Result<(), Box<dyn Error>> {
-        validit::less_equal!(self.prev, self.last);
+        validit::less_equal!(&self.prev, &self.last);
         Ok(())
     }
 }

--- a/openraft/src/membership/effective_membership.rs
+++ b/openraft/src/membership/effective_membership.rs
@@ -58,7 +58,7 @@ where
     LID: RaftLogId<C::NodeId>,
 {
     fn from(v: (&LID, Membership<C>)) -> Self {
-        EffectiveMembership::new(Some(*v.0.get_log_id()), v.1)
+        EffectiveMembership::new(Some(v.0.get_log_id().clone()), v.1)
     }
 }
 
@@ -75,7 +75,7 @@ where C: RaftTypeConfig
         let configs = membership.get_joint_config();
         let mut joint = vec![];
         for c in configs {
-            joint.push(c.iter().copied().collect::<Vec<_>>());
+            joint.push(c.iter().cloned().collect::<Vec<_>>());
         }
 
         let quorum_set = Joint::from(joint);
@@ -88,7 +88,7 @@ where C: RaftTypeConfig
     }
 
     pub(crate) fn new_from_stored_membership(stored: StoredMembership<C>) -> Self {
-        Self::new(*stored.log_id(), stored.membership().clone())
+        Self::new(stored.log_id().clone(), stored.membership().clone())
     }
 
     pub(crate) fn stored_membership(&self) -> &Arc<StoredMembership<C>> {
@@ -115,7 +115,7 @@ where C: RaftTypeConfig
 
     /// Returns an Iterator of all voter node ids. Learners are not included.
     pub fn voter_ids(&self) -> impl Iterator<Item = C::NodeId> + '_ {
-        self.voter_ids.iter().copied()
+        self.voter_ids.iter().cloned()
     }
 
     /// Returns an Iterator of all learner node ids. Voters are not included.

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -144,7 +144,7 @@ where C: RaftTypeConfig
 
     /// Returns an Iterator of all learner node ids. Voters are not included.
     pub fn learner_ids(&self) -> impl Iterator<Item = C::NodeId> + '_ {
-        self.nodes.keys().filter(|x| !self.is_voter(x)).copied()
+        self.nodes.keys().filter(|x| !self.is_voter(x)).cloned()
     }
 }
 
@@ -188,7 +188,7 @@ where C: RaftTypeConfig
             if res.contains_key(k) {
                 continue;
             }
-            res.insert(*k, v.clone());
+            res.insert(k.clone(), v.clone());
         }
 
         res
@@ -281,19 +281,19 @@ where C: RaftTypeConfig
 
         let new_membership = match change {
             ChangeMembers::AddVoterIds(add_voter_ids) => {
-                let new_voter_ids = last.union(&add_voter_ids).copied().collect::<BTreeSet<_>>();
+                let new_voter_ids = last.union(&add_voter_ids).cloned().collect::<BTreeSet<_>>();
                 self.next_coherent(new_voter_ids, retain)
             }
             ChangeMembers::AddVoters(add_voters) => {
                 // Add nodes without overriding existent
                 self.nodes = Self::extend_nodes(self.nodes, &add_voters);
 
-                let add_voter_ids = add_voters.keys().copied().collect::<BTreeSet<_>>();
-                let new_voter_ids = last.union(&add_voter_ids).copied().collect::<BTreeSet<_>>();
+                let add_voter_ids = add_voters.keys().cloned().collect::<BTreeSet<_>>();
+                let new_voter_ids = last.union(&add_voter_ids).cloned().collect::<BTreeSet<_>>();
                 self.next_coherent(new_voter_ids, retain)
             }
             ChangeMembers::RemoveVoters(remove_voter_ids) => {
-                let new_voter_ids = last.difference(&remove_voter_ids).copied().collect::<BTreeSet<_>>();
+                let new_voter_ids = last.difference(&remove_voter_ids).cloned().collect::<BTreeSet<_>>();
                 self.next_coherent(new_voter_ids, retain)
             }
             ChangeMembers::ReplaceAllVoters(all_voter_ids) => self.next_coherent(all_voter_ids, retain),
@@ -333,7 +333,7 @@ where C: RaftTypeConfig
     pub(crate) fn to_quorum_set(&self) -> Joint<C::NodeId, Vec<C::NodeId>, Vec<Vec<C::NodeId>>> {
         let mut qs = vec![];
         for c in self.get_joint_config().iter() {
-            qs.push(c.iter().copied().collect::<Vec<_>>());
+            qs.push(c.iter().cloned().collect::<Vec<_>>());
         }
         Joint::new(qs)
     }

--- a/openraft/src/metrics/wait.rs
+++ b/openraft/src/metrics/wait.rs
@@ -101,7 +101,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
     pub async fn current_leader(&self, leader_id: C::NodeId, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
-            |m| m.current_leader == Some(leader_id),
+            |m| m.current_leader.as_ref() == Some(&leader_id),
             &format!("{} .current_leader == {}", msg.to_string(), leader_id),
         )
         .await

--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -87,7 +87,7 @@ mod tokio_rt {
 
                 let done = (offset + n_read as u64) == end;
                 let req = InstallSnapshotRequest {
-                    vote,
+                    vote: vote.clone(),
                     meta: snapshot.meta.clone(),
                     offset,
                     data: buf,

--- a/openraft/src/node.rs
+++ b/openraft/src/node.rs
@@ -19,7 +19,6 @@ pub trait NodeIdEssential:
     + Debug
     + Display
     + Hash
-    + Copy
     + Clone
     + Default
     + 'static

--- a/openraft/src/progress/entry/mod.rs
+++ b/openraft/src/progress/entry/mod.rs
@@ -14,7 +14,7 @@ use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
 
 /// State of replication to a target node.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[derive(PartialEq, Eq)]
 pub(crate) struct ProgressEntry<C>
 where C: RaftTypeConfig
@@ -37,7 +37,7 @@ where C: RaftTypeConfig
     #[allow(dead_code)]
     pub(crate) fn new(matching: Option<LogId<C::NodeId>>) -> Self {
         Self {
-            matching,
+            matching: matching.clone(),
             inflight: Inflight::None,
             searching_end: matching.next_index(),
         }
@@ -70,8 +70,8 @@ where C: RaftTypeConfig
         match &self.inflight {
             Inflight::None => false,
             Inflight::Logs { log_id_range, .. } => {
-                let lid = Some(*upto);
-                lid > log_id_range.prev
+                let lid = Some(upto);
+                lid > log_id_range.prev.as_ref()
             }
             Inflight::Snapshot { last_log_id: _, .. } => false,
         }
@@ -84,7 +84,7 @@ where C: RaftTypeConfig
             "update_matching"
         );
 
-        self.inflight.ack(matching);
+        self.inflight.ack(matching.clone());
 
         debug_assert!(matching >= self.matching);
         self.matching = matching;
@@ -176,7 +176,7 @@ where C: RaftTypeConfig
         // Replicate by snapshot.
         if self.searching_end < purge_upto_next {
             let snapshot_last = log_state.snapshot_last_log_id();
-            self.inflight = Inflight::snapshot(snapshot_last.copied());
+            self.inflight = Inflight::snapshot(snapshot_last.cloned());
             return Ok(&self.inflight);
         }
 
@@ -249,17 +249,17 @@ where C: RaftTypeConfig
 
         self.inflight.validate()?;
 
-        match self.inflight {
+        match &self.inflight {
             Inflight::None => {}
             Inflight::Logs { log_id_range, .. } => {
                 // matching <= prev_log_id              <= last_log_id
                 //             prev_log_id.next_index() <= searching_end
-                validit::less_equal!(self.matching, log_id_range.prev);
+                validit::less_equal!(&self.matching, &log_id_range.prev);
                 validit::less_equal!(log_id_range.prev.next_index(), self.searching_end);
             }
             Inflight::Snapshot { last_log_id, .. } => {
                 // There is no need to send a snapshot smaller than last matching.
-                validit::less!(self.matching, last_log_id);
+                validit::less!(&self.matching, last_log_id);
             }
         }
         Ok(())

--- a/openraft/src/progress/inflight/mod.rs
+++ b/openraft/src/progress/inflight/mod.rs
@@ -112,7 +112,7 @@ where C: RaftTypeConfig
                 *self = {
                     debug_assert!(upto >= log_id_range.prev);
                     debug_assert!(upto <= log_id_range.last);
-                    Inflight::logs(upto, log_id_range.last)
+                    Inflight::logs(upto, log_id_range.last.clone())
                 }
             }
             Inflight::Snapshot { last_log_id } => {

--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -35,7 +35,7 @@ pub(crate) trait Progress<ID, V, P, QS>
 where
     ID: PartialEq + 'static,
     V: Borrow<P>,
-    P: PartialOrd + Copy,
+    P: PartialOrd + Clone,
     QS: QuorumSet<ID>,
 {
     /// Update one of the scalar value and re-calculate the committed value with provided function.
@@ -144,10 +144,10 @@ where
 
 impl<ID, V, P, QS> Display for VecProgress<ID, V, P, QS>
 where
-    ID: PartialEq + Debug + Copy + 'static,
-    V: Copy + 'static,
+    ID: PartialEq + Debug + Clone + 'static,
+    V: Clone + 'static,
     V: Borrow<P>,
-    P: PartialOrd + Ord + Copy + 'static,
+    P: PartialOrd + Ord + Clone + 'static,
     QS: QuorumSet<ID> + 'static,
     ID: Display,
     V: Display,
@@ -211,7 +211,7 @@ where
     ID: 'static,
     V: Borrow<P>,
     QS: QuorumSet<ID>,
-    P: Copy,
+    P: Clone,
 {
     pub(crate) fn new(quorum_set: QS, learner_ids: impl IntoIterator<Item = ID>, default_v: impl Fn() -> V) -> Self {
         let mut vector = quorum_set.ids().map(|id| (id, default_v())).collect::<Vec<_>>();
@@ -222,7 +222,7 @@ where
 
         Self {
             quorum_set,
-            granted: *default_v().borrow(),
+            granted: default_v().borrow().clone(),
             voter_count,
             vector,
             stat: Default::default(),
@@ -281,7 +281,7 @@ impl<ID, V, P, QS> Progress<ID, V, P, QS> for VecProgress<ID, V, P, QS>
 where
     ID: PartialEq + 'static,
     V: Borrow<P>,
-    P: PartialOrd + Copy,
+    P: PartialOrd + Clone,
     QS: QuorumSet<ID>,
 {
     /// Update one of the scalar value and re-calculate the committed value.
@@ -333,7 +333,7 @@ where
 
         let elt = &mut self.vector[index];
 
-        let prev_progress = *elt.1.borrow();
+        let prev_progress = elt.1.borrow().clone();
 
         f(&mut elt.1);
 
@@ -374,7 +374,7 @@ where
                 self.stat.is_quorum_count += 1;
 
                 if self.quorum_set.is_quorum(it) {
-                    self.granted = *prog;
+                    self.granted = prog.clone();
                     break;
                 }
             }

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -99,18 +99,18 @@ where
     /// Return the node ids that has granted this vote.
     #[allow(dead_code)]
     pub(crate) fn granters(&self) -> impl Iterator<Item = C::NodeId> + '_ {
-        self.progress().iter().filter(|(_, granted)| *granted).map(|(target, _)| *target)
+        self.progress().iter().filter(|(_, granted)| *granted).map(|(target, _)| target.clone())
     }
 
     pub(crate) fn into_leader(self) -> Leader<C, QS> {
         // Mark the vote as committed, i.e., being granted and saved by a quorum.
         let vote = {
-            let vote = *self.vote_ref();
+            let vote = self.vote_ref().clone();
             debug_assert!(!vote.is_committed());
             vote.into_committed()
         };
 
-        let last_leader_log_ids = self.last_log_id().copied().into_iter().collect::<Vec<_>>();
+        let last_leader_log_ids = self.last_log_id().cloned().into_iter().collect::<Vec<_>>();
 
         Leader::new(vote, self.quorum_set.clone(), self.learner_ids, &last_leader_log_ids)
     }

--- a/openraft/src/quorum/quorum_set_impl.rs
+++ b/openraft/src/quorum/quorum_set_impl.rs
@@ -4,7 +4,7 @@ use crate::quorum::quorum_set::QuorumSet;
 
 /// Impl a simple majority quorum set
 impl<ID> QuorumSet<ID> for BTreeSet<ID>
-where ID: PartialOrd + Ord + Copy + 'static
+where ID: PartialOrd + Ord + Clone + 'static
 {
     type Iter = std::collections::btree_set::IntoIter<ID>;
 
@@ -29,7 +29,7 @@ where ID: PartialOrd + Ord + Copy + 'static
 
 /// Impl a simple majority quorum set
 impl<ID> QuorumSet<ID> for Vec<ID>
-where ID: PartialOrd + Ord + Copy + 'static
+where ID: PartialOrd + Ord + Clone + 'static
 {
     type Iter = std::collections::btree_set::IntoIter<ID>;
 

--- a/openraft/src/raft/message/vote.rs
+++ b/openraft/src/raft/message/vote.rs
@@ -53,9 +53,9 @@ where C: RaftTypeConfig
 {
     pub fn new(vote: impl Borrow<Vote<C::NodeId>>, last_log_id: Option<LogId<C::NodeId>>, granted: bool) -> Self {
         Self {
-            vote: *vote.borrow(),
+            vote: vote.borrow().clone(),
             vote_granted: granted,
-            last_log_id: last_log_id.map(|x| *x.borrow()),
+            last_log_id: last_log_id.map(|x| x.borrow().clone()),
         }
     }
 
@@ -74,7 +74,7 @@ where C: RaftTypeConfig
             f,
             "{{{}, last_log:{:?}}}",
             self.vote,
-            self.last_log_id.map(|x| x.to_string())
+            self.last_log_id.as_ref().map(|x| x.to_string())
         )
     }
 }

--- a/openraft/src/raft_state/io_state.rs
+++ b/openraft/src/raft_state/io_state.rs
@@ -93,8 +93,8 @@ where C: RaftTypeConfig
         // Applied does not have to be flushed in local store.
         // less_equal!(self.applied.as_ref(), a.submitted().and_then(|x| x.last_log_id()));
 
-        less_equal!(self.snapshot, self.applied);
-        less_equal!(self.purged, self.snapshot);
+        less_equal!(&self.snapshot, &self.applied);
+        less_equal!(&self.purged, &self.snapshot);
         Ok(())
     }
 }
@@ -103,7 +103,7 @@ impl<C> IOState<C>
 where C: RaftTypeConfig
 {
     pub(crate) fn new(
-        vote: Vote<C::NodeId>,
+        vote: &Vote<C::NodeId>,
         applied: Option<LogId<C::NodeId>>,
         snapshot: Option<LogId<C::NodeId>>,
         purged: Option<LogId<C::NodeId>>,

--- a/openraft/src/raft_state/io_state/io_id.rs
+++ b/openraft/src/raft_state/io_state/io_id.rs
@@ -26,7 +26,7 @@ use crate::Vote;
 /// [`append()`]: `crate::storage::RaftLogStorage::append()`
 /// [`truncate()`]: `crate::storage::RaftLogStorage::truncate()`
 /// [`purge()`]: `crate::storage::RaftLogStorage::purge()`
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
 pub(crate) enum IOId<C>
 where C: RaftTypeConfig
@@ -68,11 +68,11 @@ where C: RaftTypeConfig
 impl<C> IOId<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(vote: Vote<C::NodeId>) -> Self {
+    pub(crate) fn new(vote: &Vote<C::NodeId>) -> Self {
         if vote.is_committed() {
-            Self::new_log_io(vote.into_committed(), None)
+            Self::new_log_io(vote.clone().into_committed(), None)
         } else {
-            Self::new_vote_io(vote.into_non_committed())
+            Self::new_vote_io(vote.clone().into_non_committed())
         }
     }
 
@@ -89,8 +89,8 @@ where C: RaftTypeConfig
     // The above lint is disabled because in future Vote may not be `Copy`
     pub(crate) fn to_vote(&self) -> Vote<C::NodeId> {
         match self {
-            Self::Vote(non_committed_vote) => non_committed_vote.into_vote(),
-            Self::Log(log_io_id) => log_io_id.committed_vote.into_vote(),
+            Self::Vote(non_committed_vote) => non_committed_vote.clone().into_vote(),
+            Self::Log(log_io_id) => log_io_id.committed_vote.clone().into_vote(),
         }
     }
 
@@ -113,8 +113,8 @@ where C: RaftTypeConfig
         match self {
             Self::Vote(_vote) => ErrorSubject::Vote,
             Self::Log(log_io_id) => {
-                if let Some(log_id) = log_io_id.log_id {
-                    ErrorSubject::Log(log_id)
+                if let Some(log_id) = &log_io_id.log_id {
+                    ErrorSubject::Log(log_id.clone())
                 } else {
                     ErrorSubject::Logs
                 }

--- a/openraft/src/raft_state/io_state/log_io_id.rs
+++ b/openraft/src/raft_state/io_state/log_io_id.rs
@@ -20,7 +20,7 @@ use crate::RaftTypeConfig;
 ///
 /// See: [LogId Appended Multiple
 /// Times](crate::docs::protocol::replication::log_replication#logid-appended-multiple-times).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
 #[derive(PartialOrd, Ord)]
 pub(crate) struct LogIOId<C>

--- a/openraft/src/raft_state/membership_state/change_handler.rs
+++ b/openraft/src/raft_state/membership_state/change_handler.rs
@@ -52,8 +52,8 @@ where C: RaftTypeConfig
             Ok(())
         } else {
             Err(InProgress {
-                committed: *committed.log_id(),
-                membership_log_id: *effective.log_id(),
+                committed: committed.log_id().clone(),
+                membership_log_id: effective.log_id().clone(),
             })
         }
     }

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -222,7 +222,7 @@ where C: RaftTypeConfig
     ///
     /// Returns the previously accepted value.
     pub(crate) fn accept_io(&mut self, accepted: IOId<C>) -> Option<IOId<C>> {
-        let curr_accepted = self.io_state.io_progress.accepted().copied();
+        let curr_accepted = self.io_state.io_progress.accepted().cloned();
 
         tracing::debug!(
             "{}: accept_log: current: {}, new_accepted: {}",
@@ -233,16 +233,16 @@ where C: RaftTypeConfig
 
         if cfg!(debug_assertions) {
             let new_vote = accepted.to_vote();
-            let current_vote = curr_accepted.map(|io_id| io_id.to_vote());
+            let current_vote = curr_accepted.clone().map(|io_id| io_id.to_vote());
             assert!(
-                Some(new_vote) >= current_vote,
+                Some(&new_vote) >= current_vote.as_ref(),
                 "new accepted.committed_vote {} must be >= current accepted.committed_vote: {}",
                 new_vote,
                 current_vote.display(),
             );
         }
 
-        if Some(accepted) > curr_accepted {
+        if Some(&accepted) > curr_accepted.as_ref() {
             self.io_state.io_progress.accept(accepted);
         }
 
@@ -265,9 +265,9 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn update_committed(&mut self, committed: &Option<LogIdOf<C>>) -> Option<Option<LogIdOf<C>>> {
         if committed.as_ref() > self.committed() {
-            let prev = self.committed().copied();
+            let prev = self.committed().cloned();
 
-            self.committed = *committed;
+            self.committed = committed.clone();
             self.membership_state.commit(committed);
 
             Some(prev)
@@ -394,7 +394,7 @@ where C: RaftTypeConfig
         let last_leader_log_ids = self.log_ids.by_last_leader();
 
         Leader::new(
-            self.vote_ref().into_committed(),
+            self.vote_ref().clone().into_committed(),
             em.to_quorum_set(),
             em.learner_ids(),
             last_leader_log_ids,

--- a/openraft/src/replication/replication_session_id.rs
+++ b/openraft/src/replication/replication_session_id.rs
@@ -29,7 +29,7 @@ use crate::Vote;
 /// Now node `c` is a new empty node, no log is replicated to it.
 /// But the delayed message `{target=c, matched=log_id-1}` may be process by raft core and make raft
 /// core believe node `c` already has `log_id=1`, and commit it.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
 pub(crate) struct ReplicationSessionId<C>
 where C: RaftTypeConfig
@@ -65,10 +65,10 @@ where C: RaftTypeConfig
     }
 
     pub(crate) fn committed_vote(&self) -> CommittedVote<C> {
-        self.leader_vote
+        self.leader_vote.clone()
     }
 
     pub(crate) fn vote(&self) -> Vote<C::NodeId> {
-        self.leader_vote.into_vote()
+        self.leader_vote.clone().into_vote()
     }
 }

--- a/openraft/src/storage/callback.rs
+++ b/openraft/src/storage/callback.rs
@@ -124,7 +124,7 @@ where C: RaftTypeConfig
         let res = match result {
             Ok(x) => {
                 tracing::debug!("LogApplied upto {}", self.last_log_id);
-                let resp = (self.last_log_id, x);
+                let resp = (self.last_log_id.clone(), x);
                 self.tx.send(Ok(resp))
             }
             Err(e) => {

--- a/openraft/src/storage/log_reader_ext.rs
+++ b/openraft/src/storage/log_reader_ext.rs
@@ -30,7 +30,7 @@ where C: RaftTypeConfig
             ));
         }
 
-        Ok(*entries[0].get_log_id())
+        Ok(entries[0].get_log_id().clone())
     }
 }
 

--- a/openraft/src/storage/snapshot_meta.rs
+++ b/openraft/src/storage/snapshot_meta.rs
@@ -48,8 +48,8 @@ where C: RaftTypeConfig
 {
     pub fn signature(&self) -> SnapshotSignature<C> {
         SnapshotSignature {
-            last_log_id: self.last_log_id,
-            last_membership_log_id: *self.last_membership.log_id(),
+            last_log_id: self.last_log_id.clone(),
+            last_membership_log_id: self.last_membership.log_id().clone(),
             snapshot_id: self.snapshot_id.clone(),
         }
     }

--- a/openraft/src/storage/v2/raft_log_storage_ext.rs
+++ b/openraft/src/storage/v2/raft_log_storage_ext.rs
@@ -30,7 +30,7 @@ where C: RaftTypeConfig
     {
         let entries = entries.into_iter().collect::<Vec<_>>();
 
-        let last_log_id = *entries.last().unwrap().get_log_id();
+        let last_log_id = entries.last().unwrap().get_log_id().clone();
 
         let (tx, mut rx) = C::mpsc_unbounded();
 

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -440,9 +440,9 @@ where
             Duration::default(),
             Vote::default(),
         );
-        want.io_state.io_progress.accept(IOId::new(Vote::default()));
-        want.io_state.io_progress.submit(IOId::new(Vote::default()));
-        want.io_state.io_progress.flush(IOId::new(Vote::default()));
+        want.io_state.io_progress.accept(IOId::new(&Vote::default()));
+        want.io_state.io_progress.submit(IOId::new(&Vote::default()));
+        want.io_state.io_progress.flush(IOId::new(&Vote::default()));
 
         assert_eq!(want, initial, "uninitialized state");
         Ok(())
@@ -565,7 +565,7 @@ where
             "state machine has higher log"
         );
         assert_eq!(
-            initial.last_purged_log_id().copied(),
+            initial.last_purged_log_id().cloned(),
             Some(log_id_0(3, 1)),
             "state machine has higher log"
         );
@@ -790,13 +790,13 @@ where
         C::sleep(Duration::from_millis(1_000)).await;
 
         let ent = store.try_get_log_entry(3).await?;
-        assert_eq!(Some(log_id_0(1, 3)), ent.map(|x| *x.get_log_id()));
+        assert_eq!(Some(log_id_0(1, 3)), ent.map(|x| x.get_log_id().clone()));
 
         let ent = store.try_get_log_entry(0).await?;
-        assert_eq!(None, ent.map(|x| *x.get_log_id()));
+        assert_eq!(None, ent.map(|x| x.get_log_id().clone()));
 
         let ent = store.try_get_log_entry(11).await?;
-        assert_eq!(None, ent.map(|x| *x.get_log_id()));
+        assert_eq!(None, ent.map(|x| x.get_log_id().clone()));
 
         Ok(())
     }
@@ -1215,7 +1215,7 @@ where
         let snapshot_last_log_id = Some(log_id_0(3, 3));
         let snapshot_last_membership =
             StoredMembership::new(Some(log_id_0(1, 2)), Membership::new(vec![btreeset![1, 2, 3]], None));
-        let snapshot_applied_state = (snapshot_last_log_id, snapshot_last_membership.clone());
+        let snapshot_applied_state = (snapshot_last_log_id.clone(), snapshot_last_membership.clone());
 
         tracing::info!("--- build and get snapshot on leader state machine");
         let ss1 = sm_l.get_snapshot_builder().await.build_snapshot().await?;
@@ -1327,7 +1327,7 @@ where
 {
     let entries = entries.into_iter().collect::<Vec<_>>();
 
-    let last_log_id = *entries.last().unwrap().get_log_id();
+    let last_log_id = entries.last().unwrap().get_log_id().clone();
 
     let (tx, mut rx) = C::mpsc_unbounded();
 

--- a/openraft/src/vote/committed.rs
+++ b/openraft/src/vote/committed.rs
@@ -10,7 +10,7 @@ use crate::Vote;
 /// Represents a committed Vote that has been accepted by a quorum.
 ///
 /// The inner `Vote`'s attribute `committed` is always set to `true`
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
 #[derive(PartialOrd)]
 pub(crate) struct CommittedVote<C>

--- a/openraft/src/vote/leader_id/leader_id_adv.rs
+++ b/openraft/src/vote/leader_id/leader_id_adv.rs
@@ -31,12 +31,12 @@ impl<NID: NodeId> LeaderId<NID> {
     }
 
     pub fn voted_for(&self) -> Option<NID> {
-        Some(self.node_id)
+        Some(self.node_id.clone())
     }
 
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn to_committed(&self) -> CommittedLeaderId<NID> {
-        *self
+        self.clone()
     }
 
     /// Return if it is the same leader as the committed leader id.

--- a/openraft/src/vote/leader_id/leader_id_std.rs
+++ b/openraft/src/vote/leader_id/leader_id_std.rs
@@ -52,7 +52,7 @@ impl<NID: NodeId> LeaderId<NID> {
     }
 
     pub fn voted_for(&self) -> Option<NID> {
-        self.voted_for
+        self.voted_for.clone()
     }
 
     #[allow(clippy::wrong_self_convention)]

--- a/openraft/src/vote/non_committed.rs
+++ b/openraft/src/vote/non_committed.rs
@@ -9,7 +9,7 @@ use crate::Vote;
 /// Represents a non-committed Vote that has **NOT** been granted by a quorum.
 ///
 /// The inner `Vote`'s attribute `committed` is always set to `false`
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
 #[derive(PartialOrd)]
 pub(crate) struct NonCommittedVote<C>


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

##### Refactor: remvoe `Copy` bound from `NodeId`

The `NodeId` type is currently defined as:

```rust
type NodeId: .. + Copy + .. + 'static;
```

This commit removes the `Copy` bound from `NodeId`.
This modification will allow the use of non-`Copy` types as `NodeId`,
providing greater flexibility for applications that prefer
variable-length strings or other non-`Copy` types for node
identification.

This change maintain compatibility by updating derived `Copy`
implementations with manual implementations:

```rust
// Before
#[derive(Copy...)]
pub struct LogId<NID: NodeId> {}

// After
impl<NID: Copy> Copy for LogId<NID> {}
```

- Fix: #1250


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1255)
<!-- Reviewable:end -->
