### PR TITLE
Chore: replace usage of `ProgressEntry::matching` with `ProgressEntry::matching()`

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -333,7 +333,7 @@ where
 
             let rpc = AppendEntriesRequest {
                 vote: my_vote.clone(),
-                prev_log_id: progress.matching.clone(),
+                prev_log_id: progress.matching().cloned(),
                 entries: vec![],
                 leader_commit: self.engine.state.committed().cloned(),
             };
@@ -842,7 +842,7 @@ where
             session_id,
             self.config.clone(),
             self.engine.state.committed().cloned(),
-            progress_entry.matching,
+            progress_entry.matching().cloned(),
             network,
             snapshot_network,
             self.log_store.get_log_reader().await,

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -94,7 +94,7 @@ fn test_leader_append_membership_for_leader() -> anyhow::Result<()> {
     );
 
     assert!(
-        eng.leader.as_ref().unwrap().progress.get(&4).matching.is_none(),
+        eng.leader.as_ref().unwrap().progress.get(&4).matching().is_none(),
         "exists, but it is a None"
     );
 

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -403,11 +403,11 @@ where C: RaftTypeConfig
         // The leader may not be in membership anymore
         if let Some(prog_entry) = self.leader.progress.get_mut(&id) {
             tracing::debug!(
-                self_matching = display(prog_entry.matching.display()),
+                self_matching = display(prog_entry.matching().display()),
                 "update progress"
             );
 
-            if prog_entry.matching >= upto {
+            if prog_entry.matching() >= upto.as_ref() {
                 return;
             }
             // TODO: It should be self.state.last_log_id() but None is ok.

--- a/openraft/src/progress/entry/tests.rs
+++ b/openraft/src/progress/entry/tests.rs
@@ -49,12 +49,12 @@ fn test_update_matching() -> anyhow::Result<()> {
         pe.inflight = inflight_logs(5, 10);
         pe.new_updater(&engine_config).update_matching(Some(log_id(6)));
         assert_eq!(inflight_logs(6, 10), pe.inflight);
-        assert_eq!(Some(log_id(6)), pe.matching);
+        assert_eq!(Some(&log_id(6)), pe.matching());
         assert_eq!(20, pe.searching_end);
 
         pe.new_updater(&engine_config).update_matching(Some(log_id(10)));
         assert_eq!(Inflight::None, pe.inflight);
-        assert_eq!(Some(log_id(10)), pe.matching);
+        assert_eq!(Some(&log_id(10)), pe.matching());
         assert_eq!(20, pe.searching_end);
     }
 

--- a/openraft/src/progress/entry/update.rs
+++ b/openraft/src/progress/entry/update.rs
@@ -52,13 +52,13 @@ where C: RaftTypeConfig
         let allow_reset = self.entry.allow_log_reversion || self.engine_config.allow_log_reversion;
 
         if allow_reset {
-            if conflict < self.entry.matching.next_index() {
+            if conflict < self.entry.matching().next_index() {
                 tracing::warn!(
                     "conflict {} < last matching {}: \
                     follower log is reverted; \
                     with 'allow_log_reversion' enabled, this is allowed.",
                     conflict,
-                    self.entry.matching.display(),
+                    self.entry.matching().display(),
                 );
 
                 self.entry.matching = None;
@@ -66,11 +66,11 @@ where C: RaftTypeConfig
             }
         } else {
             debug_assert!(
-                conflict >= self.entry.matching.next_index(),
+                conflict >= self.entry.matching().next_index(),
                 "follower log reversion is not allowed \
                 without `allow_log_reversion` enabled; \
                 matching: {}; conflict: {}",
-                self.entry.matching.display(),
+                self.entry.matching().display(),
                 conflict
             );
         }
@@ -88,7 +88,7 @@ where C: RaftTypeConfig
         debug_assert!(matching >= self.entry.matching);
         self.entry.matching = matching;
 
-        let matching_next = self.entry.matching.next_index();
+        let matching_next = self.entry.matching().next_index();
         self.entry.searching_end = std::cmp::max(self.entry.searching_end, matching_next);
     }
 }


### PR DESCRIPTION

## Changelog

##### Chore: replace usage of `ProgressEntry::matching` with `ProgressEntry::matching()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1298)
<!-- Reviewable:end -->
