### PR TITLE
Change: change `LogId<NID:NodeId>` to `LogId<C:RaftTypeConfig>`

### DIFF
--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -52,14 +52,14 @@ pub struct StoredSnapshot {
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct StateMachine {
-    pub last_applied_log: Option<LogId<NodeId>>,
+    pub last_applied_log: Option<LogId<TypeConfig>>,
     pub last_membership: StoredMembership<TypeConfig>,
 }
 
 pub struct LogStore {
     vote: RwLock<Option<Vote<TypeConfig>>>,
     log: RwLock<BTreeMap<u64, Entry<TypeConfig>>>,
-    last_purged_log_id: RwLock<Option<LogId<NodeId>>>,
+    last_purged_log_id: RwLock<Option<LogId<TypeConfig>>>,
 }
 
 impl LogStore {
@@ -203,7 +203,7 @@ impl RaftLogStorage<TypeConfig> for Arc<LogStore> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn truncate(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<TypeConfig>> {
+    async fn truncate(&mut self, log_id: LogId<TypeConfig>) -> Result<(), StorageError<TypeConfig>> {
         let mut log = self.log.write().await;
         log.split_off(&log_id.index);
 
@@ -211,7 +211,7 @@ impl RaftLogStorage<TypeConfig> for Arc<LogStore> {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn purge(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<TypeConfig>> {
+    async fn purge(&mut self, log_id: LogId<TypeConfig>) -> Result<(), StorageError<TypeConfig>> {
         {
             let mut p = self.last_purged_log_id.write().await;
             *p = Some(log_id);
@@ -244,7 +244,7 @@ impl RaftLogStorage<TypeConfig> for Arc<LogStore> {
 impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
+    ) -> Result<(Option<LogId<TypeConfig>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
         let sm = self.sm.read().await;
         Ok((sm.last_applied_log, sm.last_membership.clone()))
     }

--- a/examples/memstore/src/log_store.rs
+++ b/examples/memstore/src/log_store.rs
@@ -24,13 +24,13 @@ pub struct LogStore<C: RaftTypeConfig> {
 #[derive(Debug)]
 pub struct LogStoreInner<C: RaftTypeConfig> {
     /// The last purged log id.
-    last_purged_log_id: Option<LogId<C::NodeId>>,
+    last_purged_log_id: Option<LogId<C>>,
 
     /// The Raft log.
     log: BTreeMap<u64, C::Entry>,
 
     /// The commit log id.
-    committed: Option<LogId<C::NodeId>>,
+    committed: Option<LogId<C>>,
 
     /// The current granted vote.
     vote: Option<Vote<C>>,
@@ -75,12 +75,12 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
         })
     }
 
-    async fn save_committed(&mut self, committed: Option<LogId<C::NodeId>>) -> Result<(), StorageError<C>> {
+    async fn save_committed(&mut self, committed: Option<LogId<C>>) -> Result<(), StorageError<C>> {
         self.committed = committed;
         Ok(())
     }
 
-    async fn read_committed(&mut self) -> Result<Option<LogId<C::NodeId>>, StorageError<C>> {
+    async fn read_committed(&mut self) -> Result<Option<LogId<C>>, StorageError<C>> {
         Ok(self.committed.clone())
     }
 
@@ -104,7 +104,7 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
         Ok(())
     }
 
-    async fn truncate(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C>> {
+    async fn truncate(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>> {
         let keys = self.log.range(log_id.index..).map(|(k, _v)| *k).collect::<Vec<_>>();
         for key in keys {
             self.log.remove(&key);
@@ -113,7 +113,7 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
         Ok(())
     }
 
-    async fn purge(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C>> {
+    async fn purge(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>> {
         {
             let ld = &mut self.last_purged_log_id;
             assert!(ld.as_ref() <= Some(&log_id));
@@ -173,12 +173,12 @@ mod impl_log_store {
             inner.get_log_state().await
         }
 
-        async fn save_committed(&mut self, committed: Option<LogId<C::NodeId>>) -> Result<(), StorageError<C>> {
+        async fn save_committed(&mut self, committed: Option<LogId<C>>) -> Result<(), StorageError<C>> {
             let mut inner = self.inner.lock().await;
             inner.save_committed(committed).await
         }
 
-        async fn read_committed(&mut self) -> Result<Option<LogId<C::NodeId>>, StorageError<C>> {
+        async fn read_committed(&mut self) -> Result<Option<LogId<C>>, StorageError<C>> {
             let mut inner = self.inner.lock().await;
             inner.read_committed().await
         }
@@ -194,12 +194,12 @@ mod impl_log_store {
             inner.append(entries, callback).await
         }
 
-        async fn truncate(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C>> {
+        async fn truncate(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>> {
             let mut inner = self.inner.lock().await;
             inner.truncate(log_id).await
         }
 
-        async fn purge(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C>> {
+        async fn purge(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>> {
             let mut inner = self.inner.lock().await;
             inner.purge(log_id).await
         }

--- a/examples/raft-kv-memstore-grpc/src/lib.rs
+++ b/examples/raft-kv-memstore-grpc/src/lib.rs
@@ -73,7 +73,7 @@ impl From<protobuf::Vote> for typ::Vote {
     }
 }
 
-impl From<protobuf::LogId> for LogId<NodeId> {
+impl From<protobuf::LogId> for LogId<TypeConfig> {
     fn from(proto_log_id: protobuf::LogId) -> Self {
         let leader_id: LeaderId<NodeId> = proto_log_id.leader_id.unwrap().into();
         LogId::new(leader_id, proto_log_id.index)
@@ -116,8 +116,8 @@ impl From<typ::Vote> for protobuf::Vote {
         }
     }
 }
-impl From<LogId<NodeId>> for protobuf::LogId {
-    fn from(log_id: LogId<NodeId>) -> Self {
+impl From<LogId<TypeConfig>> for protobuf::LogId {
+    fn from(log_id: LogId<TypeConfig>) -> Self {
         protobuf::LogId {
             index: log_id.index,
             leader_id: Some(log_id.leader_id.into()),

--- a/examples/raft-kv-memstore-grpc/src/store/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/store/mod.rs
@@ -19,7 +19,6 @@ use serde::Serialize;
 
 use crate::protobuf::Response;
 use crate::typ;
-use crate::NodeId;
 use crate::TypeConfig;
 
 pub type LogStore = memstore::LogStore<TypeConfig>;
@@ -39,7 +38,7 @@ pub struct StoredSnapshot {
 /// and value as String, but you could set any type of value that has the serialization impl.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct StateMachineData {
-    pub last_applied: Option<LogId<NodeId>>,
+    pub last_applied: Option<LogId<TypeConfig>>,
 
     pub last_membership: StoredMembership<TypeConfig>,
 
@@ -126,7 +125,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
+    ) -> Result<(Option<LogId<TypeConfig>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
         let state_machine = self.state_machine.lock().unwrap();
         Ok((state_machine.last_applied, state_machine.last_membership.clone()))
     }

--- a/examples/raft-kv-memstore-network-v2/src/store.rs
+++ b/examples/raft-kv-memstore-network-v2/src/store.rs
@@ -17,7 +17,6 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::typ;
-use crate::NodeId;
 use crate::TypeConfig;
 
 pub type LogStore = memstore::LogStore<TypeConfig>;
@@ -56,7 +55,7 @@ pub struct StoredSnapshot {
 /// and value as String, but you could set any type of value that has the serialization impl.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct StateMachineData {
-    pub last_applied: Option<LogId<NodeId>>,
+    pub last_applied: Option<LogId<TypeConfig>>,
 
     pub last_membership: StoredMembership<TypeConfig>,
 
@@ -133,7 +132,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
+    ) -> Result<(Option<LogId<TypeConfig>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
         let state_machine = self.state_machine.lock().unwrap();
         Ok((state_machine.last_applied, state_machine.last_membership.clone()))
     }

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -20,7 +20,6 @@ use serde::Serialize;
 use crate::decode_buffer;
 use crate::encode;
 use crate::typ;
-use crate::NodeId;
 use crate::TypeConfig;
 
 pub type LogStore = memstore::LogStore<TypeConfig>;
@@ -59,7 +58,7 @@ pub struct StoredSnapshot {
 /// and value as String, but you could set any type of value that has the serialization impl.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct StateMachineData {
-    pub last_applied: Option<LogId<NodeId>>,
+    pub last_applied: Option<LogId<TypeConfig>>,
 
     pub last_membership: StoredMembership<TypeConfig>,
 
@@ -154,7 +153,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
+    ) -> Result<(Option<LogId<TypeConfig>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
         let state_machine = self.state_machine.lock().unwrap();
         Ok((state_machine.last_applied, state_machine.last_membership.clone()))
     }

--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -19,7 +19,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::RwLock;
 
-use crate::NodeId;
 use crate::TypeConfig;
 
 pub type LogStore = memstore::LogStore<TypeConfig>;
@@ -63,7 +62,7 @@ pub struct StoredSnapshot {
 /// and value as String, but you could set any type of value that has the serialization impl.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct StateMachineData {
-    pub last_applied_log: Option<LogId<NodeId>>,
+    pub last_applied_log: Option<LogId<TypeConfig>>,
 
     pub last_membership: StoredMembership<TypeConfig>,
 
@@ -136,7 +135,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<NodeId>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
+    ) -> Result<(Option<LogId<TypeConfig>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
         let state_machine = self.state_machine.read().await;
         Ok((state_machine.last_applied_log, state_machine.last_membership.clone()))
     }

--- a/openraft/src/core/heartbeat/event.rs
+++ b/openraft/src/core/heartbeat/event.rs
@@ -30,17 +30,13 @@ where C: RaftTypeConfig
     ///
     /// When there are no new logs to replicate, the Leader sends a heartbeat to replicate committed
     /// log id to followers to update their committed log id.
-    pub(crate) committed: Option<LogId<C::NodeId>>,
+    pub(crate) committed: Option<LogId<C>>,
 }
 
 impl<C> HeartbeatEvent<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(
-        time: InstantOf<C>,
-        session_id: ReplicationSessionId<C>,
-        committed: Option<LogId<C::NodeId>>,
-    ) -> Self {
+    pub(crate) fn new(time: InstantOf<C>, session_id: ReplicationSessionId<C>, committed: Option<LogId<C>>) -> Self {
         Self {
             time,
             session_id,

--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -39,7 +39,7 @@ where C: RaftTypeConfig
         leader_vote: CommittedVote<C>,
         // TODO: need this?
         // /// The cluster this replication works for.
-        // membership_log_id: Option<LogId<C::NodeId>>,
+        // membership_log_id: Option<LogId<C>>,
     },
 
     /// [`StorageError`] error has taken place locally(not on remote node),

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -107,7 +107,7 @@ use crate::StorageError;
 /// A temp struct to hold the data for a node that is being applied.
 #[derive(Debug)]
 pub(crate) struct ApplyingEntry<C: RaftTypeConfig> {
-    log_id: LogId<C::NodeId>,
+    log_id: LogId<C>,
     membership: Option<Membership<C>>,
 }
 
@@ -124,7 +124,7 @@ where C: RaftTypeConfig
 }
 
 impl<C: RaftTypeConfig> ApplyingEntry<C> {
-    pub(crate) fn new(log_id: LogId<C::NodeId>, membership: Option<Membership<C>>) -> Self {
+    pub(crate) fn new(log_id: LogId<C>, membership: Option<Membership<C>>) -> Self {
         Self { log_id, membership }
     }
 }
@@ -133,7 +133,7 @@ impl<C: RaftTypeConfig> ApplyingEntry<C> {
 pub(crate) struct ApplyResult<C: RaftTypeConfig> {
     pub(crate) since: u64,
     pub(crate) end: u64,
-    pub(crate) last_applied: LogId<C::NodeId>,
+    pub(crate) last_applied: LogId<C>,
     pub(crate) applying_entries: Vec<ApplyingEntry<C>>,
     pub(crate) apply_results: Vec<C::R>,
 }
@@ -545,7 +545,7 @@ where
                     .map(|(id, p)| {
                         (
                             id.clone(),
-                            <ProgressEntry<C> as Borrow<Option<LogId<C::NodeId>>>>::borrow(p).clone(),
+                            <ProgressEntry<C> as Borrow<Option<LogId<C>>>>::borrow(p).clone(),
                         )
                     })
                     .collect(),
@@ -761,8 +761,8 @@ where
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn apply_to_state_machine(
         &mut self,
-        first: LogId<C::NodeId>,
-        last: LogId<C::NodeId>,
+        first: LogId<C>,
+        last: LogId<C>,
     ) -> Result<(), StorageError<C>> {
         tracing::debug!("{}: {}..={}", func_name!(), first, last);
 

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -65,12 +65,12 @@ where C: RaftTypeConfig
     },
 
     /// Replicate the committed log id to other nodes
-    ReplicateCommitted { committed: Option<LogId<C::NodeId>> },
+    ReplicateCommitted { committed: Option<LogId<C>> },
 
     /// Broadcast heartbeat to all other nodes.
     BroadcastHeartbeat {
         session_id: ReplicationSessionId<C>,
-        committed: Option<LogId<C::NodeId>>,
+        committed: Option<LogId<C>>,
     },
 
     /// Save the committed log id to [`RaftLogStorage`].
@@ -79,7 +79,7 @@ where C: RaftTypeConfig
     /// latest state.
     ///
     /// [`RaftLogStorage`]: crate::storage::RaftLogStorage
-    SaveCommitted { committed: LogId<C::NodeId> },
+    SaveCommitted { committed: LogId<C> },
 
     /// Commit log entries that are already persisted in the store, upto `upto`, inclusive.
     ///
@@ -91,8 +91,8 @@ where C: RaftTypeConfig
     /// [`RaftLogStorage::save_committed()`]: crate::storage::RaftLogStorage::save_committed
     /// [`RaftStateMachine::apply()`]: crate::storage::RaftStateMachine::apply
     Apply {
-        already_committed: Option<LogId<C::NodeId>>,
-        upto: LogId<C::NodeId>,
+        already_committed: Option<LogId<C>>,
+        upto: LogId<C>,
     },
 
     /// Replicate log entries or snapshot to a target.
@@ -118,11 +118,11 @@ where C: RaftTypeConfig
     SendVote { vote_req: VoteRequest<C> },
 
     /// Purge log from the beginning to `upto`, inclusive.
-    PurgeLog { upto: LogId<C::NodeId> },
+    PurgeLog { upto: LogId<C> },
 
     /// Delete logs that conflict with the leader from a follower/learner since log id `since`,
     /// inclusive.
-    TruncateLog { since: LogId<C::NodeId> },
+    TruncateLog { since: LogId<C> },
 
     /// A command send to state machine worker [`sm::worker::Worker`].
     ///
@@ -296,14 +296,14 @@ where C: RaftTypeConfig
     /// This is only used by [`Raft::initialize()`], because when initializing there is no leader.
     ///
     /// [`Raft::initialize()`]: `crate::Raft::initialize()`
-    LogFlushed { log_id: Option<LogId<C::NodeId>> },
+    LogFlushed { log_id: Option<LogId<C>> },
 
     /// Wait until the log is applied to the state machine.
     #[allow(dead_code)]
-    Applied { log_id: Option<LogId<C::NodeId>> },
+    Applied { log_id: Option<LogId<C>> },
 
     /// Wait until snapshot is built and includes the log id.
-    Snapshot { log_id: Option<LogId<C::NodeId>> },
+    Snapshot { log_id: Option<LogId<C>> },
 }
 
 impl<C> fmt::Display for Condition<C>

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -379,7 +379,7 @@ where C: RaftTypeConfig
     pub(crate) fn handle_append_entries(
         &mut self,
         vote: &Vote<C>,
-        prev_log_id: Option<LogId<C::NodeId>>,
+        prev_log_id: Option<LogId<C>>,
         entries: Vec<C::Entry>,
         tx: Option<AppendEntriesTx<C>>,
     ) -> bool {
@@ -418,7 +418,7 @@ where C: RaftTypeConfig
     pub(crate) fn append_entries(
         &mut self,
         vote: &Vote<C>,
-        prev_log_id: Option<LogId<C::NodeId>>,
+        prev_log_id: Option<LogId<C>>,
         entries: Vec<C::Entry>,
     ) -> Result<(), RejectAppendEntries<C>> {
         self.vote_handler().update_vote(vote)?;
@@ -434,7 +434,7 @@ where C: RaftTypeConfig
 
     /// Commit entries for follower/learner.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn handle_commit_entries(&mut self, leader_committed: Option<LogId<C::NodeId>>) {
+    pub(crate) fn handle_commit_entries(&mut self, leader_committed: Option<LogId<C>>) {
         tracing::debug!(
             leader_committed = display(leader_committed.display()),
             my_accepted = display(self.state.accepted_io().display()),
@@ -654,7 +654,7 @@ where C: RaftTypeConfig
 
         self.leader_handler()
             .unwrap()
-            .leader_append_entries(vec![C::Entry::new_blank(LogId::<C::NodeId>::default())]);
+            .leader_append_entries(vec![C::Entry::new_blank(LogId::<C>::default())]);
     }
 
     /// Check if a raft node is in a state that allows to initialize.

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -59,7 +59,7 @@ where C: RaftTypeConfig
     ///
     /// Also clean conflicting entries and update membership state.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn append_entries(&mut self, prev_log_id: Option<LogId<C::NodeId>>, mut entries: Vec<C::Entry>) {
+    pub(crate) fn append_entries(&mut self, prev_log_id: Option<LogId<C>>, mut entries: Vec<C::Entry>) {
         tracing::debug!(
             "{}: local last_log_id: {}, request: prev_log_id: {}, entries: {}",
             func_name!(),
@@ -113,7 +113,7 @@ where C: RaftTypeConfig
     /// If not, truncate the local log and return an error.
     pub(crate) fn ensure_log_consecutive(
         &mut self,
-        prev_log_id: Option<&LogId<C::NodeId>>,
+        prev_log_id: Option<&LogId<C>>,
     ) -> Result<(), RejectAppendEntries<C>> {
         if let Some(prev) = prev_log_id {
             if !self.state.has_log_id(prev) {
@@ -161,7 +161,7 @@ where C: RaftTypeConfig
 
     /// Commit entries that are already committed by the leader.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn commit_entries(&mut self, leader_committed: Option<LogId<C::NodeId>>) {
+    pub(crate) fn commit_entries(&mut self, leader_committed: Option<LogId<C>>) {
         let accepted = self.state.accepted_io().cloned();
         let accepted = accepted.and_then(|x| x.last_log_id().cloned());
         let committed = std::cmp::min(accepted.clone(), leader_committed.clone());

--- a/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
+++ b/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
@@ -4,8 +4,8 @@ use crate::engine::LogIdList;
 use crate::CommittedLeaderId;
 use crate::LogId;
 
-fn log_id(term: u64, index: u64) -> LogId<u64> {
-    LogId::<u64> {
+fn log_id(term: u64, index: u64) -> LogId<UTConfig> {
+    LogId {
         leader_id: CommittedLeaderId::new(term, 0),
         index,
     }

--- a/openraft/src/engine/handler/log_handler/mod.rs
+++ b/openraft/src/engine/handler/log_handler/mod.rs
@@ -61,7 +61,7 @@ where C: RaftTypeConfig
 
     /// Update the log id it expect to purge up to. It won't trigger purge immediately.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn update_purge_upto(&mut self, purge_upto: LogId<C::NodeId>) {
+    pub(crate) fn update_purge_upto(&mut self, purge_upto: LogId<C>) {
         debug_assert!(self.state.purge_upto() <= Some(&purge_upto));
         self.state.purge_upto = Some(purge_upto);
     }
@@ -74,7 +74,7 @@ where C: RaftTypeConfig
     /// `max_keep` specifies the number of applied logs to keep.
     /// `max_keep==0` means every applied log can be purged.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn calc_purge_upto(&self) -> Option<LogId<C::NodeId>> {
+    pub(crate) fn calc_purge_upto(&self) -> Option<LogId<C>> {
         let st = &self.state;
         let max_keep = self.config.max_in_snapshot_log_to_keep;
         let batch_size = self.config.purge_batch_size;

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -56,7 +56,7 @@ where C: RaftTypeConfig
     ///
     /// It is called by the leader when a new membership log is appended to log store.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn append_membership(&mut self, log_id: &LogId<C::NodeId>, m: &Membership<C>) {
+    pub(crate) fn append_membership(&mut self, log_id: &LogId<C>, m: &Membership<C>) {
         tracing::debug!("update effective membership: log_id:{} {}", log_id, m);
 
         debug_assert!(
@@ -149,7 +149,7 @@ where C: RaftTypeConfig
     /// Update progress when replicated data(logs or snapshot) matches on follower/learner and is
     /// accepted.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn update_matching(&mut self, node_id: C::NodeId, log_id: Option<LogId<C::NodeId>>) {
+    pub(crate) fn update_matching(&mut self, node_id: C::NodeId, log_id: Option<LogId<C>>) {
         tracing::debug!(
             node_id = display(&node_id),
             log_id = display(log_id.display()),
@@ -182,7 +182,7 @@ where C: RaftTypeConfig
     ///
     /// In raft a log that is granted and in the leader term is committed.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn try_commit_quorum_accepted(&mut self, granted: Option<LogId<C::NodeId>>) {
+    pub(crate) fn try_commit_quorum_accepted(&mut self, granted: Option<LogId<C>>) {
         // Only when the log id is proposed by current leader, it is committed.
         if let Some(ref c) = granted {
             if !self.state.vote_ref().is_same_leader(c.committed_leader_id()) {
@@ -213,7 +213,7 @@ where C: RaftTypeConfig
     /// Update progress when replicated data(logs or snapshot) does not match follower/learner state
     /// and is rejected.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn update_conflicting(&mut self, target: C::NodeId, conflict: LogId<C::NodeId>) {
+    pub(crate) fn update_conflicting(&mut self, target: C::NodeId, conflict: LogId<C>) {
         // TODO(2): test it?
 
         let prog_entry = self.leader.progress.get_mut(&target).unwrap();
@@ -390,7 +390,7 @@ where C: RaftTypeConfig
     ///
     /// Writing to local log store does not have to wait for a replication response from remote
     /// node. Thus it can just be done in a fast-path.
-    pub(crate) fn update_local_progress(&mut self, upto: Option<LogId<C::NodeId>>) {
+    pub(crate) fn update_local_progress(&mut self, upto: Option<LogId<C>>) {
         tracing::debug!(upto = display(upto.display()), "{}", func_name!());
 
         if upto.is_none() {

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -209,8 +209,7 @@ where C: RaftTypeConfig
         // If the leader has not yet proposed any log, propose a blank log and initiate replication;
         // Otherwise, just initiate replication.
         if last_log_id < noop_log_id {
-            self.leader_handler()
-                .leader_append_entries(vec![C::Entry::new_blank(LogId::<C::NodeId>::default())]);
+            self.leader_handler().leader_append_entries(vec![C::Entry::new_blank(LogId::<C>::default())]);
         } else {
             self.replication_handler().initiate_replication();
         }

--- a/openraft/src/entry/mod.rs
+++ b/openraft/src/entry/mod.rs
@@ -21,7 +21,7 @@ pub use traits::RaftPayload;
 pub struct Entry<C>
 where C: RaftTypeConfig
 {
-    pub log_id: LogId<C::NodeId>,
+    pub log_id: LogId<C>,
 
     /// This entry's payload.
     pub payload: EntryPayload<C>,
@@ -97,14 +97,14 @@ where C: RaftTypeConfig
     }
 }
 
-impl<C> RaftLogId<C::NodeId> for Entry<C>
+impl<C> RaftLogId<C> for Entry<C>
 where C: RaftTypeConfig
 {
-    fn get_log_id(&self) -> &LogId<C::NodeId> {
+    fn get_log_id(&self) -> &LogId<C> {
         &self.log_id
     }
 
-    fn set_log_id(&mut self, log_id: &LogId<C::NodeId>) {
+    fn set_log_id(&mut self, log_id: &LogId<C>) {
         self.log_id = log_id.clone();
     }
 }
@@ -112,14 +112,14 @@ where C: RaftTypeConfig
 impl<C> RaftEntry<C> for Entry<C>
 where C: RaftTypeConfig
 {
-    fn new_blank(log_id: LogId<C::NodeId>) -> Self {
+    fn new_blank(log_id: LogId<C>) -> Self {
         Self {
             log_id,
             payload: EntryPayload::Blank,
         }
     }
 
-    fn new_membership(log_id: LogId<C::NodeId>, m: Membership<C>) -> Self {
+    fn new_membership(log_id: LogId<C>, m: Membership<C>) -> Self {
         Self {
             log_id,
             payload: EntryPayload::Membership(m),

--- a/openraft/src/entry/traits.rs
+++ b/openraft/src/entry/traits.rs
@@ -21,7 +21,7 @@ where C: RaftTypeConfig
 }
 
 /// Defines operations on an entry.
-pub trait RaftEntry<C>: RaftPayload<C> + RaftLogId<C::NodeId>
+pub trait RaftEntry<C>: RaftPayload<C> + RaftLogId<C>
 where
     C: RaftTypeConfig,
     Self: OptionalSerde + Debug + Display + OptionalSend + OptionalSync,
@@ -29,12 +29,12 @@ where
     /// Create a new blank log entry.
     ///
     /// The returned instance must return `true` for `Self::is_blank()`.
-    fn new_blank(log_id: LogId<C::NodeId>) -> Self;
+    fn new_blank(log_id: LogId<C>) -> Self;
 
     /// Create a new membership log entry.
     ///
     /// The returned instance must return `Some()` for `Self::get_membership()`.
-    fn new_membership(log_id: LogId<C::NodeId>, m: Membership<C>) -> Self;
+    fn new_membership(log_id: LogId<C>, m: Membership<C>) -> Self;
 }
 
 /// Build a raft log entry from app data.

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -587,8 +587,8 @@ pub struct QuorumNotEnough<C: RaftTypeConfig> {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 #[error("the cluster is already undergoing a configuration change at log {membership_log_id:?}, last committed membership log id: {committed:?}")]
 pub struct InProgress<C: RaftTypeConfig> {
-    pub committed: Option<LogId<C::NodeId>>,
-    pub membership_log_id: Option<LogId<C::NodeId>>,
+    pub committed: Option<LogId<C>>,
+    pub membership_log_id: Option<LogId<C>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -602,7 +602,7 @@ pub struct LearnerNotFound<C: RaftTypeConfig> {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 #[error("not allowed to initialize due to current raft state: last_log_id: {last_log_id:?} vote: {vote}")]
 pub struct NotAllowed<C: RaftTypeConfig> {
-    pub last_log_id: Option<LogId<C::NodeId>>,
+    pub last_log_id: Option<LogId<C>>,
     pub vote: Vote<C>,
 }
 
@@ -640,7 +640,7 @@ pub(crate) enum RejectVoteRequest<C: RaftTypeConfig> {
 
     #[allow(dead_code)]
     #[error("reject vote request by a greater last-log-id: {0:?}")]
-    ByLastLogId(Option<LogId<C::NodeId>>),
+    ByLastLogId(Option<LogId<C>>),
 }
 
 impl<C> From<RejectVoteRequest<C>> for AppendEntriesResponse<C>
@@ -662,10 +662,7 @@ pub(crate) enum RejectAppendEntries<C: RaftTypeConfig> {
     ByVote(Vote<C>),
 
     #[error("reject AppendEntries because of conflicting log-id: {local:?}; expect to be: {expect:?}")]
-    ByConflictingLogId {
-        expect: LogId<C::NodeId>,
-        local: Option<LogId<C::NodeId>>,
-    },
+    ByConflictingLogId { expect: LogId<C>, local: Option<LogId<C>> },
 }
 
 impl<C> From<RejectVoteRequest<C>> for RejectAppendEntries<C>

--- a/openraft/src/log_id/log_id_option_ext.rs
+++ b/openraft/src/log_id/log_id_option_ext.rs
@@ -1,5 +1,5 @@
 use crate::LogId;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 
 /// This helper trait extracts information from an `Option<LogId>`.
 pub trait LogIdOptionExt {
@@ -12,7 +12,9 @@ pub trait LogIdOptionExt {
     fn next_index(&self) -> u64;
 }
 
-impl<NID: NodeId> LogIdOptionExt for Option<LogId<NID>> {
+impl<C> LogIdOptionExt for Option<LogId<C>>
+where C: RaftTypeConfig
+{
     fn index(&self) -> Option<u64> {
         self.as_ref().map(|x| x.index)
     }
@@ -25,7 +27,9 @@ impl<NID: NodeId> LogIdOptionExt for Option<LogId<NID>> {
     }
 }
 
-impl<NID: NodeId> LogIdOptionExt for Option<&LogId<NID>> {
+impl<C> LogIdOptionExt for Option<&LogId<C>>
+where C: RaftTypeConfig
+{
     fn index(&self) -> Option<u64> {
         self.map(|x| x.index)
     }

--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -13,7 +13,7 @@ pub use log_index_option_ext::LogIndexOptionExt;
 pub use raft_log_id::RaftLogId;
 
 use crate::CommittedLeaderId;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 
 /// The identity of a raft log.
 ///
@@ -21,41 +21,54 @@ use crate::NodeId;
 /// parts: a leader id, which refers to the leader that proposed this log, and an integer index.
 #[derive(Debug, Default, Clone, PartialOrd, Ord, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct LogId<NID: NodeId> {
+pub struct LogId<C>
+where C: RaftTypeConfig
+{
     /// The id of the leader that proposed this log
-    pub leader_id: CommittedLeaderId<NID>,
+    pub leader_id: CommittedLeaderId<C::NodeId>,
     /// The index of a log in the storage.
     ///
     /// Log index is a consecutive integer.
     pub index: u64,
 }
 
-impl<NID> Copy for LogId<NID> where NID: NodeId + Copy {}
+impl<C> Copy for LogId<C>
+where
+    C: RaftTypeConfig,
+    C::NodeId: Copy,
+{
+}
 
-impl<NID: NodeId> RaftLogId<NID> for LogId<NID> {
-    fn get_log_id(&self) -> &LogId<NID> {
+impl<C> RaftLogId<C> for LogId<C>
+where C: RaftTypeConfig
+{
+    fn get_log_id(&self) -> &LogId<C> {
         self
     }
 
-    fn set_log_id(&mut self, log_id: &LogId<NID>) {
+    fn set_log_id(&mut self, log_id: &LogId<C>) {
         *self = log_id.clone()
     }
 }
 
-impl<NID: NodeId> Display for LogId<NID> {
+impl<C> Display for LogId<C>
+where C: RaftTypeConfig
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}.{}", self.leader_id, self.index)
     }
 }
 
-impl<NID: NodeId> LogId<NID> {
+impl<C> LogId<C>
+where C: RaftTypeConfig
+{
     /// Creates a log id proposed by a committed leader with `leader_id` at the given index.
-    pub fn new(leader_id: CommittedLeaderId<NID>, index: u64) -> Self {
+    pub fn new(leader_id: CommittedLeaderId<C::NodeId>, index: u64) -> Self {
         LogId { leader_id, index }
     }
 
     /// Returns the leader id that proposed this log.
-    pub fn committed_leader_id(&self) -> &CommittedLeaderId<NID> {
+    pub fn committed_leader_id(&self) -> &CommittedLeaderId<C::NodeId> {
         &self.leader_id
     }
 }

--- a/openraft/src/log_id/raft_log_id.rs
+++ b/openraft/src/log_id/raft_log_id.rs
@@ -1,22 +1,24 @@
 use crate::CommittedLeaderId;
 use crate::LogId;
-use crate::NodeId;
+use crate::RaftTypeConfig;
 
 /// Defines API to operate an object that contains a log-id, such as a log entry or a log id.
-pub trait RaftLogId<NID: NodeId> {
+pub trait RaftLogId<C>
+where C: RaftTypeConfig
+{
     /// Returns a reference to the leader id that proposed this log id.  
     ///
     /// When a `LeaderId` is committed, some of its data can be discarded.
     /// For example, a leader id in standard raft is `(term, node_id)`, but a log id does not have
     /// to store the `node_id`, because in standard raft there is at most one leader that can be
     /// established.
-    fn leader_id(&self) -> &CommittedLeaderId<NID> {
+    fn leader_id(&self) -> &CommittedLeaderId<C::NodeId> {
         self.get_log_id().committed_leader_id()
     }
 
     /// Return a reference to the log-id it stores.
-    fn get_log_id(&self) -> &LogId<NID>;
+    fn get_log_id(&self) -> &LogId<C>;
 
     /// Update the log id it contains.
-    fn set_log_id(&mut self, log_id: &LogId<NID>);
+    fn set_log_id(&mut self, log_id: &LogId<C>);
 }

--- a/openraft/src/log_id_range.rs
+++ b/openraft/src/log_id_range.rs
@@ -14,16 +14,23 @@ use crate::RaftTypeConfig;
 /// A log id range of continuous series of log entries.
 ///
 /// The range of log to send is left open right close: `(prev, last]`.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[derive(PartialEq, Eq)]
 pub(crate) struct LogIdRange<C>
 where C: RaftTypeConfig
 {
     /// The prev log id before the first to send, exclusive.
-    pub(crate) prev: Option<LogId<C::NodeId>>,
+    pub(crate) prev: Option<LogId<C>>,
 
     /// The last log id to send, inclusive.
-    pub(crate) last: Option<LogId<C::NodeId>>,
+    pub(crate) last: Option<LogId<C>>,
+}
+
+impl<C> Copy for LogIdRange<C>
+where
+    C: RaftTypeConfig,
+    C::NodeId: Copy,
+{
 }
 
 impl<C> Display for LogIdRange<C>
@@ -46,7 +53,7 @@ where C: RaftTypeConfig
 impl<C> LogIdRange<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(prev: Option<LogId<C::NodeId>>, last: Option<LogId<C::NodeId>>) -> Self {
+    pub(crate) fn new(prev: Option<LogId<C>>, last: Option<LogId<C>>) -> Self {
         Self { prev, last }
     }
 
@@ -65,7 +72,7 @@ mod tests {
     use crate::CommittedLeaderId;
     use crate::LogId;
 
-    fn log_id(index: u64) -> LogId<u64> {
+    fn log_id(index: u64) -> LogId<UTConfig> {
         LogId {
             leader_id: CommittedLeaderId::new(1, 1),
             index,

--- a/openraft/src/membership/effective_membership.rs
+++ b/openraft/src/membership/effective_membership.rs
@@ -55,7 +55,7 @@ where C: RaftTypeConfig
 impl<C, LID> From<(&LID, Membership<C>)> for EffectiveMembership<C>
 where
     C: RaftTypeConfig,
-    LID: RaftLogId<C::NodeId>,
+    LID: RaftLogId<C>,
 {
     fn from(v: (&LID, Membership<C>)) -> Self {
         EffectiveMembership::new(Some(v.0.get_log_id().clone()), v.1)
@@ -65,11 +65,11 @@ where
 impl<C> EffectiveMembership<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new_arc(log_id: Option<LogId<C::NodeId>>, membership: Membership<C>) -> Arc<Self> {
+    pub(crate) fn new_arc(log_id: Option<LogId<C>>, membership: Membership<C>) -> Arc<Self> {
         Arc::new(Self::new(log_id, membership))
     }
 
-    pub fn new(log_id: Option<LogId<C::NodeId>>, membership: Membership<C>) -> Self {
+    pub fn new(log_id: Option<LogId<C>>, membership: Membership<C>) -> Self {
         let voter_ids = membership.voter_ids().collect();
 
         let configs = membership.get_joint_config();
@@ -95,7 +95,7 @@ where C: RaftTypeConfig
         &self.stored_membership
     }
 
-    pub fn log_id(&self) -> &Option<LogId<C::NodeId>> {
+    pub fn log_id(&self) -> &Option<LogId<C>> {
         self.stored_membership.log_id()
     }
 

--- a/openraft/src/membership/stored_membership.rs
+++ b/openraft/src/membership/stored_membership.rs
@@ -21,7 +21,7 @@ pub struct StoredMembership<C>
 where C: RaftTypeConfig
 {
     /// The id of the log that stores this membership config
-    log_id: Option<LogId<C::NodeId>>,
+    log_id: Option<LogId<C>>,
 
     /// Membership config
     membership: Membership<C>,
@@ -30,11 +30,11 @@ where C: RaftTypeConfig
 impl<C> StoredMembership<C>
 where C: RaftTypeConfig
 {
-    pub fn new(log_id: Option<LogId<C::NodeId>>, membership: Membership<C>) -> Self {
+    pub fn new(log_id: Option<LogId<C>>, membership: Membership<C>) -> Self {
         Self { log_id, membership }
     }
 
-    pub fn log_id(&self) -> &Option<LogId<C::NodeId>> {
+    pub fn log_id(&self) -> &Option<LogId<C>> {
         &self.log_id
     }
 

--- a/openraft/src/metrics/metric.rs
+++ b/openraft/src/metrics/metric.rs
@@ -17,10 +17,10 @@ where C: RaftTypeConfig
     Term(u64),
     Vote(Vote<C>),
     LastLogIndex(Option<u64>),
-    Applied(Option<LogId<C::NodeId>>),
+    Applied(Option<LogId<C>>),
     AppliedIndex(Option<u64>),
-    Snapshot(Option<LogId<C::NodeId>>),
-    Purged(Option<LogId<C::NodeId>>),
+    Snapshot(Option<LogId<C>>),
+    Purged(Option<LogId<C>>),
 }
 
 impl<C> Metric<C>

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -38,17 +38,17 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     pub last_log_index: Option<u64>,
 
     /// The last log index has been applied to this Raft node's state machine.
-    pub last_applied: Option<LogId<C::NodeId>>,
+    pub last_applied: Option<LogId<C>>,
 
     /// The id of the last log included in snapshot.
     /// If there is no snapshot, it is (0,0).
-    pub snapshot: Option<LogId<C::NodeId>>,
+    pub snapshot: Option<LogId<C>>,
 
     /// The last log id that has purged from storage, inclusive.
     ///
     /// `purged` is also the first log id Openraft knows, although the corresponding log entry has
     /// already been deleted.
-    pub purged: Option<LogId<C::NodeId>>,
+    pub purged: Option<LogId<C>>,
 
     // ---
     // --- cluster ---
@@ -189,10 +189,10 @@ where C: RaftTypeConfig
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct RaftDataMetrics<C: RaftTypeConfig> {
-    pub last_log: Option<LogId<C::NodeId>>,
-    pub last_applied: Option<LogId<C::NodeId>>,
-    pub snapshot: Option<LogId<C::NodeId>>,
-    pub purged: Option<LogId<C::NodeId>>,
+    pub last_log: Option<LogId<C>>,
+    pub last_applied: Option<LogId<C>>,
+    pub snapshot: Option<LogId<C>>,
+    pub purged: Option<LogId<C>>,
 
     /// For a leader, it is the elapsed time in milliseconds since the most recently acknowledged
     /// timestamp by a quorum.

--- a/openraft/src/metrics/wait.rs
+++ b/openraft/src/metrics/wait.rs
@@ -212,7 +212,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
     pub async fn snapshot(
         &self,
-        snapshot_last_log_id: LogId<C::NodeId>,
+        snapshot_last_log_id: LogId<C>,
         msg: impl ToString,
     ) -> Result<RaftMetrics<C>, WaitError> {
         self.eq(Metric::Snapshot(Some(snapshot_last_log_id)), msg).await
@@ -220,11 +220,7 @@ where C: RaftTypeConfig
 
     /// Wait for `purged` to become `want` or timeout.
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
-    pub async fn purged(
-        &self,
-        want: Option<LogId<C::NodeId>>,
-        msg: impl ToString,
-    ) -> Result<RaftMetrics<C>, WaitError> {
+    pub async fn purged(&self, want: Option<LogId<C>>, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
         self.eq(Metric::Purged(want), msg).await
     }
 

--- a/openraft/src/progress/entry/mod.rs
+++ b/openraft/src/progress/entry/mod.rs
@@ -24,7 +24,7 @@ pub(crate) struct ProgressEntry<C>
 where C: RaftTypeConfig
 {
     /// The id of the last matching log on the target following node.
-    pub(crate) matching: Option<LogId<C::NodeId>>,
+    pub(crate) matching: Option<LogId<C>>,
 
     /// The data being transmitted in flight.
     ///
@@ -48,7 +48,7 @@ impl<C> ProgressEntry<C>
 where C: RaftTypeConfig
 {
     #[allow(dead_code)]
-    pub(crate) fn new(matching: Option<LogId<C::NodeId>>) -> Self {
+    pub(crate) fn new(matching: Option<LogId<C>>) -> Self {
         Self {
             matching: matching.clone(),
             inflight: Inflight::None,
@@ -85,7 +85,7 @@ where C: RaftTypeConfig
     /// Return if a range of log id `..=log_id` is inflight sending.
     ///
     /// `prev_log_id` is never inflight.
-    pub(crate) fn is_log_range_inflight(&self, upto: &LogId<C::NodeId>) -> bool {
+    pub(crate) fn is_log_range_inflight(&self, upto: &LogId<C>) -> bool {
         match &self.inflight {
             Inflight::None => false,
             Inflight::Logs { log_id_range, .. } => {
@@ -175,10 +175,10 @@ where C: RaftTypeConfig
     }
 }
 
-impl<C> Borrow<Option<LogId<C::NodeId>>> for ProgressEntry<C>
+impl<C> Borrow<Option<LogId<C>>> for ProgressEntry<C>
 where C: RaftTypeConfig
 {
-    fn borrow(&self) -> &Option<LogId<C::NodeId>> {
+    fn borrow(&self) -> &Option<LogId<C>> {
         &self.matching
     }
 }

--- a/openraft/src/progress/entry/tests.rs
+++ b/openraft/src/progress/entry/tests.rs
@@ -8,7 +8,7 @@ use crate::raft_state::LogStateReader;
 use crate::CommittedLeaderId;
 use crate::LogId;
 
-fn log_id(index: u64) -> LogId<u64> {
+fn log_id(index: u64) -> LogId<UTConfig> {
     LogId {
         leader_id: CommittedLeaderId::new(1, 1),
         index,
@@ -87,10 +87,10 @@ fn test_update_conflicting() -> anyhow::Result<()> {
 
 /// LogStateReader impl for testing
 struct LogState {
-    last: Option<LogId<u64>>,
-    snap_last: Option<LogId<u64>>,
-    purge_upto: Option<LogId<u64>>,
-    purged: Option<LogId<u64>>,
+    last: Option<LogId<UTConfig>>,
+    snap_last: Option<LogId<UTConfig>>,
+    purge_upto: Option<LogId<UTConfig>>,
+    purged: Option<LogId<UTConfig>>,
 }
 
 impl LogState {
@@ -107,7 +107,7 @@ impl LogState {
 }
 
 impl LogStateReader<UTConfig> for LogState {
-    fn get_log_id(&self, index: u64) -> Option<LogId<u64>> {
+    fn get_log_id(&self, index: u64) -> Option<LogId<UTConfig>> {
         let x = Some(log_id(index));
         if x >= self.purged && x <= self.last {
             x
@@ -116,35 +116,35 @@ impl LogStateReader<UTConfig> for LogState {
         }
     }
 
-    fn last_log_id(&self) -> Option<&LogId<u64>> {
+    fn last_log_id(&self) -> Option<&LogId<UTConfig>> {
         self.last.as_ref()
     }
 
-    fn committed(&self) -> Option<&LogId<u64>> {
+    fn committed(&self) -> Option<&LogId<UTConfig>> {
         unimplemented!("testing")
     }
 
-    fn io_applied(&self) -> Option<&LogId<u64>> {
+    fn io_applied(&self) -> Option<&LogId<UTConfig>> {
         todo!()
     }
 
-    fn io_snapshot_last_log_id(&self) -> Option<&LogId<u64>> {
+    fn io_snapshot_last_log_id(&self) -> Option<&LogId<UTConfig>> {
         todo!()
     }
 
-    fn io_purged(&self) -> Option<&LogId<u64>> {
+    fn io_purged(&self) -> Option<&LogId<UTConfig>> {
         todo!()
     }
 
-    fn snapshot_last_log_id(&self) -> Option<&LogId<u64>> {
+    fn snapshot_last_log_id(&self) -> Option<&LogId<UTConfig>> {
         self.snap_last.as_ref()
     }
 
-    fn purge_upto(&self) -> Option<&LogId<u64>> {
+    fn purge_upto(&self) -> Option<&LogId<UTConfig>> {
         self.purge_upto.as_ref()
     }
 
-    fn last_purged_log_id(&self) -> Option<&LogId<u64>> {
+    fn last_purged_log_id(&self) -> Option<&LogId<UTConfig>> {
         self.purged.as_ref()
     }
 }

--- a/openraft/src/progress/entry/update.rs
+++ b/openraft/src/progress/entry/update.rs
@@ -76,7 +76,7 @@ where C: RaftTypeConfig
         }
     }
 
-    pub(crate) fn update_matching(&mut self, matching: Option<LogId<C::NodeId>>) {
+    pub(crate) fn update_matching(&mut self, matching: Option<LogId<C>>) {
         tracing::debug!(
             "update_matching: current progress_entry: {}; matching: {}",
             self.entry,

--- a/openraft/src/progress/inflight/tests.rs
+++ b/openraft/src/progress/inflight/tests.rs
@@ -6,7 +6,7 @@ use crate::progress::Inflight;
 use crate::CommittedLeaderId;
 use crate::LogId;
 
-fn log_id(index: u64) -> LogId<u64> {
+fn log_id(index: u64) -> LogId<UTConfig> {
     LogId {
         leader_id: CommittedLeaderId::new(1, 1),
         index,

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -80,7 +80,7 @@ where
         &self.vote
     }
 
-    pub(crate) fn last_log_id(&self) -> Option<&LogId<C::NodeId>> {
+    pub(crate) fn last_log_id(&self) -> Option<&LogId<C>> {
         self.last_log_id.as_ref()
     }
 

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -160,7 +160,7 @@ where
     /// Assign log ids to the entries.
     ///
     /// This method update the `self.last_log_id`.
-    pub(crate) fn assign_log_ids<'a, LID: RaftLogId<C::NodeId> + 'a>(
+    pub(crate) fn assign_log_ids<'a, LID: RaftLogId<C> + 'a>(
         &mut self,
         entries: impl IntoIterator<Item = &'a mut LID>,
     ) {

--- a/openraft/src/raft/message/append_entries.rs
+++ b/openraft/src/raft/message/append_entries.rs
@@ -18,7 +18,7 @@ use crate::Vote;
 pub struct AppendEntriesRequest<C: RaftTypeConfig> {
     pub vote: Vote<C>,
 
-    pub prev_log_id: Option<LogId<C::NodeId>>,
+    pub prev_log_id: Option<LogId<C>>,
 
     /// The new log entries to store.
     ///
@@ -27,7 +27,7 @@ pub struct AppendEntriesRequest<C: RaftTypeConfig> {
     pub entries: Vec<C::Entry>,
 
     /// The leader's committed log id.
-    pub leader_commit: Option<LogId<C::NodeId>>,
+    pub leader_commit: Option<LogId<C>>,
 }
 
 impl<C: RaftTypeConfig> fmt::Debug for AppendEntriesRequest<C> {
@@ -86,7 +86,7 @@ pub enum AppendEntriesResponse<C: RaftTypeConfig> {
     ///
     /// [`RPCError`]: crate::error::RPCError
     /// [`RaftNetwork::append_entries`]: crate::network::RaftNetwork::append_entries
-    PartialSuccess(Option<LogId<C::NodeId>>),
+    PartialSuccess(Option<LogId<C>>),
 
     /// The first log id([`AppendEntriesRequest::prev_log_id`]) of the entries to send does not
     /// match on the remote target node.

--- a/openraft/src/raft/message/client_write.rs
+++ b/openraft/src/raft/message/client_write.rs
@@ -20,7 +20,7 @@ pub type ClientWriteResult<C> = Result<ClientWriteResponse<C>, ClientWriteError<
 )]
 pub struct ClientWriteResponse<C: RaftTypeConfig> {
     /// The id of the log that is applied.
-    pub log_id: LogId<C::NodeId>,
+    pub log_id: LogId<C>,
 
     /// Application specific response data.
     pub data: C::R,
@@ -35,7 +35,7 @@ where C: RaftTypeConfig
     /// Create a new instance of `ClientWriteResponse`.
     #[allow(dead_code)]
     #[since(version = "0.9.5")]
-    pub(crate) fn new_app_response(log_id: LogId<C::NodeId>, data: C::R) -> Self {
+    pub(crate) fn new_app_response(log_id: LogId<C>, data: C::R) -> Self {
         Self {
             log_id,
             data,
@@ -44,7 +44,7 @@ where C: RaftTypeConfig
     }
 
     #[since(version = "0.9.5")]
-    pub fn log_id(&self) -> &LogId<C::NodeId> {
+    pub fn log_id(&self) -> &LogId<C> {
         &self.log_id
     }
 

--- a/openraft/src/raft/message/transfer_leader.rs
+++ b/openraft/src/raft/message/transfer_leader.rs
@@ -18,13 +18,13 @@ where C: RaftTypeConfig
     pub(crate) to_node_id: C::NodeId,
 
     /// The last log id the `to_node_id` node should at least have to become Leader.
-    pub(crate) last_log_id: Option<LogId<C::NodeId>>,
+    pub(crate) last_log_id: Option<LogId<C>>,
 }
 
 impl<C> TransferLeaderRequest<C>
 where C: RaftTypeConfig
 {
-    pub fn new(from: Vote<C>, to: C::NodeId, last_log_id: Option<LogId<C::NodeId>>) -> Self {
+    pub fn new(from: Vote<C>, to: C::NodeId, last_log_id: Option<LogId<C>>) -> Self {
         Self {
             from_leader: from,
             to_node_id: to,
@@ -45,7 +45,7 @@ where C: RaftTypeConfig
     /// The last log id on the `to_node_id` node should at least have to become Leader.
     ///
     /// This is the last log id on the Leader when the leadership is transferred.
-    pub fn last_log_id(&self) -> Option<&LogId<C::NodeId>> {
+    pub fn last_log_id(&self) -> Option<&LogId<C>> {
         self.last_log_id.as_ref()
     }
 }

--- a/openraft/src/raft/message/vote.rs
+++ b/openraft/src/raft/message/vote.rs
@@ -11,7 +11,7 @@ use crate::Vote;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct VoteRequest<C: RaftTypeConfig> {
     pub vote: Vote<C>,
-    pub last_log_id: Option<LogId<C::NodeId>>,
+    pub last_log_id: Option<LogId<C>>,
 }
 
 impl<C> fmt::Display for VoteRequest<C>
@@ -25,7 +25,7 @@ where C: RaftTypeConfig
 impl<C> VoteRequest<C>
 where C: RaftTypeConfig
 {
-    pub fn new(vote: Vote<C>, last_log_id: Option<LogId<C::NodeId>>) -> Self {
+    pub fn new(vote: Vote<C>, last_log_id: Option<LogId<C>>) -> Self {
         Self { vote, last_log_id }
     }
 }
@@ -45,13 +45,13 @@ pub struct VoteResponse<C: RaftTypeConfig> {
     pub vote_granted: bool,
 
     /// The last log id stored on the remote voter.
-    pub last_log_id: Option<LogId<C::NodeId>>,
+    pub last_log_id: Option<LogId<C>>,
 }
 
 impl<C> VoteResponse<C>
 where C: RaftTypeConfig
 {
-    pub fn new(vote: impl Borrow<Vote<C>>, last_log_id: Option<LogId<C::NodeId>>, granted: bool) -> Self {
+    pub fn new(vote: impl Borrow<Vote<C>>, last_log_id: Option<LogId<C>>, granted: bool) -> Self {
         Self {
             vote: vote.borrow().clone(),
             vote_granted: granted,

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -532,7 +532,7 @@ where C: RaftTypeConfig
     /// ```
     /// Read more about how it works: [Read Operation](crate::docs::protocol::read)
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn ensure_linearizable(&self) -> Result<Option<LogId<C::NodeId>>, RaftError<C, CheckIsLeaderError<C>>> {
+    pub async fn ensure_linearizable(&self) -> Result<Option<LogId<C>>, RaftError<C, CheckIsLeaderError<C>>> {
         let (read_log_id, applied) = self.get_read_log_id().await?;
 
         if read_log_id.index() > applied.index() {
@@ -581,7 +581,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn get_read_log_id(
         &self,
-    ) -> Result<(Option<LogId<C::NodeId>>, Option<LogId<C::NodeId>>), RaftError<C, CheckIsLeaderError<C>>> {
+    ) -> Result<(Option<LogId<C>>, Option<LogId<C>>), RaftError<C, CheckIsLeaderError<C>>> {
         let (tx, rx) = C::oneshot();
         let (read_log_id, applied) = self.inner.call_core(RaftMsg::CheckIsLeaderRequest { tx }, rx).await?;
         Ok((read_log_id, applied))
@@ -772,8 +772,8 @@ where C: RaftTypeConfig
         &self,
         metrics: &RaftMetrics<C>,
         node_id: &C::NodeId,
-        membership_log_id: Option<&LogId<C::NodeId>>,
-    ) -> Result<Option<LogId<C::NodeId>>, ()> {
+        membership_log_id: Option<&LogId<C>>,
+    ) -> Result<Option<LogId<C>>, ()> {
         if metrics.membership_config.log_id().as_ref() < membership_log_id {
             // Waiting for the latest metrics to report.
             return Err(());

--- a/openraft/src/raft_state/io_state.rs
+++ b/openraft/src/raft_state/io_state.rs
@@ -69,17 +69,17 @@ where C: RaftTypeConfig
     pub(crate) io_progress: Valid<IOProgress<IOId<C>>>,
 
     /// The last log id that has been applied to state machine.
-    pub(crate) applied: Option<LogId<C::NodeId>>,
+    pub(crate) applied: Option<LogId<C>>,
 
     /// The last log id in the currently persisted snapshot.
-    pub(crate) snapshot: Option<LogId<C::NodeId>>,
+    pub(crate) snapshot: Option<LogId<C>>,
 
     /// The last log id that has been purged from storage.
     ///
     /// `RaftState::last_purged_log_id()`
     /// is just the log id that is going to be purged, i.e., there is a `PurgeLog` command queued to
     /// be executed, and it may not be the actually purged log id.
-    pub(crate) purged: Option<LogId<C::NodeId>>,
+    pub(crate) purged: Option<LogId<C>>,
 }
 
 impl<C> Validate for IOState<C>
@@ -104,9 +104,9 @@ where C: RaftTypeConfig
 {
     pub(crate) fn new(
         vote: &Vote<C>,
-        applied: Option<LogId<C::NodeId>>,
-        snapshot: Option<LogId<C::NodeId>>,
-        purged: Option<LogId<C::NodeId>>,
+        applied: Option<LogId<C>>,
+        snapshot: Option<LogId<C>>,
+        purged: Option<LogId<C>>,
     ) -> Self {
         let mut io_progress = Valid::new(IOProgress::default());
 
@@ -123,7 +123,7 @@ where C: RaftTypeConfig
         }
     }
 
-    pub(crate) fn update_applied(&mut self, log_id: Option<LogId<C::NodeId>>) {
+    pub(crate) fn update_applied(&mut self, log_id: Option<LogId<C>>) {
         tracing::debug!(applied = display(DisplayOption(&log_id)), "{}", func_name!());
 
         // TODO: should we update flushed if applied is newer?
@@ -137,11 +137,11 @@ where C: RaftTypeConfig
         self.applied = log_id;
     }
 
-    pub(crate) fn applied(&self) -> Option<&LogId<C::NodeId>> {
+    pub(crate) fn applied(&self) -> Option<&LogId<C>> {
         self.applied.as_ref()
     }
 
-    pub(crate) fn update_snapshot(&mut self, log_id: Option<LogId<C::NodeId>>) {
+    pub(crate) fn update_snapshot(&mut self, log_id: Option<LogId<C>>) {
         tracing::debug!(snapshot = display(DisplayOption(&log_id)), "{}", func_name!());
 
         debug_assert!(
@@ -154,7 +154,7 @@ where C: RaftTypeConfig
         self.snapshot = log_id;
     }
 
-    pub(crate) fn snapshot(&self) -> Option<&LogId<C::NodeId>> {
+    pub(crate) fn snapshot(&self) -> Option<&LogId<C>> {
         self.snapshot.as_ref()
     }
 
@@ -166,11 +166,11 @@ where C: RaftTypeConfig
         self.building_snapshot
     }
 
-    pub(crate) fn update_purged(&mut self, log_id: Option<LogId<C::NodeId>>) {
+    pub(crate) fn update_purged(&mut self, log_id: Option<LogId<C>>) {
         self.purged = log_id;
     }
 
-    pub(crate) fn purged(&self) -> Option<&LogId<C::NodeId>> {
+    pub(crate) fn purged(&self) -> Option<&LogId<C>> {
         self.purged.as_ref()
     }
 }

--- a/openraft/src/raft_state/io_state/io_id.rs
+++ b/openraft/src/raft_state/io_state/io_id.rs
@@ -80,7 +80,7 @@ where C: RaftTypeConfig
         Self::Vote(vote)
     }
 
-    pub(crate) fn new_log_io(committed_vote: CommittedVote<C>, last_log_id: Option<LogId<C::NodeId>>) -> Self {
+    pub(crate) fn new_log_io(committed_vote: CommittedVote<C>, last_log_id: Option<LogId<C>>) -> Self {
         Self::Log(LogIOId::new(committed_vote, last_log_id))
     }
 
@@ -101,7 +101,7 @@ where C: RaftTypeConfig
         }
     }
 
-    pub(crate) fn last_log_id(&self) -> Option<&LogId<C::NodeId>> {
+    pub(crate) fn last_log_id(&self) -> Option<&LogId<C>> {
         match self {
             Self::Vote(_) => None,
             Self::Log(log_io_id) => log_io_id.log_id.as_ref(),

--- a/openraft/src/raft_state/io_state/log_io_id.rs
+++ b/openraft/src/raft_state/io_state/log_io_id.rs
@@ -30,7 +30,7 @@ where C: RaftTypeConfig
     pub(crate) committed_vote: CommittedVote<C>,
 
     /// The last log id that has been flushed to storage.
-    pub(crate) log_id: Option<LogId<C::NodeId>>,
+    pub(crate) log_id: Option<LogId<C>>,
 }
 
 impl<C> fmt::Display for LogIOId<C>
@@ -44,7 +44,7 @@ where C: RaftTypeConfig
 impl<C> LogIOId<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(committed_vote: CommittedVote<C>, log_id: Option<LogId<C::NodeId>>) -> Self {
+    pub(crate) fn new(committed_vote: CommittedVote<C>, log_id: Option<LogId<C>>) -> Self {
         Self { committed_vote, log_id }
     }
 }

--- a/openraft/src/raft_state/log_state_reader.rs
+++ b/openraft/src/raft_state/log_state_reader.rs
@@ -9,7 +9,7 @@ pub(crate) trait LogStateReader<C>
 where C: RaftTypeConfig
 {
     /// Get previous log id, i.e., the log id at index - 1
-    fn prev_log_id(&self, index: u64) -> Option<LogId<C::NodeId>> {
+    fn prev_log_id(&self, index: u64) -> Option<LogId<C>> {
         if index == 0 {
             None
         } else {
@@ -20,7 +20,7 @@ where C: RaftTypeConfig
     /// Return if a log id exists.
     ///
     /// It assumes a committed log will always get positive return value, according to raft spec.
-    fn has_log_id(&self, log_id: &LogId<C::NodeId>) -> bool {
+    fn has_log_id(&self, log_id: &LogId<C>) -> bool {
         if log_id.index < self.committed().next_index() {
             debug_assert!(Some(log_id) <= self.committed());
             return true;
@@ -39,40 +39,40 @@ where C: RaftTypeConfig
     /// It will return `last_purged_log_id` if index is at the last purged index.
     /// If the log at the specified index is smaller than `last_purged_log_id`, or greater than
     /// `last_log_id`, it returns None.
-    fn get_log_id(&self, index: u64) -> Option<LogId<C::NodeId>>;
+    fn get_log_id(&self, index: u64) -> Option<LogId<C>>;
 
     /// The last known log id in the store.
     ///
     /// The range of all stored log ids are `(last_purged_log_id(), last_log_id()]`, left open right
     /// close.
-    fn last_log_id(&self) -> Option<&LogId<C::NodeId>>;
+    fn last_log_id(&self) -> Option<&LogId<C>>;
 
     /// The last known committed log id, i.e., the id of the log that is accepted by a quorum of
     /// voters.
-    fn committed(&self) -> Option<&LogId<C::NodeId>>;
+    fn committed(&self) -> Option<&LogId<C>>;
 
     /// The last known applied log id, i.e., the id of the log that is applied to state machine.
     ///
     /// This is actually happened io-state which might fall behind committed log id.
-    fn io_applied(&self) -> Option<&LogId<C::NodeId>>;
+    fn io_applied(&self) -> Option<&LogId<C>>;
 
     /// The last log id in the last persisted snapshot.
     ///
     /// This is actually happened io-state which might fall behind `Self::snapshot_last_log_id()`.
-    fn io_snapshot_last_log_id(&self) -> Option<&LogId<C::NodeId>>;
+    fn io_snapshot_last_log_id(&self) -> Option<&LogId<C>>;
 
     /// The last known purged log id, inclusive.
     ///
     /// This is actually purged log id from storage.
-    fn io_purged(&self) -> Option<&LogId<C::NodeId>>;
+    fn io_purged(&self) -> Option<&LogId<C>>;
 
     /// Return the last log id the snapshot includes.
-    fn snapshot_last_log_id(&self) -> Option<&LogId<C::NodeId>>;
+    fn snapshot_last_log_id(&self) -> Option<&LogId<C>>;
 
     /// Return the log id it wants to purge up to.
     ///
     /// Logs may not be able to be purged at once because they are in use by replication tasks.
-    fn purge_upto(&self) -> Option<&LogId<C::NodeId>>;
+    fn purge_upto(&self) -> Option<&LogId<C>>;
 
     /// The greatest log id that has been purged after being applied to state machine, i.e., the
     /// oldest known log id.
@@ -81,5 +81,5 @@ where C: RaftTypeConfig
     /// left open and right close.
     ///
     /// `last_purged_log_id == last_log_id` means there is no log entry in the storage.
-    fn last_purged_log_id(&self) -> Option<&LogId<C::NodeId>>;
+    fn last_purged_log_id(&self) -> Option<&LogId<C>>;
 }

--- a/openraft/src/raft_state/membership_state/mod.rs
+++ b/openraft/src/raft_state/membership_state/mod.rs
@@ -80,7 +80,7 @@ where C: RaftTypeConfig
     }
 
     /// Update membership state if the specified committed_log_id is greater than `self.effective`
-    pub(crate) fn commit(&mut self, committed_log_id: &Option<LogId<C::NodeId>>) {
+    pub(crate) fn commit(&mut self, committed_log_id: &Option<LogId<C>>) {
         if committed_log_id >= self.effective().log_id() {
             debug_assert!(committed_log_id.index() >= self.effective().log_id().index());
             self.committed = self.effective.clone();

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -57,7 +57,7 @@ where C: RaftTypeConfig
     ///   of the leader.
     ///
     /// - A quorum could be a uniform quorum or joint quorum.
-    pub committed: Option<LogId<C::NodeId>>,
+    pub committed: Option<LogId<C>>,
 
     pub(crate) purged_next: u64,
 
@@ -82,7 +82,7 @@ where C: RaftTypeConfig
     ///
     /// If a log is in use by a replication task, the purge is postponed and is stored in this
     /// field.
-    pub(crate) purge_upto: Option<LogId<C::NodeId>>,
+    pub(crate) purge_upto: Option<LogId<C>>,
 }
 
 impl<C> Default for RaftState<C>
@@ -106,39 +106,39 @@ where C: RaftTypeConfig
 impl<C> LogStateReader<C> for RaftState<C>
 where C: RaftTypeConfig
 {
-    fn get_log_id(&self, index: u64) -> Option<LogId<C::NodeId>> {
+    fn get_log_id(&self, index: u64) -> Option<LogId<C>> {
         self.log_ids.get(index)
     }
 
-    fn last_log_id(&self) -> Option<&LogId<C::NodeId>> {
+    fn last_log_id(&self) -> Option<&LogId<C>> {
         self.log_ids.last()
     }
 
-    fn committed(&self) -> Option<&LogId<C::NodeId>> {
+    fn committed(&self) -> Option<&LogId<C>> {
         self.committed.as_ref()
     }
 
-    fn io_applied(&self) -> Option<&LogId<C::NodeId>> {
+    fn io_applied(&self) -> Option<&LogId<C>> {
         self.io_state.applied()
     }
 
-    fn io_snapshot_last_log_id(&self) -> Option<&LogId<C::NodeId>> {
+    fn io_snapshot_last_log_id(&self) -> Option<&LogId<C>> {
         self.io_state.snapshot()
     }
 
-    fn io_purged(&self) -> Option<&LogId<C::NodeId>> {
+    fn io_purged(&self) -> Option<&LogId<C>> {
         self.io_state.purged()
     }
 
-    fn snapshot_last_log_id(&self) -> Option<&LogId<C::NodeId>> {
+    fn snapshot_last_log_id(&self) -> Option<&LogId<C>> {
         self.snapshot_meta.last_log_id.as_ref()
     }
 
-    fn purge_upto(&self) -> Option<&LogId<C::NodeId>> {
+    fn purge_upto(&self) -> Option<&LogId<C>> {
         self.purge_upto.as_ref()
     }
 
-    fn last_purged_log_id(&self) -> Option<&LogId<C::NodeId>> {
+    fn last_purged_log_id(&self) -> Option<&LogId<C>> {
         if self.purged_next == 0 {
             return None;
         }
@@ -252,11 +252,11 @@ where C: RaftTypeConfig
     /// Append a list of `log_id`.
     ///
     /// The log ids in the input has to be continuous.
-    pub(crate) fn extend_log_ids_from_same_leader<'a, LID: RaftLogId<C::NodeId> + 'a>(&mut self, new_log_ids: &[LID]) {
+    pub(crate) fn extend_log_ids_from_same_leader<'a, LID: RaftLogId<C> + 'a>(&mut self, new_log_ids: &[LID]) {
         self.log_ids.extend_from_same_leader(new_log_ids)
     }
 
-    pub(crate) fn extend_log_ids<'a, LID: RaftLogId<C::NodeId> + 'a>(&mut self, new_log_id: &[LID]) {
+    pub(crate) fn extend_log_ids<'a, LID: RaftLogId<C> + 'a>(&mut self, new_log_id: &[LID]) {
         self.log_ids.extend(new_log_id)
     }
 
@@ -297,7 +297,7 @@ where C: RaftTypeConfig
     /// Find the first entry in the input that does not exist on local raft-log,
     /// by comparing the log id.
     pub(crate) fn first_conflicting_index<Ent>(&self, entries: &[Ent]) -> usize
-    where Ent: RaftLogId<C::NodeId> {
+    where Ent: RaftLogId<C> {
         let l = entries.len();
 
         for (i, ent) in entries.iter().enumerate() {

--- a/openraft/src/raft_state/tests/forward_to_leader_test.rs
+++ b/openraft/src/raft_state/tests/forward_to_leader_test.rs
@@ -6,22 +6,14 @@ use maplit::btreeset;
 
 use crate::engine::testing::UTConfig;
 use crate::error::ForwardToLeader;
+use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
-use crate::CommittedLeaderId;
 use crate::EffectiveMembership;
-use crate::LogId;
 use crate::Membership;
 use crate::MembershipState;
 use crate::RaftState;
 use crate::Vote;
-
-fn log_id(term: u64, index: u64) -> LogId<u64> {
-    LogId::<u64> {
-        leader_id: CommittedLeaderId::new(term, 0),
-        index,
-    }
-}
 
 fn m12() -> Membership<UTConfig> {
     Membership::new_with_defaults(vec![btreeset! {1,2}], [])
@@ -32,8 +24,8 @@ fn test_forward_to_leader_vote_not_committed() {
     let rs = RaftState::<UTConfig> {
         vote: Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(1, 2)),
         membership_state: MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
-            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
+            Arc::new(EffectiveMembership::new(Some(log_id(1, 0, 1)), m12())),
+            Arc::new(EffectiveMembership::new(Some(log_id(1, 0, 1)), m12())),
         ),
         ..Default::default()
     };
@@ -50,8 +42,8 @@ fn test_forward_to_leader_not_a_member() {
             Vote::new_committed(1, 3),
         ),
         membership_state: MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
-            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m12())),
+            Arc::new(EffectiveMembership::new(Some(log_id(1, 0, 1)), m12())),
+            Arc::new(EffectiveMembership::new(Some(log_id(1, 0, 1)), m12())),
         ),
         ..Default::default()
     };
@@ -70,8 +62,8 @@ fn test_forward_to_leader_has_leader() {
             Vote::new_committed(1, 3),
         ),
         membership_state: MembershipState::new(
-            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m123())),
-            Arc::new(EffectiveMembership::new(Some(log_id(1, 1)), m123())),
+            Arc::new(EffectiveMembership::new(Some(log_id(1, 0, 1)), m123())),
+            Arc::new(EffectiveMembership::new(Some(log_id(1, 0, 1)), m123())),
         ),
         ..Default::default()
     };

--- a/openraft/src/raft_state/tests/log_state_reader_test.rs
+++ b/openraft/src/raft_state/tests/log_state_reader_test.rs
@@ -5,8 +5,8 @@ use crate::CommittedLeaderId;
 use crate::LogId;
 use crate::RaftState;
 
-fn log_id(term: u64, index: u64) -> LogId<u64> {
-    LogId::<u64> {
+fn log_id(term: u64, index: u64) -> LogId<UTConfig> {
+    LogId {
         leader_id: CommittedLeaderId::new(term, 0),
         index,
     }

--- a/openraft/src/raft_state/tests/validate_test.rs
+++ b/openraft/src/raft_state/tests/validate_test.rs
@@ -7,8 +7,8 @@ use crate::CommittedLeaderId;
 use crate::LogId;
 use crate::RaftState;
 
-fn log_id(term: u64, index: u64) -> LogId<u64> {
-    LogId::<u64> {
+fn log_id(term: u64, index: u64) -> LogId<UTConfig> {
+    LogId {
         leader_id: CommittedLeaderId::new(term, 0),
         index,
     }

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -134,10 +134,10 @@ where
     config: Arc<Config>,
 
     /// The log id of the highest log entry which is known to be committed in the cluster.
-    committed: Option<LogId<C::NodeId>>,
+    committed: Option<LogId<C>>,
 
     /// Last matching log id on a follower/learner
-    matching: Option<LogId<C::NodeId>>,
+    matching: Option<LogId<C>>,
 
     /// Next replication action to run.
     next_action: Option<Data<C>>,
@@ -161,8 +161,8 @@ where
         target: C::NodeId,
         session_id: ReplicationSessionId<C>,
         config: Arc<Config>,
-        committed: Option<LogId<C::NodeId>>,
-        matching: Option<LogId<C::NodeId>>,
+        committed: Option<LogId<C>>,
+        matching: Option<LogId<C>>,
         network: N::Network,
         snapshot_network: N::Network,
         log_reader: LS::LogReader,
@@ -816,7 +816,7 @@ where
     }
 
     /// If there are more logs to send, it returns a new `Some(Data::Logs)` to send.
-    fn next_action_to_send(&mut self, matching: Option<LogId<C::NodeId>>, log_ids: LogIdRange<C>) -> Option<Data<C>> {
+    fn next_action_to_send(&mut self, matching: Option<LogId<C>>, log_ids: LogIdRange<C>) -> Option<Data<C>> {
         if matching < log_ids.last {
             Some(Data::new_logs(LogIdRange::new(matching, log_ids.last)))
         } else {
@@ -825,7 +825,7 @@ where
     }
 
     /// Check if partial success result(`matching`) is valid for a given log range to send.
-    fn debug_assert_partial_success(to_send: &LogIdRange<C>, matching: &Option<LogId<C::NodeId>>) {
+    fn debug_assert_partial_success(to_send: &LogIdRange<C>, matching: &Option<LogId<C>>) {
         debug_assert!(
             matching <= &to_send.last,
             "matching ({}) should be <= last_log_id ({})",

--- a/openraft/src/replication/replication_session_id.rs
+++ b/openraft/src/replication/replication_session_id.rs
@@ -38,7 +38,7 @@ where C: RaftTypeConfig
     pub(crate) leader_vote: CommittedVote<C>,
 
     /// The log id of the membership log this replication works for.
-    pub(crate) membership_log_id: Option<LogId<C::NodeId>>,
+    pub(crate) membership_log_id: Option<LogId<C>>,
 }
 
 impl<C> Display for ReplicationSessionId<C>
@@ -57,7 +57,7 @@ where C: RaftTypeConfig
 impl<C> ReplicationSessionId<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(vote: CommittedVote<C>, membership_log_id: Option<LogId<C::NodeId>>) -> Self {
+    pub(crate) fn new(vote: CommittedVote<C>, membership_log_id: Option<LogId<C>>) -> Self {
         Self {
             leader_vote: vote,
             membership_log_id,

--- a/openraft/src/replication/request.rs
+++ b/openraft/src/replication/request.rs
@@ -9,7 +9,7 @@ pub(crate) enum Replicate<C>
 where C: RaftTypeConfig
 {
     /// Inform replication stream to forward the committed log id to followers/learners.
-    Committed(Option<LogId<C::NodeId>>),
+    Committed(Option<LogId<C>>),
 
     /// Send a chunk of data, e.g., logs or snapshot.
     Data(Data<C>),

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -79,11 +79,11 @@ mod tests {
         // NOTE that with single-term-leader, log id is `1-3`
 
         let result = ReplicationResult::<UTConfig>(Ok(Some(log_id(1, 2, 3))));
-        let want = format!("(Match:{})", log_id(1, 2, 3));
+        let want = format!("(Match:{})", log_id::<UTConfig>(1, 2, 3));
         assert!(result.to_string().ends_with(&want), "{}", result.to_string());
 
         let result = ReplicationResult::<UTConfig>(Err(log_id(1, 2, 3)));
-        let want = format!("(Conflict:{})", log_id(1, 2, 3));
+        let want = format!("(Conflict:{})", log_id::<UTConfig>(1, 2, 3));
         assert!(result.to_string().ends_with(&want), "{}", result.to_string());
     }
 }

--- a/openraft/src/storage/callback.rs
+++ b/openraft/src/storage/callback.rs
@@ -101,8 +101,8 @@ where C: RaftTypeConfig
 pub struct LogApplied<C>
 where C: RaftTypeConfig
 {
-    last_log_id: LogId<C::NodeId>,
-    tx: OneshotSenderOf<C, Result<(LogId<C::NodeId>, Vec<C::R>), StorageError<C>>>,
+    last_log_id: LogId<C>,
+    tx: OneshotSenderOf<C, Result<(LogId<C>, Vec<C::R>), StorageError<C>>>,
 }
 
 impl<C> LogApplied<C>
@@ -110,8 +110,8 @@ where C: RaftTypeConfig
 {
     #[allow(dead_code)]
     pub(crate) fn new(
-        last_log_id: LogId<C::NodeId>,
-        tx: OneshotSenderOf<C, Result<(LogId<C::NodeId>, Vec<C::R>), StorageError<C>>>,
+        last_log_id: LogId<C>,
+        tx: OneshotSenderOf<C, Result<(LogId<C>, Vec<C::R>), StorageError<C>>>,
     ) -> Self {
         Self { last_log_id, tx }
     }

--- a/openraft/src/storage/log_reader_ext.rs
+++ b/openraft/src/storage/log_reader_ext.rs
@@ -20,7 +20,7 @@ where C: RaftTypeConfig
     }
 
     /// Get the log id of the entry at `index`.
-    async fn get_log_id(&mut self, log_index: u64) -> Result<LogId<C::NodeId>, StorageError<C>> {
+    async fn get_log_id(&mut self, log_index: u64) -> Result<LogId<C>, StorageError<C>> {
         let entries = self.try_get_log_entries(log_index..=log_index).await?;
 
         if entries.is_empty() {

--- a/openraft/src/storage/log_state.rs
+++ b/openraft/src/storage/log_state.rs
@@ -7,9 +7,9 @@ use crate::RaftTypeConfig;
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct LogState<C: RaftTypeConfig> {
     /// The greatest log id that has been purged after being applied to state machine.
-    pub last_purged_log_id: Option<LogId<C::NodeId>>,
+    pub last_purged_log_id: Option<LogId<C>>,
 
     /// The log id of the last present entry if there are any entries.
     /// Otherwise the same value as `last_purged_log_id`.
-    pub last_log_id: Option<LogId<C::NodeId>>,
+    pub last_log_id: Option<LogId<C>>,
 }

--- a/openraft/src/storage/snapshot_meta.rs
+++ b/openraft/src/storage/snapshot_meta.rs
@@ -18,7 +18,7 @@ pub struct SnapshotMeta<C>
 where C: RaftTypeConfig
 {
     /// Log entries upto which this snapshot includes, inclusive.
-    pub last_log_id: Option<LogId<C::NodeId>>,
+    pub last_log_id: Option<LogId<C>>,
 
     /// The last applied membership config.
     pub last_membership: StoredMembership<C>,
@@ -55,7 +55,7 @@ where C: RaftTypeConfig
     }
 
     /// Returns a ref to the id of the last log that is included in this snapshot.
-    pub fn last_log_id(&self) -> Option<&LogId<C::NodeId>> {
+    pub fn last_log_id(&self) -> Option<&LogId<C>> {
         self.last_log_id.as_ref()
     }
 }

--- a/openraft/src/storage/snapshot_signature.rs
+++ b/openraft/src/storage/snapshot_signature.rs
@@ -9,10 +9,10 @@ pub struct SnapshotSignature<C>
 where C: RaftTypeConfig
 {
     /// Log entries upto which this snapshot includes, inclusive.
-    pub last_log_id: Option<LogId<C::NodeId>>,
+    pub last_log_id: Option<LogId<C>>,
 
     /// The last applied membership log id.
-    pub last_membership_log_id: Option<LogId<C::NodeId>>,
+    pub last_membership_log_id: Option<LogId<C>>,
 
     /// To identify a snapshot when transferring.
     pub snapshot_id: SnapshotId,

--- a/openraft/src/storage/v2/raft_log_reader.rs
+++ b/openraft/src/storage/v2/raft_log_reader.rs
@@ -104,10 +104,7 @@ where C: RaftTypeConfig
     ///
     /// [`RaftLogStorage`]: crate::storage::RaftLogStorage
     #[since(version = "0.10.0")]
-    async fn get_key_log_ids(
-        &mut self,
-        range: RangeInclusive<LogId<C::NodeId>>,
-    ) -> Result<Vec<LogId<C::NodeId>>, StorageError<C>> {
+    async fn get_key_log_ids(&mut self, range: RangeInclusive<LogId<C>>) -> Result<Vec<LogId<C>>, StorageError<C>> {
         LogIdList::get_key_log_ids(range, self).await
     }
 }

--- a/openraft/src/storage/v2/raft_log_storage.rs
+++ b/openraft/src/storage/v2/raft_log_storage.rs
@@ -67,13 +67,13 @@ where C: RaftTypeConfig
     /// See: [`docs::data::log_pointers`].
     ///
     /// [`docs::data::log_pointers`]: `crate::docs::data::log_pointers#optionally-persisted-committed`
-    async fn save_committed(&mut self, _committed: Option<LogId<C::NodeId>>) -> Result<(), StorageError<C>> {
+    async fn save_committed(&mut self, _committed: Option<LogId<C>>) -> Result<(), StorageError<C>> {
         // By default `committed` log id is not saved
         Ok(())
     }
 
     /// Return the last saved committed log id by [`Self::save_committed`].
-    async fn read_committed(&mut self) -> Result<Option<LogId<C::NodeId>>, StorageError<C>> {
+    async fn read_committed(&mut self) -> Result<Option<LogId<C>>, StorageError<C>> {
         // By default `committed` log id is not saved and this method just return None.
         Ok(None)
     }
@@ -106,12 +106,12 @@ where C: RaftTypeConfig
     /// ### To ensure correctness:
     ///
     /// - It must not leave a **hole** in logs.
-    async fn truncate(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C>>;
+    async fn truncate(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>>;
 
     /// Purge logs upto `log_id`, inclusive
     ///
     /// ### To ensure correctness:
     ///
     /// - It must not leave a **hole** in logs.
-    async fn purge(&mut self, log_id: LogId<C::NodeId>) -> Result<(), StorageError<C>>;
+    async fn purge(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>>;
 }

--- a/openraft/src/storage/v2/raft_state_machine.rs
+++ b/openraft/src/storage/v2/raft_state_machine.rs
@@ -35,7 +35,7 @@ where C: RaftTypeConfig
     /// last-applied-log-id.
     /// Because upon startup, the last membership will be loaded by scanning logs from the
     /// `last-applied-log-id`.
-    async fn applied_state(&mut self) -> Result<(Option<LogId<C::NodeId>>, StoredMembership<C>), StorageError<C>>;
+    async fn applied_state(&mut self) -> Result<(Option<LogId<C>>, StoredMembership<C>), StorageError<C>>;
 
     /// Apply the given payload of entries to the state machine.
     ///

--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -48,13 +48,13 @@ where C: RaftTypeConfig
     Logs,
 
     /// Error about a single log entry
-    Log(LogId<C::NodeId>),
+    Log(LogId<C>),
 
     /// Error about a single log entry without knowing the log term.
     LogIndex(u64),
 
     /// Error happened when applying a log entry
-    Apply(LogId<C::NodeId>),
+    Apply(LogId<C>),
 
     /// Error happened when operating state machine.
     StateMachine,
@@ -137,7 +137,7 @@ where C: RaftTypeConfig
         }
     }
 
-    pub fn write_log_entry(log_id: LogId<C::NodeId>, source: impl Into<AnyError>) -> Self {
+    pub fn write_log_entry(log_id: LogId<C>, source: impl Into<AnyError>) -> Self {
         Self::new(ErrorSubject::Log(log_id), ErrorVerb::Write, source)
     }
 
@@ -145,7 +145,7 @@ where C: RaftTypeConfig
         Self::new(ErrorSubject::LogIndex(log_index), ErrorVerb::Read, source)
     }
 
-    pub fn read_log_entry(log_id: LogId<C::NodeId>, source: impl Into<AnyError>) -> Self {
+    pub fn read_log_entry(log_id: LogId<C>, source: impl Into<AnyError>) -> Self {
         Self::new(ErrorSubject::Log(log_id), ErrorVerb::Read, source)
     }
 
@@ -165,7 +165,7 @@ where C: RaftTypeConfig
         Self::new(ErrorSubject::Vote, ErrorVerb::Read, source)
     }
 
-    pub fn apply(log_id: LogId<C::NodeId>, source: impl Into<AnyError>) -> Self {
+    pub fn apply(log_id: LogId<C>, source: impl Into<AnyError>) -> Self {
         Self::new(ErrorSubject::Apply(log_id), ErrorVerb::Write, source)
     }
 

--- a/openraft/src/summary.rs
+++ b/openraft/src/summary.rs
@@ -83,9 +83,10 @@ mod tests {
     #[cfg(not(feature = "single-term-leader"))]
     #[test]
     fn test_display() {
+        use crate::engine::testing::UTConfig;
         use crate::MessageSummary;
 
-        let lid = crate::testing::log_id(1, 2, 3);
+        let lid = crate::testing::log_id::<UTConfig>(1, 2, 3);
         assert_eq!("T1-N2.3", lid.to_string());
         assert_eq!("T1-N2.3", lid.summary());
         assert_eq!("Some(T1-N2.3)", Some(&lid).summary());

--- a/openraft/src/testing/common.rs
+++ b/openraft/src/testing/common.rs
@@ -8,8 +8,9 @@ use crate::LogId;
 use crate::RaftTypeConfig;
 
 /// Builds a log id, for testing purposes.
-pub fn log_id<NID: crate::NodeId>(term: u64, node_id: NID, index: u64) -> LogId<NID> {
-    LogId::<NID> {
+pub fn log_id<C>(term: u64, node_id: C::NodeId, index: u64) -> LogId<C>
+where C: RaftTypeConfig {
+    LogId::<C> {
         leader_id: CommittedLeaderId::new(term, node_id),
         index,
     }

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -151,7 +151,7 @@ pub mod alias {
     pub type MutexOf<C, T> = <Rt<C> as AsyncRuntime>::Mutex<T>;
 
     // Usually used types
-    pub type LogIdOf<C> = crate::LogId<NodeIdOf<C>>;
+    pub type LogIdOf<C> = crate::LogId<C>;
     pub type VoteOf<C> = crate::Vote<C>;
     pub type LeaderIdOf<C> = crate::LeaderId<NodeIdOf<C>>;
     pub type CommittedLeaderIdOf<C> = crate::CommittedLeaderId<NodeIdOf<C>>;

--- a/stores/rocksstore/src/lib.rs
+++ b/stores/rocksstore/src/lib.rs
@@ -92,7 +92,7 @@ pub struct RocksSnapshot {
 #[derive(Default)]
 #[derive(Serialize, Deserialize)]
 pub struct StateMachine {
-    pub last_applied_log: Option<LogId<RocksNodeId>>,
+    pub last_applied_log: Option<LogId<TypeConfig>>,
 
     pub last_membership: StoredMembership<TypeConfig>,
 
@@ -173,7 +173,7 @@ mod meta {
 
     impl StoreMeta for LastPurged {
         const KEY: &'static str = "last_purged_log_id";
-        type Value = LogId<u64>;
+        type Value = LogId<TypeConfig>;
 
         fn subject(_v: Option<&Self::Value>) -> ErrorSubject<TypeConfig> {
             ErrorSubject::Store
@@ -368,7 +368,7 @@ impl RaftLogStorage<TypeConfig> for RocksLogStore {
         Ok(())
     }
 
-    async fn truncate(&mut self, log_id: LogId<RocksNodeId>) -> Result<(), StorageError<TypeConfig>> {
+    async fn truncate(&mut self, log_id: LogId<TypeConfig>) -> Result<(), StorageError<TypeConfig>> {
         tracing::debug!("truncate: [{:?}, +oo)", log_id);
 
         let from = id_to_bin(log_id.index);
@@ -379,7 +379,7 @@ impl RaftLogStorage<TypeConfig> for RocksLogStore {
         Ok(())
     }
 
-    async fn purge(&mut self, log_id: LogId<RocksNodeId>) -> Result<(), StorageError<TypeConfig>> {
+    async fn purge(&mut self, log_id: LogId<TypeConfig>) -> Result<(), StorageError<TypeConfig>> {
         tracing::debug!("delete_log: [0, {:?}]", log_id);
 
         // Write the last-purged log id before purging the logs.
@@ -401,7 +401,7 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
 
     async fn applied_state(
         &mut self,
-    ) -> Result<(Option<LogId<RocksNodeId>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
+    ) -> Result<(Option<LogId<TypeConfig>>, StoredMembership<TypeConfig>), StorageError<TypeConfig>> {
         Ok((self.sm.last_applied_log, self.sm.last_membership.clone()))
     }
 

--- a/tests/tests/client_api/t16_with_state_machine.rs
+++ b/tests/tests/client_api/t16_with_state_machine.rs
@@ -16,7 +16,6 @@ use openraft::RaftTypeConfig;
 use openraft::StorageError;
 use openraft::StoredMembership;
 use openraft_memstore::ClientResponse;
-use openraft_memstore::MemNodeId;
 use openraft_memstore::TypeConfig;
 
 use crate::fixtures::ut_harness;
@@ -99,7 +98,7 @@ async fn with_state_machine_wrong_sm_type() -> Result<()> {
         impl RaftStateMachine<TC> for FooSM {
             type SnapshotBuilder = Self;
 
-            async fn applied_state(&mut self) -> Result<(Option<LogId<MemNodeId>>, StoredMembership<TC>), Err> {
+            async fn applied_state(&mut self) -> Result<(Option<LogId<TypeConfig>>, StoredMembership<TC>), Err> {
                 todo!()
             }
 

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -725,7 +725,7 @@ impl TypedRaftRouter {
     pub async fn wait_for_snapshot(
         &self,
         node_ids: &BTreeSet<MemNodeId>,
-        want: LogId<MemNodeId>,
+        want: LogId<TypeConfig>,
         timeout: Option<Duration>,
         msg: &str,
     ) -> anyhow::Result<()> {
@@ -863,7 +863,7 @@ impl TypedRaftRouter {
         expect_term: u64,
         expect_last_log: u64,
         expect_voted_for: Option<MemNodeId>,
-        expect_sm_last_applied_log: LogId<MemNodeId>,
+        expect_sm_last_applied_log: LogId<TypeConfig>,
         expect_snapshot: &Option<(ValueTest<u64>, u64)>,
     ) -> anyhow::Result<()> {
         let last_log_id = storage.get_log_state().await?.last_log_id;
@@ -955,7 +955,7 @@ impl TypedRaftRouter {
         expect_term: u64,
         expect_last_log: u64,
         expect_voted_for: Option<MemNodeId>,
-        expect_sm_last_applied_log: LogId<MemNodeId>,
+        expect_sm_last_applied_log: LogId<TypeConfig>,
         expect_snapshot: Option<(ValueTest<u64>, u64)>,
     ) -> anyhow::Result<()> {
         let node_ids = {

--- a/tests/tests/membership/t11_add_learner.rs
+++ b/tests/tests/membership/t11_add_learner.rs
@@ -14,6 +14,7 @@ use openraft::LogId;
 use openraft::Membership;
 use openraft::RaftLogReader;
 use openraft::StorageHelper;
+use openraft_memstore::TypeConfig;
 use tokio::time::sleep;
 
 use crate::fixtures::ut_harness;
@@ -345,8 +346,8 @@ fn timeout() -> Option<Duration> {
     Some(Duration::from_millis(3_000))
 }
 
-pub fn log_id(term: u64, node_id: u64, index: u64) -> LogId<u64> {
-    LogId::<u64> {
+pub fn log_id(term: u64, node_id: u64, index: u64) -> LogId<TypeConfig> {
+    LogId {
         leader_id: CommittedLeaderId::new(term, node_id),
         index,
     }


### PR DESCRIPTION

## Changelog

##### Change: change `LogId<NID:NodeId>` to `LogId<C:RaftTypeConfig>`

This refactoring moves LogId from a per-NodeId type to a per-TypeConfig type,
to make it consistent with `RaftTypeConfig` usage across the codebase.

- Part of: #1278

Upgrade tip:

LogId is now parameterized by `RaftTypeConfig` instead of `NodeId`

- Change `LogId<NodeId>` to `LogId<C> where C: RaftTypeConfig`, for
  example, change `LogId<u64>` to `LogId<YourTypeConfig>`.

- Change trait `RaftLogId<NID: NodeId>` to `RaftLogId<C: RaftTypeConfig>`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1281)
<!-- Reviewable:end -->
