### PR TITLE
Feature: Add changelog support in the `#[since()]` macro

### DIFF
--- a/macros/src/since.rs
+++ b/macros/src/since.rs
@@ -11,6 +11,8 @@ use crate::utils;
 pub struct Since {
     pub(crate) version: Option<String>,
     pub(crate) date: Option<String>,
+    /// The change message.
+    pub(crate) change: Vec<String>,
 }
 
 impl Since {
@@ -19,6 +21,7 @@ impl Since {
         let mut since = Since {
             version: None,
             date: None,
+            change: vec![],
         };
 
         type AttributeArgs = syn::punctuated::Punctuated<syn::Meta, syn::Token![,]>;
@@ -42,6 +45,10 @@ impl Since {
 
                         "date" => {
                             since.set_date(namevalue.value.clone(), Spanned::span(&namevalue.value))?;
+                        }
+
+                        "change" => {
+                            since.set_change(namevalue.value.clone(), Spanned::span(&namevalue.value))?;
                         }
 
                         name => {
@@ -132,6 +139,10 @@ impl Since {
         if let Some(date) = &self.date {
             s.push_str(&format!(", Date({})", date));
         }
+
+        if !self.change.is_empty() {
+            s.push_str(&format!(": {}", self.change.join("; ")));
+        }
         s
     }
 
@@ -168,6 +179,14 @@ impl Since {
         })?;
 
         self.date = Some(date_str);
+
+        Ok(())
+    }
+
+    pub(crate) fn set_change(&mut self, change_lit: syn::Expr, span: Span) -> Result<(), syn::Error> {
+        let change_str = Self::parse_str(change_lit, "change", span)?;
+
+        self.change.push(change_str);
 
         Ok(())
     }

--- a/macros/tests/since/expand/multi_since.expanded.rs
+++ b/macros/tests/since/expand/multi_since.expanded.rs
@@ -1,0 +1,4 @@
+/// Since: 1.1.0, Date(2021-02-01): add Foo; add Bar; add Baz
+///
+/// Since: 1.0.0, Date(2021-01-01): Added
+const A: i32 = 0;

--- a/macros/tests/since/expand/multi_since.rs
+++ b/macros/tests/since/expand/multi_since.rs
@@ -1,0 +1,9 @@
+#[openraft_macros::since(
+    version = "1.1.0",
+    date = "2021-02-01",
+    change = "add Foo",
+    change = "add Bar",
+    change = "add Baz"
+)]
+#[openraft_macros::since(version = "1.0.0", date = "2021-01-01", change = "Added")]
+const A: i32 = 0;

--- a/macros/tests/since/expand/with_change.expanded.rs
+++ b/macros/tests/since/expand/with_change.expanded.rs
@@ -1,0 +1,2 @@
+/// Since: 1.0.0: add Foo
+const A: i32 = 0;

--- a/macros/tests/since/expand/with_change.rs
+++ b/macros/tests/since/expand/with_change.rs
@@ -1,0 +1,2 @@
+#[openraft_macros::since(version = "1.0.0", change = "add Foo")]
+const A: i32 = 0;

--- a/macros/tests/since/expand/with_date_change.expanded.rs
+++ b/macros/tests/since/expand/with_date_change.expanded.rs
@@ -1,0 +1,2 @@
+/// Since: 1.0.0, Date(2021-01-01): add Foo
+const A: i32 = 0;

--- a/macros/tests/since/expand/with_date_change.rs
+++ b/macros/tests/since/expand/with_date_change.rs
@@ -1,0 +1,2 @@
+#[openraft_macros::since(version = "1.0.0", date = "2021-01-01", change = "add Foo")]
+const A: i32 = 0;

--- a/macros/tests/since/expand/with_date_many_change.expanded.rs
+++ b/macros/tests/since/expand/with_date_many_change.expanded.rs
@@ -1,0 +1,2 @@
+/// Since: 1.0.0, Date(2021-01-01): add Foo; add Bar; add Baz
+const A: i32 = 0;

--- a/macros/tests/since/expand/with_date_many_change.rs
+++ b/macros/tests/since/expand/with_date_many_change.rs
@@ -1,0 +1,8 @@
+#[openraft_macros::since(
+    version = "1.0.0",
+    date = "2021-01-01",
+    change = "add Foo",
+    change = "add Bar",
+    change = "add Baz"
+)]
+const A: i32 = 0;


### PR DESCRIPTION

## Changelog

##### Feature: Add changelog support in the `#[since()]` macro

This commit introduces the ability to include changelogs directly in the
`#[since()]` macro. For example:

```rust
#[since(version = "0.1.0", change = "add new argument `a: u64`", change = "add T")]
```

Generates the following documentation line:

```rust
/// Since: 0.1.0: add new argument `a: u64`; add T
```

Key updates:

- Multiple `change` attributes are supported within the same `#[since()]` macro.
- Changelogs are concatenated into a single documentation line.

This enhancement makes it easier to document changes alongside version annotations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1309)
<!-- Reviewable:end -->
