### PR TITLE
Feature: Abstract Term

### DIFF
--- a/openraft/src/core/tick.rs
+++ b/openraft/src/core/tick.rs
@@ -179,6 +179,7 @@ mod tests {
         type R = ();
         type NodeId = u64;
         type Node = ();
+        type Term = u64;
         type Entry = crate::Entry<TickUTConfig>;
         type SnapshotData = Cursor<Vec<u8>>;
         type AsyncRuntime = TokioRuntime;

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -47,6 +47,7 @@ use crate::storage::SnapshotMeta;
 use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::SnapshotDataOf;
 use crate::type_config::TypeConfigExt;
+use crate::vote::raft_term::RaftTerm;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::Membership;
@@ -208,7 +209,7 @@ where C: RaftTypeConfig
     /// Start to elect this node as leader
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) fn elect(&mut self) {
-        let new_term = self.state.vote.leader_id().term + 1;
+        let new_term = self.state.vote.leader_id().term.next();
         let new_vote = Vote::new(new_term, self.config.id.clone());
 
         let candidate = self.new_candidate(new_vote.clone());

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -36,6 +36,7 @@ where N: Node + Ord
     type NodeId = u64;
     type Node = N;
     type Entry = crate::Entry<Self>;
+    type Term = u64;
     type SnapshotData = Cursor<Vec<u8>>;
     type AsyncRuntime = TokioRuntime;
     type Responder = crate::impls::OneshotResponder<Self>;

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -46,7 +46,6 @@ mod runtime;
 mod storage_error;
 mod summary;
 mod try_as_ref;
-mod vote;
 
 pub(crate) mod engine;
 pub(crate) mod log_id_range;
@@ -70,6 +69,7 @@ pub mod raft;
 pub mod storage;
 pub mod testing;
 pub mod type_config;
+pub mod vote;
 
 #[cfg(test)]
 mod feature_serde_test;

--- a/openraft/src/metrics/metric.rs
+++ b/openraft/src/metrics/metric.rs
@@ -14,7 +14,7 @@ use crate::Vote;
 pub enum Metric<C>
 where C: RaftTypeConfig
 {
-    Term(u64),
+    Term(C::Term),
     Vote(Vote<C>),
     LastLogIndex(Option<u64>),
     Applied(Option<LogId<C>>),

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -29,7 +29,7 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     // --- data ---
     // ---
     /// The current term of the Raft node.
-    pub current_term: u64,
+    pub current_term: C::Term,
 
     /// The last flushed vote.
     pub vote: Vote<C>,
@@ -167,7 +167,7 @@ where C: RaftTypeConfig
             running_state: Ok(()),
             id,
 
-            current_term: 0,
+            current_term: Default::default(),
             vote: Vote::default(),
             last_log_index: None,
             last_applied: None,

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -253,7 +253,7 @@ where C: RaftTypeConfig {
         running_state: Ok(()),
         id: NodeIdOf::<C>::default(),
         state: ServerState::Learner,
-        current_term: 0,
+        current_term: Default::default(),
         vote: Vote::default(),
         last_log_index: None,
         last_applied: None,

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -114,6 +114,7 @@ use crate::Vote;
 ///        R            = ClientResponse,
 ///        NodeId       = u64,
 ///        Node         = openraft::BasicNode,
+///        Term         = u64,
 ///        Entry        = openraft::Entry<TypeConfig>,
 ///        SnapshotData = Cursor<Vec<u8>>,
 ///        Responder    = openraft::impls::OneshotResponder<TypeConfig>,
@@ -172,8 +173,9 @@ macro_rules! declare_raft_types {
                 (R            , , String                                ),
                 (NodeId       , , u64                                   ),
                 (Node         , , $crate::impls::BasicNode              ),
+                (Term         , , u64                                   ),
                 (Entry        , , $crate::impls::Entry<Self>            ),
-                (SnapshotData , , std::io::Cursor<Vec<u8>>                       ),
+                (SnapshotData , , std::io::Cursor<Vec<u8>>              ),
                 (Responder    , , $crate::impls::OneshotResponder<Self> ),
                 (AsyncRuntime , , $crate::impls::TokioRuntime           ),
             );

--- a/openraft/src/testing/common.rs
+++ b/openraft/src/testing/common.rs
@@ -9,16 +9,23 @@ use crate::RaftTypeConfig;
 
 /// Builds a log id, for testing purposes.
 pub fn log_id<C>(term: u64, node_id: C::NodeId, index: u64) -> LogId<C>
-where C: RaftTypeConfig {
+where
+    C: RaftTypeConfig,
+    C::Term: From<u64>,
+{
     LogId::<C> {
-        leader_id: CommittedLeaderId::new(term, node_id),
+        leader_id: CommittedLeaderId::new(term.into(), node_id),
         index,
     }
 }
 
 /// Create a blank log entry for test.
-pub fn blank_ent<C: RaftTypeConfig>(term: u64, node_id: C::NodeId, index: u64) -> crate::Entry<C> {
-    crate::Entry::<C>::new_blank(LogId::new(CommittedLeaderId::new(term, node_id), index))
+pub fn blank_ent<C>(term: u64, node_id: C::NodeId, index: u64) -> crate::Entry<C>
+where
+    C: RaftTypeConfig,
+    C::Term: From<u64>,
+{
+    crate::Entry::<C>::new_blank(log_id(term, node_id, index))
 }
 
 /// Create a membership log entry without learner config for test.
@@ -29,10 +36,11 @@ pub fn membership_ent<C: RaftTypeConfig>(
     config: Vec<BTreeSet<C::NodeId>>,
 ) -> crate::Entry<C>
 where
+    C::Term: From<u64>,
     C::Node: Default,
 {
     crate::Entry::new_membership(
-        LogId::new(CommittedLeaderId::new(term, node_id), index),
+        log_id(term, node_id, index),
         crate::Membership::new_with_defaults(config, []),
     )
 }

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -16,6 +16,7 @@ pub use util::TypeConfigExt;
 use crate::entry::FromAppData;
 use crate::entry::RaftEntry;
 use crate::raft::responder::Responder;
+use crate::vote::raft_term::RaftTerm;
 use crate::AppData;
 use crate::AppDataResponse;
 use crate::Node;
@@ -43,6 +44,7 @@ use crate::OptionalSync;
 ///        R            = ClientResponse,
 ///        NodeId       = u64,
 ///        Node         = openraft::BasicNode,
+///        Term         = u64,
 ///        Entry        = openraft::Entry<TypeConfig>,
 ///        SnapshotData = Cursor<Vec<u8>>,
 ///        AsyncRuntime = openraft::TokioRuntime,
@@ -66,6 +68,16 @@ pub trait RaftTypeConfig:
 
     /// Raft log entry, which can be built from an AppData.
     type Entry: RaftEntry<Self> + FromAppData<Self::D>;
+
+    /// Type representing a Raft term number.
+    ///
+    /// A term is a logical clock in Raft that is used to detect obsolete information,
+    /// such as old leaders. It must be totally ordered and monotonically increasing.
+    ///
+    /// Common implementations are provided for standard integer types like `u64`, `i64` etc.
+    ///
+    /// See: [`RaftTerm`] for the required methods.
+    type Term: RaftTerm;
 
     /// Snapshot data for exposing a snapshot for reading & writing.
     ///
@@ -106,6 +118,7 @@ pub mod alias {
     pub type ROf<C> = <C as RaftTypeConfig>::R;
     pub type NodeIdOf<C> = <C as RaftTypeConfig>::NodeId;
     pub type NodeOf<C> = <C as RaftTypeConfig>::Node;
+    pub type TermOf<C> = <C as RaftTypeConfig>::Term;
     pub type EntryOf<C> = <C as RaftTypeConfig>::Entry;
     pub type SnapshotDataOf<C> = <C as RaftTypeConfig>::SnapshotData;
     pub type AsyncRuntimeOf<C> = <C as RaftTypeConfig>::AsyncRuntime;

--- a/openraft/src/vote/leader_id/leader_id_adv.rs
+++ b/openraft/src/vote/leader_id/leader_id_adv.rs
@@ -17,18 +17,18 @@ use crate::RaftTypeConfig;
 pub struct LeaderId<C>
 where C: RaftTypeConfig
 {
-    pub term: u64,
+    pub term: C::Term,
     pub node_id: C::NodeId,
 }
 
 impl<C> LeaderId<C>
 where C: RaftTypeConfig
 {
-    pub fn new(term: u64, node_id: C::NodeId) -> Self {
+    pub fn new(term: C::Term, node_id: C::NodeId) -> Self {
         Self { term, node_id }
     }
 
-    pub fn get_term(&self) -> u64 {
+    pub fn get_term(&self) -> C::Term {
         self.term
     }
 

--- a/openraft/src/vote/leader_id/leader_id_std.rs
+++ b/openraft/src/vote/leader_id/leader_id_std.rs
@@ -10,7 +10,7 @@ use crate::RaftTypeConfig;
 pub struct LeaderId<C>
 where C: RaftTypeConfig
 {
-    pub term: u64,
+    pub term: C::Term,
 
     pub voted_for: Option<C::NodeId>,
 }
@@ -44,14 +44,14 @@ where C: RaftTypeConfig
 impl<C> LeaderId<C>
 where C: RaftTypeConfig
 {
-    pub fn new(term: u64, node_id: C::NodeId) -> Self {
+    pub fn new(term: C::Term, node_id: C::NodeId) -> Self {
         Self {
             term,
             voted_for: Some(node_id),
         }
     }
 
-    pub fn get_term(&self) -> u64 {
+    pub fn get_term(&self) -> C::Term {
         self.term
     }
 
@@ -84,8 +84,10 @@ where C: RaftTypeConfig
 #[derive(PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-pub struct CommittedLeaderId<C> {
-    pub term: u64,
+pub struct CommittedLeaderId<C>
+where C: RaftTypeConfig
+{
+    pub term: C::Term,
     p: PhantomData<C>,
 }
 
@@ -100,7 +102,7 @@ where C: RaftTypeConfig
 impl<C> CommittedLeaderId<C>
 where C: RaftTypeConfig
 {
-    pub fn new(term: u64, node_id: C::NodeId) -> Self {
+    pub fn new(term: C::Term, node_id: C::NodeId) -> Self {
         let _ = node_id;
         Self { term, p: PhantomData }
     }

--- a/openraft/src/vote/mod.rs
+++ b/openraft/src/vote/mod.rs
@@ -11,3 +11,5 @@ pub use leader_id::CommittedLeaderId;
 pub use leader_id::LeaderId;
 pub(crate) use non_committed::NonCommittedVote;
 pub use vote::Vote;
+
+pub mod raft_term;

--- a/openraft/src/vote/raft_term/mod.rs
+++ b/openraft/src/vote/raft_term/mod.rs
@@ -1,0 +1,21 @@
+mod raft_term_impls;
+
+use std::fmt::Debug;
+use std::fmt::Display;
+
+use crate::base::OptionalFeatures;
+
+/// Type representing a Raft term number.
+///
+/// A term is a logical clock in Raft that is used to detect obsolete information,
+/// such as old leaders. It must be totally ordered and monotonically increasing.
+///
+/// Common implementations are provided for standard integer types like `u64`, `i64` etc.
+pub trait RaftTerm
+where Self: OptionalFeatures + Ord + Debug + Display + Copy + Default + 'static
+{
+    /// Returns the next term.
+    ///
+    /// Must satisfy: `self < self.next()`
+    fn next(&self) -> Self;
+}

--- a/openraft/src/vote/raft_term/raft_term_impls.rs
+++ b/openraft/src/vote/raft_term/raft_term_impls.rs
@@ -1,0 +1,54 @@
+use crate::vote::raft_term::RaftTerm;
+
+macro_rules! impl_raft_term {
+    ($($t:ty),*) => {
+        $(
+            impl RaftTerm for $t {
+                fn next(&self) -> Self {
+                    self + 1
+                }
+            }
+        )*
+    }
+}
+
+impl_raft_term!(
+    u8, u16, u32, u64, u128, //
+    i8, i16, i32, i64, i128, //
+    usize, isize
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_raft_term_impls() {
+        // Test unsigned integers
+        assert_eq!(1_u8.next(), 2_u8);
+        assert_eq!(1_u16.next(), 2_u16);
+        assert_eq!(1_u32.next(), 2_u32);
+        assert_eq!(1_u64.next(), 2_u64);
+        assert_eq!(1_u128.next(), 2_u128);
+        assert_eq!(1_usize.next(), 2_usize);
+
+        // Test signed integers
+        assert_eq!(1_i8.next(), 2_i8);
+        assert_eq!(1_i16.next(), 2_i16);
+        assert_eq!(1_i32.next(), 2_i32);
+        assert_eq!(1_i64.next(), 2_i64);
+        assert_eq!(1_i128.next(), 2_i128);
+        assert_eq!(1_isize.next(), 2_isize);
+
+        // Test default values
+        assert_eq!(u8::default().next(), 1_u8);
+        assert_eq!(i8::default().next(), 1_i8);
+        assert_eq!(usize::default().next(), 1_usize);
+        assert_eq!(isize::default().next(), 1_isize);
+
+        // Test boundary cases
+        assert_eq!(254_u8.next(), 255_u8);
+        assert_eq!(126_i8.next(), 127_i8);
+        assert_eq!((-2_i8).next(), -1_i8);
+    }
+}

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -51,14 +51,14 @@ where C: RaftTypeConfig
 impl<C> Vote<C>
 where C: RaftTypeConfig
 {
-    pub fn new(term: u64, node_id: C::NodeId) -> Self {
+    pub fn new(term: C::Term, node_id: C::NodeId) -> Self {
         Self {
             leader_id: LeaderId::new(term, node_id),
             committed: false,
         }
     }
 
-    pub fn new_committed(term: u64, node_id: C::NodeId) -> Self {
+    pub fn new_committed(term: C::Term, node_id: C::NodeId) -> Self {
         Self {
             leader_id: LeaderId::new(term, node_id),
             committed: true,


### PR DESCRIPTION

## Changelog

##### Feature: Abstract Term

Add associated type `Term: RaftTerm` to `RaftTypeConfig` so that
application can customize the data type for Raft `term`.

By default `Term` is `u64` and user application does not need to modify
to upgrade.

- Part of #1278

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1284)
<!-- Reviewable:end -->
