### PR TITLE
Chore: Replace `LogId<C>` with `LogIdOf<C>`

### DIFF
--- a/openraft/src/core/heartbeat/event.rs
+++ b/openraft/src/core/heartbeat/event.rs
@@ -4,7 +4,7 @@ use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplayOptionExt;
 use crate::replication::ReplicationSessionId;
 use crate::type_config::alias::InstantOf;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::RaftTypeConfig;
 
 /// The information for broadcasting a heartbeat.
@@ -30,13 +30,13 @@ where C: RaftTypeConfig
     ///
     /// When there are no new logs to replicate, the Leader sends a heartbeat to replicate committed
     /// log id to followers to update their committed log id.
-    pub(crate) committed: Option<LogId<C>>,
+    pub(crate) committed: Option<LogIdOf<C>>,
 }
 
 impl<C> HeartbeatEvent<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(time: InstantOf<C>, session_id: ReplicationSessionId<C>, committed: Option<LogId<C>>) -> Self {
+    pub(crate) fn new(time: InstantOf<C>, session_id: ReplicationSessionId<C>, committed: Option<LogIdOf<C>>) -> Self {
         Self {
             time,
             session_id,

--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -39,7 +39,7 @@ where C: RaftTypeConfig
         leader_vote: CommittedVote<C>,
         // TODO: need this?
         // /// The cluster this replication works for.
-        // membership_log_id: Option<LogId<C>>,
+        // membership_log_id: Option<LogIdOf<C>>,
     },
 
     /// [`StorageError`] error has taken place locally(not on remote node),

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -20,10 +20,10 @@ use crate::raft::VoteResponse;
 use crate::raft_state::IOId;
 use crate::replication::request::Replicate;
 use crate::replication::ReplicationSessionId;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::VoteOf;
 use crate::vote::committed::CommittedVote;
-use crate::LogId;
 use crate::OptionalSend;
 use crate::RaftTypeConfig;
 
@@ -65,12 +65,12 @@ where C: RaftTypeConfig
     },
 
     /// Replicate the committed log id to other nodes
-    ReplicateCommitted { committed: Option<LogId<C>> },
+    ReplicateCommitted { committed: Option<LogIdOf<C>> },
 
     /// Broadcast heartbeat to all other nodes.
     BroadcastHeartbeat {
         session_id: ReplicationSessionId<C>,
-        committed: Option<LogId<C>>,
+        committed: Option<LogIdOf<C>>,
     },
 
     /// Save the committed log id to [`RaftLogStorage`].
@@ -79,7 +79,7 @@ where C: RaftTypeConfig
     /// latest state.
     ///
     /// [`RaftLogStorage`]: crate::storage::RaftLogStorage
-    SaveCommitted { committed: LogId<C> },
+    SaveCommitted { committed: LogIdOf<C> },
 
     /// Commit log entries that are already persisted in the store, upto `upto`, inclusive.
     ///
@@ -91,8 +91,8 @@ where C: RaftTypeConfig
     /// [`RaftLogStorage::save_committed()`]: crate::storage::RaftLogStorage::save_committed
     /// [`RaftStateMachine::apply()`]: crate::storage::RaftStateMachine::apply
     Apply {
-        already_committed: Option<LogId<C>>,
-        upto: LogId<C>,
+        already_committed: Option<LogIdOf<C>>,
+        upto: LogIdOf<C>,
     },
 
     /// Replicate log entries or snapshot to a target.
@@ -118,11 +118,11 @@ where C: RaftTypeConfig
     SendVote { vote_req: VoteRequest<C> },
 
     /// Purge log from the beginning to `upto`, inclusive.
-    PurgeLog { upto: LogId<C> },
+    PurgeLog { upto: LogIdOf<C> },
 
     /// Delete logs that conflict with the leader from a follower/learner since log id `since`,
     /// inclusive.
-    TruncateLog { since: LogId<C> },
+    TruncateLog { since: LogIdOf<C> },
 
     /// A command send to state machine worker [`sm::worker::Worker`].
     ///
@@ -296,14 +296,14 @@ where C: RaftTypeConfig
     /// This is only used by [`Raft::initialize()`], because when initializing there is no leader.
     ///
     /// [`Raft::initialize()`]: `crate::Raft::initialize()`
-    LogFlushed { log_id: Option<LogId<C>> },
+    LogFlushed { log_id: Option<LogIdOf<C>> },
 
     /// Wait until the log is applied to the state machine.
     #[allow(dead_code)]
-    Applied { log_id: Option<LogId<C>> },
+    Applied { log_id: Option<LogIdOf<C>> },
 
     /// Wait until snapshot is built and includes the log id.
-    Snapshot { log_id: Option<LogId<C>> },
+    Snapshot { log_id: Option<LogIdOf<C>> },
 }
 
 impl<C> fmt::Display for Condition<C>

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -46,6 +46,7 @@ use crate::raft_state::RaftState;
 use crate::storage::Snapshot;
 use crate::storage::SnapshotMeta;
 use crate::type_config::alias::LeaderIdOf;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::SnapshotDataOf;
 use crate::type_config::alias::VoteOf;
@@ -54,7 +55,6 @@ use crate::vote::raft_vote::RaftVoteExt;
 use crate::vote::RaftLeaderId;
 use crate::vote::RaftTerm;
 use crate::vote::RaftVote;
-use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::Membership;
 use crate::RaftLogId;
@@ -192,7 +192,7 @@ where C: RaftTypeConfig
         self.check_initialize()?;
 
         // The very first log id
-        entry.set_log_id(&LogId::default());
+        entry.set_log_id(&LogIdOf::<C>::default());
 
         let m = entry.get_membership().expect("the only log entry for initializing has to be membership log");
         self.check_members_contain_me(m)?;
@@ -383,7 +383,7 @@ where C: RaftTypeConfig
     pub(crate) fn handle_append_entries(
         &mut self,
         vote: &VoteOf<C>,
-        prev_log_id: Option<LogId<C>>,
+        prev_log_id: Option<LogIdOf<C>>,
         entries: Vec<C::Entry>,
         tx: Option<AppendEntriesTx<C>>,
     ) -> bool {
@@ -422,7 +422,7 @@ where C: RaftTypeConfig
     pub(crate) fn append_entries(
         &mut self,
         vote: &VoteOf<C>,
-        prev_log_id: Option<LogId<C>>,
+        prev_log_id: Option<LogIdOf<C>>,
         entries: Vec<C::Entry>,
     ) -> Result<(), RejectAppendEntries<C>> {
         self.vote_handler().update_vote(vote)?;
@@ -438,7 +438,7 @@ where C: RaftTypeConfig
 
     /// Commit entries for follower/learner.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn handle_commit_entries(&mut self, leader_committed: Option<LogId<C>>) {
+    pub(crate) fn handle_commit_entries(&mut self, leader_committed: Option<LogIdOf<C>>) {
         tracing::debug!(
             leader_committed = display(leader_committed.display()),
             my_accepted = display(self.state.accepted_io().display()),
@@ -658,7 +658,7 @@ where C: RaftTypeConfig
 
         self.leader_handler()
             .unwrap()
-            .leader_append_entries(vec![C::Entry::new_blank(LogId::<C>::default())]);
+            .leader_append_entries(vec![C::Entry::new_blank(LogIdOf::<C>::default())]);
     }
 
     /// Check if a raft node is in a state that allows to initialize.

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -16,9 +16,9 @@ use crate::error::RejectAppendEntries;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
 use crate::storage::Snapshot;
+use crate::type_config::alias::LogIdOf;
 use crate::vote::committed::CommittedVote;
 use crate::EffectiveMembership;
-use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::RaftLogId;
 use crate::RaftState;
@@ -59,7 +59,7 @@ where C: RaftTypeConfig
     ///
     /// Also clean conflicting entries and update membership state.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn append_entries(&mut self, prev_log_id: Option<LogId<C>>, mut entries: Vec<C::Entry>) {
+    pub(crate) fn append_entries(&mut self, prev_log_id: Option<LogIdOf<C>>, mut entries: Vec<C::Entry>) {
         tracing::debug!(
             "{}: local last_log_id: {}, request: prev_log_id: {}, entries: {}",
             func_name!(),
@@ -113,7 +113,7 @@ where C: RaftTypeConfig
     /// If not, truncate the local log and return an error.
     pub(crate) fn ensure_log_consecutive(
         &mut self,
-        prev_log_id: Option<&LogId<C>>,
+        prev_log_id: Option<&LogIdOf<C>>,
     ) -> Result<(), RejectAppendEntries<C>> {
         if let Some(prev) = prev_log_id {
             if !self.state.has_log_id(prev) {
@@ -161,7 +161,7 @@ where C: RaftTypeConfig
 
     /// Commit entries that are already committed by the leader.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn commit_entries(&mut self, leader_committed: Option<LogId<C>>) {
+    pub(crate) fn commit_entries(&mut self, leader_committed: Option<LogIdOf<C>>) {
         let accepted = self.state.accepted_io().cloned();
         let accepted = accepted.and_then(|x| x.last_log_id().cloned());
         let committed = std::cmp::min(accepted.clone(), leader_committed.clone());

--- a/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
+++ b/openraft/src/engine/handler/log_handler/calc_purge_upto_test.rs
@@ -2,10 +2,11 @@ use crate::engine::testing::UTConfig;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::type_config::alias::LeaderIdOf;
+use crate::type_config::alias::LogIdOf;
 use crate::vote::RaftLeaderIdExt;
 use crate::LogId;
 
-fn log_id(term: u64, index: u64) -> LogId<UTConfig> {
+fn log_id(term: u64, index: u64) -> LogIdOf<UTConfig> {
     LogId {
         leader_id: LeaderIdOf::<UTConfig>::new_committed(term, 0),
         index,

--- a/openraft/src/engine/handler/log_handler/mod.rs
+++ b/openraft/src/engine/handler/log_handler/mod.rs
@@ -3,7 +3,7 @@ use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
 use crate::raft_state::LogStateReader;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::LogIdOptionExt;
 use crate::RaftState;
 use crate::RaftTypeConfig;
@@ -61,7 +61,7 @@ where C: RaftTypeConfig
 
     /// Update the log id it expect to purge up to. It won't trigger purge immediately.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn update_purge_upto(&mut self, purge_upto: LogId<C>) {
+    pub(crate) fn update_purge_upto(&mut self, purge_upto: LogIdOf<C>) {
         debug_assert!(self.state.purge_upto() <= Some(&purge_upto));
         self.state.purge_upto = Some(purge_upto);
     }
@@ -74,7 +74,7 @@ where C: RaftTypeConfig
     /// `max_keep` specifies the number of applied logs to keep.
     /// `max_keep==0` means every applied log can be purged.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn calc_purge_upto(&self) -> Option<LogId<C>> {
+    pub(crate) fn calc_purge_upto(&self) -> Option<LogIdOf<C>> {
         let st = &self.state;
         let max_keep = self.config.max_in_snapshot_log_to_keep;
         let batch_size = self.config.purge_batch_size;

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -19,9 +19,9 @@ use crate::raft_state::LogStateReader;
 use crate::replication::request::Replicate;
 use crate::replication::response::ReplicationResult;
 use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::LogIdOf;
 use crate::vote::raft_vote::RaftVoteExt;
 use crate::EffectiveMembership;
-use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::Membership;
 use crate::RaftState;
@@ -57,7 +57,7 @@ where C: RaftTypeConfig
     ///
     /// It is called by the leader when a new membership log is appended to log store.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn append_membership(&mut self, log_id: &LogId<C>, m: &Membership<C>) {
+    pub(crate) fn append_membership(&mut self, log_id: &LogIdOf<C>, m: &Membership<C>) {
         tracing::debug!("update effective membership: log_id:{} {}", log_id, m);
 
         debug_assert!(
@@ -150,7 +150,7 @@ where C: RaftTypeConfig
     /// Update progress when replicated data(logs or snapshot) matches on follower/learner and is
     /// accepted.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn update_matching(&mut self, node_id: C::NodeId, log_id: Option<LogId<C>>) {
+    pub(crate) fn update_matching(&mut self, node_id: C::NodeId, log_id: Option<LogIdOf<C>>) {
         tracing::debug!(
             node_id = display(&node_id),
             log_id = display(log_id.display()),
@@ -183,7 +183,7 @@ where C: RaftTypeConfig
     ///
     /// In raft a log that is granted and in the leader term is committed.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn try_commit_quorum_accepted(&mut self, granted: Option<LogId<C>>) {
+    pub(crate) fn try_commit_quorum_accepted(&mut self, granted: Option<LogIdOf<C>>) {
         // Only when the log id is proposed by current leader, it is committed.
         if let Some(ref c) = granted {
             if !self.state.vote_ref().is_same_leader(c.committed_leader_id()) {
@@ -214,7 +214,7 @@ where C: RaftTypeConfig
     /// Update progress when replicated data(logs or snapshot) does not match follower/learner state
     /// and is rejected.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn update_conflicting(&mut self, target: C::NodeId, conflict: LogId<C>) {
+    pub(crate) fn update_conflicting(&mut self, target: C::NodeId, conflict: LogIdOf<C>) {
         // TODO(2): test it?
 
         let prog_entry = self.leader.progress.get_mut(&target).unwrap();
@@ -391,7 +391,7 @@ where C: RaftTypeConfig
     ///
     /// Writing to local log store does not have to wait for a replication response from remote
     /// node. Thus it can just be done in a fast-path.
-    pub(crate) fn update_local_progress(&mut self, upto: Option<LogId<C>>) {
+    pub(crate) fn update_local_progress(&mut self, upto: Option<LogIdOf<C>>) {
         tracing::debug!(upto = display(upto.display()), "{}", func_name!());
 
         if upto.is_none() {

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -18,12 +18,12 @@ use crate::proposer::CandidateState;
 use crate::proposer::LeaderState;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
 use crate::type_config::TypeConfigExt;
 use crate::vote::raft_vote::RaftVoteExt;
 use crate::vote::RaftLeaderId;
 use crate::vote::RaftVote;
-use crate::LogId;
 use crate::OptionalSend;
 use crate::RaftState;
 use crate::RaftTypeConfig;
@@ -213,7 +213,7 @@ where C: RaftTypeConfig
         // If the leader has not yet proposed any log, propose a blank log and initiate replication;
         // Otherwise, just initiate replication.
         if last_log_id < noop_log_id {
-            self.leader_handler().leader_append_entries(vec![C::Entry::new_blank(LogId::<C>::default())]);
+            self.leader_handler().leader_append_entries(vec![C::Entry::new_blank(LogIdOf::<C>::default())]);
         } else {
             self.replication_handler().initiate_replication();
         }

--- a/openraft/src/engine/tests/initialize_test.rs
+++ b/openraft/src/engine/tests/initialize_test.rs
@@ -15,11 +15,11 @@ use crate::error::NotInMembers;
 use crate::raft::VoteRequest;
 use crate::raft_state::LogStateReader;
 use crate::testing::log_id;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::vote::raft_vote::RaftVoteExt;
 use crate::Entry;
-use crate::LogId;
 use crate::Membership;
 use crate::Vote;
 
@@ -36,7 +36,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
     let log_id0 = log_id(0, 0, 0);
 
     let m1 = || Membership::<UTConfig>::new_with_defaults(vec![btreeset! {1}], []);
-    let entry = Entry::<UTConfig>::new_membership(LogId::default(), m1());
+    let entry = Entry::<UTConfig>::new_membership(LogIdOf::<UTConfig>::default(), m1());
 
     tracing::info!("--- ok: init empty node 1 with membership(1,2)");
     tracing::info!("--- expect OK result, check output commands and state changes");
@@ -57,7 +57,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
             vec![
                 Command::AppendInputEntries {
                     committed_vote: Vote::default().into_committed(),
-                    entries: vec![Entry::<UTConfig>::new_membership(LogId::default(), m1())],
+                    entries: vec![Entry::<UTConfig>::new_membership(LogIdOf::<UTConfig>::default(), m1())],
                 },
                 // When update the effective membership, the engine set it to Follower.
                 // But when initializing, it will switch to Candidate at once, in the last output
@@ -86,7 +86,7 @@ fn test_initialize() -> anyhow::Result<()> {
     let log_id0 = log_id(0, 0, 0);
 
     let m12 = || Membership::<UTConfig>::new_with_defaults(vec![btreeset! {1,2}], []);
-    let entry = || Entry::<UTConfig>::new_membership(LogId::default(), m12());
+    let entry = || Entry::<UTConfig>::new_membership(LogIdOf::<UTConfig>::default(), m12());
 
     tracing::info!("--- ok: init empty node 1 with membership(1,2)");
     tracing::info!("--- expect OK result, check output commands and state changes");
@@ -107,7 +107,7 @@ fn test_initialize() -> anyhow::Result<()> {
             vec![
                 Command::AppendInputEntries {
                     committed_vote: Vote::default().into_committed(),
-                    entries: vec![Entry::new_membership(LogId::default(), m12())],
+                    entries: vec![Entry::new_membership(LogIdOf::<UTConfig>::default(), m12())],
                 },
                 // When update the effective membership, the engine set it to Follower.
                 // But when initializing, it will switch to Candidate at once, in the last output

--- a/openraft/src/entry/mod.rs
+++ b/openraft/src/entry/mod.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use std::fmt::Debug;
 
 use crate::log_id::RaftLogId;
-use crate::LogId;
 use crate::Membership;
 use crate::RaftTypeConfig;
 
@@ -16,12 +15,14 @@ pub use traits::FromAppData;
 pub use traits::RaftEntry;
 pub use traits::RaftPayload;
 
+use crate::type_config::alias::LogIdOf;
+
 /// A Raft log entry.
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct Entry<C>
 where C: RaftTypeConfig
 {
-    pub log_id: LogId<C>,
+    pub log_id: LogIdOf<C>,
 
     /// This entry's payload.
     pub payload: EntryPayload<C>,
@@ -53,7 +54,7 @@ where C: RaftTypeConfig
 {
     fn default() -> Self {
         Self {
-            log_id: LogId::default(),
+            log_id: LogIdOf::<C>::default(),
             payload: EntryPayload::Blank,
         }
     }
@@ -100,11 +101,11 @@ where C: RaftTypeConfig
 impl<C> RaftLogId<C> for Entry<C>
 where C: RaftTypeConfig
 {
-    fn get_log_id(&self) -> &LogId<C> {
+    fn get_log_id(&self) -> &LogIdOf<C> {
         &self.log_id
     }
 
-    fn set_log_id(&mut self, log_id: &LogId<C>) {
+    fn set_log_id(&mut self, log_id: &LogIdOf<C>) {
         self.log_id = log_id.clone();
     }
 }
@@ -112,14 +113,14 @@ where C: RaftTypeConfig
 impl<C> RaftEntry<C> for Entry<C>
 where C: RaftTypeConfig
 {
-    fn new_blank(log_id: LogId<C>) -> Self {
+    fn new_blank(log_id: LogIdOf<C>) -> Self {
         Self {
             log_id,
             payload: EntryPayload::Blank,
         }
     }
 
-    fn new_membership(log_id: LogId<C>, m: Membership<C>) -> Self {
+    fn new_membership(log_id: LogIdOf<C>, m: Membership<C>) -> Self {
         Self {
             log_id,
             payload: EntryPayload::Membership(m),
@@ -132,7 +133,7 @@ where C: RaftTypeConfig
 {
     fn from_app_data(d: C::D) -> Self {
         Entry {
-            log_id: LogId::default(),
+            log_id: LogIdOf::<C>::default(),
             payload: EntryPayload::Normal(d),
         }
     }

--- a/openraft/src/entry/traits.rs
+++ b/openraft/src/entry/traits.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::fmt::Display;
 
 use crate::log_id::RaftLogId;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::Membership;
 use crate::OptionalSend;
 use crate::OptionalSerde;
@@ -29,12 +29,12 @@ where
     /// Create a new blank log entry.
     ///
     /// The returned instance must return `true` for `Self::is_blank()`.
-    fn new_blank(log_id: LogId<C>) -> Self;
+    fn new_blank(log_id: LogIdOf<C>) -> Self;
 
     /// Create a new membership log entry.
     ///
     /// The returned instance must return `Some()` for `Self::get_membership()`.
-    fn new_membership(log_id: LogId<C>, m: Membership<C>) -> Self;
+    fn new_membership(log_id: LogIdOf<C>, m: Membership<C>) -> Self;
 }
 
 /// Build a raft log entry from app data.

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -29,8 +29,8 @@ use crate::network::RPCTypes;
 use crate::raft::AppendEntriesResponse;
 use crate::raft_types::SnapshotSegmentId;
 use crate::try_as_ref::TryAsRef;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
-use crate::LogId;
 use crate::Membership;
 use crate::RaftTypeConfig;
 use crate::StorageError;
@@ -587,8 +587,8 @@ pub struct QuorumNotEnough<C: RaftTypeConfig> {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 #[error("the cluster is already undergoing a configuration change at log {membership_log_id:?}, last committed membership log id: {committed:?}")]
 pub struct InProgress<C: RaftTypeConfig> {
-    pub committed: Option<LogId<C>>,
-    pub membership_log_id: Option<LogId<C>>,
+    pub committed: Option<LogIdOf<C>>,
+    pub membership_log_id: Option<LogIdOf<C>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -602,7 +602,7 @@ pub struct LearnerNotFound<C: RaftTypeConfig> {
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 #[error("not allowed to initialize due to current raft state: last_log_id: {last_log_id:?} vote: {vote}")]
 pub struct NotAllowed<C: RaftTypeConfig> {
-    pub last_log_id: Option<LogId<C>>,
+    pub last_log_id: Option<LogIdOf<C>>,
     pub vote: VoteOf<C>,
 }
 
@@ -640,7 +640,7 @@ pub(crate) enum RejectVoteRequest<C: RaftTypeConfig> {
 
     #[allow(dead_code)]
     #[error("reject vote request by a greater last-log-id: {0:?}")]
-    ByLastLogId(Option<LogId<C>>),
+    ByLastLogId(Option<LogIdOf<C>>),
 }
 
 impl<C> From<RejectVoteRequest<C>> for AppendEntriesResponse<C>
@@ -662,7 +662,10 @@ pub(crate) enum RejectAppendEntries<C: RaftTypeConfig> {
     ByVote(VoteOf<C>),
 
     #[error("reject AppendEntries because of conflicting log-id: {local:?}; expect to be: {expect:?}")]
-    ByConflictingLogId { expect: LogId<C>, local: Option<LogId<C>> },
+    ByConflictingLogId {
+        expect: LogIdOf<C>,
+        local: Option<LogIdOf<C>>,
+    },
 }
 
 impl<C> From<RejectVoteRequest<C>> for RejectAppendEntries<C>

--- a/openraft/src/log_id/log_id_option_ext.rs
+++ b/openraft/src/log_id/log_id_option_ext.rs
@@ -1,4 +1,4 @@
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::RaftTypeConfig;
 
 /// This helper trait extracts information from an `Option<LogId>`.
@@ -12,7 +12,7 @@ pub trait LogIdOptionExt {
     fn next_index(&self) -> u64;
 }
 
-impl<C> LogIdOptionExt for Option<LogId<C>>
+impl<C> LogIdOptionExt for Option<LogIdOf<C>>
 where C: RaftTypeConfig
 {
     fn index(&self) -> Option<u64> {
@@ -27,7 +27,7 @@ where C: RaftTypeConfig
     }
 }
 
-impl<C> LogIdOptionExt for Option<&LogId<C>>
+impl<C> LogIdOptionExt for Option<&LogIdOf<C>>
 where C: RaftTypeConfig
 {
     fn index(&self) -> Option<u64> {

--- a/openraft/src/log_id/raft_log_id.rs
+++ b/openraft/src/log_id/raft_log_id.rs
@@ -1,5 +1,5 @@
 use crate::type_config::alias::CommittedLeaderIdOf;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::RaftTypeConfig;
 
 /// Defines API to operate an object that contains a log-id, such as a log entry or a log id.
@@ -17,8 +17,8 @@ where C: RaftTypeConfig
     }
 
     /// Return a reference to the log-id it stores.
-    fn get_log_id(&self) -> &LogId<C>;
+    fn get_log_id(&self) -> &LogIdOf<C>;
 
     /// Update the log id it contains.
-    fn set_log_id(&mut self, log_id: &LogId<C>);
+    fn set_log_id(&mut self, log_id: &LogIdOf<C>);
 }

--- a/openraft/src/log_id_range.rs
+++ b/openraft/src/log_id_range.rs
@@ -6,7 +6,7 @@ use validit::Validate;
 
 use crate::display_ext::DisplayOptionExt;
 use crate::type_config::alias::CommittedLeaderIdOf;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
 
@@ -21,10 +21,10 @@ pub(crate) struct LogIdRange<C>
 where C: RaftTypeConfig
 {
     /// The prev log id before the first to send, exclusive.
-    pub(crate) prev: Option<LogId<C>>,
+    pub(crate) prev: Option<LogIdOf<C>>,
 
     /// The last log id to send, inclusive.
-    pub(crate) last: Option<LogId<C>>,
+    pub(crate) last: Option<LogIdOf<C>>,
 }
 
 impl<C> Copy for LogIdRange<C>
@@ -54,7 +54,7 @@ where C: RaftTypeConfig
 impl<C> LogIdRange<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(prev: Option<LogId<C>>, last: Option<LogId<C>>) -> Self {
+    pub(crate) fn new(prev: Option<LogIdOf<C>>, last: Option<LogIdOf<C>>) -> Self {
         Self { prev, last }
     }
 
@@ -71,9 +71,9 @@ mod tests {
     use crate::engine::testing::UTConfig;
     use crate::log_id_range::LogIdRange;
     use crate::testing;
-    use crate::LogId;
+    use crate::type_config::alias::LogIdOf;
 
-    fn log_id(index: u64) -> LogId<UTConfig> {
+    fn log_id(index: u64) -> LogIdOf<UTConfig> {
         testing::log_id(1, 1, index)
     }
 

--- a/openraft/src/membership/effective_membership.rs
+++ b/openraft/src/membership/effective_membership.rs
@@ -7,7 +7,7 @@ use crate::display_ext::DisplayOptionExt;
 use crate::log_id::RaftLogId;
 use crate::quorum::Joint;
 use crate::quorum::QuorumSet;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::Membership;
 use crate::RaftTypeConfig;
 use crate::StoredMembership;
@@ -65,11 +65,11 @@ where
 impl<C> EffectiveMembership<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new_arc(log_id: Option<LogId<C>>, membership: Membership<C>) -> Arc<Self> {
+    pub(crate) fn new_arc(log_id: Option<LogIdOf<C>>, membership: Membership<C>) -> Arc<Self> {
         Arc::new(Self::new(log_id, membership))
     }
 
-    pub fn new(log_id: Option<LogId<C>>, membership: Membership<C>) -> Self {
+    pub fn new(log_id: Option<LogIdOf<C>>, membership: Membership<C>) -> Self {
         let voter_ids = membership.voter_ids().collect();
 
         let configs = membership.get_joint_config();
@@ -95,7 +95,7 @@ where C: RaftTypeConfig
         &self.stored_membership
     }
 
-    pub fn log_id(&self) -> &Option<LogId<C>> {
+    pub fn log_id(&self) -> &Option<LogIdOf<C>> {
         self.stored_membership.log_id()
     }
 

--- a/openraft/src/membership/stored_membership.rs
+++ b/openraft/src/membership/stored_membership.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::display_ext::DisplayOption;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::Membership;
 use crate::RaftTypeConfig;
 
@@ -21,7 +21,7 @@ pub struct StoredMembership<C>
 where C: RaftTypeConfig
 {
     /// The id of the log that stores this membership config
-    log_id: Option<LogId<C>>,
+    log_id: Option<LogIdOf<C>>,
 
     /// Membership config
     membership: Membership<C>,
@@ -30,11 +30,11 @@ where C: RaftTypeConfig
 impl<C> StoredMembership<C>
 where C: RaftTypeConfig
 {
-    pub fn new(log_id: Option<LogId<C>>, membership: Membership<C>) -> Self {
+    pub fn new(log_id: Option<LogIdOf<C>>, membership: Membership<C>) -> Self {
         Self { log_id, membership }
     }
 
-    pub fn log_id(&self) -> &Option<LogId<C>> {
+    pub fn log_id(&self) -> &Option<LogIdOf<C>> {
         &self.log_id
     }
 

--- a/openraft/src/metrics/metric.rs
+++ b/openraft/src/metrics/metric.rs
@@ -2,8 +2,8 @@ use std::cmp::Ordering;
 
 use crate::base::ord_by::OrdBy;
 use crate::metrics::metric_display::MetricDisplay;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
-use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::RaftMetrics;
 use crate::RaftTypeConfig;
@@ -18,10 +18,10 @@ where C: RaftTypeConfig
     Term(C::Term),
     Vote(VoteOf<C>),
     LastLogIndex(Option<u64>),
-    Applied(Option<LogId<C>>),
+    Applied(Option<LogIdOf<C>>),
     AppliedIndex(Option<u64>),
-    Snapshot(Option<LogId<C>>),
-    Purged(Option<LogId<C>>),
+    Snapshot(Option<LogIdOf<C>>),
+    Purged(Option<LogIdOf<C>>),
 }
 
 impl<C> Metric<C>

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -9,10 +9,10 @@ use crate::metrics::HeartbeatMetrics;
 use crate::metrics::ReplicationMetrics;
 use crate::metrics::SerdeInstant;
 use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::SerdeInstantOf;
 use crate::type_config::alias::VoteOf;
 use crate::Instant;
-use crate::LogId;
 use crate::RaftTypeConfig;
 use crate::StoredMembership;
 
@@ -38,17 +38,17 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     pub last_log_index: Option<u64>,
 
     /// The last log index has been applied to this Raft node's state machine.
-    pub last_applied: Option<LogId<C>>,
+    pub last_applied: Option<LogIdOf<C>>,
 
     /// The id of the last log included in snapshot.
     /// If there is no snapshot, it is (0,0).
-    pub snapshot: Option<LogId<C>>,
+    pub snapshot: Option<LogIdOf<C>>,
 
     /// The last log id that has purged from storage, inclusive.
     ///
     /// `purged` is also the first log id Openraft knows, although the corresponding log entry has
     /// already been deleted.
-    pub purged: Option<LogId<C>>,
+    pub purged: Option<LogIdOf<C>>,
 
     // ---
     // --- cluster ---
@@ -189,10 +189,10 @@ where C: RaftTypeConfig
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct RaftDataMetrics<C: RaftTypeConfig> {
-    pub last_log: Option<LogId<C>>,
-    pub last_applied: Option<LogId<C>>,
-    pub snapshot: Option<LogId<C>>,
-    pub purged: Option<LogId<C>>,
+    pub last_log: Option<LogIdOf<C>>,
+    pub last_applied: Option<LogIdOf<C>>,
+    pub snapshot: Option<LogIdOf<C>>,
+    pub purged: Option<LogIdOf<C>>,
 
     /// For a leader, it is the elapsed time in milliseconds since the most recently acknowledged
     /// timestamp by a quorum.

--- a/openraft/src/metrics/wait.rs
+++ b/openraft/src/metrics/wait.rs
@@ -8,10 +8,10 @@ use crate::core::ServerState;
 use crate::metrics::Condition;
 use crate::metrics::Metric;
 use crate::metrics::RaftMetrics;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
 use crate::type_config::alias::WatchReceiverOf;
 use crate::type_config::TypeConfigExt;
-use crate::LogId;
 use crate::OptionalSend;
 use crate::RaftTypeConfig;
 
@@ -212,7 +212,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
     pub async fn snapshot(
         &self,
-        snapshot_last_log_id: LogId<C>,
+        snapshot_last_log_id: LogIdOf<C>,
         msg: impl ToString,
     ) -> Result<RaftMetrics<C>, WaitError> {
         self.eq(Metric::Snapshot(Some(snapshot_last_log_id)), msg).await
@@ -220,7 +220,7 @@ where C: RaftTypeConfig
 
     /// Wait for `purged` to become `want` or timeout.
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
-    pub async fn purged(&self, want: Option<LogId<C>>, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
+    pub async fn purged(&self, want: Option<LogIdOf<C>>, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
         self.eq(Metric::Purged(want), msg).await
     }
 

--- a/openraft/src/progress/entry/mod.rs
+++ b/openraft/src/progress/entry/mod.rs
@@ -13,7 +13,7 @@ use crate::engine::EngineConfig;
 use crate::progress::entry::update::Updater;
 use crate::progress::inflight::Inflight;
 use crate::raft_state::LogStateReader;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
 
@@ -24,7 +24,7 @@ pub(crate) struct ProgressEntry<C>
 where C: RaftTypeConfig
 {
     /// The id of the last matching log on the target following node.
-    pub(crate) matching: Option<LogId<C>>,
+    pub(crate) matching: Option<LogIdOf<C>>,
 
     /// The data being transmitted in flight.
     ///
@@ -48,7 +48,7 @@ impl<C> ProgressEntry<C>
 where C: RaftTypeConfig
 {
     #[allow(dead_code)]
-    pub(crate) fn new(matching: Option<LogId<C>>) -> Self {
+    pub(crate) fn new(matching: Option<LogIdOf<C>>) -> Self {
         Self {
             matching: matching.clone(),
             inflight: Inflight::None,
@@ -85,7 +85,7 @@ where C: RaftTypeConfig
     /// Return if a range of log id `..=log_id` is inflight sending.
     ///
     /// `prev_log_id` is never inflight.
-    pub(crate) fn is_log_range_inflight(&self, upto: &LogId<C>) -> bool {
+    pub(crate) fn is_log_range_inflight(&self, upto: &LogIdOf<C>) -> bool {
         match &self.inflight {
             Inflight::None => false,
             Inflight::Logs { log_id_range, .. } => {
@@ -175,10 +175,10 @@ where C: RaftTypeConfig
     }
 }
 
-impl<C> Borrow<Option<LogId<C>>> for ProgressEntry<C>
+impl<C> Borrow<Option<LogIdOf<C>>> for ProgressEntry<C>
 where C: RaftTypeConfig
 {
-    fn borrow(&self) -> &Option<LogId<C>> {
+    fn borrow(&self) -> &Option<LogIdOf<C>> {
         &self.matching
     }
 }

--- a/openraft/src/progress/entry/tests.rs
+++ b/openraft/src/progress/entry/tests.rs
@@ -6,10 +6,11 @@ use crate::progress::entry::ProgressEntry;
 use crate::progress::inflight::Inflight;
 use crate::raft_state::LogStateReader;
 use crate::type_config::alias::LeaderIdOf;
+use crate::type_config::alias::LogIdOf;
 use crate::vote::RaftLeaderIdExt;
 use crate::LogId;
 
-fn log_id(index: u64) -> LogId<UTConfig> {
+fn log_id(index: u64) -> LogIdOf<UTConfig> {
     LogId {
         leader_id: LeaderIdOf::<UTConfig>::new_committed(1, 1),
         index,
@@ -88,10 +89,10 @@ fn test_update_conflicting() -> anyhow::Result<()> {
 
 /// LogStateReader impl for testing
 struct LogState {
-    last: Option<LogId<UTConfig>>,
-    snap_last: Option<LogId<UTConfig>>,
-    purge_upto: Option<LogId<UTConfig>>,
-    purged: Option<LogId<UTConfig>>,
+    last: Option<LogIdOf<UTConfig>>,
+    snap_last: Option<LogIdOf<UTConfig>>,
+    purge_upto: Option<LogIdOf<UTConfig>>,
+    purged: Option<LogIdOf<UTConfig>>,
 }
 
 impl LogState {
@@ -108,7 +109,7 @@ impl LogState {
 }
 
 impl LogStateReader<UTConfig> for LogState {
-    fn get_log_id(&self, index: u64) -> Option<LogId<UTConfig>> {
+    fn get_log_id(&self, index: u64) -> Option<LogIdOf<UTConfig>> {
         let x = Some(log_id(index));
         if x >= self.purged && x <= self.last {
             x
@@ -117,35 +118,35 @@ impl LogStateReader<UTConfig> for LogState {
         }
     }
 
-    fn last_log_id(&self) -> Option<&LogId<UTConfig>> {
+    fn last_log_id(&self) -> Option<&LogIdOf<UTConfig>> {
         self.last.as_ref()
     }
 
-    fn committed(&self) -> Option<&LogId<UTConfig>> {
+    fn committed(&self) -> Option<&LogIdOf<UTConfig>> {
         unimplemented!("testing")
     }
 
-    fn io_applied(&self) -> Option<&LogId<UTConfig>> {
+    fn io_applied(&self) -> Option<&LogIdOf<UTConfig>> {
         todo!()
     }
 
-    fn io_snapshot_last_log_id(&self) -> Option<&LogId<UTConfig>> {
+    fn io_snapshot_last_log_id(&self) -> Option<&LogIdOf<UTConfig>> {
         todo!()
     }
 
-    fn io_purged(&self) -> Option<&LogId<UTConfig>> {
+    fn io_purged(&self) -> Option<&LogIdOf<UTConfig>> {
         todo!()
     }
 
-    fn snapshot_last_log_id(&self) -> Option<&LogId<UTConfig>> {
+    fn snapshot_last_log_id(&self) -> Option<&LogIdOf<UTConfig>> {
         self.snap_last.as_ref()
     }
 
-    fn purge_upto(&self) -> Option<&LogId<UTConfig>> {
+    fn purge_upto(&self) -> Option<&LogIdOf<UTConfig>> {
         self.purge_upto.as_ref()
     }
 
-    fn last_purged_log_id(&self) -> Option<&LogId<UTConfig>> {
+    fn last_purged_log_id(&self) -> Option<&LogIdOf<UTConfig>> {
         self.purged.as_ref()
     }
 }

--- a/openraft/src/progress/entry/update.rs
+++ b/openraft/src/progress/entry/update.rs
@@ -1,7 +1,7 @@
 use crate::display_ext::DisplayOptionExt;
 use crate::engine::EngineConfig;
 use crate::progress::entry::ProgressEntry;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
 
@@ -76,7 +76,7 @@ where C: RaftTypeConfig
         }
     }
 
-    pub(crate) fn update_matching(&mut self, matching: Option<LogId<C>>) {
+    pub(crate) fn update_matching(&mut self, matching: Option<LogIdOf<C>>) {
         tracing::debug!(
             "update_matching: current progress_entry: {}; matching: {}",
             self.entry,

--- a/openraft/src/progress/inflight/mod.rs
+++ b/openraft/src/progress/inflight/mod.rs
@@ -10,7 +10,7 @@ use validit::Validate;
 use crate::display_ext::DisplayOptionExt;
 use crate::log_id_range::LogIdRange;
 use crate::type_config::alias::CommittedLeaderIdOf;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
 
@@ -35,7 +35,7 @@ where C: RaftTypeConfig
         /// The last log id snapshot includes.
         ///
         /// It is None, if the snapshot is empty.
-        last_log_id: Option<LogId<C>>,
+        last_log_id: Option<LogIdOf<C>>,
     },
 }
 
@@ -76,7 +76,7 @@ impl<C> Inflight<C>
 where C: RaftTypeConfig
 {
     /// Create inflight state for sending logs.
-    pub(crate) fn logs(prev: Option<LogId<C>>, last: Option<LogId<C>>) -> Self {
+    pub(crate) fn logs(prev: Option<LogIdOf<C>>, last: Option<LogIdOf<C>>) -> Self {
         #![allow(clippy::nonminimal_bool)]
         if !(prev < last) {
             Self::None
@@ -88,7 +88,7 @@ where C: RaftTypeConfig
     }
 
     /// Create inflight state for sending snapshot.
-    pub(crate) fn snapshot(snapshot_last_log_id: Option<LogId<C>>) -> Self {
+    pub(crate) fn snapshot(snapshot_last_log_id: Option<LogIdOf<C>>) -> Self {
         Self::Snapshot {
             last_log_id: snapshot_last_log_id,
         }
@@ -111,7 +111,7 @@ where C: RaftTypeConfig
     }
 
     /// Update inflight state when log upto `upto` is acknowledged by a follower/learner.
-    pub(crate) fn ack(&mut self, upto: Option<LogId<C>>) {
+    pub(crate) fn ack(&mut self, upto: Option<LogIdOf<C>>) {
         match self {
             Inflight::None => {
                 unreachable!("no inflight data")

--- a/openraft/src/progress/inflight/tests.rs
+++ b/openraft/src/progress/inflight/tests.rs
@@ -4,10 +4,11 @@ use crate::engine::testing::UTConfig;
 use crate::log_id_range::LogIdRange;
 use crate::progress::Inflight;
 use crate::type_config::alias::LeaderIdOf;
+use crate::type_config::alias::LogIdOf;
 use crate::vote::RaftLeaderIdExt;
 use crate::LogId;
 
-fn log_id(index: u64) -> LogId<UTConfig> {
+fn log_id(index: u64) -> LogIdOf<UTConfig> {
     LogId {
         leader_id: LeaderIdOf::<UTConfig>::new_committed(1, 1),
         index,

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -12,7 +12,6 @@ use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
 use crate::vote::raft_vote::RaftVoteExt;
 use crate::vote::RaftVote;
-use crate::LogId;
 use crate::RaftTypeConfig;
 
 /// Candidate: voting state.
@@ -82,7 +81,7 @@ where
         &self.vote
     }
 
-    pub(crate) fn last_log_id(&self) -> Option<&LogId<C>> {
+    pub(crate) fn last_log_id(&self) -> Option<&LogIdOf<C>> {
         self.last_log_id.as_ref()
     }
 

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -11,7 +11,6 @@ use crate::type_config::alias::LogIdOf;
 use crate::type_config::TypeConfigExt;
 use crate::vote::committed::CommittedVote;
 use crate::vote::raft_vote::RaftVoteExt;
-use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::RaftLogId;
 use crate::RaftTypeConfig;
@@ -113,7 +112,7 @@ where
             first.cloned()
         } else {
             // Set to a log id that will be proposed.
-            Some(LogId::new(
+            Some(LogIdOf::<C>::new(
                 vote.committed_leader_id(),
                 last_leader_log_id.last().next_index(),
             ))
@@ -171,7 +170,7 @@ where
 
         let committed_leader_id = self.committed_vote.committed_leader_id();
 
-        let first = LogId::new(committed_leader_id, self.last_log_id().next_index());
+        let first = LogIdOf::<C>::new(committed_leader_id, self.last_log_id().next_index());
         let mut last = first.clone();
 
         for entry in entries {

--- a/openraft/src/raft/message/append_entries.rs
+++ b/openraft/src/raft/message/append_entries.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 use crate::display_ext::DisplayOptionExt;
 use crate::display_ext::DisplaySlice;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
-use crate::LogId;
 use crate::RaftTypeConfig;
 
 /// An RPC sent by a cluster leader to replicate log entries (§5.3), and as a heartbeat (§5.2).
@@ -18,7 +18,7 @@ use crate::RaftTypeConfig;
 pub struct AppendEntriesRequest<C: RaftTypeConfig> {
     pub vote: VoteOf<C>,
 
-    pub prev_log_id: Option<LogId<C>>,
+    pub prev_log_id: Option<LogIdOf<C>>,
 
     /// The new log entries to store.
     ///
@@ -27,7 +27,7 @@ pub struct AppendEntriesRequest<C: RaftTypeConfig> {
     pub entries: Vec<C::Entry>,
 
     /// The leader's committed log id.
-    pub leader_commit: Option<LogId<C>>,
+    pub leader_commit: Option<LogIdOf<C>>,
 }
 
 impl<C: RaftTypeConfig> fmt::Debug for AppendEntriesRequest<C> {
@@ -86,7 +86,7 @@ pub enum AppendEntriesResponse<C: RaftTypeConfig> {
     ///
     /// [`RPCError`]: crate::error::RPCError
     /// [`RaftNetwork::append_entries`]: crate::network::RaftNetwork::append_entries
-    PartialSuccess(Option<LogId<C>>),
+    PartialSuccess(Option<LogIdOf<C>>),
 
     /// The first log id([`AppendEntriesRequest::prev_log_id`]) of the entries to send does not
     /// match on the remote target node.

--- a/openraft/src/raft/message/client_write.rs
+++ b/openraft/src/raft/message/client_write.rs
@@ -5,7 +5,7 @@ use openraft_macros::since;
 
 use crate::display_ext::DisplayOptionExt;
 use crate::error::ClientWriteError;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::Membership;
 use crate::RaftTypeConfig;
 
@@ -20,7 +20,7 @@ pub type ClientWriteResult<C> = Result<ClientWriteResponse<C>, ClientWriteError<
 )]
 pub struct ClientWriteResponse<C: RaftTypeConfig> {
     /// The id of the log that is applied.
-    pub log_id: LogId<C>,
+    pub log_id: LogIdOf<C>,
 
     /// Application specific response data.
     pub data: C::R,
@@ -35,7 +35,7 @@ where C: RaftTypeConfig
     /// Create a new instance of `ClientWriteResponse`.
     #[allow(dead_code)]
     #[since(version = "0.9.5")]
-    pub(crate) fn new_app_response(log_id: LogId<C>, data: C::R) -> Self {
+    pub(crate) fn new_app_response(log_id: LogIdOf<C>, data: C::R) -> Self {
         Self {
             log_id,
             data,
@@ -44,7 +44,7 @@ where C: RaftTypeConfig
     }
 
     #[since(version = "0.9.5")]
-    pub fn log_id(&self) -> &LogId<C> {
+    pub fn log_id(&self) -> &LogIdOf<C> {
         &self.log_id
     }
 

--- a/openraft/src/raft/message/transfer_leader.rs
+++ b/openraft/src/raft/message/transfer_leader.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
 use crate::display_ext::DisplayOptionExt;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
-use crate::LogId;
 use crate::RaftTypeConfig;
 
 #[derive(Clone, Debug)]
@@ -18,13 +18,13 @@ where C: RaftTypeConfig
     pub(crate) to_node_id: C::NodeId,
 
     /// The last log id the `to_node_id` node should at least have to become Leader.
-    pub(crate) last_log_id: Option<LogId<C>>,
+    pub(crate) last_log_id: Option<LogIdOf<C>>,
 }
 
 impl<C> TransferLeaderRequest<C>
 where C: RaftTypeConfig
 {
-    pub fn new(from: VoteOf<C>, to: C::NodeId, last_log_id: Option<LogId<C>>) -> Self {
+    pub fn new(from: VoteOf<C>, to: C::NodeId, last_log_id: Option<LogIdOf<C>>) -> Self {
         Self {
             from_leader: from,
             to_node_id: to,
@@ -45,7 +45,7 @@ where C: RaftTypeConfig
     /// The last log id on the `to_node_id` node should at least have to become Leader.
     ///
     /// This is the last log id on the Leader when the leadership is transferred.
-    pub fn last_log_id(&self) -> Option<&LogId<C>> {
+    pub fn last_log_id(&self) -> Option<&LogIdOf<C>> {
         self.last_log_id.as_ref()
     }
 }

--- a/openraft/src/raft/message/vote.rs
+++ b/openraft/src/raft/message/vote.rs
@@ -2,8 +2,8 @@ use std::borrow::Borrow;
 use std::fmt;
 
 use crate::display_ext::DisplayOptionExt;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
-use crate::LogId;
 use crate::RaftTypeConfig;
 
 /// An RPC sent by candidates to gather votes (§5.2).
@@ -11,7 +11,7 @@ use crate::RaftTypeConfig;
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct VoteRequest<C: RaftTypeConfig> {
     pub vote: VoteOf<C>,
-    pub last_log_id: Option<LogId<C>>,
+    pub last_log_id: Option<LogIdOf<C>>,
 }
 
 impl<C> fmt::Display for VoteRequest<C>
@@ -25,7 +25,7 @@ where C: RaftTypeConfig
 impl<C> VoteRequest<C>
 where C: RaftTypeConfig
 {
-    pub fn new(vote: VoteOf<C>, last_log_id: Option<LogId<C>>) -> Self {
+    pub fn new(vote: VoteOf<C>, last_log_id: Option<LogIdOf<C>>) -> Self {
         Self { vote, last_log_id }
     }
 }
@@ -45,13 +45,13 @@ pub struct VoteResponse<C: RaftTypeConfig> {
     pub vote_granted: bool,
 
     /// The last log id stored on the remote voter.
-    pub last_log_id: Option<LogId<C>>,
+    pub last_log_id: Option<LogIdOf<C>>,
 }
 
 impl<C> VoteResponse<C>
 where C: RaftTypeConfig
 {
-    pub fn new(vote: impl Borrow<VoteOf<C>>, last_log_id: Option<LogId<C>>, granted: bool) -> Self {
+    pub fn new(vote: impl Borrow<VoteOf<C>>, last_log_id: Option<LogIdOf<C>>, granted: bool) -> Self {
         Self {
             vote: vote.borrow().clone(),
             vote_granted: granted,

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -84,13 +84,13 @@ use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
 use crate::storage::Snapshot;
 use crate::type_config::alias::JoinErrorOf;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::ResponderReceiverOf;
 use crate::type_config::alias::SnapshotDataOf;
 use crate::type_config::alias::VoteOf;
 use crate::type_config::alias::WatchReceiverOf;
 use crate::type_config::TypeConfigExt;
-use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::LogIndexOptionExt;
 use crate::OptionalSend;
@@ -542,7 +542,7 @@ where C: RaftTypeConfig
     /// ```
     /// Read more about how it works: [Read Operation](crate::docs::protocol::read)
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn ensure_linearizable(&self) -> Result<Option<LogId<C>>, RaftError<C, CheckIsLeaderError<C>>> {
+    pub async fn ensure_linearizable(&self) -> Result<Option<LogIdOf<C>>, RaftError<C, CheckIsLeaderError<C>>> {
         let (read_log_id, applied) = self.get_read_log_id().await?;
 
         if read_log_id.index() > applied.index() {
@@ -591,7 +591,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn get_read_log_id(
         &self,
-    ) -> Result<(Option<LogId<C>>, Option<LogId<C>>), RaftError<C, CheckIsLeaderError<C>>> {
+    ) -> Result<(Option<LogIdOf<C>>, Option<LogIdOf<C>>), RaftError<C, CheckIsLeaderError<C>>> {
         let (tx, rx) = C::oneshot();
         let (read_log_id, applied) = self.inner.call_core(RaftMsg::CheckIsLeaderRequest { tx }, rx).await?;
         Ok((read_log_id, applied))
@@ -782,8 +782,8 @@ where C: RaftTypeConfig
         &self,
         metrics: &RaftMetrics<C>,
         node_id: &C::NodeId,
-        membership_log_id: Option<&LogId<C>>,
-    ) -> Result<Option<LogId<C>>, ()> {
+        membership_log_id: Option<&LogIdOf<C>>,
+    ) -> Result<Option<LogIdOf<C>>, ()> {
         if metrics.membership_config.log_id().as_ref() < membership_log_id {
             // Waiting for the latest metrics to report.
             return Err(());

--- a/openraft/src/raft_state/io_state.rs
+++ b/openraft/src/raft_state/io_state.rs
@@ -7,8 +7,8 @@ use validit::Validate;
 use crate::display_ext::DisplayOption;
 use crate::raft_state::io_state::io_progress::IOProgress;
 use crate::raft_state::IOId;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
-use crate::LogId;
 use crate::RaftTypeConfig;
 
 pub(crate) mod io_id;
@@ -69,17 +69,17 @@ where C: RaftTypeConfig
     pub(crate) io_progress: Valid<IOProgress<IOId<C>>>,
 
     /// The last log id that has been applied to state machine.
-    pub(crate) applied: Option<LogId<C>>,
+    pub(crate) applied: Option<LogIdOf<C>>,
 
     /// The last log id in the currently persisted snapshot.
-    pub(crate) snapshot: Option<LogId<C>>,
+    pub(crate) snapshot: Option<LogIdOf<C>>,
 
     /// The last log id that has been purged from storage.
     ///
     /// `RaftState::last_purged_log_id()`
     /// is just the log id that is going to be purged, i.e., there is a `PurgeLog` command queued to
     /// be executed, and it may not be the actually purged log id.
-    pub(crate) purged: Option<LogId<C>>,
+    pub(crate) purged: Option<LogIdOf<C>>,
 }
 
 impl<C> Validate for IOState<C>
@@ -104,9 +104,9 @@ where C: RaftTypeConfig
 {
     pub(crate) fn new(
         vote: &VoteOf<C>,
-        applied: Option<LogId<C>>,
-        snapshot: Option<LogId<C>>,
-        purged: Option<LogId<C>>,
+        applied: Option<LogIdOf<C>>,
+        snapshot: Option<LogIdOf<C>>,
+        purged: Option<LogIdOf<C>>,
     ) -> Self {
         let mut io_progress = Valid::new(IOProgress::default());
 
@@ -123,7 +123,7 @@ where C: RaftTypeConfig
         }
     }
 
-    pub(crate) fn update_applied(&mut self, log_id: Option<LogId<C>>) {
+    pub(crate) fn update_applied(&mut self, log_id: Option<LogIdOf<C>>) {
         tracing::debug!(applied = display(DisplayOption(&log_id)), "{}", func_name!());
 
         // TODO: should we update flushed if applied is newer?
@@ -137,11 +137,11 @@ where C: RaftTypeConfig
         self.applied = log_id;
     }
 
-    pub(crate) fn applied(&self) -> Option<&LogId<C>> {
+    pub(crate) fn applied(&self) -> Option<&LogIdOf<C>> {
         self.applied.as_ref()
     }
 
-    pub(crate) fn update_snapshot(&mut self, log_id: Option<LogId<C>>) {
+    pub(crate) fn update_snapshot(&mut self, log_id: Option<LogIdOf<C>>) {
         tracing::debug!(snapshot = display(DisplayOption(&log_id)), "{}", func_name!());
 
         debug_assert!(
@@ -154,7 +154,7 @@ where C: RaftTypeConfig
         self.snapshot = log_id;
     }
 
-    pub(crate) fn snapshot(&self) -> Option<&LogId<C>> {
+    pub(crate) fn snapshot(&self) -> Option<&LogIdOf<C>> {
         self.snapshot.as_ref()
     }
 
@@ -166,11 +166,11 @@ where C: RaftTypeConfig
         self.building_snapshot
     }
 
-    pub(crate) fn update_purged(&mut self, log_id: Option<LogId<C>>) {
+    pub(crate) fn update_purged(&mut self, log_id: Option<LogIdOf<C>>) {
         self.purged = log_id;
     }
 
-    pub(crate) fn purged(&self) -> Option<&LogId<C>> {
+    pub(crate) fn purged(&self) -> Option<&LogIdOf<C>> {
         self.purged.as_ref()
     }
 }

--- a/openraft/src/raft_state/io_state/io_id.rs
+++ b/openraft/src/raft_state/io_state/io_id.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 use std::fmt;
 
 use crate::raft_state::io_state::log_io_id::LogIOId;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
 use crate::vote::committed::CommittedVote;
 use crate::vote::non_committed::NonCommittedVote;
@@ -10,7 +11,6 @@ use crate::vote::ref_vote::RefVote;
 use crate::vote::RaftVote;
 use crate::ErrorSubject;
 use crate::ErrorVerb;
-use crate::LogId;
 use crate::RaftTypeConfig;
 
 /// An ID to uniquely identify a monotonic increasing io operation to [`RaftLogStorage`].
@@ -82,7 +82,7 @@ where C: RaftTypeConfig
         Self::Vote(vote)
     }
 
-    pub(crate) fn new_log_io(committed_vote: CommittedVote<C>, last_log_id: Option<LogId<C>>) -> Self {
+    pub(crate) fn new_log_io(committed_vote: CommittedVote<C>, last_log_id: Option<LogIdOf<C>>) -> Self {
         Self::Log(LogIOId::new(committed_vote, last_log_id))
     }
 
@@ -103,7 +103,7 @@ where C: RaftTypeConfig
         }
     }
 
-    pub(crate) fn last_log_id(&self) -> Option<&LogId<C>> {
+    pub(crate) fn last_log_id(&self) -> Option<&LogIdOf<C>> {
         match self {
             Self::Vote(_) => None,
             Self::Log(log_io_id) => log_io_id.log_id.as_ref(),

--- a/openraft/src/raft_state/io_state/log_io_id.rs
+++ b/openraft/src/raft_state/io_state/log_io_id.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
 use crate::display_ext::DisplayOptionExt;
+use crate::type_config::alias::LogIdOf;
 use crate::vote::committed::CommittedVote;
-use crate::LogId;
 use crate::RaftTypeConfig;
 
 /// A monotonic increasing id for log append io operation.
@@ -30,7 +30,7 @@ where C: RaftTypeConfig
     pub(crate) committed_vote: CommittedVote<C>,
 
     /// The last log id that has been flushed to storage.
-    pub(crate) log_id: Option<LogId<C>>,
+    pub(crate) log_id: Option<LogIdOf<C>>,
 }
 
 impl<C> fmt::Display for LogIOId<C>
@@ -44,7 +44,7 @@ where C: RaftTypeConfig
 impl<C> LogIOId<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(committed_vote: CommittedVote<C>, log_id: Option<LogId<C>>) -> Self {
+    pub(crate) fn new(committed_vote: CommittedVote<C>, log_id: Option<LogIdOf<C>>) -> Self {
         Self { committed_vote, log_id }
     }
 }

--- a/openraft/src/raft_state/log_state_reader.rs
+++ b/openraft/src/raft_state/log_state_reader.rs
@@ -1,4 +1,4 @@
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
 
@@ -9,7 +9,7 @@ pub(crate) trait LogStateReader<C>
 where C: RaftTypeConfig
 {
     /// Get previous log id, i.e., the log id at index - 1
-    fn prev_log_id(&self, index: u64) -> Option<LogId<C>> {
+    fn prev_log_id(&self, index: u64) -> Option<LogIdOf<C>> {
         if index == 0 {
             None
         } else {
@@ -20,7 +20,7 @@ where C: RaftTypeConfig
     /// Return if a log id exists.
     ///
     /// It assumes a committed log will always get positive return value, according to raft spec.
-    fn has_log_id(&self, log_id: &LogId<C>) -> bool {
+    fn has_log_id(&self, log_id: &LogIdOf<C>) -> bool {
         if log_id.index < self.committed().next_index() {
             debug_assert!(Some(log_id) <= self.committed());
             return true;
@@ -39,40 +39,40 @@ where C: RaftTypeConfig
     /// It will return `last_purged_log_id` if index is at the last purged index.
     /// If the log at the specified index is smaller than `last_purged_log_id`, or greater than
     /// `last_log_id`, it returns None.
-    fn get_log_id(&self, index: u64) -> Option<LogId<C>>;
+    fn get_log_id(&self, index: u64) -> Option<LogIdOf<C>>;
 
     /// The last known log id in the store.
     ///
     /// The range of all stored log ids are `(last_purged_log_id(), last_log_id()]`, left open right
     /// close.
-    fn last_log_id(&self) -> Option<&LogId<C>>;
+    fn last_log_id(&self) -> Option<&LogIdOf<C>>;
 
     /// The last known committed log id, i.e., the id of the log that is accepted by a quorum of
     /// voters.
-    fn committed(&self) -> Option<&LogId<C>>;
+    fn committed(&self) -> Option<&LogIdOf<C>>;
 
     /// The last known applied log id, i.e., the id of the log that is applied to state machine.
     ///
     /// This is actually happened io-state which might fall behind committed log id.
-    fn io_applied(&self) -> Option<&LogId<C>>;
+    fn io_applied(&self) -> Option<&LogIdOf<C>>;
 
     /// The last log id in the last persisted snapshot.
     ///
     /// This is actually happened io-state which might fall behind `Self::snapshot_last_log_id()`.
-    fn io_snapshot_last_log_id(&self) -> Option<&LogId<C>>;
+    fn io_snapshot_last_log_id(&self) -> Option<&LogIdOf<C>>;
 
     /// The last known purged log id, inclusive.
     ///
     /// This is actually purged log id from storage.
-    fn io_purged(&self) -> Option<&LogId<C>>;
+    fn io_purged(&self) -> Option<&LogIdOf<C>>;
 
     /// Return the last log id the snapshot includes.
-    fn snapshot_last_log_id(&self) -> Option<&LogId<C>>;
+    fn snapshot_last_log_id(&self) -> Option<&LogIdOf<C>>;
 
     /// Return the log id it wants to purge up to.
     ///
     /// Logs may not be able to be purged at once because they are in use by replication tasks.
-    fn purge_upto(&self) -> Option<&LogId<C>>;
+    fn purge_upto(&self) -> Option<&LogIdOf<C>>;
 
     /// The greatest log id that has been purged after being applied to state machine, i.e., the
     /// oldest known log id.
@@ -81,5 +81,5 @@ where C: RaftTypeConfig
     /// left open and right close.
     ///
     /// `last_purged_log_id == last_log_id` means there is no log entry in the storage.
-    fn last_purged_log_id(&self) -> Option<&LogId<C>>;
+    fn last_purged_log_id(&self) -> Option<&LogIdOf<C>>;
 }

--- a/openraft/src/raft_state/membership_state/mod.rs
+++ b/openraft/src/raft_state/membership_state/mod.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use validit::Validate;
 
 use crate::EffectiveMembership;
-use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
 
@@ -16,6 +15,8 @@ mod change_handler_test;
 mod membership_state_test;
 
 pub(crate) use change_handler::ChangeHandler;
+
+use crate::type_config::alias::LogIdOf;
 
 /// The state of membership configs a raft node needs to know.
 ///
@@ -80,7 +81,7 @@ where C: RaftTypeConfig
     }
 
     /// Update membership state if the specified committed_log_id is greater than `self.effective`
-    pub(crate) fn commit(&mut self, committed_log_id: &Option<LogId<C>>) {
+    pub(crate) fn commit(&mut self, committed_log_id: &Option<LogIdOf<C>>) {
         if committed_log_id >= self.effective().log_id() {
             debug_assert!(committed_log_id.index() >= self.effective().log_id().index());
             self.committed = self.effective.clone();

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -9,7 +9,6 @@ use crate::error::ForwardToLeader;
 use crate::log_id::RaftLogId;
 use crate::storage::SnapshotMeta;
 use crate::utime::Leased;
-use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
 use crate::ServerState;
@@ -61,7 +60,7 @@ where C: RaftTypeConfig
     ///   of the leader.
     ///
     /// - A quorum could be a uniform quorum or joint quorum.
-    pub committed: Option<LogId<C>>,
+    pub committed: Option<LogIdOf<C>>,
 
     pub(crate) purged_next: u64,
 
@@ -86,7 +85,7 @@ where C: RaftTypeConfig
     ///
     /// If a log is in use by a replication task, the purge is postponed and is stored in this
     /// field.
-    pub(crate) purge_upto: Option<LogId<C>>,
+    pub(crate) purge_upto: Option<LogIdOf<C>>,
 }
 
 impl<C> Default for RaftState<C>
@@ -110,39 +109,39 @@ where C: RaftTypeConfig
 impl<C> LogStateReader<C> for RaftState<C>
 where C: RaftTypeConfig
 {
-    fn get_log_id(&self, index: u64) -> Option<LogId<C>> {
+    fn get_log_id(&self, index: u64) -> Option<LogIdOf<C>> {
         self.log_ids.get(index)
     }
 
-    fn last_log_id(&self) -> Option<&LogId<C>> {
+    fn last_log_id(&self) -> Option<&LogIdOf<C>> {
         self.log_ids.last()
     }
 
-    fn committed(&self) -> Option<&LogId<C>> {
+    fn committed(&self) -> Option<&LogIdOf<C>> {
         self.committed.as_ref()
     }
 
-    fn io_applied(&self) -> Option<&LogId<C>> {
+    fn io_applied(&self) -> Option<&LogIdOf<C>> {
         self.io_state.applied()
     }
 
-    fn io_snapshot_last_log_id(&self) -> Option<&LogId<C>> {
+    fn io_snapshot_last_log_id(&self) -> Option<&LogIdOf<C>> {
         self.io_state.snapshot()
     }
 
-    fn io_purged(&self) -> Option<&LogId<C>> {
+    fn io_purged(&self) -> Option<&LogIdOf<C>> {
         self.io_state.purged()
     }
 
-    fn snapshot_last_log_id(&self) -> Option<&LogId<C>> {
+    fn snapshot_last_log_id(&self) -> Option<&LogIdOf<C>> {
         self.snapshot_meta.last_log_id.as_ref()
     }
 
-    fn purge_upto(&self) -> Option<&LogId<C>> {
+    fn purge_upto(&self) -> Option<&LogIdOf<C>> {
         self.purge_upto.as_ref()
     }
 
-    fn last_purged_log_id(&self) -> Option<&LogId<C>> {
+    fn last_purged_log_id(&self) -> Option<&LogIdOf<C>> {
         if self.purged_next == 0 {
             return None;
         }

--- a/openraft/src/raft_state/tests/log_state_reader_test.rs
+++ b/openraft/src/raft_state/tests/log_state_reader_test.rs
@@ -2,10 +2,10 @@ use crate::engine::testing::UTConfig;
 use crate::engine::LogIdList;
 use crate::raft_state::LogStateReader;
 use crate::testing;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::RaftState;
 
-fn log_id(term: u64, index: u64) -> LogId<UTConfig> {
+fn log_id(term: u64, index: u64) -> LogIdOf<UTConfig> {
     testing::log_id(term, 0, index)
 }
 

--- a/openraft/src/raft_state/tests/validate_test.rs
+++ b/openraft/src/raft_state/tests/validate_test.rs
@@ -4,10 +4,10 @@ use crate::engine::testing::UTConfig;
 use crate::engine::LogIdList;
 use crate::storage::SnapshotMeta;
 use crate::testing;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::RaftState;
 
-fn log_id(term: u64, index: u64) -> LogId<UTConfig> {
+fn log_id(term: u64, index: u64) -> LogIdOf<UTConfig> {
     testing::log_id(term, 0, index)
 }
 

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -59,7 +59,6 @@ use crate::type_config::alias::VoteOf;
 use crate::type_config::async_runtime::mutex::Mutex;
 use crate::type_config::TypeConfigExt;
 use crate::vote::raft_vote::RaftVoteExt;
-use crate::LogId;
 use crate::RaftLogId;
 use crate::RaftNetworkFactory;
 use crate::RaftTypeConfig;
@@ -136,10 +135,10 @@ where
     config: Arc<Config>,
 
     /// The log id of the highest log entry which is known to be committed in the cluster.
-    committed: Option<LogId<C>>,
+    committed: Option<LogIdOf<C>>,
 
     /// Last matching log id on a follower/learner
-    matching: Option<LogId<C>>,
+    matching: Option<LogIdOf<C>>,
 
     /// Next replication action to run.
     next_action: Option<Data<C>>,
@@ -163,8 +162,8 @@ where
         target: C::NodeId,
         session_id: ReplicationSessionId<C>,
         config: Arc<Config>,
-        committed: Option<LogId<C>>,
-        matching: Option<LogId<C>>,
+        committed: Option<LogIdOf<C>>,
+        matching: Option<LogIdOf<C>>,
         network: N::Network,
         snapshot_network: N::Network,
         log_reader: LS::LogReader,
@@ -818,7 +817,7 @@ where
     }
 
     /// If there are more logs to send, it returns a new `Some(Data::Logs)` to send.
-    fn next_action_to_send(&mut self, matching: Option<LogId<C>>, log_ids: LogIdRange<C>) -> Option<Data<C>> {
+    fn next_action_to_send(&mut self, matching: Option<LogIdOf<C>>, log_ids: LogIdRange<C>) -> Option<Data<C>> {
         if matching < log_ids.last {
             Some(Data::new_logs(LogIdRange::new(matching, log_ids.last)))
         } else {
@@ -827,7 +826,7 @@ where
     }
 
     /// Check if partial success result(`matching`) is valid for a given log range to send.
-    fn debug_assert_partial_success(to_send: &LogIdRange<C>, matching: &Option<LogId<C>>) {
+    fn debug_assert_partial_success(to_send: &LogIdRange<C>, matching: &Option<LogIdOf<C>>) {
         debug_assert!(
             matching <= &to_send.last,
             "matching ({}) should be <= last_log_id ({})",

--- a/openraft/src/replication/replication_session_id.rs
+++ b/openraft/src/replication/replication_session_id.rs
@@ -2,9 +2,9 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 
 use crate::display_ext::DisplayOptionExt;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
 use crate::vote::committed::CommittedVote;
-use crate::LogId;
 use crate::RaftTypeConfig;
 
 /// Uniquely identifies a replication session.
@@ -38,7 +38,7 @@ where C: RaftTypeConfig
     pub(crate) leader_vote: CommittedVote<C>,
 
     /// The log id of the membership log this replication works for.
-    pub(crate) membership_log_id: Option<LogId<C>>,
+    pub(crate) membership_log_id: Option<LogIdOf<C>>,
 }
 
 impl<C> Display for ReplicationSessionId<C>
@@ -57,7 +57,7 @@ where C: RaftTypeConfig
 impl<C> ReplicationSessionId<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(vote: CommittedVote<C>, membership_log_id: Option<LogId<C>>) -> Self {
+    pub(crate) fn new(vote: CommittedVote<C>, membership_log_id: Option<LogIdOf<C>>) -> Self {
         Self {
             leader_vote: vote,
             membership_log_id,

--- a/openraft/src/replication/request.rs
+++ b/openraft/src/replication/request.rs
@@ -9,7 +9,7 @@ pub(crate) enum Replicate<C>
 where C: RaftTypeConfig
 {
     /// Inform replication stream to forward the committed log id to followers/learners.
-    Committed(Option<LogId<C>>),
+    Committed(Option<LogIdOf<C>>),
 
     /// Send a chunk of data, e.g., logs or snapshot.
     Data(Data<C>),
@@ -47,7 +47,6 @@ use crate::raft::SnapshotResponse;
 use crate::replication::callbacks::SnapshotCallback;
 use crate::storage::SnapshotMeta;
 use crate::type_config::alias::InstantOf;
-use crate::LogId;
 use crate::RaftTypeConfig;
 
 /// Request to replicate a chunk of data, logs or snapshot.

--- a/openraft/src/storage/callback.rs
+++ b/openraft/src/storage/callback.rs
@@ -5,12 +5,12 @@ use std::io;
 use crate::async_runtime::MpscUnboundedSender;
 use crate::async_runtime::MpscUnboundedWeakSender;
 use crate::core::notification::Notification;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::MpscUnboundedWeakSenderOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::async_runtime::oneshot::OneshotSender;
 use crate::ErrorSubject;
 use crate::ErrorVerb;
-use crate::LogId;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 
@@ -101,8 +101,8 @@ where C: RaftTypeConfig
 pub struct LogApplied<C>
 where C: RaftTypeConfig
 {
-    last_log_id: LogId<C>,
-    tx: OneshotSenderOf<C, Result<(LogId<C>, Vec<C::R>), StorageError<C>>>,
+    last_log_id: LogIdOf<C>,
+    tx: OneshotSenderOf<C, Result<(LogIdOf<C>, Vec<C::R>), StorageError<C>>>,
 }
 
 impl<C> LogApplied<C>
@@ -110,8 +110,8 @@ where C: RaftTypeConfig
 {
     #[allow(dead_code)]
     pub(crate) fn new(
-        last_log_id: LogId<C>,
-        tx: OneshotSenderOf<C, Result<(LogId<C>, Vec<C::R>), StorageError<C>>>,
+        last_log_id: LogIdOf<C>,
+        tx: OneshotSenderOf<C, Result<(LogIdOf<C>, Vec<C::R>), StorageError<C>>>,
     ) -> Self {
         Self { last_log_id, tx }
     }

--- a/openraft/src/storage/log_reader_ext.rs
+++ b/openraft/src/storage/log_reader_ext.rs
@@ -1,7 +1,7 @@
 use anyerror::AnyError;
 use openraft_macros::add_async_trait;
 
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::RaftLogId;
 use crate::RaftLogReader;
 use crate::RaftTypeConfig;
@@ -20,7 +20,7 @@ where C: RaftTypeConfig
     }
 
     /// Get the log id of the entry at `index`.
-    async fn get_log_id(&mut self, log_index: u64) -> Result<LogId<C>, StorageError<C>> {
+    async fn get_log_id(&mut self, log_index: u64) -> Result<LogIdOf<C>, StorageError<C>> {
         let entries = self.try_get_log_entries(log_index..=log_index).await?;
 
         if entries.is_empty() {

--- a/openraft/src/storage/log_state.rs
+++ b/openraft/src/storage/log_state.rs
@@ -1,4 +1,4 @@
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::RaftTypeConfig;
 
 /// The state about logs.
@@ -7,9 +7,9 @@ use crate::RaftTypeConfig;
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct LogState<C: RaftTypeConfig> {
     /// The greatest log id that has been purged after being applied to state machine.
-    pub last_purged_log_id: Option<LogId<C>>,
+    pub last_purged_log_id: Option<LogIdOf<C>>,
 
     /// The log id of the last present entry if there are any entries.
     /// Otherwise the same value as `last_purged_log_id`.
-    pub last_log_id: Option<LogId<C>>,
+    pub last_log_id: Option<LogIdOf<C>>,
 }

--- a/openraft/src/storage/snapshot_meta.rs
+++ b/openraft/src/storage/snapshot_meta.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::display_ext::DisplayOption;
 use crate::storage::SnapshotSignature;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::RaftTypeConfig;
 use crate::SnapshotId;
 use crate::StoredMembership;
@@ -18,7 +18,7 @@ pub struct SnapshotMeta<C>
 where C: RaftTypeConfig
 {
     /// Log entries upto which this snapshot includes, inclusive.
-    pub last_log_id: Option<LogId<C>>,
+    pub last_log_id: Option<LogIdOf<C>>,
 
     /// The last applied membership config.
     pub last_membership: StoredMembership<C>,
@@ -55,7 +55,7 @@ where C: RaftTypeConfig
     }
 
     /// Returns a ref to the id of the last log that is included in this snapshot.
-    pub fn last_log_id(&self) -> Option<&LogId<C>> {
+    pub fn last_log_id(&self) -> Option<&LogIdOf<C>> {
         self.last_log_id.as_ref()
     }
 }

--- a/openraft/src/storage/snapshot_signature.rs
+++ b/openraft/src/storage/snapshot_signature.rs
@@ -1,4 +1,4 @@
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::RaftTypeConfig;
 use crate::SnapshotId;
 
@@ -9,10 +9,10 @@ pub struct SnapshotSignature<C>
 where C: RaftTypeConfig
 {
     /// Log entries upto which this snapshot includes, inclusive.
-    pub last_log_id: Option<LogId<C>>,
+    pub last_log_id: Option<LogIdOf<C>>,
 
     /// The last applied membership log id.
-    pub last_membership_log_id: Option<LogId<C>>,
+    pub last_membership_log_id: Option<LogIdOf<C>>,
 
     /// To identify a snapshot when transferring.
     pub snapshot_id: SnapshotId,

--- a/openraft/src/storage/v2/raft_log_reader.rs
+++ b/openraft/src/storage/v2/raft_log_reader.rs
@@ -6,8 +6,8 @@ use openraft_macros::add_async_trait;
 use openraft_macros::since;
 
 use crate::engine::LogIdList;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
-use crate::LogId;
 use crate::OptionalSend;
 use crate::OptionalSync;
 use crate::RaftTypeConfig;
@@ -104,7 +104,7 @@ where C: RaftTypeConfig
     ///
     /// [`RaftLogStorage`]: crate::storage::RaftLogStorage
     #[since(version = "0.10.0")]
-    async fn get_key_log_ids(&mut self, range: RangeInclusive<LogId<C>>) -> Result<Vec<LogId<C>>, StorageError<C>> {
+    async fn get_key_log_ids(&mut self, range: RangeInclusive<LogIdOf<C>>) -> Result<Vec<LogIdOf<C>>, StorageError<C>> {
         LogIdList::get_key_log_ids(range, self).await
     }
 }

--- a/openraft/src/storage/v2/raft_log_storage.rs
+++ b/openraft/src/storage/v2/raft_log_storage.rs
@@ -2,8 +2,8 @@ use openraft_macros::add_async_trait;
 
 use crate::storage::IOFlushed;
 use crate::storage::LogState;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
-use crate::LogId;
 use crate::OptionalSend;
 use crate::OptionalSync;
 use crate::RaftLogReader;
@@ -67,13 +67,13 @@ where C: RaftTypeConfig
     /// See: [`docs::data::log_pointers`].
     ///
     /// [`docs::data::log_pointers`]: `crate::docs::data::log_pointers#optionally-persisted-committed`
-    async fn save_committed(&mut self, _committed: Option<LogId<C>>) -> Result<(), StorageError<C>> {
+    async fn save_committed(&mut self, _committed: Option<LogIdOf<C>>) -> Result<(), StorageError<C>> {
         // By default `committed` log id is not saved
         Ok(())
     }
 
     /// Return the last saved committed log id by [`Self::save_committed`].
-    async fn read_committed(&mut self) -> Result<Option<LogId<C>>, StorageError<C>> {
+    async fn read_committed(&mut self) -> Result<Option<LogIdOf<C>>, StorageError<C>> {
         // By default `committed` log id is not saved and this method just return None.
         Ok(None)
     }
@@ -106,12 +106,12 @@ where C: RaftTypeConfig
     /// ### To ensure correctness:
     ///
     /// - It must not leave a **hole** in logs.
-    async fn truncate(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>>;
+    async fn truncate(&mut self, log_id: LogIdOf<C>) -> Result<(), StorageError<C>>;
 
     /// Purge logs upto `log_id`, inclusive
     ///
     /// ### To ensure correctness:
     ///
     /// - It must not leave a **hole** in logs.
-    async fn purge(&mut self, log_id: LogId<C>) -> Result<(), StorageError<C>>;
+    async fn purge(&mut self, log_id: LogIdOf<C>) -> Result<(), StorageError<C>>;
 }

--- a/openraft/src/storage/v2/raft_state_machine.rs
+++ b/openraft/src/storage/v2/raft_state_machine.rs
@@ -2,7 +2,7 @@ use openraft_macros::add_async_trait;
 
 use crate::storage::Snapshot;
 use crate::storage::SnapshotMeta;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::OptionalSend;
 use crate::OptionalSync;
 use crate::RaftSnapshotBuilder;
@@ -35,7 +35,7 @@ where C: RaftTypeConfig
     /// last-applied-log-id.
     /// Because upon startup, the last membership will be loaded by scanning logs from the
     /// `last-applied-log-id`.
-    async fn applied_state(&mut self) -> Result<(Option<LogId<C>>, StoredMembership<C>), StorageError<C>>;
+    async fn applied_state(&mut self) -> Result<(Option<LogIdOf<C>>, StoredMembership<C>), StorageError<C>>;
 
     /// Apply the given payload of entries to the state machine.
     ///

--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use anyerror::AnyError;
 
 use crate::storage::SnapshotSignature;
-use crate::LogId;
+use crate::type_config::alias::LogIdOf;
 use crate::RaftTypeConfig;
 
 /// Convert error to StorageError::IO();
@@ -48,13 +48,13 @@ where C: RaftTypeConfig
     Logs,
 
     /// Error about a single log entry
-    Log(LogId<C>),
+    Log(LogIdOf<C>),
 
     /// Error about a single log entry without knowing the log term.
     LogIndex(u64),
 
     /// Error happened when applying a log entry
-    Apply(LogId<C>),
+    Apply(LogIdOf<C>),
 
     /// Error happened when operating state machine.
     StateMachine,
@@ -137,7 +137,7 @@ where C: RaftTypeConfig
         }
     }
 
-    pub fn write_log_entry(log_id: LogId<C>, source: impl Into<AnyError>) -> Self {
+    pub fn write_log_entry(log_id: LogIdOf<C>, source: impl Into<AnyError>) -> Self {
         Self::new(ErrorSubject::Log(log_id), ErrorVerb::Write, source)
     }
 
@@ -145,7 +145,7 @@ where C: RaftTypeConfig
         Self::new(ErrorSubject::LogIndex(log_index), ErrorVerb::Read, source)
     }
 
-    pub fn read_log_entry(log_id: LogId<C>, source: impl Into<AnyError>) -> Self {
+    pub fn read_log_entry(log_id: LogIdOf<C>, source: impl Into<AnyError>) -> Self {
         Self::new(ErrorSubject::Log(log_id), ErrorVerb::Read, source)
     }
 
@@ -165,7 +165,7 @@ where C: RaftTypeConfig
         Self::new(ErrorSubject::Vote, ErrorVerb::Read, source)
     }
 
-    pub fn apply(log_id: LogId<C>, source: impl Into<AnyError>) -> Self {
+    pub fn apply(log_id: LogIdOf<C>, source: impl Into<AnyError>) -> Self {
         Self::new(ErrorSubject::Apply(log_id), ErrorVerb::Write, source)
     }
 

--- a/openraft/src/testing/common.rs
+++ b/openraft/src/testing/common.rs
@@ -3,12 +3,13 @@
 use std::collections::BTreeSet;
 
 use crate::entry::RaftEntry;
+use crate::type_config::alias::LogIdOf;
 use crate::vote::RaftLeaderIdExt;
 use crate::LogId;
 use crate::RaftTypeConfig;
 
 /// Builds a log id, for testing purposes.
-pub fn log_id<C>(term: u64, node_id: C::NodeId, index: u64) -> LogId<C>
+pub fn log_id<C>(term: u64, node_id: C::NodeId, index: u64) -> LogIdOf<C>
 where
     C: RaftTypeConfig,
     C::Term: From<u64>,

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -23,6 +23,7 @@ use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
 use crate::storage::StorageHelper;
 use crate::testing::log::StoreBuilder;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
 use crate::type_config::TypeConfigExt;
 use crate::vote::raft_vote::RaftVoteExt;
@@ -53,7 +54,7 @@ trait ReaderExt<C>: RaftLogStorage<C>
 where C: RaftTypeConfig
 {
     /// Proxy method to invoke [`RaftLogReaderExt::get_log_id`].
-    async fn get_log_id(&mut self, log_index: u64) -> Result<LogId<C>, StorageError<C>> {
+    async fn get_log_id(&mut self, log_index: u64) -> Result<LogIdOf<C>, StorageError<C>> {
         self.get_log_reader().await.get_log_id(log_index).await
     }
 
@@ -642,7 +643,7 @@ where
         tracing::info!("--- empty store, expect []");
         {
             let initial = StorageHelper::new(&mut store, &mut sm).get_initial_state().await?;
-            assert_eq!(Vec::<LogId<C>>::new(), initial.log_ids.key_log_ids());
+            assert_eq!(Vec::<LogIdOf<C>>::new(), initial.log_ids.key_log_ids());
         }
 
         tracing::info!("--- log terms: [0], last_purged_log_id is None, expect [(0,0)]");
@@ -1374,7 +1375,7 @@ where
 }
 
 /// Create a log id with node id 0 for testing.
-fn log_id_0<C>(term: impl Into<C::Term>, index: u64) -> LogId<C>
+fn log_id_0<C>(term: impl Into<C::Term>, index: u64) -> LogIdOf<C>
 where
     C: RaftTypeConfig,
     C::NodeId: From<u64>,
@@ -1457,7 +1458,7 @@ where
     Ok(())
 }
 
-fn log_id<C>(term: u64, node_id: u64, index: u64) -> LogId<C>
+fn log_id<C>(term: u64, node_id: u64, index: u64) -> LogIdOf<C>
 where
     C: RaftTypeConfig,
     C::Term: From<u64>,

--- a/tests/tests/client_api/t16_with_state_machine.rs
+++ b/tests/tests/client_api/t16_with_state_machine.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use maplit::btreeset;
+use openraft::alias::LogIdOf;
 use openraft::error::Fatal;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
@@ -9,7 +10,6 @@ use openraft::storage::SnapshotMeta;
 use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Entry;
-use openraft::LogId;
 use openraft::OptionalSend;
 use openraft::RaftSnapshotBuilder;
 use openraft::RaftTypeConfig;
@@ -98,7 +98,7 @@ async fn with_state_machine_wrong_sm_type() -> Result<()> {
         impl RaftStateMachine<TC> for FooSM {
             type SnapshotBuilder = Self;
 
-            async fn applied_state(&mut self) -> Result<(Option<LogId<TypeConfig>>, StoredMembership<TC>), Err> {
+            async fn applied_state(&mut self) -> Result<(Option<LogIdOf<TypeConfig>>, StoredMembership<TC>), Err> {
                 todo!()
             }
 

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -48,7 +48,6 @@ use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use openraft::Config;
-use openraft::LogId;
 use openraft::LogIdOptionExt;
 use openraft::OptionalSend;
 use openraft::RPCTypes;
@@ -185,6 +184,7 @@ impl fmt::Display for Direction {
     }
 }
 
+use openraft::alias::LogIdOf;
 use openraft::alias::VoteOf;
 use openraft::network::v2::RaftNetworkV2;
 use openraft::vote::RaftLeaderId;
@@ -729,7 +729,7 @@ impl TypedRaftRouter {
     pub async fn wait_for_snapshot(
         &self,
         node_ids: &BTreeSet<MemNodeId>,
-        want: LogId<TypeConfig>,
+        want: LogIdOf<TypeConfig>,
         timeout: Option<Duration>,
         msg: &str,
     ) -> anyhow::Result<()> {
@@ -867,7 +867,7 @@ impl TypedRaftRouter {
         expect_term: u64,
         expect_last_log: u64,
         expect_voted_for: Option<MemNodeId>,
-        expect_sm_last_applied_log: LogId<TypeConfig>,
+        expect_sm_last_applied_log: LogIdOf<TypeConfig>,
         expect_snapshot: &Option<(ValueTest<u64>, u64)>,
     ) -> anyhow::Result<()> {
         let last_log_id = storage.get_log_state().await?.last_log_id;
@@ -959,7 +959,7 @@ impl TypedRaftRouter {
         expect_term: u64,
         expect_last_log: u64,
         expect_voted_for: Option<MemNodeId>,
-        expect_sm_last_applied_log: LogId<TypeConfig>,
+        expect_sm_last_applied_log: LogIdOf<TypeConfig>,
         expect_snapshot: Option<(ValueTest<u64>, u64)>,
     ) -> anyhow::Result<()> {
         let node_ids = {


### PR DESCRIPTION

## Changelog

##### Chore: Replace `LogId<C>` with `LogIdOf<C>`

This change prepares for a future update where `LogId` will become an
associated type of `RaftTypeConfig`. By replacing `LogId` with `LogIdOf`
now, the transition to `C::LogId` in a future commit will require
minimal code changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1295)
<!-- Reviewable:end -->
