### PR TITLE
Feature: `Raft::trigger()::allow_next_revert()` allow to reset replication for next detected follower log revert

### DIFF
--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -77,7 +77,8 @@ fn test_startup_as_leader_without_logs() -> anyhow::Result<()> {
                 targets: vec![ReplicationProgress(3, ProgressEntry {
                     matching: None,
                     inflight: Inflight::None,
-                    searching_end: 4
+                    searching_end: 4,
+                    reset_on_reversion: false,
                 })]
             },
             Command::AppendInputEntries {
@@ -128,7 +129,8 @@ fn test_startup_as_leader_with_proposed_logs() -> anyhow::Result<()> {
                 targets: vec![ReplicationProgress(3, ProgressEntry {
                     matching: None,
                     inflight: Inflight::None,
-                    searching_end: 7
+                    searching_end: 7,
+                    reset_on_reversion: false,
                 })]
             },
             Command::Replicate {

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -1,8 +1,11 @@
 //! Error types exposed by this crate.
 
+mod allow_next_revert_error;
 pub mod decompose;
 pub mod into_ok;
 mod invalid_sm;
+mod node_not_found;
+mod operation;
 mod replication_closed;
 mod streaming_error;
 
@@ -14,7 +17,10 @@ use std::time::Duration;
 
 use anyerror::AnyError;
 
+pub use self::allow_next_revert_error::AllowNextRevertError;
 pub use self::invalid_sm::InvalidStateMachineType;
+pub use self::node_not_found::NodeNotFound;
+pub use self::operation::Operation;
 pub use self::replication_closed::ReplicationClosed;
 pub use self::streaming_error::StreamingError;
 use crate::network::RPCTypes;

--- a/openraft/src/error/allow_next_revert_error.rs
+++ b/openraft/src/error/allow_next_revert_error.rs
@@ -1,0 +1,12 @@
+use crate::error::ForwardToLeader;
+use crate::error::NodeNotFound;
+use crate::RaftTypeConfig;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+pub enum AllowNextRevertError<C: RaftTypeConfig> {
+    #[error("Can not set allow_next_revert; error: {0}")]
+    NodeNotFound(#[from] NodeNotFound<C>),
+    #[error("Can not set allow_next_revert; error: {0}")]
+    ForwardToLeader(#[from] ForwardToLeader<C>),
+}

--- a/openraft/src/error/node_not_found.rs
+++ b/openraft/src/error/node_not_found.rs
@@ -1,0 +1,16 @@
+use crate::error::Operation;
+use crate::RaftTypeConfig;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+#[error("Node {node_id} not found when: ({operation})")]
+pub struct NodeNotFound<C: RaftTypeConfig> {
+    pub node_id: C::NodeId,
+    pub operation: Operation,
+}
+
+impl<C: RaftTypeConfig> NodeNotFound<C> {
+    pub fn new(node_id: C::NodeId, operation: Operation) -> Self {
+        Self { node_id, operation }
+    }
+}

--- a/openraft/src/error/operation.rs
+++ b/openraft/src/error/operation.rs
@@ -1,0 +1,49 @@
+use std::fmt;
+
+/// Operations that can be executed on a Raft node.
+///
+/// These commands represent operations that affect the Raft node's behavior or state. They are
+/// primarily used in error reporting to provide context about what operation was attempted when an
+/// error occurred.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+pub enum Operation {
+    /// Set a flag to allow a target replication state to revert to a previous state for one time.
+    AllowNextRevert,
+
+    /// Transfer leadership to the specified node.
+    TransferLeader,
+
+    /// Send a heartbeat message to a follower or learner.
+    SendHeartbeat,
+
+    /// Receive a snapshot.
+    ReceiveSnapshot,
+
+    /// Install a snapshot.
+    InstallSnapshot,
+
+    /// Write application data via Raft protocol.
+    ClientWrite,
+
+    /// Initialize an empty Raft node with a cluster membership config.
+    Initialize,
+
+    /// Start an election.
+    Elect,
+}
+
+impl fmt::Display for Operation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Operation::AllowNextRevert => write!(f, "set flag to allow replication revert for once"),
+            Operation::TransferLeader => write!(f, "transfer leadership"),
+            Operation::SendHeartbeat => write!(f, "send heartbeat"),
+            Operation::ReceiveSnapshot => write!(f, "receive snapshot"),
+            Operation::InstallSnapshot => write!(f, "install snapshot"),
+            Operation::ClientWrite => write!(f, "write application data"),
+            Operation::Initialize => write!(f, "initialize"),
+            Operation::Elect => write!(f, "elect"),
+        }
+    }
+}

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -352,7 +352,8 @@ where C: RaftTypeConfig
         &self.inner.config
     }
 
-    /// Return a handle to manually trigger raft actions, such as elect or build snapshot.
+    /// Return a [`Trigger`] handle to manually trigger raft actions, such as elect or build
+    /// snapshot.
     ///
     /// Example:
     /// ```ignore

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -550,7 +550,6 @@ where
 
         match &replication_result.0 {
             Ok(matching) => {
-                self.validate_matching(matching);
                 self.matching = matching.clone();
             }
             Err(_conflict) => {
@@ -567,32 +566,6 @@ where
                 },
             }
         });
-    }
-
-    /// Validate the value for updating matching log id.
-    ///
-    /// If the matching log id is reverted to a smaller value:
-    /// - log a warning message if [`loosen-follower-log-revert`] feature flag is enabled;
-    /// - otherwise panic, consider it as a bug.
-    ///
-    /// [`loosen-follower-log-revert`]: crate::docs::feature_flags#feature_flag_loosen_follower_log_revert
-    fn validate_matching(&self, matching: &Option<LogId<C::NodeId>>) {
-        if cfg!(feature = "loosen-follower-log-revert") {
-            if &self.matching > matching {
-                tracing::warn!(
-                    "follower log is reverted from {} to {}; with 'loosen-follower-log-revert' enabled, this is allowed",
-                    self.matching.display(),
-                    matching.display(),
-                );
-            }
-        } else {
-            debug_assert!(
-                &self.matching <= matching,
-                "follower log is reverted from {} to {}",
-                self.matching.display(),
-                matching.display(),
-            );
-        }
     }
 
     /// Drain all events in the channel in backoff mode, i.e., there was an un-retry-able error and

--- a/tests/tests/replication/main.rs
+++ b/tests/tests/replication/main.rs
@@ -10,3 +10,4 @@ mod t50_append_entries_backoff_rejoin;
 mod t51_append_entries_too_large;
 #[cfg(feature = "loosen-follower-log-revert")]
 mod t60_feature_loosen_follower_log_revert;
+mod t61_allow_follower_log_revert;

--- a/tests/tests/replication/t61_allow_follower_log_revert.rs
+++ b/tests/tests/replication/t61_allow_follower_log_revert.rs
@@ -1,0 +1,116 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::error::AllowNextRevertError;
+use openraft::error::ForwardToLeader;
+use openraft::error::NodeNotFound;
+use openraft::error::Operation;
+use openraft::Config;
+
+use crate::fixtures::ut_harness;
+use crate::fixtures::RaftRouter;
+
+/// With `Trigger::allow_next_revert()`  the leader allows follower to revert its log to an
+/// earlier state for one time.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn allow_follower_log_revert() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            enable_heartbeat: false,
+            // Make sure the replication is done in more than one steps
+            max_payload_entries: 1,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
+
+    tracing::info!(log_index, "--- write 10 logs");
+    {
+        log_index += router.client_request_many(0, "0", 10).await?;
+        for i in [0, 1] {
+            router.wait(&i, timeout()).applied_index(Some(log_index), format!("{} writes", 10)).await?;
+        }
+    }
+    tracing::info!(log_index, "--- allow next detected log revert");
+    {
+        let n0 = router.get_raft_handle(&0)?;
+        n0.trigger().allow_next_revert(&1, true).await??;
+    }
+
+    tracing::info!(log_index, "--- erase Learner-1 and restart");
+    {
+        let (_raft, _ls, _sm) = router.remove_node(1).unwrap();
+        let (log, sm) = openraft_memstore::new_mem_store();
+
+        router.new_raft_node_with_sto(1, log, sm).await;
+        router.add_learner(0, 1).await?;
+        log_index += 1; // add learner
+    }
+
+    tracing::info!(log_index, "--- write another 10 logs, leader should not panic");
+    {
+        log_index += router.client_request_many(0, "0", 10).await?;
+        for i in [0, 1] {
+            router.wait(&i, timeout()).applied_index(Some(log_index), format!("{} writes", 10)).await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Test error returned when `Trigger::allow_next_revert()` is called.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn allow_follower_log_revert_errors() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
+
+    tracing::info!(log_index, "--- allow next detected log revert to unknown node");
+    {
+        let n0 = router.get_raft_handle(&0)?;
+        let res = n0.trigger().allow_next_revert(&2, true).await?;
+        assert_eq!(
+            Err(AllowNextRevertError::NodeNotFound(NodeNotFound::new(
+                2,
+                Operation::AllowNextRevert
+            ))),
+            res
+        );
+    }
+
+    tracing::info!(log_index, "--- allow next detected log revert on non-leader node");
+    {
+        let n1 = router.get_raft_handle(&1)?;
+        let res = n1.trigger().allow_next_revert(&0, true).await?;
+        assert_eq!(
+            Err(AllowNextRevertError::ForwardToLeader(ForwardToLeader::new(0, ()))),
+            res
+        );
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}


### PR DESCRIPTION
## Changelog

##### Feature: `Raft::trigger()::allow_next_revert()` allow to reset replication for next detected follower log revert

This method requests the RaftCore to allow to reset replication for a
specific node when log revert is detected.

- `allow=true`: This method instructs the RaftCore to allow the target
  node's log to revert to a previous state for one time.

- `allow=false`: This method instructs the RaftCore to panic if the
  target node's log revert

This method returns `Fatal` error if failed to send the request to
RaftCore, e.g. when RaftCore is shut down.
Otherwise, it returns a `Ok(Result<_,_>)`, the inner result is:
- `Ok(())` if the request is successfully processed,
- or `Err(AllowNextRevertError)` explaining why the request is rejected.

### Behavior

- If this node is the Leader, it will attempt to replicate logs to the
  target node from the beginning.
- If this node is not the Leader, the request is ignored.
- If the target node is not found, the request is ignored.

### Automatic Replication Reset

When the `loosen-follower-log-revert` feature flag is enabled, the
Leader automatically reset replication if it detects that the target
node's log has reverted. This feature is primarily useful in testing
environments.

### Production Considerations

In production environments, state reversion is a critical issue that
should not be automatically handled. However, there may be scenarios
where a Follower's data is intentionally removed and needs to rejoin the
cluster(without membership changes). In such cases, the Leader should
reinitialize replication for that node with the following steps:

- Shut down the target node.
- call [`Self::allow_next_revert`] on the Leader.
- Clear the target node's data directory.
- Restart the target node.

- Fix: #1251

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1259)
<!-- Reviewable:end -->
