### PR TITLE
Chore: use fixtures::log_id to create a log id for testing RaftTypeConfig implementation

### DIFF
--- a/tests/tests/append_entries/t10_conflict_with_empty_entries.rs
+++ b/tests/tests/append_entries/t10_conflict_with_empty_entries.rs
@@ -7,13 +7,13 @@ use openraft::network::RPCOption;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::blank_ent;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::Vote;
 use openraft_memstore::ClientRequest;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/append_entries/t10_see_higher_vote.rs
+++ b/tests/tests/append_entries/t10_see_higher_vote.rs
@@ -7,13 +7,13 @@ use openraft::network::v2::RaftNetworkV2;
 use openraft::network::RPCOption;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::VoteRequest;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::ServerState;
 use openraft::Vote;
 use openraft_memstore::ClientRequest;
 use tokio::time::sleep;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/append_entries/t11_append_conflicts.rs
+++ b/tests/tests/append_entries/t11_append_conflicts.rs
@@ -6,7 +6,6 @@ use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
 use openraft::storage::RaftLogStorage;
 use openraft::testing::blank_ent;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Entry;
 use openraft::RaftLogReader;
@@ -14,6 +13,7 @@ use openraft::RaftTypeConfig;
 use openraft::ServerState;
 use openraft::Vote;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/append_entries/t11_append_entries_with_bigger_term.rs
+++ b/tests/tests/append_entries/t11_append_entries_with_bigger_term.rs
@@ -7,10 +7,10 @@ use openraft::network::v2::RaftNetworkV2;
 use openraft::network::RPCOption;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Vote;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/append_entries/t11_append_updates_membership.rs
+++ b/tests/tests/append_entries/t11_append_updates_membership.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::blank_ent;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Entry;
 use openraft::EntryPayload;
@@ -13,6 +12,7 @@ use openraft::Membership;
 use openraft::ServerState;
 use openraft::Vote;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
+++ b/tests/tests/append_entries/t61_heartbeat_reject_vote.rs
@@ -5,12 +5,12 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::VoteRequest;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::TokioInstant;
 use openraft::Vote;
 use tokio::time::sleep;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/client_api/t10_client_writes.rs
+++ b/tests/tests/client_api/t10_client_writes.rs
@@ -4,13 +4,13 @@ use anyhow::Result;
 use futures::prelude::*;
 use maplit::btreeset;
 use openraft::raft::ClientWriteResponse;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::SnapshotPolicy;
 use openraft_memstore::ClientRequest;
 use openraft_memstore::IntoMemClientRequest;
 use openraft_memstore::TypeConfig;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/client_api/t12_trigger_purge_log.rs
+++ b/tests/tests/client_api/t12_trigger_purge_log.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::SnapshotPolicy;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/client_api/t13_get_snapshot.rs
+++ b/tests/tests/client_api/t13_get_snapshot.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/client_api/t13_install_full_snapshot.rs
+++ b/tests/tests/client_api/t13_install_full_snapshot.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Vote;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/client_api/t13_trigger_snapshot.rs
+++ b/tests/tests/client_api/t13_trigger_snapshot.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/client_api/t16_with_raft_state.rs
+++ b/tests/tests/client_api/t16_with_raft_state.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::error::Fatal;
-use openraft::testing::log_id;
 use openraft::Config;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/client_api/t16_with_state_machine.rs
+++ b/tests/tests/client_api/t16_with_state_machine.rs
@@ -7,7 +7,6 @@ use openraft::error::Fatal;
 use openraft::storage::RaftStateMachine;
 use openraft::storage::Snapshot;
 use openraft::storage::SnapshotMeta;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Entry;
 use openraft::OptionalSend;
@@ -18,6 +17,7 @@ use openraft::StoredMembership;
 use openraft_memstore::ClientResponse;
 use openraft_memstore::TypeConfig;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::MemStateMachine;
 use crate::fixtures::RaftRouter;

--- a/tests/tests/client_api/t51_write_when_leader_quit.rs
+++ b/tests/tests/client_api/t51_write_when_leader_quit.rs
@@ -7,13 +7,13 @@ use openraft::error::ClientWriteError;
 use openraft::error::ForwardToLeader;
 use openraft::error::RaftError;
 use openraft::raft::AppendEntriesRequest;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Vote;
 use openraft_memstore::ClientRequest;
 use openraft_memstore::IntoMemClientRequest;
 use tokio::sync::oneshot;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -83,6 +83,13 @@ pub type MemStateMachine = Arc<SMInner>;
 /// A concrete Raft type used during testing.
 pub type MemRaft = Raft<MemConfig>;
 
+pub fn log_id(term: u64, node_id: u64, index: u64) -> LogIdOf<TypeConfig> {
+    LogIdOf::<TypeConfig>::new(
+        <TypeConfig as RaftTypeConfig>::LeaderId::new_committed(term, node_id),
+        index,
+    )
+}
+
 /// Create a harness that sets up tracing and a tokio runtime for testing.
 pub fn ut_harness<F, Fut>(f: F) -> anyhow::Result<()>
 where

--- a/tests/tests/life_cycle/t10_initialization.rs
+++ b/tests/tests/life_cycle/t10_initialization.rs
@@ -8,7 +8,6 @@ use openraft::error::InitializeError;
 use openraft::error::NotAllowed;
 use openraft::error::NotInMembers;
 use openraft::storage::RaftStateMachine;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::EffectiveMembership;
 use openraft::EntryPayload;
@@ -18,6 +17,7 @@ use openraft::ServerState;
 use openraft::StoredMembership;
 use openraft::Vote;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/log_store/t10_save_committed.rs
+++ b/tests/tests/log_store/t10_save_committed.rs
@@ -4,9 +4,9 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::storage::RaftLogStorage;
-use openraft::testing::log_id;
 use openraft::Config;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/membership/t10_single_node.rs
+++ b/tests/tests/membership/t10_single_node.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/membership/t11_add_learner.rs
+++ b/tests/tests/membership/t11_add_learner.rs
@@ -7,7 +7,6 @@ use maplit::btreeset;
 use openraft::error::ChangeMembershipError;
 use openraft::error::ClientWriteError;
 use openraft::error::InProgress;
-use openraft::testing::log_id;
 use openraft::ChangeMembers;
 use openraft::Config;
 use openraft::Membership;
@@ -15,6 +14,7 @@ use openraft::RaftLogReader;
 use openraft::StorageHelper;
 use tokio::time::sleep;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/membership/t31_remove_leader.rs
+++ b/tests/tests/membership/t31_remove_leader.rs
@@ -4,12 +4,12 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::error::ClientWriteError;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::ServerState;
 use openraft_memstore::ClientRequest;
 use openraft_memstore::IntoMemClientRequest;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
+++ b/tests/tests/membership/t99_new_leader_auto_commit_uniform_config.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::storage::RaftLogStorageExt;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::Membership;
 use openraft::Raft;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/metrics/t10_purged.rs
+++ b/tests/tests/metrics/t10_purged.rs
@@ -4,9 +4,9 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::storage::RaftLogStorage;
-use openraft::testing::log_id;
 use openraft::Config;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/metrics/t30_leader_metrics.rs
+++ b/tests/tests/metrics/t30_leader_metrics.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreemap;
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::ServerState;
 #[allow(unused_imports)]
@@ -13,6 +12,7 @@ use pretty_assertions::assert_eq;
 use pretty_assertions::assert_ne;
 use tokio::time::sleep;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_building/t10_build_snapshot.rs
+++ b/tests/tests/snapshot_building/t10_build_snapshot.rs
@@ -9,7 +9,6 @@ use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
 use openraft::storage::RaftLogStorageExt;
 use openraft::testing::blank_ent;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Entry;
 use openraft::EntryPayload;
@@ -18,6 +17,7 @@ use openraft::RaftLogReader;
 use openraft::SnapshotPolicy;
 use openraft::Vote;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_append.rs
+++ b/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_append.rs
@@ -8,11 +8,11 @@ use openraft::network::RPCOption;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::blank_ent;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Vote;
 use openraft_memstore::BlockOperation;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_apply.rs
+++ b/tests/tests/snapshot_building/t35_building_snapshot_does_not_block_apply.rs
@@ -8,11 +8,11 @@ use openraft::network::RPCOption;
 use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
 use openraft::testing::blank_ent;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Vote;
 use openraft_memstore::BlockOperation;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_streaming/t10_api_install_snapshot.rs
+++ b/tests/tests/snapshot_streaming/t10_api_install_snapshot.rs
@@ -4,10 +4,10 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::raft::InstallSnapshotRequest;
 use openraft::storage::SnapshotMeta;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Vote;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_streaming/t10_api_install_snapshot_with_lower_vote.rs
+++ b/tests/tests/snapshot_streaming/t10_api_install_snapshot_with_lower_vote.rs
@@ -7,10 +7,10 @@ use openraft::raft::AppendEntriesRequest;
 use openraft::raft::InstallSnapshotRequest;
 use openraft::storage::Snapshot;
 use openraft::storage::SnapshotMeta;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Vote;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_streaming/t20_startup_snapshot.rs
+++ b/tests/tests/snapshot_streaming/t20_startup_snapshot.rs
@@ -4,9 +4,9 @@ use std::time::Duration;
 use maplit::btreeset;
 use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
-use openraft::testing::log_id;
 use openraft::Config;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_streaming/t30_purge_in_snapshot_logs.rs
+++ b/tests/tests/snapshot_streaming/t30_purge_in_snapshot_logs.rs
@@ -3,11 +3,11 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::RaftLogReader;
 use tokio::time::sleep;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_streaming/t31_snapshot_overrides_membership.rs
+++ b/tests/tests/snapshot_streaming/t31_snapshot_overrides_membership.rs
@@ -9,7 +9,6 @@ use openraft::network::RaftNetworkFactory;
 use openraft::raft::AppendEntriesRequest;
 use openraft::storage::StorageHelper;
 use openraft::testing::blank_ent;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::EffectiveMembership;
 use openraft::Entry;
@@ -18,6 +17,7 @@ use openraft::Membership;
 use openraft::SnapshotPolicy;
 use openraft::Vote;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_streaming/t32_snapshot_uses_prev_snap_membership.rs
+++ b/tests/tests/snapshot_streaming/t32_snapshot_uses_prev_snap_membership.rs
@@ -3,13 +3,13 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::Membership;
 use openraft::RaftLogReader;
 use openraft::SnapshotPolicy;
 use openraft::StorageHelper;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_streaming/t33_snapshot_delete_conflict_logs.rs
+++ b/tests/tests/snapshot_streaming/t33_snapshot_delete_conflict_logs.rs
@@ -11,7 +11,6 @@ use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftLogStorageExt;
 use openraft::storage::RaftStateMachine;
 use openraft::testing::blank_ent;
-use openraft::testing::log_id;
 use openraft::testing::membership_ent;
 use openraft::Config;
 use openraft::Entry;
@@ -24,6 +23,7 @@ use openraft::SnapshotPolicy;
 use openraft::StorageHelper;
 use openraft::Vote;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_streaming/t34_replication_does_not_block_purge.rs
+++ b/tests/tests/snapshot_streaming/t34_replication_does_not_block_purge.rs
@@ -3,11 +3,11 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::RaftLogReader;
 use tokio::time::sleep;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_streaming/t50_snapshot_line_rate_to_snapshot.rs
+++ b/tests/tests/snapshot_streaming/t50_snapshot_line_rate_to_snapshot.rs
@@ -3,10 +3,10 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::SnapshotPolicy;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_streaming/t50_snapshot_when_lacking_log.rs
+++ b/tests/tests/snapshot_streaming/t50_snapshot_when_lacking_log.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::SnapshotPolicy;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_streaming/t51_after_snapshot_add_learner_and_request_a_log.rs
+++ b/tests/tests/snapshot_streaming/t51_after_snapshot_add_learner_and_request_a_log.rs
@@ -3,10 +3,10 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::SnapshotPolicy;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_streaming/t60_snapshot_chunk_size.rs
+++ b/tests/tests/snapshot_streaming/t60_snapshot_chunk_size.rs
@@ -3,11 +3,11 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::ServerState;
 use openraft::SnapshotPolicy;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/snapshot_streaming/t90_issue_808_snapshot_to_unreachable_node_should_not_block.rs
+++ b/tests/tests/snapshot_streaming/t90_issue_808_snapshot_to_unreachable_node_should_not_block.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::testing::log_id;
 use openraft::Config;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 

--- a/tests/tests/state_machine/t20_state_machine_apply_membership.rs
+++ b/tests/tests/state_machine/t20_state_machine_apply_membership.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::storage::RaftStateMachine;
-use openraft::testing::log_id;
 use openraft::Config;
 use openraft::LogIdOptionExt;
 use openraft::Membership;
 use openraft::StoredMembership;
 
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 use crate::fixtures::RaftRouter;
 


### PR DESCRIPTION

## Changelog

##### Chore: use fixtures::log_id to create a log id for testing RaftTypeConfig implementation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1307)
<!-- Reviewable:end -->
