### PR TITLE
Chore: use engine::testing::log_id() when using UTConfig

### DIFF
--- a/openraft/src/engine/handler/following_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/append_entries_test.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Condition;
@@ -11,7 +12,6 @@ use crate::engine::Engine;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
 use crate::testing::blank_ent;
-use crate::testing::log_id;
 use crate::type_config::alias::VoteOf;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;

--- a/openraft/src/engine/handler/following_handler/commit_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/commit_entries_test.rs
@@ -3,12 +3,12 @@ use std::time::Duration;
 
 use maplit::btreeset;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::vote::raft_vote::RaftVoteExt;

--- a/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
@@ -4,13 +4,13 @@ use std::time::Duration;
 use maplit::btreeset;
 
 use crate::core::ServerState;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::entry::RaftEntry;
 use crate::raft_state::LogStateReader;
 use crate::testing::blank_ent;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::vote::raft_vote::RaftVoteExt;

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -6,6 +6,7 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::core::sm;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Condition;
@@ -15,7 +16,6 @@ use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
 use crate::storage::Snapshot;
 use crate::storage::SnapshotMeta;
-use crate::testing::log_id;
 use crate::type_config::alias::VoteOf;
 use crate::type_config::TypeConfigExt;
 use crate::vote::raft_vote::RaftVoteExt;

--- a/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
+++ b/openraft/src/engine/handler/following_handler/truncate_logs_test.rs
@@ -3,12 +3,12 @@ use std::time::Duration;
 
 use maplit::btreeset;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft_state::LogStateReader;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;

--- a/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
+++ b/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
@@ -4,9 +4,9 @@ use std::time::Duration;
 use maplit::btreeset;
 
 use crate::core::ServerState;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Engine;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -9,6 +9,7 @@ use pretty_assertions::assert_ne;
 #[allow(unused_imports)]
 use pretty_assertions::assert_str_eq;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
@@ -20,7 +21,6 @@ use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
 use crate::replication::request::Replicate;
 use crate::testing::blank_ent;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::vote::raft_vote::RaftVoteExt;

--- a/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
+++ b/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
@@ -9,9 +9,9 @@ use pretty_assertions::assert_ne;
 #[allow(unused_imports)]
 use pretty_assertions::assert_str_eq;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Engine;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -4,11 +4,11 @@ use std::time::Duration;
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::replication::ReplicationSessionId;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::vote::raft_vote::RaftVoteExt;

--- a/openraft/src/engine/handler/leader_handler/transfer_leader_test.rs
+++ b/openraft/src/engine/handler/leader_handler/transfer_leader_test.rs
@@ -9,11 +9,11 @@ use pretty_assertions::assert_ne;
 #[allow(unused_imports)]
 use pretty_assertions::assert_str_eq;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::raft::TransferLeaderRequest;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;

--- a/openraft/src/engine/handler/log_handler/purge_log_test.rs
+++ b/openraft/src/engine/handler/log_handler/purge_log_test.rs
@@ -1,9 +1,9 @@
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft_state::LogStateReader;
-use crate::testing::log_id;
 
 fn eng() -> Engine<UTConfig> {
     let mut eng = Engine::testing_default(0);

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
@@ -13,7 +14,6 @@ use crate::engine::ReplicationProgress;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::progress::Progress;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;

--- a/openraft/src/engine/handler/replication_handler/update_matching_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_matching_test.rs
@@ -4,13 +4,13 @@ use std::time::Duration;
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::Inflight;
 use crate::progress::Progress;
 use crate::raft_state::LogStateReader;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;

--- a/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
+++ b/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
@@ -4,9 +4,9 @@ use std::time::Duration;
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Engine;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;

--- a/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
+++ b/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
@@ -1,10 +1,10 @@
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Engine;
 use crate::storage::SnapshotMeta;
-use crate::testing::log_id;
 use crate::Membership;
 use crate::StoredMembership;
 

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Condition;
@@ -13,7 +14,6 @@ use crate::engine::Respond;
 use crate::error::Infallible;
 use crate::raft::VoteResponse;
 use crate::raft_state::IOId;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;

--- a/openraft/src/engine/handler/vote_handler/become_leader_test.rs
+++ b/openraft/src/engine/handler/vote_handler/become_leader_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
@@ -14,7 +15,6 @@ use crate::log_id_range::LogIdRange;
 use crate::progress::entry::ProgressEntry;
 use crate::raft_state::IOId;
 use crate::replication::request::Replicate;
-use crate::testing::log_id;
 use crate::type_config::alias::EntryOf;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;

--- a/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
@@ -5,12 +5,12 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::error::RejectVoteRequest;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -1,6 +1,10 @@
 use std::io::Cursor;
 
 use crate::impls::TokioRuntime;
+use crate::type_config::alias::LeaderIdOf;
+use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::NodeIdOf;
+use crate::vote::RaftLeaderIdExt;
 use crate::Node;
 use crate::RaftTypeConfig;
 
@@ -42,4 +46,9 @@ where N: Node + Ord
     type SnapshotData = Cursor<Vec<u8>>;
     type AsyncRuntime = TokioRuntime;
     type Responder = crate::impls::OneshotResponder<Self>;
+}
+
+/// Builds a log id, for testing purposes.
+pub(crate) fn log_id(term: u64, node_id: NodeIdOf<UTConfig>, index: u64) -> LogIdOf<UTConfig> {
+    LogIdOf::<UTConfig>::new(LeaderIdOf::<UTConfig>::new_committed(term, node_id), index)
 }

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Condition;
@@ -14,7 +15,6 @@ use crate::error::RejectAppendEntries;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
 use crate::testing::blank_ent;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::vote::raft_vote::RaftVoteExt;

--- a/openraft/src/engine/tests/elect_test.rs
+++ b/openraft/src/engine/tests/elect_test.rs
@@ -6,12 +6,12 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft::VoteRequest;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -5,13 +5,13 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -6,6 +6,7 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
@@ -17,7 +18,6 @@ use crate::progress::entry::ProgressEntry;
 use crate::raft::VoteResponse;
 use crate::raft_state::IOId;
 use crate::replication::request::Replicate;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::vote::raft_vote::RaftVoteExt;

--- a/openraft/src/engine/tests/initialize_test.rs
+++ b/openraft/src/engine/tests/initialize_test.rs
@@ -4,6 +4,7 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::core::ServerState;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
@@ -14,7 +15,6 @@ use crate::error::NotAllowed;
 use crate::error::NotInMembers;
 use crate::raft::VoteRequest;
 use crate::raft_state::LogStateReader;
-use crate::testing::log_id;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -5,6 +5,7 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::core::sm;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Condition;
@@ -15,7 +16,6 @@ use crate::raft::SnapshotResponse;
 use crate::raft_state::IOId;
 use crate::storage::Snapshot;
 use crate::storage::SnapshotMeta;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::vote::raft_vote::RaftVoteExt;
 use crate::Membership;

--- a/openraft/src/engine/tests/log_id_list_test.rs
+++ b/openraft/src/engine/tests/log_id_list_test.rs
@@ -1,7 +1,7 @@
 use crate::engine::leader_log_ids::LeaderLogIds;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::LogIdList;
-use crate::testing::log_id;
 
 #[test]
 fn test_log_id_list_extend_from_same_leader() -> anyhow::Result<()> {

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
@@ -15,7 +16,6 @@ use crate::progress::entry::ProgressEntry;
 use crate::progress::Inflight;
 use crate::raft_state::IOId;
 use crate::replication::request::Replicate;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::vote::raft_vote::RaftVoteExt;

--- a/openraft/src/engine/tests/trigger_purge_log_test.rs
+++ b/openraft/src/engine/tests/trigger_purge_log_test.rs
@@ -4,13 +4,13 @@ use std::time::Duration;
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::progress::Progress;
 use crate::storage::SnapshotMeta;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -5,11 +5,11 @@ use maplit::btreeset;
 use tokio::time::sleep;
 
 use crate::core::ServerState;
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::log_id::LogIdOptionExt;
 use crate::metrics::Wait;
 use crate::metrics::WaitError;
-use crate::testing::log_id;
 use crate::type_config::alias::NodeIdOf;
 use crate::type_config::alias::WatchSenderOf;
 use crate::type_config::TypeConfigExt;

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -225,12 +225,12 @@ where
 #[cfg(test)]
 mod tests {
     use crate::engine::leader_log_ids::LeaderLogIds;
+    use crate::engine::testing::log_id;
     use crate::engine::testing::UTConfig;
     use crate::entry::RaftEntry;
     use crate::progress::Progress;
     use crate::proposer::Leader;
     use crate::testing::blank_ent;
-    use crate::testing::log_id;
     use crate::type_config::TypeConfigExt;
     use crate::vote::raft_vote::RaftVoteExt;
     use crate::Entry;

--- a/openraft/src/raft_state/membership_state/change_handler_test.rs
+++ b/openraft/src/raft_state/membership_state/change_handler_test.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use maplit::btreeset;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::error::ChangeMembershipError;
 use crate::error::EmptyMembership;
 use crate::error::InProgress;
 use crate::error::LearnerNotFound;
-use crate::testing::log_id;
 use crate::ChangeMembers;
 use crate::EffectiveMembership;
 use crate::Membership;

--- a/openraft/src/raft_state/membership_state/membership_state_test.rs
+++ b/openraft/src/raft_state/membership_state/membership_state_test.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use maplit::btreeset;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
-use crate::testing::log_id;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;

--- a/openraft/src/raft_state/tests/is_initialized_test.rs
+++ b/openraft/src/raft_state/tests/is_initialized_test.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
+use crate::engine::testing::log_id;
 use crate::engine::testing::UTConfig;
 use crate::engine::LogIdList;
-use crate::testing::log_id;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::RaftState;


### PR DESCRIPTION

## Changelog

##### Chore: use engine::testing::log_id() when using UTConfig

In such scenario, no generic type is required for `log_id()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1306)
<!-- Reviewable:end -->
