### PR TITLE
Change: `RaftPayload::get_membership()` now returns an owned `Membership`

### DIFF
--- a/openraft/src/core/sm/worker.rs
+++ b/openraft/src/core/sm/worker.rs
@@ -186,7 +186,7 @@ where
         #[allow(clippy::needless_collect)]
         let applying_entries = entries
             .iter()
-            .map(|e| ApplyingEntry::new(e.get_log_id().clone(), e.get_membership().cloned()))
+            .map(|e| ApplyingEntry::new(e.get_log_id().clone(), e.get_membership()))
             .collect::<Vec<_>>();
 
         let n_entries = end - since;

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -195,7 +195,7 @@ where C: RaftTypeConfig
         entry.set_log_id(&LogIdOf::<C>::default());
 
         let m = entry.get_membership().expect("the only log entry for initializing has to be membership log");
-        self.check_members_contain_me(m)?;
+        self.check_members_contain_me(&m)?;
 
         // FollowingHandler requires vote to be committed.
         let vote = <VoteOf<C> as RaftVote<C>>::from_leader_id(Default::default(), true);

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -343,7 +343,7 @@ where C: RaftTypeConfig
         // Find the last 2 membership config entries: the committed and the effective.
         for ent in entries.rev() {
             if let Some(m) = ent.get_membership() {
-                memberships.insert(0, StoredMembership::new(Some(ent.get_log_id().clone()), m.clone()));
+                memberships.insert(0, StoredMembership::new(Some(ent.get_log_id().clone()), m));
                 if memberships.len() == 2 {
                     break;
                 }

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -67,7 +67,7 @@ where C: RaftTypeConfig
                     membership_entry.is_none(),
                     "only one membership entry is allowed in a batch"
                 );
-                membership_entry = Some((entry.get_log_id().clone(), m.clone()));
+                membership_entry = Some((entry.get_log_id().clone(), m));
             }
         }
 

--- a/openraft/src/entry/mod.rs
+++ b/openraft/src/entry/mod.rs
@@ -93,7 +93,7 @@ where C: RaftTypeConfig
         self.payload.is_blank()
     }
 
-    fn get_membership(&self) -> Option<&Membership<C>> {
+    fn get_membership(&self) -> Option<Membership<C>> {
         self.payload.get_membership()
     }
 }

--- a/openraft/src/entry/payload.rs
+++ b/openraft/src/entry/payload.rs
@@ -67,9 +67,9 @@ impl<C: RaftTypeConfig> RaftPayload<C> for EntryPayload<C> {
         matches!(self, EntryPayload::Blank)
     }
 
-    fn get_membership(&self) -> Option<&Membership<C>> {
+    fn get_membership(&self) -> Option<Membership<C>> {
         if let EntryPayload::Membership(m) = self {
-            Some(m)
+            Some(m.clone())
         } else {
             None
         }

--- a/openraft/src/entry/traits.rs
+++ b/openraft/src/entry/traits.rs
@@ -14,8 +14,8 @@ where C: RaftTypeConfig
     /// Return `true` if the entry payload is blank.
     fn is_blank(&self) -> bool;
 
-    /// Return `Some(&Membership)` if the entry payload is a membership payload.
-    fn get_membership(&self) -> Option<&Membership<C>>;
+    /// Return `Some(Membership)` if the entry payload is a membership payload.
+    fn get_membership(&self) -> Option<Membership<C>>;
 }
 
 /// Defines operations on an entry.

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -299,7 +299,7 @@ where
 
             for ent in entries.iter().rev() {
                 if let Some(mem) = ent.get_membership() {
-                    let em = StoredMembership::new(Some(ent.get_log_id().clone()), mem.clone());
+                    let em = StoredMembership::new(Some(ent.get_log_id().clone()), mem);
                     res.insert(0, em);
                     if res.len() == 2 {
                         return Ok(res);


### PR DESCRIPTION

## Changelog

##### Change: `RaftPayload::get_membership()` now returns an owned `Membership`

Reason for the change:

Log entries may use different data types to store a membership config,
and it might not always be possible for an application to return a
reference to an `openraft::Membership`. For instance, a log entry
implementation might store a membership config in a serialized format
internally.

To address this, `RaftPayload::get_membership()` has been updated to
return an owned instance of `Membership`. This allows the implementation
to construct a `Membership` instance on demand when the method is
called.

Performance considerations:

Membership configurations in log entries are rare in most real-world
applications. As a result, this change is unlikely to have any
measurable performance impact.

Upgrade tip:

To adapt to this change, modify your implementation of
`get_membership()` to return a cloned instance of the `Membership`
object.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1308)
<!-- Reviewable:end -->
