### PR TITLE
Chore: Replace `Vote<C>` with `VoteOf<C>`

### DIFF
--- a/examples/memstore/src/log_store.rs
+++ b/examples/memstore/src/log_store.rs
@@ -6,13 +6,13 @@ use std::fmt::Debug;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 
+use openraft::alias::VoteOf;
 use openraft::storage::IOFlushed;
 use openraft::LogId;
 use openraft::LogState;
 use openraft::RaftLogId;
 use openraft::RaftTypeConfig;
 use openraft::StorageError;
-use openraft::Vote;
 use tokio::sync::Mutex;
 
 /// RaftLogStore implementation with a in-memory storage
@@ -33,7 +33,7 @@ pub struct LogStoreInner<C: RaftTypeConfig> {
     committed: Option<LogId<C>>,
 
     /// The current granted vote.
-    vote: Option<Vote<C>>,
+    vote: Option<VoteOf<C>>,
 }
 
 impl<C: RaftTypeConfig> Default for LogStoreInner<C> {
@@ -84,12 +84,12 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
         Ok(self.committed.clone())
     }
 
-    async fn save_vote(&mut self, vote: &Vote<C>) -> Result<(), StorageError<C>> {
+    async fn save_vote(&mut self, vote: &VoteOf<C>) -> Result<(), StorageError<C>> {
         self.vote = Some(vote.clone());
         Ok(())
     }
 
-    async fn read_vote(&mut self) -> Result<Option<Vote<C>>, StorageError<C>> {
+    async fn read_vote(&mut self) -> Result<Option<VoteOf<C>>, StorageError<C>> {
         Ok(self.vote.clone())
     }
 
@@ -135,6 +135,7 @@ mod impl_log_store {
     use std::fmt::Debug;
     use std::ops::RangeBounds;
 
+    use openraft::alias::VoteOf;
     use openraft::storage::IOFlushed;
     use openraft::storage::RaftLogStorage;
     use openraft::LogId;
@@ -142,7 +143,6 @@ mod impl_log_store {
     use openraft::RaftLogReader;
     use openraft::RaftTypeConfig;
     use openraft::StorageError;
-    use openraft::Vote;
 
     use crate::log_store::LogStore;
 
@@ -157,7 +157,7 @@ mod impl_log_store {
             inner.try_get_log_entries(range).await
         }
 
-        async fn read_vote(&mut self) -> Result<Option<Vote<C>>, StorageError<C>> {
+        async fn read_vote(&mut self) -> Result<Option<VoteOf<C>>, StorageError<C>> {
             let mut inner = self.inner.lock().await;
             inner.read_vote().await
         }
@@ -183,7 +183,7 @@ mod impl_log_store {
             inner.read_committed().await
         }
 
-        async fn save_vote(&mut self, vote: &Vote<C>) -> Result<(), StorageError<C>> {
+        async fn save_vote(&mut self, vote: &VoteOf<C>) -> Result<(), StorageError<C>> {
             let mut inner = self.inner.lock().await;
             inner.save_vote(vote).await
         }

--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -7,11 +7,11 @@ use crate::raft_state::IOId;
 use crate::replication;
 use crate::replication::ReplicationSessionId;
 use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::VoteOf;
 use crate::vote::committed::CommittedVote;
 use crate::vote::non_committed::NonCommittedVote;
 use crate::RaftTypeConfig;
 use crate::StorageError;
-use crate::Vote;
 
 /// A message coming from the internal components.
 pub(crate) enum Notification<C>
@@ -33,7 +33,7 @@ where C: RaftTypeConfig
         target: C::NodeId,
 
         /// The higher vote observed.
-        higher: Vote<C>,
+        higher: VoteOf<C>,
 
         /// The Leader that sent replication request.
         leader_vote: CommittedVote<C>,

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -16,10 +16,10 @@ use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::SnapshotDataOf;
+use crate::type_config::alias::VoteOf;
 use crate::ChangeMembers;
 use crate::RaftState;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 pub(crate) mod external_command;
 
@@ -52,7 +52,7 @@ where C: RaftTypeConfig
     },
 
     InstallFullSnapshot {
-        vote: Vote<C>,
+        vote: VoteOf<C>,
         snapshot: Snapshot<C>,
         tx: ResultSender<C, SnapshotResponse<C>>,
     },
@@ -101,7 +101,7 @@ where C: RaftTypeConfig
     /// Otherwise, just reset Leader lease so that the node `to` can become Leader.
     HandleTransferLeader {
         /// The vote of the Leader that is transferring the leadership.
-        from: Vote<C>,
+        from: VoteOf<C>,
         /// The assigned node to be the next Leader.
         to: C::NodeId,
     },

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -21,11 +21,11 @@ use crate::raft_state::IOId;
 use crate::replication::request::Replicate;
 use crate::replication::ReplicationSessionId;
 use crate::type_config::alias::OneshotSenderOf;
+use crate::type_config::alias::VoteOf;
 use crate::vote::committed::CommittedVote;
 use crate::LogId;
 use crate::OptionalSend;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 /// Commands to send to `RaftRuntime` to execute, to update the application state.
 #[derive(Debug)]
@@ -112,7 +112,7 @@ where C: RaftTypeConfig
     },
 
     /// Save vote to storage
-    SaveVote { vote: Vote<C> },
+    SaveVote { vote: VoteOf<C> },
 
     /// Send vote to all other members
     SendVote { vote_req: VoteRequest<C> },

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -46,6 +46,7 @@ use crate::storage::Snapshot;
 use crate::storage::SnapshotMeta;
 use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::SnapshotDataOf;
+use crate::type_config::alias::VoteOf;
 use crate::type_config::TypeConfigExt;
 use crate::vote::RaftLeaderId;
 use crate::vote::RaftTerm;
@@ -113,7 +114,7 @@ where C: RaftTypeConfig
     ///
     /// The candidate `last_log_id` is initialized with the attributes of Acceptor part:
     /// [`RaftState`]
-    pub(crate) fn new_candidate(&mut self, vote: Vote<C>) -> &mut Candidate<C, LeaderQuorumSet<C>> {
+    pub(crate) fn new_candidate(&mut self, vote: VoteOf<C>) -> &mut Candidate<C, LeaderQuorumSet<C>> {
         let now = C::now();
         let last_log_id = self.state.last_log_id().cloned();
 
@@ -380,7 +381,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn handle_append_entries(
         &mut self,
-        vote: &Vote<C>,
+        vote: &VoteOf<C>,
         prev_log_id: Option<LogId<C>>,
         entries: Vec<C::Entry>,
         tx: Option<AppendEntriesTx<C>>,
@@ -419,7 +420,7 @@ where C: RaftTypeConfig
 
     pub(crate) fn append_entries(
         &mut self,
-        vote: &Vote<C>,
+        vote: &VoteOf<C>,
         prev_log_id: Option<LogId<C>>,
         entries: Vec<C::Entry>,
     ) -> Result<(), RejectAppendEntries<C>> {
@@ -453,7 +454,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn handle_install_full_snapshot(
         &mut self,
-        vote: Vote<C>,
+        vote: VoteOf<C>,
         snapshot: Snapshot<C>,
         tx: ResultSender<C, SnapshotResponse<C>>,
     ) {

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -17,13 +17,13 @@ use crate::proposer::CandidateState;
 use crate::proposer::LeaderState;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
+use crate::type_config::alias::VoteOf;
 use crate::type_config::TypeConfigExt;
 use crate::vote::RaftLeaderId;
 use crate::LogId;
 use crate::OptionalSend;
 use crate::RaftState;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 #[cfg(test)]
 mod accept_vote_test;
@@ -60,7 +60,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn accept_vote<T, E, F>(
         &mut self,
-        vote: &Vote<C>,
+        vote: &VoteOf<C>,
         tx: ResultSender<C, T, E>,
         f: F,
     ) -> Option<ResultSender<C, T, E>>
@@ -99,7 +99,7 @@ where C: RaftTypeConfig
     /// Note: This method does not check last-log-id. handle-vote-request has to deal with
     /// last-log-id itself.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn update_vote(&mut self, vote: &Vote<C>) -> Result<(), RejectVoteRequest<C>> {
+    pub(crate) fn update_vote(&mut self, vote: &VoteOf<C>) -> Result<(), RejectVoteRequest<C>> {
         // Partial ord compare:
         // Vote does not have to be total ord.
         // `!(a >= b)` does not imply `a < b`.

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -29,11 +29,11 @@ use crate::network::RPCTypes;
 use crate::raft::AppendEntriesResponse;
 use crate::raft_types::SnapshotSegmentId;
 use crate::try_as_ref::TryAsRef;
+use crate::type_config::alias::VoteOf;
 use crate::LogId;
 use crate::Membership;
 use crate::RaftTypeConfig;
 use crate::StorageError;
-use crate::Vote;
 
 /// RaftError is returned by API methods of `Raft`.
 ///
@@ -346,8 +346,8 @@ where
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 #[error("seen a higher vote: {higher} GT mine: {sender_vote}")]
 pub(crate) struct HigherVote<C: RaftTypeConfig> {
-    pub(crate) higher: Vote<C>,
-    pub(crate) sender_vote: Vote<C>,
+    pub(crate) higher: VoteOf<C>,
+    pub(crate) sender_vote: VoteOf<C>,
 }
 
 /// Error that indicates a **temporary** network error and when it is returned, Openraft will retry
@@ -603,7 +603,7 @@ pub struct LearnerNotFound<C: RaftTypeConfig> {
 #[error("not allowed to initialize due to current raft state: last_log_id: {last_log_id:?} vote: {vote}")]
 pub struct NotAllowed<C: RaftTypeConfig> {
     pub last_log_id: Option<LogId<C>>,
-    pub vote: Vote<C>,
+    pub vote: VoteOf<C>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -636,7 +636,7 @@ pub enum NoForward {}
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub(crate) enum RejectVoteRequest<C: RaftTypeConfig> {
     #[error("reject vote request by a greater vote: {0}")]
-    ByVote(Vote<C>),
+    ByVote(VoteOf<C>),
 
     #[allow(dead_code)]
     #[error("reject vote request by a greater last-log-id: {0:?}")]
@@ -659,7 +659,7 @@ where C: RaftTypeConfig
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum RejectAppendEntries<C: RaftTypeConfig> {
     #[error("reject AppendEntries by a greater vote: {0}")]
-    ByVote(Vote<C>),
+    ByVote(VoteOf<C>),
 
     #[error("reject AppendEntries because of conflicting log-id: {local:?}; expect to be: {expect:?}")]
     ByConflictingLogId { expect: LogId<C>, local: Option<LogId<C>> },

--- a/openraft/src/metrics/metric.rs
+++ b/openraft/src/metrics/metric.rs
@@ -1,11 +1,11 @@
 use std::cmp::Ordering;
 
 use crate::metrics::metric_display::MetricDisplay;
+use crate::type_config::alias::VoteOf;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::RaftMetrics;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 /// A metric entry of a Raft node.
 ///
@@ -15,7 +15,7 @@ pub enum Metric<C>
 where C: RaftTypeConfig
 {
     Term(C::Term),
-    Vote(Vote<C>),
+    Vote(VoteOf<C>),
     LastLogIndex(Option<u64>),
     Applied(Option<LogId<C>>),
     AppliedIndex(Option<u64>),

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -10,6 +10,7 @@ use crate::metrics::ReplicationMetrics;
 use crate::metrics::SerdeInstant;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::SerdeInstantOf;
+use crate::type_config::alias::VoteOf;
 use crate::Instant;
 use crate::LogId;
 use crate::RaftTypeConfig;
@@ -32,7 +33,7 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     pub current_term: C::Term,
 
     /// The last flushed vote.
-    pub vote: Vote<C>,
+    pub vote: VoteOf<C>,
 
     /// The last log index has been appended to this Raft node's log.
     pub last_log_index: Option<u64>,
@@ -280,7 +281,7 @@ where C: RaftTypeConfig
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct RaftServerMetrics<C: RaftTypeConfig> {
     pub id: C::NodeId,
-    pub vote: Vote<C>,
+    pub vote: VoteOf<C>,
     pub state: ServerState,
     pub current_leader: Option<C::NodeId>,
 

--- a/openraft/src/metrics/wait.rs
+++ b/openraft/src/metrics/wait.rs
@@ -8,12 +8,12 @@ use crate::core::ServerState;
 use crate::metrics::Condition;
 use crate::metrics::Metric;
 use crate::metrics::RaftMetrics;
+use crate::type_config::alias::VoteOf;
 use crate::type_config::alias::WatchReceiverOf;
 use crate::type_config::TypeConfigExt;
 use crate::LogId;
 use crate::OptionalSend;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 // Error variants related to metrics.
 #[derive(Debug, thiserror::Error)]
@@ -93,7 +93,7 @@ where C: RaftTypeConfig
 
     /// Wait for `vote` to become `want` or timeout.
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
-    pub async fn vote(&self, want: Vote<C>, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
+    pub async fn vote(&self, want: VoteOf<C>, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
         self.eq(Metric::Vote(want), msg).await
     }
 

--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -28,6 +28,7 @@ mod tokio_rt {
     use crate::raft::InstallSnapshotRequest;
     use crate::raft::SnapshotResponse;
     use crate::storage::Snapshot;
+    use crate::type_config::alias::VoteOf;
     use crate::type_config::TypeConfigExt;
     use crate::ErrorSubject;
     use crate::ErrorVerb;
@@ -37,7 +38,6 @@ mod tokio_rt {
     use crate::RaftTypeConfig;
     use crate::StorageError;
     use crate::ToStorageResult;
-    use crate::Vote;
 
     /// This chunk based implementation requires `SnapshotData` to be `AsyncRead + AsyncSeek`.
     impl<C: RaftTypeConfig> SnapshotTransport<C> for Chunked
@@ -45,7 +45,7 @@ mod tokio_rt {
     {
         async fn send_snapshot<Net>(
             net: &mut Net,
-            vote: Vote<C>,
+            vote: VoteOf<C>,
             mut snapshot: Snapshot<C>,
             mut cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
             option: RPCOption,
@@ -272,12 +272,12 @@ use crate::network::RPCOption;
 use crate::raft::InstallSnapshotRequest;
 use crate::raft::SnapshotResponse;
 use crate::storage::Snapshot;
+use crate::type_config::alias::VoteOf;
 use crate::OptionalSend;
 use crate::Raft;
 use crate::RaftNetwork;
 use crate::RaftTypeConfig;
 use crate::SnapshotId;
-use crate::Vote;
 
 /// Send and Receive snapshot by chunks.
 pub struct Chunked {}
@@ -299,7 +299,7 @@ pub trait SnapshotTransport<C: RaftTypeConfig> {
     // TODO: consider removing dependency on RaftNetwork
     async fn send_snapshot<Net>(
         net: &mut Net,
-        vote: Vote<C>,
+        vote: VoteOf<C>,
         snapshot: Snapshot<C>,
         cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         option: RPCOption,

--- a/openraft/src/network/v2/adapt_v1.rs
+++ b/openraft/src/network/v2/adapt_v1.rs
@@ -13,10 +13,10 @@ use crate::raft::SnapshotResponse;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::storage::Snapshot;
+use crate::type_config::alias::VoteOf;
 use crate::OptionalSend;
 use crate::RaftNetwork;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 impl<C, V1> RaftNetworkV2<C> for V1
 where
@@ -38,7 +38,7 @@ where
 
     async fn full_snapshot(
         &mut self,
-        vote: Vote<C>,
+        vote: VoteOf<C>,
         snapshot: Snapshot<C>,
         cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         option: RPCOption,

--- a/openraft/src/network/v2/network.rs
+++ b/openraft/src/network/v2/network.rs
@@ -18,10 +18,10 @@ use crate::raft::SnapshotResponse;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::storage::Snapshot;
+use crate::type_config::alias::VoteOf;
 use crate::OptionalSend;
 use crate::OptionalSync;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 /// A trait defining the interface for a Raft network between cluster members.
 ///
@@ -75,7 +75,7 @@ where C: RaftTypeConfig
     /// [`Raft::install_full_snapshot()`]: crate::raft::Raft::install_full_snapshot
     async fn full_snapshot(
         &mut self,
-        vote: Vote<C>,
+        vote: VoteOf<C>,
         snapshot: Snapshot<C>,
         cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         option: RPCOption,

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -9,9 +9,9 @@ use crate::proposer::Leader;
 use crate::quorum::QuorumSet;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::VoteOf;
 use crate::LogId;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 /// Candidate: voting state.
 #[derive(Clone, Debug)]
@@ -25,7 +25,7 @@ where
     starting_time: InstantOf<C>,
 
     /// The vote.
-    vote: Vote<C>,
+    vote: VoteOf<C>,
 
     last_log_id: Option<LogIdOf<C>>,
 
@@ -61,7 +61,7 @@ where
 {
     pub(crate) fn new(
         starting_time: InstantOf<C>,
-        vote: Vote<C>,
+        vote: VoteOf<C>,
         last_log_id: Option<LogIdOf<C>>,
         quorum_set: QS,
         learner_ids: impl IntoIterator<Item = C::NodeId>,
@@ -76,7 +76,7 @@ where
         }
     }
 
-    pub(crate) fn vote_ref(&self) -> &Vote<C> {
+    pub(crate) fn vote_ref(&self) -> &VoteOf<C> {
         &self.vote
     }
 

--- a/openraft/src/raft/message/append_entries.rs
+++ b/openraft/src/raft/message/append_entries.rs
@@ -2,9 +2,9 @@ use std::fmt;
 
 use crate::display_ext::DisplayOptionExt;
 use crate::display_ext::DisplaySlice;
+use crate::type_config::alias::VoteOf;
 use crate::LogId;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 /// An RPC sent by a cluster leader to replicate log entries (§5.3), and as a heartbeat (§5.2).
 ///
@@ -16,7 +16,7 @@ use crate::Vote;
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct AppendEntriesRequest<C: RaftTypeConfig> {
-    pub vote: Vote<C>,
+    pub vote: VoteOf<C>,
 
     pub prev_log_id: Option<LogId<C>>,
 
@@ -95,7 +95,7 @@ pub enum AppendEntriesResponse<C: RaftTypeConfig> {
     /// Seen a vote `v` that does not hold `mine_vote >= v`.
     /// And a leader's vote(committed vote) must be total order with other vote.
     /// Therefore it has to be a higher vote: `mine_vote < v`
-    HigherVote(Vote<C>),
+    HigherVote(VoteOf<C>),
 }
 
 impl<C> AppendEntriesResponse<C>

--- a/openraft/src/raft/message/install_snapshot.rs
+++ b/openraft/src/raft/message/install_snapshot.rs
@@ -1,15 +1,15 @@
 use std::fmt;
 
 use crate::storage::SnapshotMeta;
+use crate::type_config::alias::VoteOf;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 /// An RPC sent by the Raft leader to send chunks of a snapshot to a follower (§7).
 #[derive(Clone, Debug)]
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct InstallSnapshotRequest<C: RaftTypeConfig> {
-    pub vote: Vote<C>,
+    pub vote: VoteOf<C>,
 
     /// Metadata of a snapshot: snapshot_id, last_log_ed membership etc.
     pub meta: SnapshotMeta<C>,
@@ -44,7 +44,7 @@ impl<C: RaftTypeConfig> fmt::Display for InstallSnapshotRequest<C> {
 #[display("{{vote:{}}}", vote)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct InstallSnapshotResponse<C: RaftTypeConfig> {
-    pub vote: Vote<C>,
+    pub vote: VoteOf<C>,
 }
 
 /// The response to `Raft::install_full_snapshot` API.
@@ -54,11 +54,11 @@ pub struct InstallSnapshotResponse<C: RaftTypeConfig> {
 #[display("SnapshotResponse{{vote:{}}}", vote)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct SnapshotResponse<C: RaftTypeConfig> {
-    pub vote: Vote<C>,
+    pub vote: VoteOf<C>,
 }
 
 impl<C: RaftTypeConfig> SnapshotResponse<C> {
-    pub fn new(vote: Vote<C>) -> Self {
+    pub fn new(vote: VoteOf<C>) -> Self {
         Self { vote }
     }
 }

--- a/openraft/src/raft/message/transfer_leader.rs
+++ b/openraft/src/raft/message/transfer_leader.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 
 use crate::display_ext::DisplayOptionExt;
+use crate::type_config::alias::VoteOf;
 use crate::LogId;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 #[derive(Clone, Debug)]
 #[derive(PartialEq, Eq)]
@@ -12,7 +12,7 @@ pub struct TransferLeaderRequest<C>
 where C: RaftTypeConfig
 {
     /// The vote of the Leader that is transferring the leadership.
-    pub(crate) from_leader: Vote<C>,
+    pub(crate) from_leader: VoteOf<C>,
 
     /// The assigned node to be the next Leader.
     pub(crate) to_node_id: C::NodeId,
@@ -24,7 +24,7 @@ where C: RaftTypeConfig
 impl<C> TransferLeaderRequest<C>
 where C: RaftTypeConfig
 {
-    pub fn new(from: Vote<C>, to: C::NodeId, last_log_id: Option<LogId<C>>) -> Self {
+    pub fn new(from: VoteOf<C>, to: C::NodeId, last_log_id: Option<LogId<C>>) -> Self {
         Self {
             from_leader: from,
             to_node_id: to,
@@ -33,7 +33,7 @@ where C: RaftTypeConfig
     }
 
     /// From which Leader the leadership is transferred.
-    pub fn from_leader(&self) -> &Vote<C> {
+    pub fn from_leader(&self) -> &VoteOf<C> {
         &self.from_leader
     }
 

--- a/openraft/src/raft/message/vote.rs
+++ b/openraft/src/raft/message/vote.rs
@@ -2,15 +2,15 @@ use std::borrow::Borrow;
 use std::fmt;
 
 use crate::display_ext::DisplayOptionExt;
+use crate::type_config::alias::VoteOf;
 use crate::LogId;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 /// An RPC sent by candidates to gather votes (§5.2).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct VoteRequest<C: RaftTypeConfig> {
-    pub vote: Vote<C>,
+    pub vote: VoteOf<C>,
     pub last_log_id: Option<LogId<C>>,
 }
 
@@ -25,7 +25,7 @@ where C: RaftTypeConfig
 impl<C> VoteRequest<C>
 where C: RaftTypeConfig
 {
-    pub fn new(vote: Vote<C>, last_log_id: Option<LogId<C>>) -> Self {
+    pub fn new(vote: VoteOf<C>, last_log_id: Option<LogId<C>>) -> Self {
         Self { vote, last_log_id }
     }
 }
@@ -39,7 +39,7 @@ pub struct VoteResponse<C: RaftTypeConfig> {
     ///
     /// `vote` that equals the candidate.vote does not mean the vote is granted.
     /// The `vote` may be updated when a previous Leader sees a higher vote.
-    pub vote: Vote<C>,
+    pub vote: VoteOf<C>,
 
     /// It is true if a node accepted and saved the VoteRequest.
     pub vote_granted: bool,
@@ -51,7 +51,7 @@ pub struct VoteResponse<C: RaftTypeConfig> {
 impl<C> VoteResponse<C>
 where C: RaftTypeConfig
 {
-    pub fn new(vote: impl Borrow<Vote<C>>, last_log_id: Option<LogId<C>>, granted: bool) -> Self {
+    pub fn new(vote: impl Borrow<VoteOf<C>>, last_log_id: Option<LogId<C>>, granted: bool) -> Self {
         Self {
             vote: vote.borrow().clone(),
             vote_granted: granted,
@@ -61,7 +61,7 @@ where C: RaftTypeConfig
 
     /// Returns `true` if the response indicates that the target node has granted a vote to the
     /// candidate.
-    pub fn is_granted_to(&self, candidate_vote: &Vote<C>) -> bool {
+    pub fn is_granted_to(&self, candidate_vote: &VoteOf<C>) -> bool {
         &self.vote == candidate_vote
     }
 }

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -86,6 +86,7 @@ use crate::type_config::alias::JoinErrorOf;
 use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::ResponderReceiverOf;
 use crate::type_config::alias::SnapshotDataOf;
+use crate::type_config::alias::VoteOf;
 use crate::type_config::alias::WatchReceiverOf;
 use crate::type_config::TypeConfigExt;
 use crate::LogId;
@@ -96,7 +97,6 @@ use crate::RaftNetworkFactory;
 use crate::RaftState;
 pub use crate::RaftTypeConfig;
 use crate::StorageHelper;
-use crate::Vote;
 
 /// Define types for a Raft type configuration.
 ///
@@ -424,7 +424,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn install_full_snapshot(
         &self,
-        vote: Vote<C>,
+        vote: VoteOf<C>,
         snapshot: Snapshot<C>,
     ) -> Result<SnapshotResponse<C>, Fatal<C>> {
         tracing::info!("Raft::install_full_snapshot()");

--- a/openraft/src/raft_state/io_state.rs
+++ b/openraft/src/raft_state/io_state.rs
@@ -7,9 +7,9 @@ use validit::Validate;
 use crate::display_ext::DisplayOption;
 use crate::raft_state::io_state::io_progress::IOProgress;
 use crate::raft_state::IOId;
+use crate::type_config::alias::VoteOf;
 use crate::LogId;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 pub(crate) mod io_id;
 pub(crate) mod io_progress;
@@ -103,7 +103,7 @@ impl<C> IOState<C>
 where C: RaftTypeConfig
 {
     pub(crate) fn new(
-        vote: &Vote<C>,
+        vote: &VoteOf<C>,
         applied: Option<LogId<C>>,
         snapshot: Option<LogId<C>>,
         purged: Option<LogId<C>>,

--- a/openraft/src/raft_state/io_state/io_id.rs
+++ b/openraft/src/raft_state/io_state/io_id.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 use std::fmt;
 
 use crate::raft_state::io_state::log_io_id::LogIOId;
+use crate::type_config::alias::VoteOf;
 use crate::vote::committed::CommittedVote;
 use crate::vote::non_committed::NonCommittedVote;
 use crate::vote::ref_vote::RefVote;
@@ -9,7 +10,6 @@ use crate::ErrorSubject;
 use crate::ErrorVerb;
 use crate::LogId;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 /// An ID to uniquely identify a monotonic increasing io operation to [`RaftLogStorage`].
 ///
@@ -68,7 +68,7 @@ where C: RaftTypeConfig
 impl<C> IOId<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(vote: &Vote<C>) -> Self {
+    pub(crate) fn new(vote: &VoteOf<C>) -> Self {
         if vote.is_committed() {
             Self::new_log_io(vote.clone().into_committed(), None)
         } else {
@@ -87,7 +87,7 @@ where C: RaftTypeConfig
     /// Returns the vote the io operation is submitted by.
     #[allow(clippy::wrong_self_convention)]
     // The above lint is disabled because in future Vote may not be `Copy`
-    pub(crate) fn to_vote(&self) -> Vote<C> {
+    pub(crate) fn to_vote(&self) -> VoteOf<C> {
         match self {
             Self::Vote(non_committed_vote) => non_committed_vote.clone().into_vote(),
             Self::Log(log_io_id) => log_io_id.committed_vote.clone().into_vote(),

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -41,6 +41,7 @@ use crate::proposer::Leader;
 use crate::proposer::LeaderQuorumSet;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::VoteOf;
 use crate::vote::RaftLeaderId;
 
 /// A struct used to represent the raft state which a Raft node needs.
@@ -50,7 +51,7 @@ pub struct RaftState<C>
 where C: RaftTypeConfig
 {
     /// The vote state of this node.
-    pub(crate) vote: Leased<Vote<C>, InstantOf<C>>,
+    pub(crate) vote: Leased<VoteOf<C>, InstantOf<C>>,
 
     /// The LogId of the last log committed(AKA applied) to the state machine.
     ///
@@ -150,7 +151,7 @@ where C: RaftTypeConfig
 impl<C> VoteStateReader<C> for RaftState<C>
 where C: RaftTypeConfig
 {
-    fn vote_ref(&self) -> &Vote<C> {
+    fn vote_ref(&self) -> &VoteOf<C> {
         self.vote.deref()
     }
 }
@@ -188,7 +189,7 @@ impl<C> RaftState<C>
 where C: RaftTypeConfig
 {
     /// Get a reference to the current vote.
-    pub fn vote_ref(&self) -> &Vote<C> {
+    pub fn vote_ref(&self) -> &VoteOf<C> {
         self.vote.deref()
     }
 

--- a/openraft/src/raft_state/vote_state_reader.rs
+++ b/openraft/src/raft_state/vote_state_reader.rs
@@ -1,5 +1,5 @@
+use crate::type_config::alias::VoteOf;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 // TODO: remove it?
 /// APIs to get vote.
@@ -8,5 +8,5 @@ pub(crate) trait VoteStateReader<C>
 where C: RaftTypeConfig
 {
     /// Get a reference to the current vote.
-    fn vote_ref(&self) -> &Vote<C>;
+    fn vote_ref(&self) -> &VoteOf<C>;
 }

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -54,6 +54,7 @@ use crate::type_config::alias::MpscUnboundedWeakSenderOf;
 use crate::type_config::alias::MutexOf;
 use crate::type_config::alias::OneshotReceiverOf;
 use crate::type_config::alias::OneshotSenderOf;
+use crate::type_config::alias::VoteOf;
 use crate::type_config::async_runtime::mutex::Mutex;
 use crate::type_config::TypeConfigExt;
 use crate::vote::RaftLeaderId;
@@ -62,7 +63,6 @@ use crate::RaftLogId;
 use crate::RaftNetworkFactory;
 use crate::RaftTypeConfig;
 use crate::StorageError;
-use crate::Vote;
 
 /// The handle to a spawned replication stream.
 pub(crate) struct ReplicationHandle<C>
@@ -748,7 +748,7 @@ where
 
     async fn send_snapshot(
         network: Arc<MutexOf<C, N::Network>>,
-        vote: Vote<C>,
+        vote: VoteOf<C>,
         snapshot: Snapshot<C>,
         option: RPCOption,
         cancel: OneshotReceiverOf<C, ()>,

--- a/openraft/src/replication/replication_session_id.rs
+++ b/openraft/src/replication/replication_session_id.rs
@@ -2,10 +2,10 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 
 use crate::display_ext::DisplayOptionExt;
+use crate::type_config::alias::VoteOf;
 use crate::vote::committed::CommittedVote;
 use crate::LogId;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 /// Uniquely identifies a replication session.
 ///
@@ -68,7 +68,7 @@ where C: RaftTypeConfig
         self.leader_vote.clone()
     }
 
-    pub(crate) fn vote(&self) -> Vote<C> {
+    pub(crate) fn vote(&self) -> VoteOf<C> {
         self.leader_vote.clone().into_vote()
     }
 }

--- a/openraft/src/storage/v2/raft_log_reader.rs
+++ b/openraft/src/storage/v2/raft_log_reader.rs
@@ -6,12 +6,12 @@ use openraft_macros::add_async_trait;
 use openraft_macros::since;
 
 use crate::engine::LogIdList;
+use crate::type_config::alias::VoteOf;
 use crate::LogId;
 use crate::OptionalSend;
 use crate::OptionalSync;
 use crate::RaftTypeConfig;
 use crate::StorageError;
-use crate::Vote;
 /// A trait defining the interface for a Raft log subsystem.
 ///
 /// This interface is accessed read-only by replication sub task: `ReplicationCore`.
@@ -50,7 +50,7 @@ where C: RaftTypeConfig
     /// See: [log-stream](`crate::docs::protocol::replication::log_stream`)
     ///
     /// [`RaftLogStorage::save_vote`]: crate::storage::RaftLogStorage::save_vote
-    async fn read_vote(&mut self) -> Result<Option<Vote<C>>, StorageError<C>>;
+    async fn read_vote(&mut self) -> Result<Option<VoteOf<C>>, StorageError<C>>;
 
     /// Returns log entries within range `[start, end)`, `end` is exclusive,
     /// potentially limited by implementation-defined constraints.

--- a/openraft/src/storage/v2/raft_log_storage.rs
+++ b/openraft/src/storage/v2/raft_log_storage.rs
@@ -2,13 +2,13 @@ use openraft_macros::add_async_trait;
 
 use crate::storage::IOFlushed;
 use crate::storage::LogState;
+use crate::type_config::alias::VoteOf;
 use crate::LogId;
 use crate::OptionalSend;
 use crate::OptionalSync;
 use crate::RaftLogReader;
 use crate::RaftTypeConfig;
 use crate::StorageError;
-use crate::Vote;
 
 /// API for log store.
 ///
@@ -52,7 +52,7 @@ where C: RaftTypeConfig
     /// ### To ensure correctness:
     ///
     /// The vote must be persisted on disk before returning.
-    async fn save_vote(&mut self, vote: &Vote<C>) -> Result<(), StorageError<C>>;
+    async fn save_vote(&mut self, vote: &VoteOf<C>) -> Result<(), StorageError<C>>;
 
     /// Saves the last committed log id to storage.
     ///

--- a/openraft/src/storage/v2/raft_log_storage_ext.rs
+++ b/openraft/src/storage/v2/raft_log_storage_ext.rs
@@ -7,11 +7,11 @@ use crate::log_id::RaftLogId;
 use crate::raft_state::io_state::io_id::IOId;
 use crate::storage::IOFlushed;
 use crate::storage::RaftLogStorage;
+use crate::type_config::alias::VoteOf;
 use crate::type_config::TypeConfigExt;
 use crate::OptionalSend;
 use crate::RaftTypeConfig;
 use crate::StorageError;
-use crate::Vote;
 
 /// Extension trait for RaftLogStorage to provide utility methods.
 ///
@@ -34,7 +34,7 @@ where C: RaftTypeConfig
 
         let (tx, mut rx) = C::mpsc_unbounded();
 
-        let io_id = IOId::<C>::new_log_io(Vote::<C>::default().into_committed(), Some(last_log_id));
+        let io_id = IOId::<C>::new_log_io(VoteOf::<C>::default().into_committed(), Some(last_log_id));
         let notify = Notification::LocalIO { io_id };
 
         let callback = IOFlushed::<C>::new(notify, tx.downgrade());

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -23,6 +23,7 @@ use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
 use crate::storage::StorageHelper;
 use crate::testing::log::StoreBuilder;
+use crate::type_config::alias::VoteOf;
 use crate::type_config::TypeConfigExt;
 use crate::vote::RaftLeaderIdExt;
 use crate::LogId;
@@ -70,7 +71,7 @@ where C: RaftTypeConfig
     }
 
     /// Proxy method to invoke [`RaftLogReader::read_vote`].
-    async fn read_vote(&mut self) -> Result<Option<Vote<C>>, StorageError<C>> {
+    async fn read_vote(&mut self) -> Result<Option<VoteOf<C>>, StorageError<C>> {
         self.get_log_reader().await.read_vote().await
     }
 
@@ -1444,7 +1445,7 @@ where
     let (tx, mut rx) = C::mpsc_unbounded();
 
     // Dummy log io id for blocking append
-    let io_id = IOId::<C>::new_log_io(Vote::<C>::default().into_committed(), Some(last_log_id));
+    let io_id = IOId::<C>::new_log_io(VoteOf::<C>::default().into_committed(), Some(last_log_id));
     let notify = Notification::LocalIO { io_id };
     let cb = IOFlushed::new(notify, tx.downgrade());
 

--- a/openraft/src/vote/committed.rs
+++ b/openraft/src/vote/committed.rs
@@ -2,10 +2,10 @@ use std::cmp::Ordering;
 use std::fmt;
 
 use crate::type_config::alias::CommittedLeaderIdOf;
+use crate::type_config::alias::VoteOf;
 use crate::vote::ref_vote::RefVote;
 use crate::vote::RaftLeaderId;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 /// Represents a committed Vote that has been accepted by a quorum.
 ///
@@ -16,7 +16,7 @@ use crate::Vote;
 pub(crate) struct CommittedVote<C>
 where C: RaftTypeConfig
 {
-    vote: Vote<C>,
+    vote: VoteOf<C>,
 }
 
 /// The `CommittedVote` is totally ordered.
@@ -37,7 +37,7 @@ where C: RaftTypeConfig
 impl<C> CommittedVote<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(mut vote: Vote<C>) -> Self {
+    pub(crate) fn new(mut vote: VoteOf<C>) -> Self {
         vote.committed = true;
         Self { vote }
     }
@@ -46,7 +46,7 @@ where C: RaftTypeConfig
         self.vote.leader_id().to_committed()
     }
 
-    pub(crate) fn into_vote(self) -> Vote<C> {
+    pub(crate) fn into_vote(self) -> VoteOf<C> {
         self.vote
     }
 

--- a/openraft/src/vote/non_committed.rs
+++ b/openraft/src/vote/non_committed.rs
@@ -1,9 +1,9 @@
 use std::fmt;
 
 use crate::type_config::alias::LeaderIdOf;
+use crate::type_config::alias::VoteOf;
 use crate::vote::ref_vote::RefVote;
 use crate::RaftTypeConfig;
-use crate::Vote;
 
 /// Represents a non-committed Vote that has **NOT** been granted by a quorum.
 ///
@@ -14,13 +14,13 @@ use crate::Vote;
 pub(crate) struct NonCommittedVote<C>
 where C: RaftTypeConfig
 {
-    vote: Vote<C>,
+    vote: VoteOf<C>,
 }
 
 impl<C> NonCommittedVote<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(vote: Vote<C>) -> Self {
+    pub(crate) fn new(vote: VoteOf<C>) -> Self {
         debug_assert!(!vote.committed);
         Self { vote }
     }
@@ -29,7 +29,7 @@ where C: RaftTypeConfig
         &self.vote.leader_id
     }
 
-    pub(crate) fn into_vote(self) -> Vote<C> {
+    pub(crate) fn into_vote(self) -> VoteOf<C> {
         self.vote
     }
 


### PR DESCRIPTION

## Changelog

##### Chore: Replace `Vote<C>` with `VoteOf<C>`

Introduce the type alias `VoteOf<C>` to simplify future migration from the
fixed type `Vote<C>` to an associated type `C::Vote`.

By defining `VoteOf<C> = Vote<C>` now,
and later updating it to `VoteOf<C> = C::Vote`,
the migration can be handled with minimal code changes, avoiding
large-scale modifications in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1291)
<!-- Reviewable:end -->
