### PR TITLE
Change: remove unused RaftPayload::is_blank()

### DIFF
--- a/openraft/src/entry/mod.rs
+++ b/openraft/src/entry/mod.rs
@@ -89,10 +89,6 @@ where C: RaftTypeConfig
 impl<C> RaftPayload<C> for Entry<C>
 where C: RaftTypeConfig
 {
-    fn is_blank(&self) -> bool {
-        self.payload.is_blank()
-    }
-
     fn get_membership(&self) -> Option<Membership<C>> {
         self.payload.get_membership()
     }

--- a/openraft/src/entry/payload.rs
+++ b/openraft/src/entry/payload.rs
@@ -63,10 +63,6 @@ where C: RaftTypeConfig
 }
 
 impl<C: RaftTypeConfig> RaftPayload<C> for EntryPayload<C> {
-    fn is_blank(&self) -> bool {
-        matches!(self, EntryPayload::Blank)
-    }
-
     fn get_membership(&self) -> Option<Membership<C>> {
         if let EntryPayload::Membership(m) = self {
             Some(m.clone())

--- a/openraft/src/entry/traits.rs
+++ b/openraft/src/entry/traits.rs
@@ -14,9 +14,6 @@ use crate::RaftTypeConfig;
 pub trait RaftPayload<C>
 where C: RaftTypeConfig
 {
-    /// Return `true` if the entry payload is blank.
-    fn is_blank(&self) -> bool;
-
     /// Return `Some(Membership)` if the entry payload is a membership payload.
     fn get_membership(&self) -> Option<Membership<C>>;
 }


### PR DESCRIPTION

## Changelog

##### Change: remove unused RaftPayload::is_blank()

OpenRaft does not need to know whether a log entry is blank or not.

Upgrade tip:

Remove implementation of `RaftPayload::is_blank()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1316)
<!-- Reviewable:end -->
