### PR TITLE
Refactor: `Node` no longer requires `Default`

### DIFF
--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -6,10 +6,18 @@ use crate::RaftTypeConfig;
 
 /// Trivial Raft type config for Engine related unit tests,
 /// with an optional custom node type `N` for Node type.
-#[derive(Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub(crate) struct UTConfig<N = ()> {
     _p: std::marker::PhantomData<N>,
+}
+
+impl<N> Default for UTConfig<N> {
+    fn default() -> Self {
+        Self {
+            _p: std::marker::PhantomData,
+        }
+    }
 }
 
 impl<N> Clone for UTConfig<N> {

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -19,7 +19,7 @@ use crate::RaftTypeConfig;
 ///
 /// It could be a joint of one, two or more configs, i.e., a quorum is a node set that is superset
 /// of a majority of every config.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct Membership<C>
 where C: RaftTypeConfig
@@ -33,6 +33,17 @@ where C: RaftTypeConfig
     ///
     /// A node-id key that is in `nodes` but is not in `configs` is a **learner**.
     pub(crate) nodes: BTreeMap<C::NodeId, C::Node>,
+}
+
+impl<C> Default for Membership<C>
+where C: RaftTypeConfig
+{
+    fn default() -> Self {
+        Membership {
+            configs: vec![],
+            nodes: BTreeMap::new(),
+        }
+    }
 }
 
 impl<C> From<BTreeMap<C::NodeId, C::Node>> for Membership<C>

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -262,10 +262,7 @@ where C: RaftTypeConfig {
         current_leader: None,
         millis_since_quorum_ack: None,
         last_quorum_acked: None,
-        membership_config: Arc::new(StoredMembership::new(
-            None,
-            Membership::new_with_defaults(vec![btreeset! {}], []),
-        )),
+        membership_config: Arc::new(StoredMembership::new(None, Membership::default())),
         heartbeat: None,
 
         snapshot: None,

--- a/openraft/src/node.rs
+++ b/openraft/src/node.rs
@@ -46,11 +46,11 @@ impl<T> NodeId for T where T: Sized
 /// network address, but the used [`Node`] implementation can be customized to include additional
 /// information.
 pub trait Node
-where Self: Sized + OptionalFeatures + Eq + PartialEq + Debug + Clone + Default + 'static
+where Self: Sized + OptionalFeatures + Eq + PartialEq + Debug + Clone + 'static
 {
 }
 
-impl<T> Node for T where T: Sized + OptionalFeatures + Eq + PartialEq + Debug + Clone + Default + 'static {}
+impl<T> Node for T where T: Sized + OptionalFeatures + Eq + PartialEq + Debug + Clone + 'static {}
 
 /// EmptyNode is an implementation of trait [`Node`] that contains nothing.
 ///

--- a/openraft/src/testing/common.rs
+++ b/openraft/src/testing/common.rs
@@ -26,7 +26,10 @@ pub fn membership_ent<C: RaftTypeConfig>(
     node_id: C::NodeId,
     index: u64,
     config: Vec<BTreeSet<C::NodeId>>,
-) -> crate::Entry<C> {
+) -> crate::Entry<C>
+where
+    C::Node: Default,
+{
     crate::Entry::new_membership(
         LogId::new(CommittedLeaderId::new(term, node_id), index),
         crate::Membership::new_with_defaults(config, []),

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -113,6 +113,7 @@ where
     C::D: Debug,
     C::R: Debug,
     C::NodeId: From<u64>,
+    C::Node: Default,
     LS: RaftLogStorage<C>,
     SM: RaftStateMachine<C>,
     B: StoreBuilder<C, LS, SM, G>,
@@ -1391,7 +1392,10 @@ where C::NodeId: From<u64> {
 
 /// Create a membership entry with node_id 0 for test.
 fn membership_ent_0<C: RaftTypeConfig>(term: u64, index: u64, bs: BTreeSet<C::NodeId>) -> C::Entry
-where C::NodeId: From<u64> {
+where
+    C::NodeId: From<u64>,
+    C::Node: Default,
+{
     C::Entry::new_membership(log_id_0(term, index), Membership::new_with_defaults(vec![bs], []))
 }
 


### PR DESCRIPTION

## Changelog

##### Refactor: `Node` no longer requires `Default`

Openraft internally does not require `Node` to implement `Default`.
`Default for Node` is only required in tests. Therefore in this commit
the `Default` is removed from trait `Node` and the contraint is added to
test suite codes where `Default` is required to build a `node` for
testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1277)
<!-- Reviewable:end -->
