### PR TITLE
Refactor: example raft-kv-rocksdb reuses example/rocksstore

### DIFF
--- a/examples/raft-kv-rocksdb/Cargo.toml
+++ b/examples/raft-kv-rocksdb/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/bin/main.rs"
 
 [dependencies]
 openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
+openraft-rocksstore = { path = "../rocksstore" }
 
 tokio = { version = "1.35.1", features = ["full"] }
 byteorder = "1.4.3"

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -1,24 +1,18 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::io::Cursor;
-use std::ops::RangeBounds;
 use std::path::Path;
 use std::sync::Arc;
 
-use byteorder::BigEndian;
-use byteorder::ReadBytesExt;
-use byteorder::WriteBytesExt;
-use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
 use openraft::AnyError;
 use openraft::EntryPayload;
 use openraft::ErrorVerb;
 use openraft::OptionalSend;
-use openraft::RaftLogReader;
 use openraft::RaftSnapshotBuilder;
+use openraft_rocksstore::log_store::RocksLogStore;
 use rocksdb::ColumnFamily;
 use rocksdb::ColumnFamilyDescriptor;
-use rocksdb::Direction;
 use rocksdb::Options;
 use rocksdb::DB;
 use serde::Deserialize;
@@ -249,219 +243,21 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct LogStore {
-    db: Arc<DB>,
-}
 type StorageResult<T> = Result<T, StorageError>;
 
-/// converts an id to a byte vector for storing in the database.
-/// Note that we're using big endian encoding to ensure correct sorting of keys
-fn id_to_bin(id: u64) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(8);
-    buf.write_u64::<BigEndian>(id).unwrap();
-    buf
-}
-
-fn bin_to_id(buf: &[u8]) -> u64 {
-    (&buf[0..8]).read_u64::<BigEndian>().unwrap()
-}
-
-impl LogStore {
-    fn store(&self) -> &ColumnFamily {
-        self.db.cf_handle("store").unwrap()
-    }
-
-    fn logs(&self) -> &ColumnFamily {
-        self.db.cf_handle("logs").unwrap()
-    }
-
-    fn flush(&self, subject: ErrorSubject, verb: ErrorVerb) -> Result<(), StorageError> {
-        self.db.flush_wal(true).map_err(|e| StorageError::new(subject, verb, AnyError::new(&e)))?;
-        Ok(())
-    }
-
-    fn get_last_purged_(&self) -> StorageResult<Option<LogId>> {
-        Ok(self
-            .db
-            .get_cf(self.store(), b"last_purged_log_id")
-            .map_err(|e| StorageError::read(&e))?
-            .and_then(|v| serde_json::from_slice(&v).ok()))
-    }
-
-    fn set_last_purged_(&self, log_id: LogId) -> StorageResult<()> {
-        self.db
-            .put_cf(
-                self.store(),
-                b"last_purged_log_id",
-                serde_json::to_vec(&log_id).unwrap().as_slice(),
-            )
-            .map_err(|e| StorageError::write(&e))?;
-
-        self.flush(ErrorSubject::Store, ErrorVerb::Write)?;
-        Ok(())
-    }
-
-    fn set_committed_(&self, committed: &Option<LogId>) -> Result<(), StorageError> {
-        let json = serde_json::to_vec(committed).unwrap();
-
-        self.db.put_cf(self.store(), b"committed", json).map_err(|e| StorageError::write(&e))?;
-
-        self.flush(ErrorSubject::Store, ErrorVerb::Write)?;
-        Ok(())
-    }
-
-    fn get_committed_(&self) -> StorageResult<Option<LogId>> {
-        Ok(self
-            .db
-            .get_cf(self.store(), b"committed")
-            .map_err(|e| StorageError::read(&e))?
-            .and_then(|v| serde_json::from_slice(&v).ok()))
-    }
-
-    fn set_vote_(&self, vote: &Vote) -> StorageResult<()> {
-        self.db
-            .put_cf(self.store(), b"vote", serde_json::to_vec(vote).unwrap())
-            .map_err(|e| StorageError::write_vote(&e))?;
-
-        self.flush(ErrorSubject::Vote, ErrorVerb::Write)?;
-        Ok(())
-    }
-
-    fn get_vote_(&self) -> StorageResult<Option<Vote>> {
-        Ok(self
-            .db
-            .get_cf(self.store(), b"vote")
-            .map_err(|e| StorageError::write_vote(&e))?
-            .and_then(|v| serde_json::from_slice(&v).ok()))
-    }
-}
-
-impl RaftLogReader<TypeConfig> for LogStore {
-    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend>(
-        &mut self,
-        range: RB,
-    ) -> StorageResult<Vec<Entry>> {
-        let start = match range.start_bound() {
-            std::ops::Bound::Included(x) => id_to_bin(*x),
-            std::ops::Bound::Excluded(x) => id_to_bin(*x + 1),
-            std::ops::Bound::Unbounded => id_to_bin(0),
-        };
-        self.db
-            .iterator_cf(self.logs(), rocksdb::IteratorMode::From(&start, Direction::Forward))
-            .map(|res| {
-                let (id, val) = res.unwrap();
-                let entry: StorageResult<Entry> = serde_json::from_slice(&val).map_err(|e| StorageError::read_logs(&e));
-                let id = bin_to_id(&id);
-
-                assert_eq!(Ok(id), entry.as_ref().map(|e| e.log_id.index));
-                (id, entry)
-            })
-            .take_while(|(id, _)| range.contains(id))
-            .map(|x| x.1)
-            .collect()
-    }
-
-    async fn read_vote(&mut self) -> Result<Option<Vote>, StorageError> {
-        self.get_vote_()
-    }
-}
-
-impl RaftLogStorage<TypeConfig> for LogStore {
-    type LogReader = Self;
-
-    async fn get_log_state(&mut self) -> StorageResult<LogState> {
-        let last = self.db.iterator_cf(self.logs(), rocksdb::IteratorMode::End).next().and_then(|res| {
-            let (_, ent) = res.unwrap();
-            Some(serde_json::from_slice::<Entry>(&ent).ok()?.log_id)
-        });
-
-        let last_purged_log_id = self.get_last_purged_()?;
-
-        let last_log_id = match last {
-            None => last_purged_log_id,
-            Some(x) => Some(x),
-        };
-        Ok(LogState {
-            last_purged_log_id,
-            last_log_id,
-        })
-    }
-
-    async fn save_committed(&mut self, _committed: Option<LogId>) -> Result<(), StorageError> {
-        self.set_committed_(&_committed)?;
-        Ok(())
-    }
-
-    async fn read_committed(&mut self) -> Result<Option<LogId>, StorageError> {
-        let c = self.get_committed_()?;
-        Ok(c)
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    async fn save_vote(&mut self, vote: &Vote) -> Result<(), StorageError> {
-        self.set_vote_(vote)
-    }
-
-    #[tracing::instrument(level = "trace", skip_all)]
-    async fn append<I>(&mut self, entries: I, callback: IOFlushed) -> StorageResult<()>
-    where
-        I: IntoIterator<Item = Entry> + Send,
-        I::IntoIter: Send,
-    {
-        for entry in entries {
-            let id = id_to_bin(entry.log_id.index);
-            assert_eq!(bin_to_id(&id), entry.log_id.index);
-            self.db
-                .put_cf(
-                    self.logs(),
-                    id,
-                    serde_json::to_vec(&entry).map_err(|e| StorageError::write_logs(&e))?,
-                )
-                .map_err(|e| StorageError::write_logs(&e))?;
-        }
-
-        callback.io_completed(Ok(()));
-
-        Ok(())
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn truncate(&mut self, log_id: LogId) -> StorageResult<()> {
-        tracing::debug!("delete_log: [{:?}, +oo)", log_id);
-
-        let from = id_to_bin(log_id.index);
-        let to = id_to_bin(0xff_ff_ff_ff_ff_ff_ff_ff);
-        self.db.delete_range_cf(self.logs(), &from, &to).map_err(|e| StorageError::write_logs(&e))
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
-    async fn purge(&mut self, log_id: LogId) -> Result<(), StorageError> {
-        tracing::debug!("delete_log: [0, {:?}]", log_id);
-
-        self.set_last_purged_(log_id)?;
-        let from = id_to_bin(0);
-        let to = id_to_bin(log_id.index + 1);
-        self.db.delete_range_cf(self.logs(), &from, &to).map_err(|e| StorageError::write_logs(&e))
-    }
-
-    async fn get_log_reader(&mut self) -> Self::LogReader {
-        self.clone()
-    }
-}
-
-pub(crate) async fn new_storage<P: AsRef<Path>>(db_path: P) -> (LogStore, StateMachineStore) {
+pub(crate) async fn new_storage<P: AsRef<Path>>(db_path: P) -> (RocksLogStore<TypeConfig>, StateMachineStore) {
     let mut db_opts = Options::default();
     db_opts.create_missing_column_families(true);
     db_opts.create_if_missing(true);
 
     let store = ColumnFamilyDescriptor::new("store", Options::default());
+    let meta = ColumnFamilyDescriptor::new("meta", Options::default());
     let logs = ColumnFamilyDescriptor::new("logs", Options::default());
 
-    let db = DB::open_cf_descriptors(&db_opts, db_path, vec![store, logs]).unwrap();
+    let db = DB::open_cf_descriptors(&db_opts, db_path, vec![store, meta, logs]).unwrap();
     let db = Arc::new(db);
 
-    let log_store = LogStore { db: db.clone() };
+    let log_store = RocksLogStore::new(db.clone());
     let sm_store = StateMachineStore::new(db).await.unwrap();
 
     (log_store, sm_store)

--- a/examples/rocksstore/Cargo.toml
+++ b/examples/rocksstore/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/databendlabs/openraft"
 openraft = { path= "../../openraft", version = "0.10.0", features=["serde", "type-alias"] }
 
 rocksdb = "0.22.0"
-rand = "*"
+rand = "0.8"
 byteorder = "1.4.3"
 
 serde = { version = "1.0.114", features = ["derive"] }

--- a/examples/rocksstore/src/log_store.rs
+++ b/examples/rocksstore/src/log_store.rs
@@ -1,0 +1,282 @@
+use std::error::Error;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::ops::RangeBounds;
+use std::sync::Arc;
+
+use byteorder::BigEndian;
+use byteorder::ReadBytesExt;
+use byteorder::WriteBytesExt;
+use meta::StoreMeta;
+use openraft::alias::EntryOf;
+use openraft::alias::LogIdOf;
+use openraft::alias::VoteOf;
+use openraft::storage::IOFlushed;
+use openraft::storage::RaftLogStorage;
+use openraft::LogState;
+use openraft::OptionalSend;
+use openraft::RaftLogId;
+use openraft::RaftLogReader;
+use openraft::RaftTypeConfig;
+use openraft::StorageError;
+use rocksdb::ColumnFamily;
+use rocksdb::Direction;
+use rocksdb::DB;
+
+#[derive(Debug, Clone)]
+pub struct RocksLogStore<C>
+where C: RaftTypeConfig
+{
+    db: Arc<DB>,
+    _p: PhantomData<C>,
+}
+
+impl<C> RocksLogStore<C>
+where C: RaftTypeConfig
+{
+    pub fn new(db: Arc<DB>) -> Self {
+        db.cf_handle("meta").expect("column family `meta` not found");
+        db.cf_handle("logs").expect("column family `logs` not found");
+
+        Self {
+            db,
+            _p: Default::default(),
+        }
+    }
+
+    fn cf_meta(&self) -> &ColumnFamily {
+        self.db.cf_handle("meta").unwrap()
+    }
+
+    fn cf_logs(&self) -> &ColumnFamily {
+        self.db.cf_handle("logs").unwrap()
+    }
+
+    /// Get a store metadata.
+    ///
+    /// It returns `None` if the store does not have such a metadata stored.
+    fn get_meta<M: StoreMeta<C>>(&self) -> Result<Option<M::Value>, StorageError<C>> {
+        let bytes = self.db.get_cf(self.cf_meta(), M::KEY).map_err(M::read_err)?;
+
+        let Some(bytes) = bytes else {
+            return Ok(None);
+        };
+
+        let t = serde_json::from_slice(&bytes).map_err(M::read_err)?;
+
+        Ok(Some(t))
+    }
+
+    /// Save a store metadata.
+    fn put_meta<M: StoreMeta<C>>(&self, value: &M::Value) -> Result<(), StorageError<C>> {
+        let json_value = serde_json::to_vec(value).map_err(|e| M::write_err(value, e))?;
+
+        self.db.put_cf(self.cf_meta(), M::KEY, json_value).map_err(|e| M::write_err(value, e))?;
+
+        Ok(())
+    }
+}
+
+impl<C> RaftLogReader<C> for RocksLogStore<C>
+where C: RaftTypeConfig
+{
+    async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend>(
+        &mut self,
+        range: RB,
+    ) -> Result<Vec<C::Entry>, StorageError<C>> {
+        let start = match range.start_bound() {
+            std::ops::Bound::Included(x) => id_to_bin(*x),
+            std::ops::Bound::Excluded(x) => id_to_bin(*x + 1),
+            std::ops::Bound::Unbounded => id_to_bin(0),
+        };
+
+        let mut res = Vec::new();
+
+        let it = self.db.iterator_cf(self.cf_logs(), rocksdb::IteratorMode::From(&start, Direction::Forward));
+        for item_res in it {
+            let (id, val) = item_res.map_err(read_logs_err)?;
+
+            let id = bin_to_id(&id);
+            if !range.contains(&id) {
+                break;
+            }
+
+            let entry: EntryOf<C> = serde_json::from_slice(&val).map_err(read_logs_err)?;
+
+            assert_eq!(id, entry.get_log_id().index);
+
+            res.push(entry);
+        }
+        Ok(res)
+    }
+
+    async fn read_vote(&mut self) -> Result<Option<VoteOf<C>>, StorageError<C>> {
+        self.get_meta::<meta::Vote>()
+    }
+}
+
+impl<C> RaftLogStorage<C> for RocksLogStore<C>
+where C: RaftTypeConfig
+{
+    type LogReader = Self;
+
+    async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C>> {
+        let last = self.db.iterator_cf(self.cf_logs(), rocksdb::IteratorMode::End).next();
+
+        let last_log_id = match last {
+            None => None,
+            Some(res) => {
+                let (_log_index, entry_bytes) = res.map_err(read_logs_err)?;
+                let ent = serde_json::from_slice::<EntryOf<C>>(&entry_bytes).map_err(read_logs_err)?;
+                Some(ent.get_log_id().clone())
+            }
+        };
+
+        let last_purged_log_id = self.get_meta::<meta::LastPurged>()?;
+
+        let last_log_id = match last_log_id {
+            None => last_purged_log_id.clone(),
+            Some(x) => Some(x),
+        };
+
+        Ok(LogState {
+            last_purged_log_id,
+            last_log_id,
+        })
+    }
+
+    async fn get_log_reader(&mut self) -> Self::LogReader {
+        self.clone()
+    }
+
+    async fn save_vote(&mut self, vote: &VoteOf<C>) -> Result<(), StorageError<C>> {
+        self.put_meta::<meta::Vote>(vote)?;
+        self.db.flush_wal(true).map_err(|e| StorageError::write_vote(&e))?;
+        Ok(())
+    }
+
+    async fn append<I>(&mut self, entries: I, callback: IOFlushed<C>) -> Result<(), StorageError<C>>
+    where I: IntoIterator<Item = EntryOf<C>> + Send {
+        for entry in entries {
+            let id = id_to_bin(entry.get_log_id().index);
+            assert_eq!(bin_to_id(&id), entry.get_log_id().index);
+            self.db
+                .put_cf(
+                    self.cf_logs(),
+                    id,
+                    serde_json::to_vec(&entry).map_err(|e| StorageError::write_logs(&e))?,
+                )
+                .map_err(|e| StorageError::write_logs(&e))?;
+        }
+
+        self.db.flush_wal(true).map_err(|e| StorageError::write_logs(&e))?;
+
+        // If there is error, the callback will be dropped.
+        callback.io_completed(Ok(()));
+        Ok(())
+    }
+
+    async fn truncate(&mut self, log_id: LogIdOf<C>) -> Result<(), StorageError<C>> {
+        tracing::debug!("truncate: [{:?}, +oo)", log_id);
+
+        let from = id_to_bin(log_id.index);
+        let to = id_to_bin(0xff_ff_ff_ff_ff_ff_ff_ff);
+        self.db.delete_range_cf(self.cf_logs(), &from, &to).map_err(|e| StorageError::write_logs(&e))?;
+
+        self.db.flush_wal(true).map_err(|e| StorageError::write_logs(&e))?;
+        Ok(())
+    }
+
+    async fn purge(&mut self, log_id: LogIdOf<C>) -> Result<(), StorageError<C>> {
+        tracing::debug!("delete_log: [0, {:?}]", log_id);
+
+        // Write the last-purged log id before purging the logs.
+        // The logs at and before last-purged log id will be ignored by openraft.
+        // Therefore, there is no need to do it in a transaction.
+        self.put_meta::<meta::LastPurged>(&log_id)?;
+
+        let from = id_to_bin(0);
+        let to = id_to_bin(log_id.index + 1);
+        self.db.delete_range_cf(self.cf_logs(), &from, &to).map_err(|e| StorageError::write_logs(&e))?;
+
+        // Purging does not need to be persistent.
+        Ok(())
+    }
+}
+
+/// Metadata of a raft-store.
+///
+/// In raft, except logs and state machine, the store also has to store several piece of metadata.
+/// This sub mod defines the key-value pairs of these metadata.
+mod meta {
+    use openraft::alias::LogIdOf;
+    use openraft::alias::VoteOf;
+    use openraft::AnyError;
+    use openraft::ErrorSubject;
+    use openraft::ErrorVerb;
+    use openraft::RaftTypeConfig;
+    use openraft::StorageError;
+
+    /// Defines metadata key and value
+    pub(crate) trait StoreMeta<C>
+    where C: RaftTypeConfig
+    {
+        /// The key used to store in rocksdb
+        const KEY: &'static str;
+
+        /// The type of the value to store
+        type Value: serde::Serialize + serde::de::DeserializeOwned;
+
+        /// The subject this meta belongs to, and will be embedded into the returned storage error.
+        fn subject(v: Option<&Self::Value>) -> ErrorSubject<C>;
+
+        fn read_err(e: impl std::error::Error + 'static) -> StorageError<C> {
+            StorageError::new(Self::subject(None), ErrorVerb::Read, AnyError::new(&e))
+        }
+
+        fn write_err(v: &Self::Value, e: impl std::error::Error + 'static) -> StorageError<C> {
+            StorageError::new(Self::subject(Some(v)), ErrorVerb::Write, AnyError::new(&e))
+        }
+    }
+
+    pub(crate) struct LastPurged {}
+    pub(crate) struct Vote {}
+
+    impl<C> StoreMeta<C> for LastPurged
+    where C: RaftTypeConfig
+    {
+        const KEY: &'static str = "last_purged_log_id";
+        type Value = LogIdOf<C>;
+
+        fn subject(_v: Option<&Self::Value>) -> ErrorSubject<C> {
+            ErrorSubject::Store
+        }
+    }
+    impl<C> StoreMeta<C> for Vote
+    where C: RaftTypeConfig
+    {
+        const KEY: &'static str = "vote";
+        type Value = VoteOf<C>;
+
+        fn subject(_v: Option<&Self::Value>) -> ErrorSubject<C> {
+            ErrorSubject::Vote
+        }
+    }
+}
+
+/// converts an id to a byte vector for storing in the database.
+/// Note that we're using big endian encoding to ensure correct sorting of keys
+fn id_to_bin(id: u64) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(8);
+    buf.write_u64::<BigEndian>(id).unwrap();
+    buf
+}
+
+fn bin_to_id(buf: &[u8]) -> u64 {
+    (&buf[0..8]).read_u64::<BigEndian>().unwrap()
+}
+
+fn read_logs_err<C>(e: impl Error + 'static) -> StorageError<C>
+where C: RaftTypeConfig {
+    StorageError::read_logs(&e)
+}

--- a/examples/rocksstore/src/test.rs
+++ b/examples/rocksstore/src/test.rs
@@ -3,14 +3,14 @@ use openraft::testing::log::Suite;
 use openraft::StorageError;
 use tempfile::TempDir;
 
-use crate::RocksLogStore;
+use crate::log_store::RocksLogStore;
 use crate::RocksStateMachine;
 use crate::TypeConfig;
 
 struct RocksBuilder {}
 
-impl StoreBuilder<TypeConfig, RocksLogStore, RocksStateMachine, TempDir> for RocksBuilder {
-    async fn build(&self) -> Result<(TempDir, RocksLogStore, RocksStateMachine), StorageError<TypeConfig>> {
+impl StoreBuilder<TypeConfig, RocksLogStore<TypeConfig>, RocksStateMachine, TempDir> for RocksBuilder {
+    async fn build(&self) -> Result<(TempDir, RocksLogStore<TypeConfig>, RocksStateMachine), StorageError<TypeConfig>> {
         let td = TempDir::new().expect("couldn't create temp dir");
         let (log_store, sm) = crate::new(td.path()).await;
         Ok((td, log_store, sm))

--- a/openraft/src/vote/raft_term/mod.rs
+++ b/openraft/src/vote/raft_term/mod.rs
@@ -3,6 +3,8 @@ mod raft_term_impls;
 use std::fmt::Debug;
 use std::fmt::Display;
 
+use openraft_macros::since;
+
 use crate::base::OptionalFeatures;
 
 /// Type representing a Raft term number.
@@ -11,6 +13,7 @@ use crate::base::OptionalFeatures;
 /// such as old leaders. It must be totally ordered and monotonically increasing.
 ///
 /// Common implementations are provided for standard integer types like `u64`, `i64` etc.
+#[since(version = "0.10.0")]
 pub trait RaftTerm
 where Self: OptionalFeatures + Ord + Debug + Display + Copy + Default + 'static
 {


### PR DESCRIPTION

## Changelog

##### Refactor: example raft-kv-rocksdb reuses example/rocksstore


##### Chore: add "since" doc to new trait RaftTerm

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1286)
<!-- Reviewable:end -->
