### PR TITLE
Refactor: remove NodeIdEssential and NodeEssential traits

### DIFF
--- a/openraft/src/base/mod.rs
+++ b/openraft/src/base/mod.rs
@@ -14,9 +14,13 @@ mod threaded {
     use std::future::Future;
     use std::pin::Pin;
 
+    /// A trait that is empty if the `singlethreaded` feature flag is enabled,
+    /// otherwise it extends `Send`.
     pub trait OptionalSend: Send {}
     impl<T: Send + ?Sized> OptionalSend for T {}
 
+    /// A trait that is empty if the `singlethreaded` feature flag is enabled,
+    /// otherwise it extends `Sync`.
     pub trait OptionalSync: Sync {}
     impl<T: Sync + ?Sized> OptionalSync for T {}
 
@@ -32,9 +36,13 @@ mod threaded {
     use std::future::Future;
     use std::pin::Pin;
 
+    /// A trait that is empty if the `singlethreaded` feature flag is enabled,
+    /// otherwise it extends `Send`.
     pub trait OptionalSend {}
     impl<T: ?Sized> OptionalSend for T {}
 
+    /// A trait that is empty if the `singlethreaded` feature flag is enabled,
+    /// otherwise it extends `Sync`.
     pub trait OptionalSync {}
     impl<T: ?Sized> OptionalSync for T {}
 
@@ -46,14 +54,21 @@ mod threaded {
 
 #[cfg(not(feature = "serde"))]
 mod serde_able {
-    #[doc(hidden)]
+    /// A trait that extends `Serialize` and `Deserialize` if the `serde` feature flag
+    /// is enabled, otherwise it is empty trait.
     pub trait OptionalSerde {}
     impl<T> OptionalSerde for T {}
 }
 
 #[cfg(feature = "serde")]
 mod serde_able {
-    #[doc(hidden)]
+    /// A trait that extends `Serialize` and `Deserialize` if the `serde` feature flag
+    /// is enabled, otherwise it is empty trait.
     pub trait OptionalSerde: serde::Serialize + for<'a> serde::Deserialize<'a> {}
     impl<T> OptionalSerde for T where T: serde::Serialize + for<'a> serde::Deserialize<'a> {}
 }
+
+/// A trait that combines all optional features.
+pub trait OptionalFeatures: OptionalSend + OptionalSync + OptionalSerde {}
+
+impl<T> OptionalFeatures for T where T: OptionalSend + OptionalSync + OptionalSerde {}

--- a/openraft/src/node.rs
+++ b/openraft/src/node.rs
@@ -3,31 +3,29 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::hash::Hash;
 
-use crate::OptionalSend;
-use crate::OptionalSync;
+use crate::base::OptionalFeatures;
 
-/// Essential trait bound for node-id, except serde.
-#[doc(hidden)]
-pub trait NodeIdEssential:
-    Sized
-    + OptionalSend
-    + OptionalSync
-    + Eq
-    + PartialEq
-    + Ord
-    + PartialOrd
-    + Debug
-    + Display
-    + Hash
-    + Clone
-    + Default
-    + 'static
+/// A Raft node's ID.
+///
+/// A `NodeId` uniquely identifies a node in the Raft cluster.
+pub trait NodeId
+where Self: Sized
+        + OptionalFeatures
+        + Eq
+        + PartialEq
+        + Ord
+        + PartialOrd
+        + Debug
+        + Display
+        + Hash
+        + Clone
+        + Default
+        + 'static
 {
 }
 
-impl<T> NodeIdEssential for T where T: Sized
-        + OptionalSend
-        + OptionalSync
+impl<T> NodeId for T where T: Sized
+        + OptionalFeatures
         + Eq
         + PartialEq
         + Ord
@@ -42,45 +40,17 @@ impl<T> NodeIdEssential for T where T: Sized
 {
 }
 
-/// A Raft node's ID.
-///
-/// A `NodeId` uniquely identifies a node in the Raft cluster.
-#[cfg(feature = "serde")]
-pub trait NodeId: NodeIdEssential + serde::Serialize + for<'a> serde::Deserialize<'a> {}
-
-#[cfg(feature = "serde")]
-impl<T> NodeId for T where T: NodeIdEssential + serde::Serialize + for<'a> serde::Deserialize<'a> {}
-
-#[cfg(not(feature = "serde"))]
-pub trait NodeId: NodeIdEssential {}
-
-#[cfg(not(feature = "serde"))]
-impl<T> NodeId for T where T: NodeIdEssential {}
-
-/// Essential trait bound for application level node-data, except serde.
-pub trait NodeEssential:
-    Sized + OptionalSend + OptionalSync + Eq + PartialEq + Debug + Clone + Default + 'static
-{
-}
-impl<T> NodeEssential for T where T: Sized + OptionalSend + OptionalSync + Eq + PartialEq + Debug + Clone + Default + 'static
-{}
-
 /// A Raft `Node`, this trait holds all relevant node information.
 ///
-/// For the most generic case `BasicNode` provides an example implementation including the node's
-/// network address, but the used `Node` implementation can be customized to include additional
+/// For the most generic case [`BasicNode`] provides an example implementation including the node's
+/// network address, but the used [`Node`] implementation can be customized to include additional
 /// information.
-#[cfg(feature = "serde")]
-pub trait Node: NodeEssential + serde::Serialize + for<'a> serde::Deserialize<'a> {}
+pub trait Node
+where Self: Sized + OptionalFeatures + Eq + PartialEq + Debug + Clone + Default + 'static
+{
+}
 
-#[cfg(feature = "serde")]
-impl<T> Node for T where T: NodeEssential + serde::Serialize + for<'a> serde::Deserialize<'a> {}
-
-#[cfg(not(feature = "serde"))]
-pub trait Node: NodeEssential {}
-
-#[cfg(not(feature = "serde"))]
-impl<T> Node for T where T: NodeEssential {}
+impl<T> Node for T where T: Sized + OptionalFeatures + Eq + PartialEq + Debug + Clone + Default + 'static {}
 
 /// EmptyNode is an implementation of trait [`Node`] that contains nothing.
 ///


### PR DESCRIPTION

## Changelog

##### Refactor: remove NodeIdEssential and NodeEssential traits

These two traits are used to simplify NodeId and Node constraints.
But with `Optional*` traits, these two are no longer needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1276)
<!-- Reviewable:end -->
