### PR TITLE
Chore: add default for unwrap

### DIFF
--- a/examples/raft-kv-memstore-grpc/src/pb_impl/impl_vote.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/impl_vote.rs
@@ -27,7 +27,7 @@ impl fmt::Display for Vote {
         write!(
             f,
             "<{}:{}>",
-            self.leader_id.as_ref().unwrap(),
+            self.leader_id.as_ref().unwrap_or(&Default::default()),
             if self.is_committed() { "Q" } else { "-" }
         )
     }


### PR DESCRIPTION
If we do not add a default, I am getting a runtime panic because leader-id could be None?

```
thread 'main' panicked at src/pb_impl/impl_vote.rs:30:37:
called `Option::unwrap()` on a `None` value
stack backtrace:
```

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1294)
<!-- Reviewable:end -->
