### PR TITLE
Fix: add missing RaftStateMachine trait bound

### DIFF
--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -952,7 +952,7 @@ where C: RaftTypeConfig
     #[since(version = "0.10.0")]
     pub fn external_state_machine_request<F, SM>(&self, req: F)
     where
-        SM: 'static,
+        SM: RaftStateMachine<C> + 'static,
         F: FnOnce(&mut SM) -> BoxFuture<()> + OptionalSend + 'static,
     {
         let input_sm_type = std::any::type_name::<SM>();


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

This commit adds the missing `RaftStateMachine<C>` trait bound to `Raft::external_state_machine_request()`'s `SM` parameter, based on the discussion [here](https://github.com/databendlabs/openraft/pull/1206#discussion_r1909951691).


**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

   No need to add unit tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1299)
<!-- Reviewable:end -->
