### PR TITLE
Change: change `Vote<NID:NodeId>` to `Vote<C:RaftTypeConfig>`

### DIFF
--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -57,7 +57,7 @@ pub struct StateMachine {
 }
 
 pub struct LogStore {
-    vote: RwLock<Option<Vote<NodeId>>>,
+    vote: RwLock<Option<Vote<TypeConfig>>>,
     log: RwLock<BTreeMap<u64, Entry<TypeConfig>>>,
     last_purged_log_id: RwLock<Option<LogId<NodeId>>>,
 }
@@ -116,7 +116,7 @@ impl RaftLogReader<TypeConfig> for Arc<LogStore> {
         Ok(entries)
     }
 
-    async fn read_vote(&mut self) -> Result<Option<Vote<NodeId>>, StorageError<TypeConfig>> {
+    async fn read_vote(&mut self) -> Result<Option<Vote<TypeConfig>>, StorageError<TypeConfig>> {
         Ok(self.vote.read().await.clone())
     }
 }
@@ -196,7 +196,7 @@ impl RaftLogStorage<TypeConfig> for Arc<LogStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn save_vote(&mut self, vote: &Vote<NodeId>) -> Result<(), StorageError<TypeConfig>> {
+    async fn save_vote(&mut self, vote: &Vote<TypeConfig>) -> Result<(), StorageError<TypeConfig>> {
         let mut v = self.vote.write().await;
         *v = Some(*vote);
         Ok(())

--- a/examples/memstore/src/log_store.rs
+++ b/examples/memstore/src/log_store.rs
@@ -33,7 +33,7 @@ pub struct LogStoreInner<C: RaftTypeConfig> {
     committed: Option<LogId<C::NodeId>>,
 
     /// The current granted vote.
-    vote: Option<Vote<C::NodeId>>,
+    vote: Option<Vote<C>>,
 }
 
 impl<C: RaftTypeConfig> Default for LogStoreInner<C> {
@@ -84,12 +84,12 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
         Ok(self.committed.clone())
     }
 
-    async fn save_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), StorageError<C>> {
+    async fn save_vote(&mut self, vote: &Vote<C>) -> Result<(), StorageError<C>> {
         self.vote = Some(vote.clone());
         Ok(())
     }
 
-    async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C>> {
+    async fn read_vote(&mut self) -> Result<Option<Vote<C>>, StorageError<C>> {
         Ok(self.vote.clone())
     }
 
@@ -157,7 +157,7 @@ mod impl_log_store {
             inner.try_get_log_entries(range).await
         }
 
-        async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C>> {
+        async fn read_vote(&mut self) -> Result<Option<Vote<C>>, StorageError<C>> {
             let mut inner = self.inner.lock().await;
             inner.read_vote().await
         }
@@ -183,7 +183,7 @@ mod impl_log_store {
             inner.read_committed().await
         }
 
-        async fn save_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), StorageError<C>> {
+        async fn save_vote(&mut self, vote: &Vote<C>) -> Result<(), StorageError<C>> {
             let mut inner = self.inner.lock().await;
             inner.save_vote(vote).await
         }

--- a/examples/raft-kv-memstore-grpc/src/lib.rs
+++ b/examples/raft-kv-memstore-grpc/src/lib.rs
@@ -37,10 +37,9 @@ pub mod protobuf {
 
 pub mod typ {
 
-    use crate::NodeId;
     use crate::TypeConfig;
 
-    pub type Vote = openraft::Vote<NodeId>;
+    pub type Vote = openraft::Vote<TypeConfig>;
     pub type SnapshotMeta = openraft::SnapshotMeta<TypeConfig>;
     pub type SnapshotData = <TypeConfig as openraft::RaftTypeConfig>::SnapshotData;
     pub type Snapshot = openraft::Snapshot<TypeConfig>;

--- a/examples/raft-kv-memstore-grpc/src/network/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/network/mod.rs
@@ -78,7 +78,7 @@ impl RaftNetworkV2<TypeConfig> for NetworkConnection {
 
     async fn full_snapshot(
         &mut self,
-        vote: openraft::Vote<<TypeConfig as openraft::RaftTypeConfig>::NodeId>,
+        vote: openraft::Vote<TypeConfig>,
         snapshot: openraft::Snapshot<TypeConfig>,
         _cancel: impl std::future::Future<Output = openraft::error::ReplicationClosed> + openraft::OptionalSend + 'static,
         _option: RPCOption,

--- a/examples/raft-kv-memstore-network-v2/src/lib.rs
+++ b/examples/raft-kv-memstore-network-v2/src/lib.rs
@@ -34,13 +34,11 @@ pub type LogStore = store::LogStore;
 pub type StateMachineStore = store::StateMachineStore;
 
 pub mod typ {
-
-    use crate::NodeId;
     use crate::TypeConfig;
 
     pub type Raft = openraft::Raft<TypeConfig>;
 
-    pub type Vote = openraft::Vote<NodeId>;
+    pub type Vote = openraft::Vote<TypeConfig>;
     pub type SnapshotMeta = openraft::SnapshotMeta<TypeConfig>;
     pub type SnapshotData = <TypeConfig as openraft::RaftTypeConfig>::SnapshotData;
     pub type Snapshot = openraft::Snapshot<TypeConfig>;

--- a/examples/raft-kv-memstore-network-v2/src/network.rs
+++ b/examples/raft-kv-memstore-network-v2/src/network.rs
@@ -48,7 +48,7 @@ impl RaftNetworkV2<TypeConfig> for Connection {
     /// A real application should replace this method with customized implementation.
     async fn full_snapshot(
         &mut self,
-        vote: Vote<NodeId>,
+        vote: Vote<TypeConfig>,
         snapshot: Snapshot<TypeConfig>,
         _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         _option: RPCOption,

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/lib.rs
@@ -36,12 +36,11 @@ pub type StateMachineStore = store::StateMachineStore;
 
 pub mod typ {
 
-    use crate::NodeId;
     use crate::TypeConfig;
 
     pub type Raft = openraft::Raft<TypeConfig>;
 
-    pub type Vote = openraft::Vote<NodeId>;
+    pub type Vote = openraft::Vote<TypeConfig>;
     pub type SnapshotMeta = openraft::SnapshotMeta<TypeConfig>;
     pub type SnapshotData = <TypeConfig as openraft::RaftTypeConfig>::SnapshotData;
     pub type Snapshot = openraft::Snapshot<TypeConfig>;

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/network.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/network.rs
@@ -48,7 +48,7 @@ impl RaftNetworkV2<TypeConfig> for Connection {
     /// A real application should replace this method with customized implementation.
     async fn full_snapshot(
         &mut self,
-        vote: Vote<NodeId>,
+        vote: Vote<TypeConfig>,
         snapshot: Snapshot<TypeConfig>,
         _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         _option: RPCOption,

--- a/examples/raft-kv-memstore-singlethreaded/src/store.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/store.rs
@@ -116,7 +116,7 @@ pub struct LogStore {
     committed: RefCell<Option<LogId<NodeId>>>,
 
     /// The current granted vote.
-    vote: RefCell<Option<Vote<NodeId>>>,
+    vote: RefCell<Option<Vote<TypeConfig>>>,
 }
 
 impl RaftLogReader<TypeConfig> for Rc<LogStore> {
@@ -129,7 +129,7 @@ impl RaftLogReader<TypeConfig> for Rc<LogStore> {
         Ok(response)
     }
 
-    async fn read_vote(&mut self) -> Result<Option<Vote<NodeId>>, StorageError<TypeConfig>> {
+    async fn read_vote(&mut self) -> Result<Option<Vote<TypeConfig>>, StorageError<TypeConfig>> {
         Ok(*self.vote.borrow())
     }
 }
@@ -312,7 +312,7 @@ impl RaftLogStorage<TypeConfig> for Rc<LogStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn save_vote(&mut self, vote: &Vote<NodeId>) -> Result<(), StorageError<TypeConfig>> {
+    async fn save_vote(&mut self, vote: &Vote<TypeConfig>) -> Result<(), StorageError<TypeConfig>> {
         let mut v = self.vote.borrow_mut();
         *v = Some(*vote);
         Ok(())

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -337,7 +337,7 @@ impl LogStore {
             .and_then(|v| serde_json::from_slice(&v).ok()))
     }
 
-    fn set_vote_(&self, vote: &Vote<NodeId>) -> StorageResult<()> {
+    fn set_vote_(&self, vote: &Vote<TypeConfig>) -> StorageResult<()> {
         self.db
             .put_cf(self.store(), b"vote", serde_json::to_vec(vote).unwrap())
             .map_err(|e| StorageError::write_vote(&e))?;
@@ -346,7 +346,7 @@ impl LogStore {
         Ok(())
     }
 
-    fn get_vote_(&self) -> StorageResult<Option<Vote<NodeId>>> {
+    fn get_vote_(&self) -> StorageResult<Option<Vote<TypeConfig>>> {
         Ok(self
             .db
             .get_cf(self.store(), b"vote")
@@ -381,7 +381,7 @@ impl RaftLogReader<TypeConfig> for LogStore {
             .collect()
     }
 
-    async fn read_vote(&mut self) -> Result<Option<Vote<NodeId>>, StorageError<TypeConfig>> {
+    async fn read_vote(&mut self) -> Result<Option<Vote<TypeConfig>>, StorageError<TypeConfig>> {
         self.get_vote_()
     }
 }
@@ -418,7 +418,7 @@ impl RaftLogStorage<TypeConfig> for LogStore {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn save_vote(&mut self, vote: &Vote<NodeId>) -> Result<(), StorageError<TypeConfig>> {
+    async fn save_vote(&mut self, vote: &Vote<TypeConfig>) -> Result<(), StorageError<TypeConfig>> {
         self.set_vote_(vote)
     }
 

--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -33,7 +33,7 @@ where C: RaftTypeConfig
         target: C::NodeId,
 
         /// The higher vote observed.
-        higher: Vote<C::NodeId>,
+        higher: Vote<C>,
 
         /// The Leader that sent replication request.
         leader_vote: CommittedVote<C>,

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -52,7 +52,7 @@ where C: RaftTypeConfig
     },
 
     InstallFullSnapshot {
-        vote: Vote<C::NodeId>,
+        vote: Vote<C>,
         snapshot: Snapshot<C>,
         tx: ResultSender<C, SnapshotResponse<C>>,
     },
@@ -101,7 +101,7 @@ where C: RaftTypeConfig
     /// Otherwise, just reset Leader lease so that the node `to` can become Leader.
     HandleTransferLeader {
         /// The vote of the Leader that is transferring the leadership.
-        from: Vote<C::NodeId>,
+        from: Vote<C>,
         /// The assigned node to be the next Leader.
         to: C::NodeId,
     },

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -112,7 +112,7 @@ where C: RaftTypeConfig
     },
 
     /// Save vote to storage
-    SaveVote { vote: Vote<C::NodeId> },
+    SaveVote { vote: Vote<C> },
 
     /// Send vote to all other members
     SendVote { vote_req: VoteRequest<C> },

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -111,7 +111,7 @@ where C: RaftTypeConfig
     ///
     /// The candidate `last_log_id` is initialized with the attributes of Acceptor part:
     /// [`RaftState`]
-    pub(crate) fn new_candidate(&mut self, vote: Vote<C::NodeId>) -> &mut Candidate<C, LeaderQuorumSet<C>> {
+    pub(crate) fn new_candidate(&mut self, vote: Vote<C>) -> &mut Candidate<C, LeaderQuorumSet<C>> {
         let now = C::now();
         let last_log_id = self.state.last_log_id().cloned();
 
@@ -378,7 +378,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn handle_append_entries(
         &mut self,
-        vote: &Vote<C::NodeId>,
+        vote: &Vote<C>,
         prev_log_id: Option<LogId<C::NodeId>>,
         entries: Vec<C::Entry>,
         tx: Option<AppendEntriesTx<C>>,
@@ -417,7 +417,7 @@ where C: RaftTypeConfig
 
     pub(crate) fn append_entries(
         &mut self,
-        vote: &Vote<C::NodeId>,
+        vote: &Vote<C>,
         prev_log_id: Option<LogId<C::NodeId>>,
         entries: Vec<C::Entry>,
     ) -> Result<(), RejectAppendEntries<C>> {
@@ -451,7 +451,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn handle_install_full_snapshot(
         &mut self,
-        vote: Vote<C::NodeId>,
+        vote: Vote<C>,
         snapshot: Snapshot<C>,
         tx: ResultSender<C, SnapshotResponse<C>>,
     ) {

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -59,7 +59,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn accept_vote<T, E, F>(
         &mut self,
-        vote: &Vote<C::NodeId>,
+        vote: &Vote<C>,
         tx: ResultSender<C, T, E>,
         f: F,
     ) -> Option<ResultSender<C, T, E>>
@@ -98,7 +98,7 @@ where C: RaftTypeConfig
     /// Note: This method does not check last-log-id. handle-vote-request has to deal with
     /// last-log-id itself.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn update_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), RejectVoteRequest<C>> {
+    pub(crate) fn update_vote(&mut self, vote: &Vote<C>) -> Result<(), RejectVoteRequest<C>> {
         // Partial ord compare:
         // Vote does not have to be total ord.
         // `!(a >= b)` does not imply `a < b`.

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -346,8 +346,8 @@ where
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 #[error("seen a higher vote: {higher} GT mine: {sender_vote}")]
 pub(crate) struct HigherVote<C: RaftTypeConfig> {
-    pub(crate) higher: Vote<C::NodeId>,
-    pub(crate) sender_vote: Vote<C::NodeId>,
+    pub(crate) higher: Vote<C>,
+    pub(crate) sender_vote: Vote<C>,
 }
 
 /// Error that indicates a **temporary** network error and when it is returned, Openraft will retry
@@ -603,7 +603,7 @@ pub struct LearnerNotFound<C: RaftTypeConfig> {
 #[error("not allowed to initialize due to current raft state: last_log_id: {last_log_id:?} vote: {vote}")]
 pub struct NotAllowed<C: RaftTypeConfig> {
     pub last_log_id: Option<LogId<C::NodeId>>,
-    pub vote: Vote<C::NodeId>,
+    pub vote: Vote<C>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -636,7 +636,7 @@ pub enum NoForward {}
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub(crate) enum RejectVoteRequest<C: RaftTypeConfig> {
     #[error("reject vote request by a greater vote: {0}")]
-    ByVote(Vote<C::NodeId>),
+    ByVote(Vote<C>),
 
     #[allow(dead_code)]
     #[error("reject vote request by a greater last-log-id: {0:?}")]
@@ -659,7 +659,7 @@ where C: RaftTypeConfig
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum RejectAppendEntries<C: RaftTypeConfig> {
     #[error("reject AppendEntries by a greater vote: {0}")]
-    ByVote(Vote<C::NodeId>),
+    ByVote(Vote<C>),
 
     #[error("reject AppendEntries because of conflicting log-id: {local:?}; expect to be: {expect:?}")]
     ByConflictingLogId {

--- a/openraft/src/metrics/metric.rs
+++ b/openraft/src/metrics/metric.rs
@@ -15,7 +15,7 @@ pub enum Metric<C>
 where C: RaftTypeConfig
 {
     Term(u64),
-    Vote(Vote<C::NodeId>),
+    Vote(Vote<C>),
     LastLogIndex(Option<u64>),
     Applied(Option<LogId<C::NodeId>>),
     AppliedIndex(Option<u64>),

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -32,7 +32,7 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     pub current_term: u64,
 
     /// The last flushed vote.
-    pub vote: Vote<C::NodeId>,
+    pub vote: Vote<C>,
 
     /// The last log index has been appended to this Raft node's log.
     pub last_log_index: Option<u64>,
@@ -280,7 +280,7 @@ where C: RaftTypeConfig
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct RaftServerMetrics<C: RaftTypeConfig> {
     pub id: C::NodeId,
-    pub vote: Vote<C::NodeId>,
+    pub vote: Vote<C>,
     pub state: ServerState,
     pub current_leader: Option<C::NodeId>,
 

--- a/openraft/src/metrics/wait.rs
+++ b/openraft/src/metrics/wait.rs
@@ -93,7 +93,7 @@ where C: RaftTypeConfig
 
     /// Wait for `vote` to become `want` or timeout.
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
-    pub async fn vote(&self, want: Vote<C::NodeId>, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
+    pub async fn vote(&self, want: Vote<C>, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
         self.eq(Metric::Vote(want), msg).await
     }
 

--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -45,7 +45,7 @@ mod tokio_rt {
     {
         async fn send_snapshot<Net>(
             net: &mut Net,
-            vote: Vote<C::NodeId>,
+            vote: Vote<C>,
             mut snapshot: Snapshot<C>,
             mut cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
             option: RPCOption,
@@ -299,7 +299,7 @@ pub trait SnapshotTransport<C: RaftTypeConfig> {
     // TODO: consider removing dependency on RaftNetwork
     async fn send_snapshot<Net>(
         net: &mut Net,
-        vote: Vote<C::NodeId>,
+        vote: Vote<C>,
         snapshot: Snapshot<C>,
         cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         option: RPCOption,

--- a/openraft/src/network/v2/adapt_v1.rs
+++ b/openraft/src/network/v2/adapt_v1.rs
@@ -38,7 +38,7 @@ where
 
     async fn full_snapshot(
         &mut self,
-        vote: Vote<C::NodeId>,
+        vote: Vote<C>,
         snapshot: Snapshot<C>,
         cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         option: RPCOption,

--- a/openraft/src/network/v2/network.rs
+++ b/openraft/src/network/v2/network.rs
@@ -75,7 +75,7 @@ where C: RaftTypeConfig
     /// [`Raft::install_full_snapshot()`]: crate::raft::Raft::install_full_snapshot
     async fn full_snapshot(
         &mut self,
-        vote: Vote<C::NodeId>,
+        vote: Vote<C>,
         snapshot: Snapshot<C>,
         cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         option: RPCOption,

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -25,7 +25,7 @@ where
     starting_time: InstantOf<C>,
 
     /// The vote.
-    vote: Vote<C::NodeId>,
+    vote: Vote<C>,
 
     last_log_id: Option<LogIdOf<C>>,
 
@@ -61,7 +61,7 @@ where
 {
     pub(crate) fn new(
         starting_time: InstantOf<C>,
-        vote: Vote<C::NodeId>,
+        vote: Vote<C>,
         last_log_id: Option<LogIdOf<C>>,
         quorum_set: QS,
         learner_ids: impl IntoIterator<Item = C::NodeId>,
@@ -76,7 +76,7 @@ where
         }
     }
 
-    pub(crate) fn vote_ref(&self) -> &Vote<C::NodeId> {
+    pub(crate) fn vote_ref(&self) -> &Vote<C> {
         &self.vote
     }
 

--- a/openraft/src/raft/message/append_entries.rs
+++ b/openraft/src/raft/message/append_entries.rs
@@ -16,7 +16,7 @@ use crate::Vote;
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct AppendEntriesRequest<C: RaftTypeConfig> {
-    pub vote: Vote<C::NodeId>,
+    pub vote: Vote<C>,
 
     pub prev_log_id: Option<LogId<C::NodeId>>,
 
@@ -95,7 +95,7 @@ pub enum AppendEntriesResponse<C: RaftTypeConfig> {
     /// Seen a vote `v` that does not hold `mine_vote >= v`.
     /// And a leader's vote(committed vote) must be total order with other vote.
     /// Therefore it has to be a higher vote: `mine_vote < v`
-    HigherVote(Vote<C::NodeId>),
+    HigherVote(Vote<C>),
 }
 
 impl<C> AppendEntriesResponse<C>

--- a/openraft/src/raft/message/install_snapshot.rs
+++ b/openraft/src/raft/message/install_snapshot.rs
@@ -9,7 +9,7 @@ use crate::Vote;
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct InstallSnapshotRequest<C: RaftTypeConfig> {
-    pub vote: Vote<C::NodeId>,
+    pub vote: Vote<C>,
 
     /// Metadata of a snapshot: snapshot_id, last_log_ed membership etc.
     pub meta: SnapshotMeta<C>,
@@ -44,7 +44,7 @@ impl<C: RaftTypeConfig> fmt::Display for InstallSnapshotRequest<C> {
 #[display("{{vote:{}}}", vote)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct InstallSnapshotResponse<C: RaftTypeConfig> {
-    pub vote: Vote<C::NodeId>,
+    pub vote: Vote<C>,
 }
 
 /// The response to `Raft::install_full_snapshot` API.
@@ -54,11 +54,11 @@ pub struct InstallSnapshotResponse<C: RaftTypeConfig> {
 #[display("SnapshotResponse{{vote:{}}}", vote)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct SnapshotResponse<C: RaftTypeConfig> {
-    pub vote: Vote<C::NodeId>,
+    pub vote: Vote<C>,
 }
 
 impl<C: RaftTypeConfig> SnapshotResponse<C> {
-    pub fn new(vote: Vote<C::NodeId>) -> Self {
+    pub fn new(vote: Vote<C>) -> Self {
         Self { vote }
     }
 }

--- a/openraft/src/raft/message/transfer_leader.rs
+++ b/openraft/src/raft/message/transfer_leader.rs
@@ -12,7 +12,7 @@ pub struct TransferLeaderRequest<C>
 where C: RaftTypeConfig
 {
     /// The vote of the Leader that is transferring the leadership.
-    pub(crate) from_leader: Vote<C::NodeId>,
+    pub(crate) from_leader: Vote<C>,
 
     /// The assigned node to be the next Leader.
     pub(crate) to_node_id: C::NodeId,
@@ -24,7 +24,7 @@ where C: RaftTypeConfig
 impl<C> TransferLeaderRequest<C>
 where C: RaftTypeConfig
 {
-    pub fn new(from: Vote<C::NodeId>, to: C::NodeId, last_log_id: Option<LogId<C::NodeId>>) -> Self {
+    pub fn new(from: Vote<C>, to: C::NodeId, last_log_id: Option<LogId<C::NodeId>>) -> Self {
         Self {
             from_leader: from,
             to_node_id: to,
@@ -33,7 +33,7 @@ where C: RaftTypeConfig
     }
 
     /// From which Leader the leadership is transferred.
-    pub fn from_leader(&self) -> &Vote<C::NodeId> {
+    pub fn from_leader(&self) -> &Vote<C> {
         &self.from_leader
     }
 

--- a/openraft/src/raft/message/vote.rs
+++ b/openraft/src/raft/message/vote.rs
@@ -10,7 +10,7 @@ use crate::Vote;
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct VoteRequest<C: RaftTypeConfig> {
-    pub vote: Vote<C::NodeId>,
+    pub vote: Vote<C>,
     pub last_log_id: Option<LogId<C::NodeId>>,
 }
 
@@ -25,7 +25,7 @@ where C: RaftTypeConfig
 impl<C> VoteRequest<C>
 where C: RaftTypeConfig
 {
-    pub fn new(vote: Vote<C::NodeId>, last_log_id: Option<LogId<C::NodeId>>) -> Self {
+    pub fn new(vote: Vote<C>, last_log_id: Option<LogId<C::NodeId>>) -> Self {
         Self { vote, last_log_id }
     }
 }
@@ -39,7 +39,7 @@ pub struct VoteResponse<C: RaftTypeConfig> {
     ///
     /// `vote` that equals the candidate.vote does not mean the vote is granted.
     /// The `vote` may be updated when a previous Leader sees a higher vote.
-    pub vote: Vote<C::NodeId>,
+    pub vote: Vote<C>,
 
     /// It is true if a node accepted and saved the VoteRequest.
     pub vote_granted: bool,
@@ -51,7 +51,7 @@ pub struct VoteResponse<C: RaftTypeConfig> {
 impl<C> VoteResponse<C>
 where C: RaftTypeConfig
 {
-    pub fn new(vote: impl Borrow<Vote<C::NodeId>>, last_log_id: Option<LogId<C::NodeId>>, granted: bool) -> Self {
+    pub fn new(vote: impl Borrow<Vote<C>>, last_log_id: Option<LogId<C::NodeId>>, granted: bool) -> Self {
         Self {
             vote: vote.borrow().clone(),
             vote_granted: granted,
@@ -61,7 +61,7 @@ where C: RaftTypeConfig
 
     /// Returns `true` if the response indicates that the target node has granted a vote to the
     /// candidate.
-    pub fn is_granted_to(&self, candidate_vote: &Vote<C::NodeId>) -> bool {
+    pub fn is_granted_to(&self, candidate_vote: &Vote<C>) -> bool {
         &self.vote == candidate_vote
     }
 }

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -418,7 +418,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn install_full_snapshot(
         &self,
-        vote: Vote<C::NodeId>,
+        vote: Vote<C>,
         snapshot: Snapshot<C>,
     ) -> Result<SnapshotResponse<C>, Fatal<C>> {
         tracing::info!("Raft::install_full_snapshot()");

--- a/openraft/src/raft_state/io_state.rs
+++ b/openraft/src/raft_state/io_state.rs
@@ -103,7 +103,7 @@ impl<C> IOState<C>
 where C: RaftTypeConfig
 {
     pub(crate) fn new(
-        vote: &Vote<C::NodeId>,
+        vote: &Vote<C>,
         applied: Option<LogId<C::NodeId>>,
         snapshot: Option<LogId<C::NodeId>>,
         purged: Option<LogId<C::NodeId>>,

--- a/openraft/src/raft_state/io_state/io_id.rs
+++ b/openraft/src/raft_state/io_state/io_id.rs
@@ -68,7 +68,7 @@ where C: RaftTypeConfig
 impl<C> IOId<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(vote: &Vote<C::NodeId>) -> Self {
+    pub(crate) fn new(vote: &Vote<C>) -> Self {
         if vote.is_committed() {
             Self::new_log_io(vote.clone().into_committed(), None)
         } else {
@@ -87,14 +87,14 @@ where C: RaftTypeConfig
     /// Returns the vote the io operation is submitted by.
     #[allow(clippy::wrong_self_convention)]
     // The above lint is disabled because in future Vote may not be `Copy`
-    pub(crate) fn to_vote(&self) -> Vote<C::NodeId> {
+    pub(crate) fn to_vote(&self) -> Vote<C> {
         match self {
             Self::Vote(non_committed_vote) => non_committed_vote.clone().into_vote(),
             Self::Log(log_io_id) => log_io_id.committed_vote.clone().into_vote(),
         }
     }
 
-    pub(crate) fn as_ref_vote(&self) -> RefVote<'_, C::NodeId> {
+    pub(crate) fn as_ref_vote(&self) -> RefVote<'_, C> {
         match self {
             Self::Vote(non_committed_vote) => non_committed_vote.as_ref_vote(),
             Self::Log(log_io_id) => log_io_id.committed_vote.as_ref_vote(),

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -49,7 +49,7 @@ pub struct RaftState<C>
 where C: RaftTypeConfig
 {
     /// The vote state of this node.
-    pub(crate) vote: Leased<Vote<C::NodeId>, InstantOf<C>>,
+    pub(crate) vote: Leased<Vote<C>, InstantOf<C>>,
 
     /// The LogId of the last log committed(AKA applied) to the state machine.
     ///
@@ -146,10 +146,10 @@ where C: RaftTypeConfig
     }
 }
 
-impl<C> VoteStateReader<C::NodeId> for RaftState<C>
+impl<C> VoteStateReader<C> for RaftState<C>
 where C: RaftTypeConfig
 {
-    fn vote_ref(&self) -> &Vote<C::NodeId> {
+    fn vote_ref(&self) -> &Vote<C> {
         self.vote.deref()
     }
 }
@@ -187,7 +187,7 @@ impl<C> RaftState<C>
 where C: RaftTypeConfig
 {
     /// Get a reference to the current vote.
-    pub fn vote_ref(&self) -> &Vote<C::NodeId> {
+    pub fn vote_ref(&self) -> &Vote<C> {
         self.vote.deref()
     }
 

--- a/openraft/src/raft_state/vote_state_reader.rs
+++ b/openraft/src/raft_state/vote_state_reader.rs
@@ -1,10 +1,12 @@
-use crate::NodeId;
+use crate::RaftTypeConfig;
 use crate::Vote;
 
 // TODO: remove it?
 /// APIs to get vote.
 #[allow(dead_code)]
-pub(crate) trait VoteStateReader<NID: NodeId> {
+pub(crate) trait VoteStateReader<C>
+where C: RaftTypeConfig
+{
     /// Get a reference to the current vote.
-    fn vote_ref(&self) -> &Vote<NID>;
+    fn vote_ref(&self) -> &Vote<C>;
 }

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -747,7 +747,7 @@ where
 
     async fn send_snapshot(
         network: Arc<MutexOf<C, N::Network>>,
-        vote: Vote<C::NodeId>,
+        vote: Vote<C>,
         snapshot: Snapshot<C>,
         option: RPCOption,
         cancel: OneshotReceiverOf<C, ()>,

--- a/openraft/src/replication/replication_session_id.rs
+++ b/openraft/src/replication/replication_session_id.rs
@@ -68,7 +68,7 @@ where C: RaftTypeConfig
         self.leader_vote.clone()
     }
 
-    pub(crate) fn vote(&self) -> Vote<C::NodeId> {
+    pub(crate) fn vote(&self) -> Vote<C> {
         self.leader_vote.clone().into_vote()
     }
 }

--- a/openraft/src/storage/v2/raft_log_reader.rs
+++ b/openraft/src/storage/v2/raft_log_reader.rs
@@ -50,7 +50,7 @@ where C: RaftTypeConfig
     /// See: [log-stream](`crate::docs::protocol::replication::log_stream`)
     ///
     /// [`RaftLogStorage::save_vote`]: crate::storage::RaftLogStorage::save_vote
-    async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C>>;
+    async fn read_vote(&mut self) -> Result<Option<Vote<C>>, StorageError<C>>;
 
     /// Returns log entries within range `[start, end)`, `end` is exclusive,
     /// potentially limited by implementation-defined constraints.

--- a/openraft/src/storage/v2/raft_log_storage.rs
+++ b/openraft/src/storage/v2/raft_log_storage.rs
@@ -52,7 +52,7 @@ where C: RaftTypeConfig
     /// ### To ensure correctness:
     ///
     /// The vote must be persisted on disk before returning.
-    async fn save_vote(&mut self, vote: &Vote<C::NodeId>) -> Result<(), StorageError<C>>;
+    async fn save_vote(&mut self, vote: &Vote<C>) -> Result<(), StorageError<C>>;
 
     /// Saves the last committed log id to storage.
     ///

--- a/openraft/src/storage/v2/raft_log_storage_ext.rs
+++ b/openraft/src/storage/v2/raft_log_storage_ext.rs
@@ -34,7 +34,7 @@ where C: RaftTypeConfig
 
         let (tx, mut rx) = C::mpsc_unbounded();
 
-        let io_id = IOId::<C>::new_log_io(Vote::<C::NodeId>::default().into_committed(), Some(last_log_id));
+        let io_id = IOId::<C>::new_log_io(Vote::<C>::default().into_committed(), Some(last_log_id));
         let notify = Notification::LocalIO { io_id };
 
         let callback = IOFlushed::<C>::new(notify, tx.downgrade());

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -71,7 +71,7 @@ where C: RaftTypeConfig
     }
 
     /// Proxy method to invoke [`RaftLogReader::read_vote`].
-    async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, StorageError<C>> {
+    async fn read_vote(&mut self) -> Result<Option<Vote<C>>, StorageError<C>> {
         self.get_log_reader().await.read_vote().await
     }
 
@@ -1440,7 +1440,7 @@ where
     let (tx, mut rx) = C::mpsc_unbounded();
 
     // Dummy log io id for blocking append
-    let io_id = IOId::<C>::new_log_io(Vote::<C::NodeId>::default().into_committed(), Some(last_log_id));
+    let io_id = IOId::<C>::new_log_io(Vote::<C>::default().into_committed(), Some(last_log_id));
     let notify = Notification::LocalIO { io_id };
     let cb = IOFlushed::new(notify, tx.downgrade());
 

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -152,7 +152,7 @@ pub mod alias {
 
     // Usually used types
     pub type LogIdOf<C> = crate::LogId<NodeIdOf<C>>;
-    pub type VoteOf<C> = crate::Vote<NodeIdOf<C>>;
+    pub type VoteOf<C> = crate::Vote<C>;
     pub type LeaderIdOf<C> = crate::LeaderId<NodeIdOf<C>>;
     pub type CommittedLeaderIdOf<C> = crate::CommittedLeaderId<NodeIdOf<C>>;
     pub type SerdeInstantOf<C> = crate::metrics::SerdeInstant<InstantOf<C>>;

--- a/openraft/src/vote/committed.rs
+++ b/openraft/src/vote/committed.rs
@@ -1,7 +1,6 @@
 use std::cmp::Ordering;
 use std::fmt;
 
-use crate::type_config::alias::NodeIdOf;
 use crate::vote::ref_vote::RefVote;
 use crate::CommittedLeaderId;
 use crate::RaftTypeConfig;
@@ -16,7 +15,7 @@ use crate::Vote;
 pub(crate) struct CommittedVote<C>
 where C: RaftTypeConfig
 {
-    vote: Vote<NodeIdOf<C>>,
+    vote: Vote<C>,
 }
 
 /// The `CommittedVote` is totally ordered.
@@ -37,7 +36,7 @@ where C: RaftTypeConfig
 impl<C> CommittedVote<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(mut vote: Vote<NodeIdOf<C>>) -> Self {
+    pub(crate) fn new(mut vote: Vote<C>) -> Self {
         vote.committed = true;
         Self { vote }
     }
@@ -46,11 +45,11 @@ where C: RaftTypeConfig
         self.vote.leader_id().to_committed()
     }
 
-    pub(crate) fn into_vote(self) -> Vote<NodeIdOf<C>> {
+    pub(crate) fn into_vote(self) -> Vote<C> {
         self.vote
     }
 
-    pub(crate) fn as_ref_vote(&self) -> RefVote<'_, C::NodeId> {
+    pub(crate) fn as_ref_vote(&self) -> RefVote<'_, C> {
         RefVote::new(&self.vote.leader_id, true)
     }
 }

--- a/openraft/src/vote/leader_id/impl_into_leader_id.rs
+++ b/openraft/src/vote/leader_id/impl_into_leader_id.rs
@@ -1,9 +1,11 @@
-use crate::node::NodeId;
 use crate::vote::leader_id::CommittedLeaderId;
 use crate::vote::Vote;
+use crate::RaftTypeConfig;
 
-impl<NID: NodeId> From<Vote<NID>> for CommittedLeaderId<NID> {
-    fn from(vote: Vote<NID>) -> Self {
+impl<C> From<Vote<C>> for CommittedLeaderId<C::NodeId>
+where C: RaftTypeConfig
+{
+    fn from(vote: Vote<C>) -> Self {
         vote.leader_id.to_committed()
     }
 }

--- a/openraft/src/vote/non_committed.rs
+++ b/openraft/src/vote/non_committed.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use crate::type_config::alias::LeaderIdOf;
-use crate::type_config::alias::NodeIdOf;
 use crate::vote::ref_vote::RefVote;
 use crate::RaftTypeConfig;
 use crate::Vote;
@@ -15,13 +14,13 @@ use crate::Vote;
 pub(crate) struct NonCommittedVote<C>
 where C: RaftTypeConfig
 {
-    vote: Vote<NodeIdOf<C>>,
+    vote: Vote<C>,
 }
 
 impl<C> NonCommittedVote<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(vote: Vote<NodeIdOf<C>>) -> Self {
+    pub(crate) fn new(vote: Vote<C>) -> Self {
         debug_assert!(!vote.committed);
         Self { vote }
     }
@@ -30,11 +29,11 @@ where C: RaftTypeConfig
         &self.vote.leader_id
     }
 
-    pub(crate) fn into_vote(self) -> Vote<NodeIdOf<C>> {
+    pub(crate) fn into_vote(self) -> Vote<C> {
         self.vote
     }
 
-    pub(crate) fn as_ref_vote(&self) -> RefVote<'_, C::NodeId> {
+    pub(crate) fn as_ref_vote(&self) -> RefVote<'_, C> {
         RefVote::new(&self.vote.leader_id, false)
     }
 }

--- a/openraft/src/vote/ref_vote.rs
+++ b/openraft/src/vote/ref_vote.rs
@@ -2,21 +2,23 @@ use std::cmp::Ordering;
 use std::fmt::Formatter;
 
 use crate::LeaderId;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 
 /// Same as [`Vote`] but with a reference to the [`LeaderId`].
 ///
 /// [`Vote`]: crate::vote::Vote
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct RefVote<'a, NID: NodeId> {
-    pub(crate) leader_id: &'a LeaderId<NID>,
+pub(crate) struct RefVote<'a, C>
+where C: RaftTypeConfig
+{
+    pub(crate) leader_id: &'a LeaderId<C::NodeId>,
     pub(crate) committed: bool,
 }
 
-impl<'a, NID> RefVote<'a, NID>
-where NID: NodeId
+impl<'a, C> RefVote<'a, C>
+where C: RaftTypeConfig
 {
-    pub(crate) fn new(leader_id: &'a LeaderId<NID>, committed: bool) -> Self {
+    pub(crate) fn new(leader_id: &'a LeaderId<C::NodeId>, committed: bool) -> Self {
         Self { leader_id, committed }
     }
 
@@ -26,11 +28,11 @@ where NID: NodeId
 }
 
 // Commit vote have a total order relation with all other votes
-impl<'a, NID> PartialOrd for RefVote<'a, NID>
-where NID: NodeId
+impl<'a, C> PartialOrd for RefVote<'a, C>
+where C: RaftTypeConfig
 {
     #[inline]
-    fn partial_cmp(&self, other: &RefVote<'a, NID>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &RefVote<'a, C>) -> Option<Ordering> {
         match PartialOrd::partial_cmp(self.leader_id, other.leader_id) {
             Some(Ordering::Equal) => PartialOrd::partial_cmp(&self.committed, &other.committed),
             None => {
@@ -51,7 +53,9 @@ where NID: NodeId
     }
 }
 
-impl<'a, NID: NodeId> std::fmt::Display for RefVote<'a, NID> {
+impl<'a, C> std::fmt::Display for RefVote<'a, C>
+where C: RaftTypeConfig
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -155,7 +155,7 @@ pub struct MemLogStore {
     block: BlockConfig,
 
     /// The current hard state.
-    vote: RwLock<Option<Vote<MemNodeId>>>,
+    vote: RwLock<Option<Vote<TypeConfig>>>,
 }
 
 impl MemLogStore {
@@ -245,7 +245,7 @@ impl RaftLogReader<TypeConfig> for Arc<MemLogStore> {
         Ok(entries)
     }
 
-    async fn read_vote(&mut self) -> Result<Option<Vote<MemNodeId>>, StorageError<TypeConfig>> {
+    async fn read_vote(&mut self) -> Result<Option<Vote<TypeConfig>>, StorageError<TypeConfig>> {
         Ok(*self.vote.read().await)
     }
 }
@@ -349,7 +349,7 @@ impl RaftLogStorage<TypeConfig> for Arc<MemLogStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn save_vote(&mut self, vote: &Vote<MemNodeId>) -> Result<(), StorageError<TypeConfig>> {
+    async fn save_vote(&mut self, vote: &Vote<TypeConfig>) -> Result<(), StorageError<TypeConfig>> {
         tracing::debug!(?vote, "save_vote");
         let mut h = self.vote.write().await;
 

--- a/stores/rocksstore/src/lib.rs
+++ b/stores/rocksstore/src/lib.rs
@@ -154,7 +154,6 @@ mod meta {
     use openraft::ErrorSubject;
     use openraft::LogId;
 
-    use crate::RocksNodeId;
     use crate::TypeConfig;
 
     /// Defines metadata key and value
@@ -182,7 +181,7 @@ mod meta {
     }
     impl StoreMeta for Vote {
         const KEY: &'static str = "vote";
-        type Value = openraft::Vote<RocksNodeId>;
+        type Value = openraft::Vote<TypeConfig>;
 
         fn subject(_v: Option<&Self::Value>) -> ErrorSubject<TypeConfig> {
             ErrorSubject::Vote
@@ -262,7 +261,7 @@ impl RaftLogReader<TypeConfig> for RocksLogStore {
         Ok(res)
     }
 
-    async fn read_vote(&mut self) -> Result<Option<Vote<RocksNodeId>>, StorageError<TypeConfig>> {
+    async fn read_vote(&mut self) -> Result<Option<Vote<TypeConfig>>, StorageError<TypeConfig>> {
         self.get_meta::<meta::Vote>()
     }
 }
@@ -338,7 +337,7 @@ impl RaftLogStorage<TypeConfig> for RocksLogStore {
         })
     }
 
-    async fn save_vote(&mut self, vote: &Vote<RocksNodeId>) -> Result<(), StorageError<TypeConfig>> {
+    async fn save_vote(&mut self, vote: &Vote<TypeConfig>) -> Result<(), StorageError<TypeConfig>> {
         self.put_meta::<meta::Vote>(vote)?;
         self.db.flush_wal(true).map_err(|e| StorageError::write_vote(&e))?;
         Ok(())

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -1085,7 +1085,7 @@ impl RaftNetworkV2<MemConfig> for RaftRouterNetwork {
 
     async fn full_snapshot(
         &mut self,
-        vote: Vote<MemNodeId>,
+        vote: Vote<MemConfig>,
         snapshot: Snapshot<MemConfig>,
         _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         _option: RPCOption,


### PR DESCRIPTION

## Changelog

##### Change: change `Vote<NID:NodeId>` to `Vote<C:RaftTypeConfig>`

This refactoring moves Vote from a per-NodeId type to a per-TypeConfig type,
to make it consistent with `RaftTypeConfig` usage across the codebase.

- Part of: #1278

Upgrade tip:

Vote is now parameterized by `RaftTypeConfig` instead of `NodeId`

- Change `Vote<NodeId>` to `Vote<C> where C: RaftTypeConfig`, for
  example, change `Vote<u64>` to `Vote<YourTypeConfig>`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1279)
<!-- Reviewable:end -->
