### PR TITLE
Chore: fix trait constrain for `external_state_machine_request<SM>()`

### DIFF
--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -952,7 +952,7 @@ where C: RaftTypeConfig
     #[since(version = "0.10.0")]
     pub fn external_state_machine_request<F, SM>(&self, req: F)
     where
-        SM: 'static,
+        SM: RaftStateMachine<C>,
         F: FnOnce(&mut SM) -> BoxFuture<()> + OptionalSend + 'static,
     {
         let input_sm_type = std::any::type_name::<SM>();


### PR DESCRIPTION
## Changelog

##### Chore: fix trait constrain for `external_state_machine_request<SM>()`

Add missing trait constrain `SM: RaftStateMachine<C>` to
`external_state_machine_request<SM>()`.

- Mentioned in https://github.com/databendlabs/openraft/pull/1206#discussion_r1909951691

Thanks to @SteveLauC

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1300)
<!-- Reviewable:end -->
