### PR TITLE
Change: refine the `RaftEntry` trait

### DIFF
--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use openraft::alias::LogIdOf;
 use openraft::alias::SnapshotDataOf;
+use openraft::entry::RaftEntryExt;
 use openraft::storage::IOFlushed;
 use openraft::storage::LogState;
 use openraft::storage::RaftLogReader;
@@ -20,7 +21,6 @@ use openraft::storage::Snapshot;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::OptionalSend;
-use openraft::RaftLogId;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StoredMembership;
@@ -188,7 +188,7 @@ impl RaftLogStorage<TypeConfig> for Arc<LogStore> {
 
         let last = match last_serialized {
             None => None,
-            Some(ent) => Some(*ent.get_log_id()),
+            Some(ent) => Some(ent.to_log_id()),
         };
 
         let last_purged = self.last_purged_log_id.read().await.clone();
@@ -237,7 +237,7 @@ impl RaftLogStorage<TypeConfig> for Arc<LogStore> {
     where I: IntoIterator<Item = Entry<TypeConfig>> + Send {
         {
             let mut log = self.log.write().await;
-            log.extend(entries.into_iter().map(|entry| (entry.get_log_id().index, entry)));
+            log.extend(entries.into_iter().map(|entry| (entry.index(), entry)));
         }
         callback.io_completed(Ok(()));
         Ok(())

--- a/examples/memstore/src/log_store.rs
+++ b/examples/memstore/src/log_store.rs
@@ -8,9 +8,9 @@ use std::sync::Arc;
 
 use openraft::alias::LogIdOf;
 use openraft::alias::VoteOf;
+use openraft::entry::RaftEntryExt;
 use openraft::storage::IOFlushed;
 use openraft::LogState;
-use openraft::RaftLogId;
 use openraft::RaftTypeConfig;
 use openraft::StorageError;
 use tokio::sync::Mutex;
@@ -60,7 +60,7 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
     }
 
     async fn get_log_state(&mut self) -> Result<LogState<C>, StorageError<C>> {
-        let last = self.log.iter().next_back().map(|(_, ent)| ent.get_log_id().clone());
+        let last = self.log.iter().next_back().map(|(_, ent)| ent.to_log_id());
 
         let last_purged = self.last_purged_log_id.clone();
 
@@ -97,7 +97,7 @@ impl<C: RaftTypeConfig> LogStoreInner<C> {
     where I: IntoIterator<Item = C::Entry> {
         // Simple implementation that calls the flush-before-return `append_to_log`.
         for entry in entries {
-            self.log.insert(entry.get_log_id().index, entry);
+            self.log.insert(entry.to_log_id().index, entry);
         }
         callback.io_completed(Ok(()));
 

--- a/examples/rocksstore/src/lib.rs
+++ b/examples/rocksstore/src/lib.rs
@@ -18,13 +18,13 @@ use std::sync::Arc;
 
 use log_store::RocksLogStore;
 use openraft::alias::SnapshotDataOf;
+use openraft::entry::RaftEntryExt;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use openraft::AnyError;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
-use openraft::RaftLogId;
 use openraft::RaftSnapshotBuilder;
 use openraft::RaftTypeConfig;
 use openraft::SnapshotMeta;
@@ -179,7 +179,7 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
         for entry in entries_iter {
             tracing::debug!(%entry.log_id, "replicate to sm");
 
-            sm.last_applied_log = Some(*entry.get_log_id());
+            sm.last_applied_log = Some(entry.to_log_id());
 
             match entry.payload {
                 EntryPayload::Blank => res.push(RocksResponse { value: None }),

--- a/examples/rocksstore/src/log_store.rs
+++ b/examples/rocksstore/src/log_store.rs
@@ -11,11 +11,11 @@ use meta::StoreMeta;
 use openraft::alias::EntryOf;
 use openraft::alias::LogIdOf;
 use openraft::alias::VoteOf;
+use openraft::entry::RaftEntryExt;
 use openraft::storage::IOFlushed;
 use openraft::storage::RaftLogStorage;
 use openraft::LogState;
 use openraft::OptionalSend;
-use openraft::RaftLogId;
 use openraft::RaftLogReader;
 use openraft::RaftTypeConfig;
 use openraft::StorageError;
@@ -103,7 +103,7 @@ where C: RaftTypeConfig
 
             let entry: EntryOf<C> = serde_json::from_slice(&val).map_err(read_logs_err)?;
 
-            assert_eq!(id, entry.get_log_id().index);
+            assert_eq!(id, entry.index());
 
             res.push(entry);
         }
@@ -128,7 +128,7 @@ where C: RaftTypeConfig
             Some(res) => {
                 let (_log_index, entry_bytes) = res.map_err(read_logs_err)?;
                 let ent = serde_json::from_slice::<EntryOf<C>>(&entry_bytes).map_err(read_logs_err)?;
-                Some(ent.get_log_id().clone())
+                Some(ent.to_log_id())
             }
         };
 
@@ -158,8 +158,8 @@ where C: RaftTypeConfig
     async fn append<I>(&mut self, entries: I, callback: IOFlushed<C>) -> Result<(), StorageError<C>>
     where I: IntoIterator<Item = EntryOf<C>> + Send {
         for entry in entries {
-            let id = id_to_bin(entry.get_log_id().index);
-            assert_eq!(bin_to_id(&id), entry.get_log_id().index);
+            let id = id_to_bin(entry.index());
+            assert_eq!(bin_to_id(&id), entry.index());
             self.db
                 .put_cf(
                     self.cf_logs(),

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -43,8 +43,8 @@ use crate::engine::Condition;
 use crate::engine::Engine;
 use crate::engine::ReplicationProgress;
 use crate::engine::Respond;
-use crate::entry::FromAppData;
 use crate::entry::RaftEntry;
+use crate::entry::RaftEntryExt;
 use crate::error::AllowNextRevertError;
 use crate::error::ClientWriteError;
 use crate::error::Fatal;
@@ -55,7 +55,6 @@ use crate::error::QuorumNotEnough;
 use crate::error::RPCError;
 use crate::error::Timeout;
 use crate::log_id::LogIdOptionExt;
-use crate::log_id::RaftLogId;
 use crate::metrics::HeartbeatMetrics;
 use crate::metrics::RaftDataMetrics;
 use crate::metrics::RaftMetrics;
@@ -1246,7 +1245,7 @@ where
                 self.handle_check_is_leader_request(tx).await;
             }
             RaftMsg::ClientWriteRequest { app_data, tx } => {
-                self.write_entry(C::Entry::from_app_data(app_data), Some(tx));
+                self.write_entry(C::Entry::new_normal(Default::default(), app_data), Some(tx));
             }
             RaftMsg::Initialize { members, tx } => {
                 tracing::info!(
@@ -1746,7 +1745,7 @@ where
                 committed_vote: vote,
                 entries,
             } => {
-                let last_log_id = entries.last().unwrap().get_log_id();
+                let last_log_id = entries.last().unwrap().log_id();
                 tracing::debug!("AppendInputEntries: {}", DisplaySlice::<_>(&entries),);
 
                 let io_id = IOId::new_log_io(vote, Some(last_log_id.clone()));

--- a/openraft/src/core/sm/worker.rs
+++ b/openraft/src/core/sm/worker.rs
@@ -15,6 +15,7 @@ use crate::core::ApplyResult;
 use crate::core::ApplyingEntry;
 use crate::display_ext::DisplayOptionExt;
 use crate::display_ext::DisplaySliceExt;
+use crate::entry::RaftEntryExt;
 use crate::entry::RaftPayload;
 use crate::storage::RaftStateMachine;
 use crate::storage::Snapshot;
@@ -23,7 +24,6 @@ use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::MpscUnboundedReceiverOf;
 use crate::type_config::alias::MpscUnboundedSenderOf;
 use crate::type_config::TypeConfigExt;
-use crate::RaftLogId;
 use crate::RaftLogReader;
 use crate::RaftSnapshotBuilder;
 use crate::RaftTypeConfig;
@@ -186,7 +186,7 @@ where
         #[allow(clippy::needless_collect)]
         let applying_entries = entries
             .iter()
-            .map(|e| ApplyingEntry::new(e.get_log_id().clone(), e.get_membership().cloned()))
+            .map(|e| ApplyingEntry::new(e.to_log_id(), e.get_membership().cloned()))
             .collect::<Vec<_>>();
 
         let n_entries = end - since;

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -23,6 +23,7 @@ use crate::engine::Condition;
 use crate::engine::EngineOutput;
 use crate::engine::Respond;
 use crate::entry::RaftEntry;
+use crate::entry::RaftEntryExt;
 use crate::entry::RaftPayload;
 use crate::error::ForwardToLeader;
 use crate::error::Infallible;
@@ -57,7 +58,6 @@ use crate::vote::RaftTerm;
 use crate::vote::RaftVote;
 use crate::LogIdOptionExt;
 use crate::Membership;
-use crate::RaftLogId;
 use crate::RaftTypeConfig;
 
 /// Raft protocol algorithm.

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -2,6 +2,7 @@ use crate::engine::handler::replication_handler::ReplicationHandler;
 use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
+use crate::entry::RaftEntryExt;
 use crate::entry::RaftPayload;
 use crate::proposer::Leader;
 use crate::proposer::LeaderQuorumSet;
@@ -10,7 +11,6 @@ use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
 use crate::replication::ReplicationSessionId;
 use crate::type_config::alias::LogIdOf;
-use crate::RaftLogId;
 use crate::RaftState;
 use crate::RaftTypeConfig;
 
@@ -67,7 +67,7 @@ where C: RaftTypeConfig
                     membership_entry.is_none(),
                     "only one membership entry is allowed in a batch"
                 );
-                membership_entry = Some((entry.get_log_id().clone(), m.clone()));
+                membership_entry = Some((entry.to_log_id(), m.clone()));
             }
         }
 

--- a/openraft/src/engine/log_id_list.rs
+++ b/openraft/src/engine/log_id_list.rs
@@ -130,13 +130,13 @@ where C: RaftTypeConfig
     /// Extends a list of `log_id` that are proposed by a same leader.
     ///
     /// The log ids in the input has to be continuous.
-    pub(crate) fn extend_from_same_leader<'a, LID: RaftLogId<C> + 'a>(&mut self, new_ids: &[LID]) {
+    pub(crate) fn extend_from_same_leader<'a, LID: AsRef<LogIdOf<C>> + 'a>(&mut self, new_ids: &[LID]) {
         if let Some(first) = new_ids.first() {
-            let first_id = first.get_log_id();
+            let first_id = first.as_ref();
             self.append(first_id.clone());
 
             if let Some(last) = new_ids.last() {
-                let last_id = last.get_log_id();
+                let last_id = last.as_ref();
                 assert_eq!(last_id.leader_id, first_id.leader_id);
 
                 if last_id != first_id {
@@ -149,11 +149,11 @@ where C: RaftTypeConfig
     /// Extends a list of `log_id`.
     // leader_id: Copy is feature gated
     #[allow(clippy::clone_on_copy)]
-    pub(crate) fn extend<'a, LID: RaftLogId<C> + 'a>(&mut self, new_ids: &[LID]) {
+    pub(crate) fn extend<'a, LID: AsRef<LogIdOf<C>> + 'a>(&mut self, new_ids: &[LID]) {
         let mut prev = self.last().map(|x| x.leader_id.clone());
 
         for x in new_ids.iter() {
-            let log_id = x.get_log_id();
+            let log_id = x.as_ref();
 
             if prev.as_ref() != Some(&log_id.leader_id) {
                 self.append(log_id.clone());
@@ -163,7 +163,7 @@ where C: RaftTypeConfig
         }
 
         if let Some(last) = new_ids.last() {
-            let log_id = last.get_log_id();
+            let log_id = last.as_ref();
 
             if self.last() != Some(log_id) {
                 self.append(log_id.clone());

--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -59,6 +59,22 @@ where C: RaftTypeConfig
     }
 }
 
+impl<C> AsRef<LogId<C>> for LogId<C>
+where C: RaftTypeConfig
+{
+    fn as_ref(&self) -> &LogId<C> {
+        self
+    }
+}
+
+impl<C> AsMut<LogId<C>> for LogId<C>
+where C: RaftTypeConfig
+{
+    fn as_mut(&mut self) -> &mut LogId<C> {
+        self
+    }
+}
+
 impl<C> LogId<C>
 where C: RaftTypeConfig
 {

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -12,7 +12,6 @@ use crate::type_config::TypeConfigExt;
 use crate::vote::committed::CommittedVote;
 use crate::vote::raft_vote::RaftVoteExt;
 use crate::LogIdOptionExt;
-use crate::RaftLogId;
 use crate::RaftTypeConfig;
 
 /// Leading state data.
@@ -162,7 +161,7 @@ where
     /// Assign log ids to the entries.
     ///
     /// This method update the `self.last_log_id`.
-    pub(crate) fn assign_log_ids<'a, LID: RaftLogId<C> + 'a>(
+    pub(crate) fn assign_log_ids<'a, LID: AsMut<LogIdOf<C>> + 'a>(
         &mut self,
         entries: impl IntoIterator<Item = &'a mut LID>,
     ) {
@@ -174,7 +173,7 @@ where
         let mut last = first.clone();
 
         for entry in entries {
-            entry.set_log_id(&last);
+            *entry.as_mut() = last.clone();
             tracing::debug!("assign log id: {}", last);
             last.index += 1;
         }
@@ -227,6 +226,7 @@ mod tests {
     use crate::engine::leader_log_ids::LeaderLogIds;
     use crate::engine::testing::UTConfig;
     use crate::entry::RaftEntry;
+    use crate::entry::RaftEntryExt;
     use crate::progress::Progress;
     use crate::proposer::Leader;
     use crate::testing::blank_ent;
@@ -234,7 +234,6 @@ mod tests {
     use crate::type_config::TypeConfigExt;
     use crate::vote::raft_vote::RaftVoteExt;
     use crate::Entry;
-    use crate::RaftLogId;
     use crate::Vote;
 
     #[test]
@@ -297,7 +296,7 @@ mod tests {
         leader.assign_log_ids(&mut entries);
 
         assert_eq!(
-            entries[0].get_log_id(),
+            entries[0].log_id(),
             &log_id(2, 2, 4),
             "entry log id assigned following last-log-id"
         );
@@ -312,7 +311,7 @@ mod tests {
         let mut entries: Vec<Entry<UTConfig>> = vec![blank_ent(1, 1, 1)];
         leading.assign_log_ids(&mut entries);
 
-        assert_eq!(entries[0].get_log_id(), &log_id(0, 0, 0),);
+        assert_eq!(entries[0].log_id(), &log_id(0, 0, 0),);
         assert_eq!(Some(log_id(0, 0, 0)), leading.last_log_id);
     }
 
@@ -336,9 +335,9 @@ mod tests {
         let mut entries: Vec<Entry<UTConfig>> = vec![blank_ent(1, 1, 1), blank_ent(1, 1, 1), blank_ent(1, 1, 1)];
 
         leading.assign_log_ids(&mut entries);
-        assert_eq!(entries[0].get_log_id(), &log_id(2, 2, 9));
-        assert_eq!(entries[1].get_log_id(), &log_id(2, 2, 10));
-        assert_eq!(entries[2].get_log_id(), &log_id(2, 2, 11));
+        assert_eq!(entries[0].log_id(), &log_id(2, 2, 9));
+        assert_eq!(entries[1].log_id(), &log_id(2, 2, 10));
+        assert_eq!(entries[2].log_id(), &log_id(2, 2, 11));
         assert_eq!(Some(log_id(2, 2, 11)), leading.last_log_id);
     }
 

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -6,7 +6,6 @@ use validit::Validate;
 
 use crate::engine::LogIdList;
 use crate::error::ForwardToLeader;
-use crate::log_id::RaftLogId;
 use crate::storage::SnapshotMeta;
 use crate::utime::Leased;
 use crate::LogIdOptionExt;
@@ -255,11 +254,11 @@ where C: RaftTypeConfig
     /// Append a list of `log_id`.
     ///
     /// The log ids in the input has to be continuous.
-    pub(crate) fn extend_log_ids_from_same_leader<'a, LID: RaftLogId<C> + 'a>(&mut self, new_log_ids: &[LID]) {
+    pub(crate) fn extend_log_ids_from_same_leader<'a, LID: AsRef<LogIdOf<C>> + 'a>(&mut self, new_log_ids: &[LID]) {
         self.log_ids.extend_from_same_leader(new_log_ids)
     }
 
-    pub(crate) fn extend_log_ids<'a, LID: RaftLogId<C> + 'a>(&mut self, new_log_id: &[LID]) {
+    pub(crate) fn extend_log_ids<'a, LID: AsRef<LogIdOf<C>> + 'a>(&mut self, new_log_id: &[LID]) {
         self.log_ids.extend(new_log_id)
     }
 
@@ -300,11 +299,11 @@ where C: RaftTypeConfig
     /// Find the first entry in the input that does not exist on local raft-log,
     /// by comparing the log id.
     pub(crate) fn first_conflicting_index<Ent>(&self, entries: &[Ent]) -> usize
-    where Ent: RaftLogId<C> {
+    where Ent: AsRef<LogIdOf<C>> {
         let l = entries.len();
 
         for (i, ent) in entries.iter().enumerate() {
-            let log_id = ent.get_log_id();
+            let log_id = ent.as_ref();
 
             if !self.has_log_id(log_id) {
                 tracing::debug!(

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -27,6 +27,7 @@ use crate::core::notification::Notification;
 use crate::core::sm::handle::SnapshotReader;
 use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplayOptionExt;
+use crate::entry::RaftEntryExt;
 use crate::error::HigherVote;
 use crate::error::PayloadTooLarge;
 use crate::error::RPCError;
@@ -59,7 +60,6 @@ use crate::type_config::alias::VoteOf;
 use crate::type_config::async_runtime::mutex::Mutex;
 use crate::type_config::TypeConfigExt;
 use crate::vote::raft_vote::RaftVoteExt;
-use crate::RaftLogId;
 use crate::RaftNetworkFactory;
 use crate::RaftTypeConfig;
 use crate::StorageError;
@@ -398,8 +398,8 @@ where
                 // limited_get_log_entries will return logs smaller than the range [start, end).
                 let logs = self.log_reader.limited_get_log_entries(start, end).await?;
 
-                let first = logs.first().map(|x| x.get_log_id()).unwrap();
-                let last = logs.last().map(|x| x.get_log_id().clone()).unwrap();
+                let first = logs.first().map(|x| x.log_id()).unwrap();
+                let last = logs.last().map(|x| x.to_log_id()).unwrap();
 
                 debug_assert!(
                     !logs.is_empty() && logs.len() <= (end - start) as usize,

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -7,6 +7,7 @@ use validit::Valid;
 
 use crate::display_ext::DisplayOptionExt;
 use crate::engine::LogIdList;
+use crate::entry::RaftEntryExt;
 use crate::entry::RaftPayload;
 use crate::log_id::RaftLogId;
 use crate::raft_state::IOState;
@@ -193,8 +194,8 @@ where
             let chunk_end = std::cmp::min(end, start + chunk_size);
             let entries = log_reader.try_get_log_entries(start..chunk_end).await?;
 
-            let first = entries.first().map(|x| x.get_log_id().index);
-            let last = entries.last().map(|x| x.get_log_id().index);
+            let first = entries.first().map(|x| x.index());
+            let last = entries.last().map(|x| x.index());
 
             let make_err = || {
                 let err = AnyError::error(format!(
@@ -299,7 +300,7 @@ where
 
             for ent in entries.iter().rev() {
                 if let Some(mem) = ent.get_membership() {
-                    let em = StoredMembership::new(Some(ent.get_log_id().clone()), mem.clone());
+                    let em = StoredMembership::new(Some(ent.to_log_id()), mem.clone());
                     res.insert(0, em);
                     if res.len() == 2 {
                         return Ok(res);

--- a/openraft/src/storage/log_reader_ext.rs
+++ b/openraft/src/storage/log_reader_ext.rs
@@ -1,8 +1,8 @@
 use anyerror::AnyError;
 use openraft_macros::add_async_trait;
 
+use crate::entry::RaftEntryExt;
 use crate::type_config::alias::LogIdOf;
-use crate::RaftLogId;
 use crate::RaftLogReader;
 use crate::RaftTypeConfig;
 use crate::StorageError;
@@ -30,7 +30,7 @@ where C: RaftTypeConfig
             ));
         }
 
-        Ok(entries[0].get_log_id().clone())
+        Ok(entries[0].to_log_id())
     }
 }
 

--- a/openraft/src/storage/v2/raft_log_storage_ext.rs
+++ b/openraft/src/storage/v2/raft_log_storage_ext.rs
@@ -3,7 +3,7 @@ use openraft_macros::add_async_trait;
 use crate::async_runtime::MpscUnboundedReceiver;
 use crate::async_runtime::MpscUnboundedSender;
 use crate::core::notification::Notification;
-use crate::log_id::RaftLogId;
+use crate::entry::RaftEntryExt;
 use crate::raft_state::io_state::io_id::IOId;
 use crate::storage::IOFlushed;
 use crate::storage::RaftLogStorage;
@@ -31,7 +31,7 @@ where C: RaftTypeConfig
     {
         let entries = entries.into_iter().collect::<Vec<_>>();
 
-        let last_log_id = entries.last().unwrap().get_log_id().clone();
+        let last_log_id = entries.last().unwrap().to_log_id();
 
         let (tx, mut rx) = C::mpsc_unbounded();
 

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -11,7 +11,7 @@ use crate::async_runtime::MpscUnboundedReceiver;
 use crate::async_runtime::MpscUnboundedSender;
 use crate::core::notification::Notification;
 use crate::entry::RaftEntry;
-use crate::log_id::RaftLogId;
+use crate::entry::RaftEntryExt;
 use crate::membership::EffectiveMembership;
 use crate::raft_state::io_state::io_id::IOId;
 use crate::raft_state::LogStateReader;
@@ -845,8 +845,8 @@ where
             let logs = store.try_get_log_entries(5..7).await?;
 
             assert_eq!(logs.len(), 2);
-            assert_eq!(*logs[0].get_log_id(), log_id_0(1, 5));
-            assert_eq!(*logs[1].get_log_id(), log_id_0(1, 6));
+            assert_eq!(logs[0].to_log_id(), log_id_0(1, 5));
+            assert_eq!(logs[1].to_log_id(), log_id_0(1, 6));
         }
 
         Ok(())
@@ -867,7 +867,7 @@ where
 
             assert!(!logs.is_empty());
             assert!(logs.len() <= 2);
-            assert_eq!(*logs[0].get_log_id(), log_id_0(1, 5));
+            assert_eq!(logs[0].to_log_id(), log_id_0(1, 5));
         }
 
         Ok(())
@@ -883,13 +883,13 @@ where
         C::sleep(Duration::from_millis(1_000)).await;
 
         let ent = store.try_get_log_entry(3).await?;
-        assert_eq!(Some(log_id_0(1, 3)), ent.map(|x| x.get_log_id().clone()));
+        assert_eq!(Some(log_id_0(1, 3)), ent.map(|x| x.to_log_id()));
 
         let ent = store.try_get_log_entry(0).await?;
-        assert_eq!(None, ent.map(|x| x.get_log_id().clone()));
+        assert_eq!(None, ent.map(|x| x.to_log_id()));
 
         let ent = store.try_get_log_entry(11).await?;
-        assert_eq!(None, ent.map(|x| x.get_log_id().clone()));
+        assert_eq!(None, ent.map(|x| x.to_log_id()));
 
         Ok(())
     }
@@ -1072,7 +1072,7 @@ where
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 10);
-        assert_eq!(logs[0].get_log_id().index, 1);
+        assert_eq!(logs[0].index(), 1);
 
         assert_eq!(
             LogState {
@@ -1097,7 +1097,7 @@ where
 
         let logs = store.try_get_log_entries(0..100).await?;
         assert_eq!(logs.len(), 5);
-        assert_eq!(logs[0].get_log_id().index, 6);
+        assert_eq!(logs[0].index(), 6);
 
         assert_eq!(
             LogState {
@@ -1189,7 +1189,7 @@ where
         let last = store.try_get_log_entries(0..).await?.into_iter().last().unwrap();
 
         assert_eq!(l, 11, "expected 11 entries to exist in the log");
-        assert_eq!(*last.get_log_id(), log_id_0(2, 11), "unexpected log id");
+        assert_eq!(last.to_log_id(), log_id_0(2, 11), "unexpected log id");
         Ok(())
     }
 
@@ -1441,7 +1441,7 @@ where
 {
     let entries = entries.into_iter().collect::<Vec<_>>();
 
-    let last_log_id = entries.last().unwrap().get_log_id().clone();
+    let last_log_id = entries.last().unwrap().to_log_id();
 
     let (tx, mut rx) = C::mpsc_unbounded();
 

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -13,7 +13,6 @@ pub use async_runtime::MpscUnbounded;
 pub use async_runtime::OneshotSender;
 pub use util::TypeConfigExt;
 
-use crate::entry::FromAppData;
 use crate::entry::RaftEntry;
 use crate::raft::responder::Responder;
 use crate::vote::raft_vote::RaftVote;
@@ -89,7 +88,7 @@ pub trait RaftTypeConfig:
     type Vote: RaftVote<Self>;
 
     /// Raft log entry, which can be built from an AppData.
-    type Entry: RaftEntry<Self> + FromAppData<Self::D>;
+    type Entry: RaftEntry<Self>;
 
     /// Snapshot data for exposing a snapshot for reading & writing.
     ///
@@ -129,6 +128,8 @@ pub mod alias {
 
     pub type DOf<C> = <C as RaftTypeConfig>::D;
     pub type ROf<C> = <C as RaftTypeConfig>::R;
+    pub type AppDataOf<C> = <C as RaftTypeConfig>::D;
+    pub type AppResponseOf<C> = <C as RaftTypeConfig>::R;
     pub type NodeIdOf<C> = <C as RaftTypeConfig>::NodeId;
     pub type NodeOf<C> = <C as RaftTypeConfig>::Node;
     pub type TermOf<C> = <C as RaftTypeConfig>::Term;

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use openraft::alias::SnapshotDataOf;
+use openraft::entry::RaftEntryExt;
 use openraft::storage::IOFlushed;
 use openraft::storage::LogState;
 use openraft::storage::RaftLogReader;
@@ -26,7 +27,6 @@ use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::LogId;
 use openraft::OptionalSend;
-use openraft::RaftLogId;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StoredMembership;
@@ -336,7 +336,7 @@ impl RaftLogStorage<TypeConfig> for Arc<MemLogStore> {
             Some(serialized) => {
                 let ent: Entry<TypeConfig> =
                     serde_json::from_str(serialized).map_err(|e| StorageError::read_logs(&e))?;
-                Some(*ent.get_log_id())
+                Some(ent.to_log_id())
             }
         };
 
@@ -392,8 +392,7 @@ impl RaftLogStorage<TypeConfig> for Arc<MemLogStore> {
     where I: IntoIterator<Item = Entry<TypeConfig>> + OptionalSend {
         let mut log = self.log.write().await;
         for entry in entries {
-            let s =
-                serde_json::to_string(&entry).map_err(|e| StorageError::write_log_entry(*entry.get_log_id(), &e))?;
+            let s = serde_json::to_string(&entry).map_err(|e| StorageError::write_log_entry(entry.to_log_id(), &e))?;
             log.insert(entry.log_id.index, s);
         }
 

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -52,7 +52,6 @@ use openraft::LogIdOptionExt;
 use openraft::OptionalSend;
 use openraft::RPCTypes;
 use openraft::Raft;
-use openraft::RaftLogId;
 use openraft::RaftLogReader;
 use openraft::RaftMetrics;
 use openraft::RaftState;
@@ -186,6 +185,7 @@ impl fmt::Display for Direction {
 
 use openraft::alias::LogIdOf;
 use openraft::alias::VoteOf;
+use openraft::entry::RaftEntryExt;
 use openraft::network::v2::RaftNetworkV2;
 use openraft::vote::RaftLeaderId;
 use openraft::vote::RaftLeaderIdExt;
@@ -1045,7 +1045,7 @@ impl RaftNetworkV2<MemConfig> for RaftRouterNetwork {
                     rpc.entries.truncate(quota as usize);
                     *x = Some(0);
                     if let Some(last) = rpc.entries.last() {
-                        Some(Some(*last.get_log_id()))
+                        Some(Some(last.to_log_id()))
                     } else {
                         Some(rpc.prev_log_id)
                     }


### PR DESCRIPTION
## Changelog

##### Change: refine the `RaftEntry` trait

- The `RaftEntry` trait now requires `AsRef<LogIdOf<C>>` and
  `AsMut<LogIdOf<C>>`, providing a more standard API for accessing the
  log ID of a log entry. As a result, the `RaftEntry: RaftLogId`
  requirement is no longer needed.

- A new method, `new_normal()`, has been added to the `RaftEntry` trait
  to replace the `FromAppData` trait.

- Additional utility methods for working with entries are now provided
  in the `RaftEntryExt` trait.


- Part of #1278

Upgrade tips:

1. **For applications using a custom `RaftEntry` implementation** (e.g.,
   declared with `declare_raft_types!(MyTypes: Entry = MyEntry)`):
   - Update the `RaftEntry` implementation for your custom entry type
     (`MyEntry`) by adding the `new_normal()` method.
   - Implement `AsRef<LogId>` and `AsMut<LogId>` for your custom entry
     type.

2. **For applications using the default `Entry` provided by OpenRaft**:
   - No changes are required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1293)
<!-- Reviewable:end -->
