### PR TITLE
Refactor: Deprecate `LogId::leader_id()`

### DIFF
--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -151,7 +151,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
         let snapshot_idx = self.snapshot_idx.fetch_add(1, Ordering::Relaxed);
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/examples/raft-kv-memstore-grpc/src/lib.rs
+++ b/examples/raft-kv-memstore-grpc/src/lib.rs
@@ -60,7 +60,7 @@ impl From<pb::VoteResponse> for VoteResponse {
 impl From<LogId> for pb::LogId {
     fn from(log_id: LogId) -> Self {
         pb::LogId {
-            term: *log_id.leader_id(),
+            term: *log_id.committed_leader_id(),
             index: log_id.index(),
         }
     }

--- a/examples/raft-kv-memstore-grpc/src/store/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/store/mod.rs
@@ -85,7 +85,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
         };
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/examples/raft-kv-memstore-network-v2/src/store.rs
+++ b/examples/raft-kv-memstore-network-v2/src/store.rs
@@ -92,7 +92,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
         };
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -106,7 +106,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
         };
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/examples/raft-kv-memstore-singlethreaded/src/store.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/store.rs
@@ -146,7 +146,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Rc<StateMachineStore> {
         };
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -105,7 +105,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
 
         let snapshot_idx = self.snapshot_idx.fetch_add(1, Ordering::Relaxed) + 1;
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -89,7 +89,7 @@ impl RaftSnapshotBuilder<TypeConfig> for StateMachineStore {
         };
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id(), last.index(), self.snapshot_idx)
+            format!("{}-{}-{}", last.committed_leader_id(), last.index(), self.snapshot_idx)
         } else {
             format!("--{}", self.snapshot_idx)
         };

--- a/examples/rocksstore/src/lib.rs
+++ b/examples/rocksstore/src/lib.rs
@@ -130,7 +130,7 @@ impl RaftSnapshotBuilder<TypeConfig> for RocksStateMachine {
         let snapshot_idx: u64 = rand::thread_rng().gen_range(0..1000);
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -55,7 +55,7 @@ impl<C> Display for LogId<C>
 where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}", self.leader_id(), self.index())
+        write!(f, "{}.{}", self.committed_leader_id(), self.index())
     }
 }
 
@@ -72,6 +72,7 @@ where C: RaftTypeConfig
         &self.leader_id
     }
 
+    #[deprecated(since = "0.10.0", note = "Use `committed_leader_id` instead.")]
     pub fn leader_id(&self) -> &CommittedLeaderIdOf<C> {
         &self.leader_id
     }

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -339,7 +339,7 @@ where
 
         if !log_ids.is_empty() {
             if let Some(purged) = purged {
-                if purged.leader_id() == log_ids[0].leader_id() {
+                if purged.committed_leader_id() == log_ids[0].committed_leader_id() {
                     if log_ids.len() >= 2 {
                         log_ids[0] = purged;
                     } else {

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -294,7 +294,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<MemStateMachine> {
         };
 
         let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id(), last.index(), snapshot_idx)
+            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
         } else {
             format!("--{}", snapshot_idx)
         };

--- a/tests/tests/append_entries/t11_append_inconsistent_log.rs
+++ b/tests/tests/append_entries/t11_append_inconsistent_log.rs
@@ -115,7 +115,7 @@ async fn append_inconsistent_log() -> Result<()> {
     let logs = sto0.try_get_log_entries(60..=60).await?;
     assert_eq!(
         3,
-        logs.first().unwrap().log_id.leader_id().term,
+        logs.first().unwrap().log_id.committed_leader_id().term,
         "log is overridden by leader logs"
     );
 

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -937,7 +937,7 @@ impl TypedRaftRouter {
             }
 
             assert_eq!(
-                &snap.meta.last_log_id.unwrap_or_default().leader_id().term,
+                &snap.meta.last_log_id.unwrap_or_default().committed_leader_id().term,
                 term,
                 "expected node {} to have snapshot with term {}, got {:?}",
                 id,


### PR DESCRIPTION

## Changelog

##### Refactor: Deprecate `LogId::leader_id()`

The method `LogId::leader_id()` returns a `&CommittedLeaderId` instead
of a `LeaderId`, which can be misleading.

This commit deprecates `leader_id()` and recommends using the more
descriptive `LogId::committed_leader_id()` method instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1312)
<!-- Reviewable:end -->
