### PR TITLE
Chore adjust code format

### DIFF
--- a/openraft/src/raft_state/tests/forward_to_leader_test.rs
+++ b/openraft/src/raft_state/tests/forward_to_leader_test.rs
@@ -6,22 +6,29 @@ use maplit::btreeset;
 
 use crate::engine::testing::UTConfig;
 use crate::error::ForwardToLeader;
-use crate::testing::log_id;
+use crate::type_config::alias::LeaderIdOf;
+use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::NodeIdOf;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
+use crate::vote::RaftLeaderIdExt;
 use crate::EffectiveMembership;
 use crate::Membership;
 use crate::MembershipState;
 use crate::RaftState;
 use crate::Vote;
 
-fn m12() -> Membership<UTConfig> {
+fn log_id(term: u64, node_id: NodeIdOf<UTConfig<u64>>, index: u64) -> LogIdOf<UTConfig<u64>> {
+    LogIdOf::<UTConfig<u64>>::new(LeaderIdOf::<UTConfig<u64>>::new_committed(term, node_id), index)
+}
+
+fn m12() -> Membership<UTConfig<u64>> {
     Membership::new_with_defaults(vec![btreeset! {1,2}], [])
 }
 
 #[test]
 fn test_forward_to_leader_vote_not_committed() {
-    let rs = RaftState::<UTConfig> {
+    let rs = RaftState::<UTConfig<u64>> {
         vote: Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(1, 2)),
         membership_state: MembershipState::new(
             Arc::new(EffectiveMembership::new(Some(log_id(1, 0, 1)), m12())),
@@ -35,7 +42,7 @@ fn test_forward_to_leader_vote_not_committed() {
 
 #[test]
 fn test_forward_to_leader_not_a_member() {
-    let rs = RaftState::<UTConfig> {
+    let rs = RaftState::<UTConfig<u64>> {
         vote: Leased::new(
             UTConfig::<()>::now(),
             Duration::from_millis(500),

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -634,10 +634,7 @@ where
     }
 
     pub async fn get_initial_state_log_ids(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
-        let log_id = |t: u64, n: u64, i| LogId::<C> {
-            leader_id: C::LeaderId::new_committed(t.into(), n.into()),
-            index: i,
-        };
+        let log_id = |t: u64, n: u64, i| LogId::<C>::new(C::LeaderId::new_committed(t.into(), n.into()), i);
 
         tracing::info!("--- empty store, expect []");
         {
@@ -1379,7 +1376,7 @@ where
     C: RaftTypeConfig,
     C::NodeId: From<u64>,
 {
-    LogId::new(C::LeaderId::new_committed(term.into(), NODE_ID.into()), index)
+    LogIdOf::new(C::LeaderId::new_committed(term.into(), NODE_ID.into()), index)
 }
 
 /// Create a blank log entry with node_id 0 for test.


### PR DESCRIPTION

## Changelog

##### Chore adjust code format


##### Chore: forwart_to_leader_test should use a dedicate log_id()

Because it use type config `UTConfig<u64>` instead of the default `UTConfig`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1318)
<!-- Reviewable:end -->
