### PR TITLE
Change: change `LeaderId<NID:NodeId>` to `LeaderId<C:RaftTypeConfig>`

### DIFF
--- a/examples/raft-kv-memstore-grpc/src/lib.rs
+++ b/examples/raft-kv-memstore-grpc/src/lib.rs
@@ -56,7 +56,7 @@ pub mod typ {
     pub type ClientWriteResponse = openraft::raft::ClientWriteResponse<TypeConfig>;
 }
 
-impl From<protobuf::LeaderId> for LeaderId<NodeId> {
+impl From<protobuf::LeaderId> for LeaderId<TypeConfig> {
     fn from(proto_leader_id: protobuf::LeaderId) -> Self {
         LeaderId::new(proto_leader_id.term, proto_leader_id.node_id)
     }
@@ -64,7 +64,7 @@ impl From<protobuf::LeaderId> for LeaderId<NodeId> {
 
 impl From<protobuf::Vote> for typ::Vote {
     fn from(proto_vote: protobuf::Vote) -> Self {
-        let leader_id: LeaderId<NodeId> = proto_vote.leader_id.unwrap().into();
+        let leader_id: LeaderId<TypeConfig> = proto_vote.leader_id.unwrap().into();
         if proto_vote.committed {
             typ::Vote::new_committed(leader_id.term, leader_id.node_id)
         } else {
@@ -75,7 +75,7 @@ impl From<protobuf::Vote> for typ::Vote {
 
 impl From<protobuf::LogId> for LogId<TypeConfig> {
     fn from(proto_log_id: protobuf::LogId) -> Self {
-        let leader_id: LeaderId<NodeId> = proto_log_id.leader_id.unwrap().into();
+        let leader_id: LeaderId<TypeConfig> = proto_log_id.leader_id.unwrap().into();
         LogId::new(leader_id, proto_log_id.index)
     }
 }
@@ -96,8 +96,8 @@ impl From<protobuf::VoteResponse> for VoteResponse<TypeConfig> {
     }
 }
 
-impl From<LeaderId<NodeId>> for protobuf::LeaderId {
-    fn from(leader_id: LeaderId<NodeId>) -> Self {
+impl From<LeaderId<TypeConfig>> for protobuf::LeaderId {
+    fn from(leader_id: LeaderId<TypeConfig>) -> Self {
         protobuf::LeaderId {
             term: leader_id.term,
             node_id: leader_id.node_id,

--- a/openraft/src/engine/log_id_list.rs
+++ b/openraft/src/engine/log_id_list.rs
@@ -148,7 +148,8 @@ where C: RaftTypeConfig
     }
 
     /// Extends a list of `log_id`.
-    #[allow(dead_code)]
+    // leader_id: Copy is feature gated
+    #[allow(clippy::clone_on_copy)]
     pub(crate) fn extend<'a, LID: RaftLogId<C> + 'a>(&mut self, new_ids: &[LID]) {
         let mut prev = self.last().map(|x| x.leader_id.clone());
 
@@ -217,7 +218,8 @@ where C: RaftTypeConfig
     }
 
     /// Delete log ids from `at`, inclusive.
-    #[allow(dead_code)]
+    // leader_id: Copy is feature gated
+    #[allow(clippy::clone_on_copy)]
     pub(crate) fn truncate(&mut self, at: u64) {
         let res = self.key_log_ids.binary_search_by(|log_id| log_id.index.cmp(&at));
 
@@ -277,6 +279,8 @@ where C: RaftTypeConfig
     /// Get the log id at the specified index.
     ///
     /// It will return `last_purged_log_id` if index is at the last purged index.
+    // leader_id: Copy is feature gated
+    #[allow(clippy::clone_on_copy)]
     pub(crate) fn get(&self, index: u64) -> Option<LogId<C>> {
         let res = self.key_log_ids.binary_search_by(|log_id| log_id.index.cmp(&index));
 

--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -25,7 +25,7 @@ pub struct LogId<C>
 where C: RaftTypeConfig
 {
     /// The id of the leader that proposed this log
-    pub leader_id: CommittedLeaderId<C::NodeId>,
+    pub leader_id: CommittedLeaderId<C>,
     /// The index of a log in the storage.
     ///
     /// Log index is a consecutive integer.
@@ -63,12 +63,12 @@ impl<C> LogId<C>
 where C: RaftTypeConfig
 {
     /// Creates a log id proposed by a committed leader with `leader_id` at the given index.
-    pub fn new(leader_id: CommittedLeaderId<C::NodeId>, index: u64) -> Self {
+    pub fn new(leader_id: CommittedLeaderId<C>, index: u64) -> Self {
         LogId { leader_id, index }
     }
 
     /// Returns the leader id that proposed this log.
-    pub fn committed_leader_id(&self) -> &CommittedLeaderId<C::NodeId> {
+    pub fn committed_leader_id(&self) -> &CommittedLeaderId<C> {
         &self.leader_id
     }
 }

--- a/openraft/src/log_id/raft_log_id.rs
+++ b/openraft/src/log_id/raft_log_id.rs
@@ -12,7 +12,7 @@ where C: RaftTypeConfig
     /// For example, a leader id in standard raft is `(term, node_id)`, but a log id does not have
     /// to store the `node_id`, because in standard raft there is at most one leader that can be
     /// established.
-    fn leader_id(&self) -> &CommittedLeaderId<C::NodeId> {
+    fn leader_id(&self) -> &CommittedLeaderId<C> {
         self.get_log_id().committed_leader_id()
     }
 

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -78,6 +78,8 @@ where
     /// Create a new Leader.
     ///
     /// `last_leader_log_id` is the first and last log id proposed by the last leader.
+    // leader_id: Copy is feature gated
+    #[allow(clippy::clone_on_copy)]
     pub(crate) fn new(
         vote: CommittedVote<C>,
         quorum_set: QS,

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -153,7 +153,7 @@ pub mod alias {
     // Usually used types
     pub type LogIdOf<C> = crate::LogId<C>;
     pub type VoteOf<C> = crate::Vote<C>;
-    pub type LeaderIdOf<C> = crate::LeaderId<NodeIdOf<C>>;
-    pub type CommittedLeaderIdOf<C> = crate::CommittedLeaderId<NodeIdOf<C>>;
+    pub type LeaderIdOf<C> = crate::LeaderId<C>;
+    pub type CommittedLeaderIdOf<C> = crate::CommittedLeaderId<C>;
     pub type SerdeInstantOf<C> = crate::metrics::SerdeInstant<InstantOf<C>>;
 }

--- a/openraft/src/vote/committed.rs
+++ b/openraft/src/vote/committed.rs
@@ -41,7 +41,7 @@ where C: RaftTypeConfig
         Self { vote }
     }
 
-    pub(crate) fn committed_leader_id(&self) -> CommittedLeaderId<C::NodeId> {
+    pub(crate) fn committed_leader_id(&self) -> CommittedLeaderId<C> {
         self.vote.leader_id().to_committed()
     }
 

--- a/openraft/src/vote/leader_id/impl_into_leader_id.rs
+++ b/openraft/src/vote/leader_id/impl_into_leader_id.rs
@@ -2,7 +2,7 @@ use crate::vote::leader_id::CommittedLeaderId;
 use crate::vote::Vote;
 use crate::RaftTypeConfig;
 
-impl<C> From<Vote<C>> for CommittedLeaderId<C::NodeId>
+impl<C> From<Vote<C>> for CommittedLeaderId<C>
 where C: RaftTypeConfig
 {
     fn from(vote: Vote<C>) -> Self {

--- a/openraft/src/vote/leader_id/leader_id_adv.rs
+++ b/openraft/src/vote/leader_id/leader_id_adv.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::NodeId;
+use crate::RaftTypeConfig;
 
 /// LeaderId is identifier of a `leader`.
 ///
@@ -14,15 +14,17 @@ use crate::NodeId;
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[derive(PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct LeaderId<NID>
-where NID: NodeId
+pub struct LeaderId<C>
+where C: RaftTypeConfig
 {
     pub term: u64,
-    pub node_id: NID,
+    pub node_id: C::NodeId,
 }
 
-impl<NID: NodeId> LeaderId<NID> {
-    pub fn new(term: u64, node_id: NID) -> Self {
+impl<C> LeaderId<C>
+where C: RaftTypeConfig
+{
+    pub fn new(term: u64, node_id: C::NodeId) -> Self {
         Self { term, node_id }
     }
 
@@ -30,24 +32,26 @@ impl<NID: NodeId> LeaderId<NID> {
         self.term
     }
 
-    pub fn voted_for(&self) -> Option<NID> {
+    pub fn voted_for(&self) -> Option<C::NodeId> {
         Some(self.node_id.clone())
     }
 
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_committed(&self) -> CommittedLeaderId<NID> {
+    pub(crate) fn to_committed(&self) -> CommittedLeaderId<C> {
         self.clone()
     }
 
     /// Return if it is the same leader as the committed leader id.
     ///
     /// A committed leader may have less info than a non-committed.
-    pub(crate) fn is_same_as_committed(&self, other: &CommittedLeaderId<NID>) -> bool {
+    pub(crate) fn is_same_as_committed(&self, other: &CommittedLeaderId<C>) -> bool {
         self == other
     }
 }
 
-impl<NID: NodeId> fmt::Display for LeaderId<NID> {
+impl<C> fmt::Display for LeaderId<C>
+where C: RaftTypeConfig
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "T{}-N{}", self.term, self.node_id)
     }
@@ -55,20 +59,21 @@ impl<NID: NodeId> fmt::Display for LeaderId<NID> {
 
 /// The unique identifier of a leader that is already granted by a quorum in phase-1(voting).
 ///
-/// [`CommittedLeaderId`] may contains less information than [`LeaderId`], because it implies the
+/// [`CommittedLeaderId`] may contain less information than [`LeaderId`], because it implies the
 /// constraint that **a quorum has granted it**.
 ///
 /// For a total order `LeaderId`, the [`CommittedLeaderId`] is the same.
 ///
-/// For a partial order `LeaderId`, we know that all of the granted
+/// For a partial order `LeaderId`, we know that all the granted
 /// leader-id must be a total order set. Therefor once it is granted by a quorum, it only keeps the
 /// information that makes leader-ids a correct total order set, e.g., in standard raft, `voted_for:
 /// Option<node_id>` can be removed from `(term, voted_for)` once it is granted. This is why
 /// standard raft stores just a `term` in log entry.
-pub type CommittedLeaderId<NID> = LeaderId<NID>;
+pub type CommittedLeaderId<C> = LeaderId<C>;
 
 #[cfg(test)]
 mod tests {
+    use crate::engine::testing::UTConfig;
     use crate::LeaderId;
 
     #[cfg(feature = "serde")]
@@ -76,11 +81,11 @@ mod tests {
     fn test_committed_leader_id_serde() -> anyhow::Result<()> {
         use crate::CommittedLeaderId;
 
-        let c = CommittedLeaderId::<u32>::new(5, 10);
+        let c = CommittedLeaderId::<UTConfig>::new(5, 10);
         let s = serde_json::to_string(&c)?;
         assert_eq!(r#"{"term":5,"node_id":10}"#, s);
 
-        let c2: CommittedLeaderId<u32> = serde_json::from_str(&s)?;
+        let c2: CommittedLeaderId<UTConfig> = serde_json::from_str(&s)?;
         assert_eq!(CommittedLeaderId::new(5, 10), c2);
 
         Ok(())
@@ -89,7 +94,7 @@ mod tests {
     #[test]
     fn test_leader_id_partial_order() -> anyhow::Result<()> {
         #[allow(clippy::redundant_closure)]
-        let lid = |term, node_id| LeaderId::<u64>::new(term, node_id);
+        let lid = |term, node_id| LeaderId::<UTConfig>::new(term, node_id);
 
         // Compare term first
         assert!(lid(2, 2) > lid(1, 2));

--- a/openraft/src/vote/ref_vote.rs
+++ b/openraft/src/vote/ref_vote.rs
@@ -11,14 +11,14 @@ use crate::RaftTypeConfig;
 pub(crate) struct RefVote<'a, C>
 where C: RaftTypeConfig
 {
-    pub(crate) leader_id: &'a LeaderId<C::NodeId>,
+    pub(crate) leader_id: &'a LeaderId<C>,
     pub(crate) committed: bool,
 }
 
 impl<'a, C> RefVote<'a, C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(leader_id: &'a LeaderId<C::NodeId>, committed: bool) -> Self {
+    pub(crate) fn new(leader_id: &'a LeaderId<C>, committed: bool) -> Self {
         Self { leader_id, committed }
     }
 

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -10,13 +10,20 @@ use crate::LeaderId;
 use crate::RaftTypeConfig;
 
 /// `Vote` represent the privilege of a node.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct Vote<C: RaftTypeConfig> {
     /// The id of the node that tries to become the leader.
-    pub leader_id: LeaderId<C::NodeId>,
+    pub leader_id: LeaderId<C>,
 
     pub committed: bool,
+}
+
+impl<C> Copy for Vote<C>
+where
+    C: RaftTypeConfig,
+    C::NodeId: Copy,
+{
 }
 
 impl<C> PartialOrd for Vote<C>
@@ -91,11 +98,11 @@ where C: RaftTypeConfig
     /// Return the [`LeaderId`] this vote represents for.
     ///
     /// The leader may or may not be granted by a quorum.
-    pub fn leader_id(&self) -> &LeaderId<C::NodeId> {
+    pub fn leader_id(&self) -> &LeaderId<C> {
         &self.leader_id
     }
 
-    pub(crate) fn is_same_leader(&self, leader_id: &CommittedLeaderId<C::NodeId>) -> bool {
+    pub(crate) fn is_same_leader(&self, leader_id: &CommittedLeaderId<C>) -> bool {
         self.leader_id().is_same_as_committed(leader_id)
     }
 }


### PR DESCRIPTION

## Changelog

##### Change: change `LeaderId<NID:NodeId>` to `LeaderId<C:RaftTypeConfig>`

This refactoring moves LeaderId from a per-NodeId type to a per-TypeConfig type,
to make it consistent with `RaftTypeConfig` usage across the codebase.

- Part of: #1278

Upgrade tip:

LeaderId is now parameterized by `RaftTypeConfig` instead of `NodeId`

- Change `LeaderId<NodeId>` to `LeaderId<C> where C: RaftTypeConfig`, for
  example, change `LeaderId<u64>` to `LeaderId<YourTypeConfig>`.

- Change `CommittedLeaderId<NodeId>` to `CommittedLeaderId<RaftTypeConfig>`.


##### Change: change `LogId<NID:NodeId>` to `LogId<C:RaftTypeConfig>`

This refactoring moves LogId from a per-NodeId type to a per-TypeConfig type,
to make it consistent with `RaftTypeConfig` usage across the codebase.

- Part of: #1278

Upgrade tip:

LogId is now parameterized by `RaftTypeConfig` instead of `NodeId`

- Change `LogId<NodeId>` to `LogId<C> where C: RaftTypeConfig`, for
  example, change `LogId<u64>` to `LogId<YourTypeConfig>`.

- Change trait `RaftLogId<NID: NodeId>` to `RaftLogId<C: RaftTypeConfig>`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1282)
<!-- Reviewable:end -->
