### PR TITLE
Feature: Retrieve Key Log IDs via `RaftLogReader::get_key_log_ids()`

### DIFF
--- a/openraft/src/engine/leader_log_ids.rs
+++ b/openraft/src/engine/leader_log_ids.rs
@@ -1,0 +1,54 @@
+use std::fmt;
+use std::ops::RangeInclusive;
+
+use crate::type_config::alias::LogIdOf;
+use crate::RaftTypeConfig;
+
+/// The first and the last log id belonging to a Leader.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LeaderLogIds<C: RaftTypeConfig> {
+    log_id_range: Option<RangeInclusive<LogIdOf<C>>>,
+}
+
+impl<C> fmt::Display for LeaderLogIds<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.log_id_range {
+            None => write!(f, "None"),
+            Some(rng) => write!(f, "({}, {})", rng.start(), rng.end()),
+        }
+    }
+}
+
+impl<C> LeaderLogIds<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(log_id_range: Option<RangeInclusive<LogIdOf<C>>>) -> Self {
+        Self { log_id_range }
+    }
+
+    /// Used only in tests
+    #[allow(dead_code)]
+    pub(crate) fn new_single(log_id: LogIdOf<C>) -> Self {
+        Self {
+            log_id_range: Some(log_id.clone()..=log_id),
+        }
+    }
+
+    /// Used only in tests
+    #[allow(dead_code)]
+    pub(crate) fn new_start_end(first: LogIdOf<C>, last: LogIdOf<C>) -> Self {
+        Self {
+            log_id_range: Some(first..=last),
+        }
+    }
+
+    pub(crate) fn first(&self) -> Option<&LogIdOf<C>> {
+        self.log_id_range.as_ref().map(|x| x.start())
+    }
+
+    pub(crate) fn last(&self) -> Option<&LogIdOf<C>> {
+        self.log_id_range.as_ref().map(|x| x.end())
+    }
+}

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -31,11 +31,12 @@ mod command_kind;
 mod engine_config;
 mod engine_impl;
 mod engine_output;
-mod log_id_list;
 mod replication_progress;
 
 pub(crate) mod command;
 pub(crate) mod handler;
+pub(crate) mod leader_log_ids;
+pub(crate) mod log_id_list;
 pub(crate) mod time_state;
 
 #[cfg(test)]

--- a/openraft/src/engine/tests/log_id_list_test.rs
+++ b/openraft/src/engine/tests/log_id_list_test.rs
@@ -1,3 +1,4 @@
+use crate::engine::leader_log_ids::LeaderLogIds;
 use crate::engine::testing::UTConfig;
 use crate::engine::LogIdList;
 use crate::testing::log_id;
@@ -357,23 +358,29 @@ fn test_log_id_list_get_log_id() -> anyhow::Result<()> {
 fn test_log_id_list_by_last_leader() -> anyhow::Result<()> {
     // len == 0
     let ids = LogIdList::<UTConfig>::default();
-    assert_eq!(ids.by_last_leader(), &[]);
+    assert_eq!(ids.by_last_leader(), LeaderLogIds::new(None));
 
     // len == 1
     let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1)]);
-    assert_eq!(&[log_id(1, 1, 1)], ids.by_last_leader());
+    assert_eq!(LeaderLogIds::new_single(log_id(1, 1, 1)), ids.by_last_leader());
 
     // len == 2, the last leader has only one log
     let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(3, 1, 3)]);
-    assert_eq!(&[log_id(3, 1, 3)], ids.by_last_leader());
+    assert_eq!(LeaderLogIds::new_single(log_id(3, 1, 3)), ids.by_last_leader());
 
     // len == 2, the last leader has two logs
     let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(1, 1, 3)]);
-    assert_eq!(&[log_id(1, 1, 1), log_id(1, 1, 3)], ids.by_last_leader());
+    assert_eq!(
+        LeaderLogIds::new_start_end(log_id(1, 1, 1), log_id(1, 1, 3)),
+        ids.by_last_leader()
+    );
 
     // len > 2, the last leader has only more than one logs
     let ids = LogIdList::<UTConfig>::new([log_id(1, 1, 1), log_id(7, 1, 8), log_id(7, 1, 10)]);
-    assert_eq!(&[log_id(7, 1, 8), log_id(7, 1, 10)], ids.by_last_leader());
+    assert_eq!(
+        LeaderLogIds::new_start_end(log_id(7, 1, 8), log_id(7, 1, 10)),
+        ids.by_last_leader()
+    );
 
     Ok(())
 }

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplayOptionExt;
+use crate::engine::leader_log_ids::LeaderLogIds;
 use crate::progress::Progress;
 use crate::progress::VecProgress;
 use crate::proposer::Leader;
@@ -110,8 +111,13 @@ where
             vote.into_committed()
         };
 
-        let last_leader_log_ids = self.last_log_id().cloned().into_iter().collect::<Vec<_>>();
+        // TODO: tricky: the new LeaderId is different from the last log id
+        //       Thus only the last().index is used.
+        //       Thus the first() is ignored.
+        //       But we should not fake the first() there.
+        let last = self.last_log_id();
+        let last_leader_log_ids = LeaderLogIds::new(last.map(|last| last.clone()..=last.clone()));
 
-        Leader::new(vote, self.quorum_set.clone(), self.learner_ids, &last_leader_log_ids)
+        Leader::new(vote, self.quorum_set.clone(), self.learner_ids, last_leader_log_ids)
     }
 }

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::display_ext::DisplayInstantExt;
-use crate::display_ext::DisplaySliceExt;
+use crate::engine::leader_log_ids::LeaderLogIds;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Progress;
 use crate::progress::VecProgress;
@@ -82,19 +82,19 @@ where
         vote: CommittedVote<C>,
         quorum_set: QS,
         learner_ids: impl IntoIterator<Item = C::NodeId>,
-        last_leader_log_id: &[LogIdOf<C>],
+        last_leader_log_id: LeaderLogIds<C>,
     ) -> Self {
         debug_assert!(
             Some(vote.committed_leader_id()) >= last_leader_log_id.last().map(|x| x.committed_leader_id().clone()),
             "vote {} must GE last_leader_log_id.last() {}",
             vote,
-            last_leader_log_id.display()
+            last_leader_log_id
         );
         debug_assert!(
             Some(vote.committed_leader_id()) >= last_leader_log_id.first().map(|x| x.committed_leader_id().clone()),
             "vote {} must GE last_leader_log_id.first() {}",
             vote,
-            last_leader_log_id.display()
+            last_leader_log_id
         );
 
         let learner_ids = learner_ids.into_iter().collect::<Vec<_>>();
@@ -222,6 +222,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::engine::leader_log_ids::LeaderLogIds;
     use crate::engine::testing::UTConfig;
     use crate::entry::RaftEntry;
     use crate::progress::Progress;
@@ -238,7 +239,12 @@ mod tests {
         tracing::info!("--- vote greater than last log id, create new noop_log_id");
         {
             let vote = Vote::new(2, 2).into_committed();
-            let leader = Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], vec![], &[log_id(1, 2, 1), log_id(1, 2, 3)]);
+            let leader = Leader::<UTConfig, _>::new(
+                vote,
+                vec![1, 2, 3],
+                vec![],
+                LeaderLogIds::new_start_end(log_id(1, 2, 1), log_id(1, 2, 3)),
+            );
 
             assert_eq!(leader.noop_log_id(), Some(&log_id(2, 2, 4)));
             assert_eq!(leader.last_log_id(), Some(&log_id(1, 2, 3)));
@@ -247,7 +253,12 @@ mod tests {
         tracing::info!("--- vote equals last log id, reuse noop_log_id");
         {
             let vote = Vote::new(1, 2).into_committed();
-            let leader = Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], vec![], &[log_id(1, 2, 1), log_id(1, 2, 3)]);
+            let leader = Leader::<UTConfig, _>::new(
+                vote,
+                vec![1, 2, 3],
+                vec![],
+                LeaderLogIds::new_start_end(log_id(1, 2, 1), log_id(1, 2, 3)),
+            );
 
             assert_eq!(leader.noop_log_id(), Some(&log_id(1, 2, 1)));
             assert_eq!(leader.last_log_id(), Some(&log_id(1, 2, 3)));
@@ -256,7 +267,8 @@ mod tests {
         tracing::info!("--- vote equals last log id, reuse noop_log_id, last_leader_log_id.len()==1");
         {
             let vote = Vote::new(1, 2).into_committed();
-            let leader = Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], vec![], &[log_id(1, 2, 3)]);
+            let leader =
+                Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], vec![], LeaderLogIds::new_single(log_id(1, 2, 3)));
 
             assert_eq!(leader.noop_log_id(), Some(&log_id(1, 2, 3)));
             assert_eq!(leader.last_log_id(), Some(&log_id(1, 2, 3)));
@@ -265,7 +277,7 @@ mod tests {
         tracing::info!("--- no last log ids, create new noop_log_id, last_leader_log_id.len()==0");
         {
             let vote = Vote::new(1, 2).into_committed();
-            let leader = Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], vec![], &[]);
+            let leader = Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], vec![], LeaderLogIds::new(None));
 
             assert_eq!(leader.noop_log_id(), Some(&log_id(1, 2, 0)));
             assert_eq!(leader.last_log_id(), None);
@@ -275,7 +287,8 @@ mod tests {
     #[test]
     fn test_leader_established() {
         let vote = Vote::new(2, 2).into_committed();
-        let mut leader = Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], vec![], &[log_id(1, 2, 3)]);
+        let mut leader =
+            Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], vec![], LeaderLogIds::new_single(log_id(1, 2, 3)));
 
         let mut entries = vec![Entry::<UTConfig>::new_blank(log_id(5, 5, 2))];
         leader.assign_log_ids(&mut entries);
@@ -291,7 +304,7 @@ mod tests {
     #[test]
     fn test_1_entry_none_last_log_id() {
         let vote = Vote::new(0, 0).into_committed();
-        let mut leading = Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], vec![], &[]);
+        let mut leading = Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], vec![], LeaderLogIds::new(None));
 
         let mut entries: Vec<Entry<UTConfig>> = vec![blank_ent(1, 1, 1)];
         leading.assign_log_ids(&mut entries);
@@ -303,7 +316,8 @@ mod tests {
     #[test]
     fn test_no_entries_provided() {
         let vote = Vote::new(2, 2).into_committed();
-        let mut leading = Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], vec![], &[log_id(1, 1, 8)]);
+        let mut leading =
+            Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], vec![], LeaderLogIds::new_single(log_id(1, 1, 8)));
 
         let mut entries: Vec<Entry<UTConfig>> = vec![];
         leading.assign_log_ids(&mut entries);
@@ -313,7 +327,8 @@ mod tests {
     #[test]
     fn test_multiple_entries() {
         let vote = Vote::new(2, 2).into_committed();
-        let mut leading = Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], [], &[log_id(1, 1, 8)]);
+        let mut leading =
+            Leader::<UTConfig, _>::new(vote, vec![1, 2, 3], [], LeaderLogIds::new_single(log_id(1, 1, 8)));
 
         let mut entries: Vec<Entry<UTConfig>> = vec![blank_ent(1, 1, 1), blank_ent(1, 1, 1), blank_ent(1, 1, 1)];
 
@@ -326,7 +341,12 @@ mod tests {
 
     #[test]
     fn test_leading_last_quorum_acked_time_leader_is_voter() {
-        let mut leading = Leader::<UTConfig, Vec<u64>>::new(Vote::new(2, 1).into_committed(), vec![1, 2, 3], [4], &[]);
+        let mut leading = Leader::<UTConfig, Vec<u64>>::new(
+            Vote::new(2, 1).into_committed(),
+            vec![1, 2, 3],
+            [4],
+            LeaderLogIds::new(None),
+        );
 
         let now1 = UTConfig::<()>::now();
 
@@ -337,7 +357,12 @@ mod tests {
 
     #[test]
     fn test_leading_last_quorum_acked_time_leader_is_learner() {
-        let mut leading = Leader::<UTConfig, Vec<u64>>::new(Vote::new(2, 4).into_committed(), vec![1, 2, 3], [4], &[]);
+        let mut leading = Leader::<UTConfig, Vec<u64>>::new(
+            Vote::new(2, 4).into_committed(),
+            vec![1, 2, 3],
+            [4],
+            LeaderLogIds::new(None),
+        );
 
         let t2 = UTConfig::<()>::now();
         let _ = leading.clock_progress.increase_to(&2, Some(t2));
@@ -352,7 +377,12 @@ mod tests {
 
     #[test]
     fn test_leading_last_quorum_acked_time_leader_is_not_member() {
-        let mut leading = Leader::<UTConfig, Vec<u64>>::new(Vote::new(2, 5).into_committed(), vec![1, 2, 3], [4], &[]);
+        let mut leading = Leader::<UTConfig, Vec<u64>>::new(
+            Vote::new(2, 5).into_committed(),
+            vec![1, 2, 3],
+            [4],
+            LeaderLogIds::new(None),
+        );
 
         let t2 = UTConfig::<()>::now();
         let _ = leading.clock_progress.increase_to(&2, Some(t2));

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -10,8 +10,10 @@ use crate::engine::LogIdList;
 use crate::entry::RaftPayload;
 use crate::log_id::RaftLogId;
 use crate::raft_state::IOState;
+use crate::storage::log_reader_ext::RaftLogReaderExt;
 use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;
@@ -120,7 +122,8 @@ where
             last_purged_log_id.display(),
             last_log_id.display()
         );
-        let log_ids = LogIdList::load_log_ids(last_purged_log_id.clone(), last_log_id, &mut log_reader).await?;
+
+        let log_id_list = self.get_key_log_ids(last_purged_log_id.clone(), last_log_id.clone()).await?;
 
         let snapshot = self.state_machine.get_current_snapshot().await?;
 
@@ -162,7 +165,7 @@ where
             //       before serving.
             vote: Leased::new(now, Duration::default(), vote),
             purged_next: last_purged_log_id.next_index(),
-            log_ids,
+            log_ids: log_id_list,
             membership_state: mem_state,
             snapshot_meta,
 
@@ -308,5 +311,46 @@ where
         }
 
         Ok(res)
+    }
+
+    // TODO: store purged: Option<LogId> separately.
+    /// Get key-log-ids from the log store.
+    ///
+    /// Key-log-ids are the first log id of each Leader.
+    async fn get_key_log_ids(
+        &mut self,
+        purged: Option<LogIdOf<C>>,
+        last: Option<LogIdOf<C>>,
+    ) -> Result<LogIdList<C>, StorageError<C>> {
+        let mut log_reader = self.log_store.get_log_reader().await;
+
+        let last = match last {
+            None => return Ok(LogIdList::new(vec![])),
+            Some(x) => x,
+        };
+
+        if purged.index() == Some(last.index) {
+            return Ok(LogIdList::new(vec![last]));
+        }
+
+        let first = log_reader.get_log_id(purged.next_index()).await?;
+
+        let mut log_ids = log_reader.get_key_log_ids(first..=last).await?;
+
+        if !log_ids.is_empty() {
+            if let Some(purged) = purged {
+                if purged.leader_id() == log_ids[0].leader_id() {
+                    if log_ids.len() >= 2 {
+                        log_ids[0] = purged;
+                    } else {
+                        log_ids.insert(0, purged);
+                    }
+                } else {
+                    log_ids.insert(0, purged);
+                }
+            }
+        }
+
+        Ok(LogIdList::new(log_ids))
     }
 }

--- a/openraft/src/storage/log_reader_ext.rs
+++ b/openraft/src/storage/log_reader_ext.rs
@@ -37,6 +37,6 @@ where C: RaftTypeConfig
 impl<C, LR> RaftLogReaderExt<C> for LR
 where
     C: RaftTypeConfig,
-    LR: RaftLogReader<C>,
+    LR: RaftLogReader<C> + ?Sized,
 {
 }

--- a/openraft/src/storage/v2/raft_log_reader.rs
+++ b/openraft/src/storage/v2/raft_log_reader.rs
@@ -1,9 +1,12 @@
 use std::fmt::Debug;
 use std::ops::RangeBounds;
+use std::ops::RangeInclusive;
 
 use openraft_macros::add_async_trait;
 use openraft_macros::since;
 
+use crate::engine::LogIdList;
+use crate::LogId;
 use crate::OptionalSend;
 use crate::OptionalSync;
 use crate::RaftTypeConfig;
@@ -61,5 +64,50 @@ where C: RaftTypeConfig
     #[since(version = "0.10.0")]
     async fn limited_get_log_entries(&mut self, start: u64, end: u64) -> Result<Vec<C::Entry>, StorageError<C>> {
         self.try_get_log_entries(start..end).await
+    }
+
+    /// Retrieves a list of key log ids that mark the beginning of each Leader.
+    ///
+    /// This method returns log entries that represent leadership transitions in the log history,
+    /// including:
+    /// - The first log entry in the storage (regardless of Leader);
+    /// - The first log entry from each Leader;
+    /// - The last log entry in the storage (regardless of Leader);
+    ///
+    /// # Example
+    ///
+    /// Given:
+    /// Log entries: `[(2,2), (2,3), (5,4), (5,5)]` (format: `(term, index)`)
+    ///
+    /// Returns: `[(2,2), (5,4), (5,5)]`
+    ///
+    /// # Usage
+    ///
+    /// This method is called only during node startup to build an initial log index.
+    ///
+    /// # Implementation Notes
+    ///
+    /// - Optional method: If your [`RaftLogStorage`] implementation doesn't maintain this
+    ///   information, do not implement it and use the default implementation.
+    /// - Default implementation: Uses a binary search algorithm to find key log entries
+    /// - Time complexity: `O(k * log(n))` where:
+    ///   - `k` = average number of unique Leaders
+    ///   - `n` = average number of logs per Leader
+    ///
+    /// # Arguments
+    ///
+    /// - `range`: range of the log id to return, inclusive. Such as `(1, 10)..=(2, 20)`.
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of log entries marking leadership transitions and boundaries.
+    ///
+    /// [`RaftLogStorage`]: crate::storage::RaftLogStorage
+    #[since(version = "0.10.0")]
+    async fn get_key_log_ids(
+        &mut self,
+        range: RangeInclusive<LogId<C::NodeId>>,
+    ) -> Result<Vec<LogId<C::NodeId>>, StorageError<C>> {
+        LogIdList::get_key_log_ids(range, self).await
     }
 }


### PR DESCRIPTION

## Changelog

##### Feature: Retrieve Key Log IDs via `RaftLogReader::get_key_log_ids()`

Key log IDs represent the first log IDs proposed by each Leader. These
IDs enable Openraft to efficiently access log IDs at each index with
a succinct storage.

Previously, key log IDs were obtained using a binary-search-like
algorithm through `RaftLogReader`. This commit introduces the
`RaftLogReader::get_key_log_ids()` method, allowing implementations to
directly return a list of key log IDs if the `RaftLogStorage` can
provide them.

For backward compatibility, a default implementation using the original
binary-search method is provided. No application changes are required
when upgrading to this version.

Tests verifying the implementation are included in
`openraft::testing::log::suite::Suite`.

- Fixes: #1261

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1264)
<!-- Reviewable:end -->
