### PR TITLE
Chore: replace usage of `LogId.leader_id` with `LogId.leader_id()`

### DIFF
--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -151,7 +151,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
         let snapshot_idx = self.snapshot_idx.fetch_add(1, Ordering::Relaxed);
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id, last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/examples/raft-kv-memstore-grpc/src/lib.rs
+++ b/examples/raft-kv-memstore-grpc/src/lib.rs
@@ -60,7 +60,7 @@ impl From<pb::VoteResponse> for VoteResponse {
 impl From<LogId> for pb::LogId {
     fn from(log_id: LogId) -> Self {
         pb::LogId {
-            term: log_id.leader_id,
+            term: *log_id.leader_id(),
             index: log_id.index(),
         }
     }

--- a/examples/raft-kv-memstore-grpc/src/store/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/store/mod.rs
@@ -85,7 +85,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
         };
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id, last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/examples/raft-kv-memstore-network-v2/src/store.rs
+++ b/examples/raft-kv-memstore-network-v2/src/store.rs
@@ -92,7 +92,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
         };
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id, last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -106,7 +106,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
         };
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id, last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/examples/raft-kv-memstore-singlethreaded/src/store.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/store.rs
@@ -146,7 +146,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Rc<StateMachineStore> {
         };
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id, last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -105,7 +105,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
 
         let snapshot_idx = self.snapshot_idx.fetch_add(1, Ordering::Relaxed) + 1;
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id, last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -89,7 +89,7 @@ impl RaftSnapshotBuilder<TypeConfig> for StateMachineStore {
         };
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id, last.index(), self.snapshot_idx)
+            format!("{}-{}-{}", last.leader_id(), last.index(), self.snapshot_idx)
         } else {
             format!("--{}", self.snapshot_idx)
         };

--- a/examples/rocksstore/src/lib.rs
+++ b/examples/rocksstore/src/lib.rs
@@ -130,7 +130,7 @@ impl RaftSnapshotBuilder<TypeConfig> for RocksStateMachine {
         let snapshot_idx: u64 = rand::thread_rng().gen_range(0..1000);
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id, last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -586,7 +586,7 @@ where
             id: self.id.clone(),
 
             // --- data ---
-            current_term: st.vote_ref().to_leader_id().term(),
+            current_term: st.vote_ref().term(),
             vote: st.io_state().io_progress.flushed().map(|io_id| io_id.to_vote()).unwrap_or_default(),
             last_log_index: st.last_log_id().index(),
             last_applied: st.io_applied().cloned(),

--- a/openraft/src/engine/log_id_list.rs
+++ b/openraft/src/engine/log_id_list.rs
@@ -71,8 +71,8 @@ where C: RaftTypeConfig
             };
 
             // Case AA
-            if first.leader_id == last.leader_id {
-                if res.last().map(|x| &x.leader_id) < Some(&first.leader_id) {
+            if first.leader_id() == last.leader_id() {
+                if res.last().map(|x| x.leader_id()) < Some(first.leader_id()) {
                     res.push(first);
                 }
                 continue;
@@ -80,7 +80,7 @@ where C: RaftTypeConfig
 
             // Two adjacent logs with different leader_id, no need to binary search
             if first.index() + 1 == last.index() {
-                if res.last().map(|x| &x.leader_id) < Some(&first.leader_id) {
+                if res.last().map(|x| x.leader_id()) < Some(first.leader_id()) {
                     res.push(first);
                 }
                 res.push(last);
@@ -89,13 +89,13 @@ where C: RaftTypeConfig
 
             let mid = sto.get_log_id((first.index() + last.index()) / 2).await?;
 
-            if first.leader_id == mid.leader_id {
+            if first.leader_id() == mid.leader_id() {
                 // Case AAC
-                if res.last().map(|x| &x.leader_id) < Some(&first.leader_id) {
+                if res.last().map(|x| x.leader_id()) < Some(first.leader_id()) {
                     res.push(first);
                 }
                 stack.push((mid, last));
-            } else if mid.leader_id == last.leader_id {
+            } else if mid.leader_id() == last.leader_id() {
                 // Case ACC
                 stack.push((first, mid));
             } else {
@@ -137,7 +137,7 @@ where C: RaftTypeConfig
 
             if let Some(last) = new_ids.last() {
                 let last_id = last.get_log_id();
-                assert_eq!(last_id.leader_id, first_id.leader_id);
+                assert_eq!(last_id.leader_id(), first_id.leader_id());
 
                 if last_id != first_id {
                     self.append(last_id.clone());
@@ -150,15 +150,15 @@ where C: RaftTypeConfig
     // leader_id: Copy is feature gated
     #[allow(clippy::clone_on_copy)]
     pub(crate) fn extend<'a, LID: RaftLogId<C> + 'a>(&mut self, new_ids: &[LID]) {
-        let mut prev = self.last().map(|x| x.leader_id.clone());
+        let mut prev = self.last().map(|x| x.leader_id().clone());
 
         for x in new_ids.iter() {
             let log_id = x.get_log_id();
 
-            if prev.as_ref() != Some(&log_id.leader_id) {
+            if prev.as_ref() != Some(log_id.leader_id()) {
                 self.append(log_id.clone());
 
-                prev = Some(log_id.leader_id.clone());
+                prev = Some(log_id.leader_id().clone());
             }
         }
 
@@ -204,7 +204,7 @@ where C: RaftTypeConfig
 
         let last = &self.key_log_ids[l - 1];
 
-        if self.key_log_ids.get(l - 2).map(|x| &x.leader_id) == Some(&last.leader_id) {
+        if self.key_log_ids.get(l - 2).map(|x| x.leader_id()) == Some(last.leader_id()) {
             // Replace the **last log id**.
             self.key_log_ids[l - 1] = new_log_id;
             return;
@@ -237,7 +237,7 @@ where C: RaftTypeConfig
         // Add key log id if there is a gap between last.index and at - 1.
         let last = self.key_log_ids.last();
         if let Some(last) = last {
-            let (last_leader_id, last_index) = (last.leader_id.clone(), last.index());
+            let (last_leader_id, last_index) = (last.leader_id().clone(), last.index());
             if last_index < at - 1 {
                 self.append(LogIdOf::<C>::new(last_leader_id, at - 1));
             }
@@ -284,12 +284,12 @@ where C: RaftTypeConfig
         let res = self.key_log_ids.binary_search_by(|log_id| log_id.index().cmp(&index));
 
         match res {
-            Ok(i) => Some(LogIdOf::<C>::new(self.key_log_ids[i].leader_id.clone(), index)),
+            Ok(i) => Some(LogIdOf::<C>::new(self.key_log_ids[i].leader_id().clone(), index)),
             Err(i) => {
                 if i == 0 || i == self.key_log_ids.len() {
                     None
                 } else {
-                    Some(LogIdOf::<C>::new(self.key_log_ids[i - 1].leader_id.clone(), index))
+                    Some(LogIdOf::<C>::new(self.key_log_ids[i - 1].leader_id().clone(), index))
                 }
             }
         }

--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -55,7 +55,7 @@ impl<C> Display for LogId<C>
 where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}", self.leader_id, self.index())
+        write!(f, "{}.{}", self.leader_id(), self.index())
     }
 }
 

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -294,7 +294,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<MemStateMachine> {
         };
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id, last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/tests/tests/append_entries/t11_append_inconsistent_log.rs
+++ b/tests/tests/append_entries/t11_append_inconsistent_log.rs
@@ -115,7 +115,7 @@ async fn append_inconsistent_log() -> Result<()> {
     let logs = sto0.try_get_log_entries(60..=60).await?;
     assert_eq!(
         3,
-        logs.first().unwrap().log_id.leader_id.term,
+        logs.first().unwrap().log_id.leader_id().term,
         "log is overridden by leader logs"
     );
 

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -930,7 +930,7 @@ impl TypedRaftRouter {
             }
 
             assert_eq!(
-                &snap.meta.last_log_id.unwrap_or_default().leader_id.term,
+                &snap.meta.last_log_id.unwrap_or_default().leader_id().term,
                 term,
                 "expected node {} to have snapshot with term {}, got {:?}",
                 id,


### PR DESCRIPTION

## Changelog

##### Chore: replace usage of `LogId.leader_id` with `LogId.leader_id()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1297)
<!-- Reviewable:end -->
