### PR TITLE
Change: Refine Log Entry Traits

### DIFF
--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -21,7 +21,6 @@ use openraft::storage::Snapshot;
 use openraft::Entry;
 use openraft::EntryPayload;
 use openraft::OptionalSend;
-use openraft::RaftLogId;
 use openraft::SnapshotMeta;
 use openraft::StorageError;
 use openraft::StoredMembership;

--- a/examples/memstore/Cargo.toml
+++ b/examples/memstore/Cargo.toml
@@ -15,11 +15,13 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
+openraft = { path = "../../openraft", features = ["type-alias"] }
 
 tokio = { version = "1.0", default-features = false, features = ["sync"] }
 
 [features]
+
+serde = ["openraft/serde"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/raft-kv-memstore-grpc/Cargo.toml
+++ b/examples/raft-kv-memstore-grpc/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/bin/main.rs"
 
 [dependencies]
 memstore = { path = "../memstore", features = [] }
-openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
+openraft = { path = "../../openraft", features = ["type-alias"] }
 
 clap = { version = "4.1.11", features = ["derive", "env"] }
 serde = { version = "1.0.114", features = ["derive"] }
@@ -30,7 +30,6 @@ tracing = "0.1.29"
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 tonic = "0.12.3"
 tonic-build = "0.12.3"
-bincode = "1.3.3"
 dashmap = "6.1.0"
 prost = "0.13.4"
 futures = "0.3.31"

--- a/examples/raft-kv-memstore-grpc/build.rs
+++ b/examples/raft-kv-memstore-grpc/build.rs
@@ -11,20 +11,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // TODO: remove serde
 
     tonic_build::configure()
-        .type_attribute("openraftpb.Node", "#[derive(Eq, serde::Serialize, serde::Deserialize)]")
-        .type_attribute(
-            "openraftpb.SetRequest",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "openraftpb.Response",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute(
-            "openraftpb.LeaderId",
-            "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
-        )
-        .type_attribute("openraftpb.Vote", "#[derive(Eq, serde::Serialize, serde::Deserialize)]")
+        .btree_map(["."])
+        .type_attribute("openraftpb.Node", "#[derive(Eq)]")
+        .type_attribute("openraftpb.SetRequest", "#[derive(Eq)]")
+        .type_attribute("openraftpb.Response", "#[derive(Eq)]")
+        .type_attribute("openraftpb.LeaderId", "#[derive(Eq)]")
+        .type_attribute("openraftpb.Vote", "#[derive(Eq)]")
+        .type_attribute("openraftpb.NodeIdSet", "#[derive(Eq)]")
+        .type_attribute("openraftpb.Membership", "#[derive(Eq)]")
+        .type_attribute("openraftpb.Entry", "#[derive(Eq)]")
+        .type_attribute("google.protobuf.Empty", "#[derive(Eq)]")
         .compile_protos_with_config(config, &proto_files, &["proto"])?;
     Ok(())
 }

--- a/examples/raft-kv-memstore-grpc/proto/api_service.proto
+++ b/examples/raft-kv-memstore-grpc/proto/api_service.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+import "internal_service.proto";
 package openraftpb;
 
 // ApiService provides the key-value store API operations
@@ -20,8 +21,3 @@ message Response {
   optional string value = 1; // Retrieved value
 }
 
-// SetRequest represents a key-value pair to be stored
-message SetRequest {
-  string key = 1;   // Key to store
-  string value = 2; // Value to associate with the key
-}

--- a/examples/raft-kv-memstore-grpc/proto/internal_service.proto
+++ b/examples/raft-kv-memstore-grpc/proto/internal_service.proto
@@ -1,5 +1,18 @@
 syntax = "proto3";
+import "google/protobuf/empty.proto";
 package openraftpb;
+
+// SetRequest represents a key-value pair to be stored
+message SetRequest {
+  string key = 1;   // Key to store
+  string value = 2; // Value to associate with the key
+}
+
+// Node represents a single node in the Raft cluster
+message Node {
+  string rpc_addr = 1; // RPC address for node communication
+  uint64 node_id = 2;  // Unique identifier for the node
+}
 
 // LeaderId represents the leader identifier in Raft
 message LeaderId {
@@ -13,10 +26,52 @@ message Vote {
   bool committed = 2;
 }
 
+message Entry {
+  uint64 term = 1;
+  uint64 index = 2;
+
+  // Optional Application data
+  SetRequest app_data = 12;
+
+  // Optional Membership config
+  Membership membership = 13;
+}
+
+
+// NodeIds is a set of NodeIds
+message NodeIdSet {
+  map<uint64, google.protobuf.Empty> node_ids = 1;
+}
+
+// Membership config
+message Membership {
+  // Joint(includes more than one NodeIdSet) or uniform(one NodeIdSet) config.
+  repeated NodeIdSet configs = 1;
+
+  // All of the nodes in the cluster, including voters and learners.
+  // A node id that is included in `configs` is a voter, otherwise it is a learner.
+  map<uint64, Node> nodes = 2;
+}
+
 // LogId represents the log identifier in Raft
 message LogId {
   uint64 term = 1;
   uint64 index = 2;
+}
+
+// All the data in a state machine, including user defined data and membership data.
+message StateMachineData {
+  // The last log id that has been applied to the state machine
+  LogId last_applied = 1;
+
+  // User data in a map
+  map<string, string> data = 2;
+
+  // The id of the last membership config log entry that is applied.
+  LogId last_membership_log_id = 3;
+
+  // The last membership config that is applied.
+  Membership last_membership = 4;
 }
 
 // VoteRequest represents a request for votes during leader election
@@ -32,26 +87,47 @@ message VoteResponse {
   LogId last_log_id = 3;
 }
 
-// InternalService handles internal Raft cluster communication
-service InternalService {
-  // Vote handles vote requests between Raft nodes during leader election
-  rpc Vote(VoteRequest) returns (VoteResponse) {}
+message AppendEntriesRequest {
+  // The leader's vote, used to identify the leader, and must be committed
+  Vote vote = 1;
 
-  // AppendEntries handles call related to append entries RPC
-  rpc AppendEntries(RaftRequestBytes) returns (RaftReplyBytes) {}
+  // The previous log id the leader has sent to the follower
+  LogId prev_log_id = 2;
 
-  // Snapshot handles install snapshot RPC
-  rpc Snapshot(stream SnapshotRequest) returns (RaftReplyBytes) {}
+  // The entries to be appended to the follower's log
+  repeated Entry entries = 3;
+
+  // The leader's last committed log id
+  LogId leader_commit = 4;
 }
 
-// RaftRequestBytes encapsulates binary Raft request data
-message RaftRequestBytes {
-  bytes value = 1; // Serialized Raft request data
+message AppendEntriesResponse {
+  // If not None, the follower rejected the AppendEntries request due to having a higher vote.
+  // All other fields are valid only when this field is None
+  Vote rejected_by = 1;
+
+  // The follower accepts this AppendEntries request's vote, but the prev_log_id conflicts with
+  // the follower's log. The leader should retry with a smaller prev_log_id that matches the
+  // follower's log. All subsequent fields are valid only when this field is false
+  bool conflict = 2;
+
+  // The last log id the follower accepted from this request.
+  // If None, all input entries were accepted and persisted.
+  // Otherwise, only entries up to and including this id were accepted
+  LogId last_log_id = 3;
 }
 
-// RaftReplyBytes encapsulates binary Raft response data
-message RaftReplyBytes {
-  bytes value = 1; // Serialized Raft response data
+// The first chunk of snapshot transmission, which contains the snapshot meta.
+message SnapshotRequestMeta {
+  Vote vote = 1;
+
+  LogId last_log_id = 2;
+
+  LogId last_membership_log_id = 3;
+
+  Membership last_membership = 4;
+
+  string snapshot_id = 5;
 }
 
 // The item of snapshot chunk stream.
@@ -63,13 +139,25 @@ message RaftReplyBytes {
 // Since the second item, the `rpc_meta` should be empty and will be ignored by
 // the receiving end.
 message SnapshotRequest {
-
-  // bytes serialized meta data, including vote and snapshot_meta.
-  // ```text
-  // (SnapshotFormat, Vote, SnapshotMeta)
-  // ```
-  bytes rpc_meta = 1;
-
-  // Snapshot data chunk
-  bytes chunk = 2;
+  oneof payload {
+    SnapshotRequestMeta meta = 1;
+    bytes chunk = 2;
+  }
 }
+
+message SnapshotResponse {
+  Vote vote = 1;
+}
+
+// InternalService handles internal Raft cluster communication
+service InternalService {
+  // Vote handles vote requests between Raft nodes during leader election
+  rpc Vote(VoteRequest) returns (VoteResponse) {}
+
+  // AppendEntries handles call related to append entries RPC
+  rpc AppendEntries(AppendEntriesRequest) returns (AppendEntriesResponse) {}
+
+  // Snapshot handles install snapshot RPC
+  rpc Snapshot(stream SnapshotRequest) returns (SnapshotResponse) {}
+}
+

--- a/examples/raft-kv-memstore-grpc/proto/management_service.proto
+++ b/examples/raft-kv-memstore-grpc/proto/management_service.proto
@@ -1,19 +1,23 @@
 syntax = "proto3";
+import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
+import "internal_service.proto";
+import "api_service.proto";
 package openraftpb;
 
 // ManagementService handles Raft cluster management operations
 service ManagementService {
   // Init initializes a new Raft cluster with the given nodes
-  rpc Init(InitRequest) returns (RaftReplyString) {}
+  rpc Init(InitRequest) returns (google.protobuf.Empty) {}
 
   // AddLearner adds a new learner node to the Raft cluster
-  rpc AddLearner(AddLearnerRequest) returns (RaftReplyString) {}
+  rpc AddLearner(AddLearnerRequest) returns (ClientWriteResponse) {}
 
   // ChangeMembership modifies the cluster membership configuration
-  rpc ChangeMembership(ChangeMembershipRequest) returns (RaftReplyString) {}
+  rpc ChangeMembership(ChangeMembershipRequest) returns (ClientWriteResponse) {}
 
   // Metrics retrieves cluster metrics and status information
-  rpc Metrics(RaftRequestString) returns (RaftReplyString) {}
+  rpc Metrics(google.protobuf.Empty) returns (google.protobuf.StringValue) {}
 }
 
 // InitRequest contains the initial set of nodes for cluster initialization
@@ -21,30 +25,24 @@ message InitRequest {
   repeated Node nodes = 1; // List of initial cluster nodes
 }
 
-// Node represents a single node in the Raft cluster
-message Node {
-  string rpc_addr = 1; // RPC address for node communication
-  uint64 node_id = 2;  // Unique identifier for the node
-}
-
 // AddLearnerRequest specifies parameters for adding a learner node
 message AddLearnerRequest {
   Node node = 1; // Node to be added as a learner
-}
-
-// RaftRequestString represents a string-based Raft request
-message RaftRequestString {
-  string data = 1; // Request data in string format
-}
-
-// RaftReplyString represents a string-based Raft response
-message RaftReplyString {
-  string data = 1;  // Response data
-  string error = 2; // Error message, if any
 }
 
 // ChangeMembershipRequest specifies parameters for modifying cluster membership
 message ChangeMembershipRequest {
   repeated uint64 members = 1; // New set of member node IDs
   bool retain = 2;             // Whether to retain existing configuration
+}
+
+message ClientWriteResponse {
+  // The log id of the committed log entry.
+  LogId log_id = 1;
+
+  // If the committed log entry is a normal one.
+  Response data = 2;
+
+  // If the committed log entry is a change-membership entry.
+  Membership membership = 3;
 }

--- a/examples/raft-kv-memstore-grpc/src/grpc/internal_service.rs
+++ b/examples/raft-kv-memstore-grpc/src/grpc/internal_service.rs
@@ -1,5 +1,3 @@
-use bincode::deserialize;
-use bincode::serialize;
 use futures::StreamExt;
 use openraft::Snapshot;
 use tonic::Request;
@@ -8,13 +6,10 @@ use tonic::Status;
 use tonic::Streaming;
 use tracing::debug;
 
+use crate::protobuf as pb;
 use crate::protobuf::internal_service_server::InternalService;
-use crate::protobuf::RaftReplyBytes;
-use crate::protobuf::RaftRequestBytes;
-use crate::protobuf::SnapshotRequest;
 use crate::protobuf::VoteRequest;
 use crate::protobuf::VoteResponse;
-use crate::store::StateMachineData;
 use crate::typ::*;
 
 /// Internal gRPC service implementation for Raft protocol communications.
@@ -41,22 +36,6 @@ impl InternalServiceImpl {
     pub fn new(raft_node: Raft) -> Self {
         InternalServiceImpl { raft_node }
     }
-
-    /// Helper function to deserialize request bytes
-    fn deserialize_request<T: for<'a> serde::Deserialize<'a>>(value: &[u8]) -> Result<T, Status> {
-        deserialize(value).map_err(|e| Status::internal(format!("Failed to deserialize request: {}", e)))
-    }
-
-    /// Helper function to serialize response
-    fn serialize_response<T: serde::Serialize>(value: T) -> Result<Vec<u8>, Status> {
-        serialize(&value).map_err(|e| Status::internal(format!("Failed to serialize response: {}", e)))
-    }
-
-    /// Helper function to create a standard response
-    fn create_response<T: serde::Serialize>(value: T) -> Result<Response<RaftReplyBytes>, Status> {
-        let value = Self::serialize_response(value)?;
-        Ok(Response::new(RaftReplyBytes { value }))
-    }
 }
 
 #[tonic::async_trait]
@@ -75,15 +54,10 @@ impl InternalService for InternalServiceImpl {
     /// Nodes vote for candidates based on log completeness and term numbers.
     async fn vote(&self, request: Request<VoteRequest>) -> Result<Response<VoteResponse>, Status> {
         debug!("Processing vote request");
-        let req = request.into_inner();
 
-        // Deserialize the vote request
-        let vote_req = req.into();
-
-        // Process the vote request
         let vote_resp = self
             .raft_node
-            .vote(vote_req)
+            .vote(request.into_inner().into())
             .await
             .map_err(|e| Status::internal(format!("Vote operation failed: {}", e)))?;
 
@@ -103,22 +77,20 @@ impl InternalService for InternalServiceImpl {
     /// # Protocol Details
     /// This implements the AppendEntries RPC from the Raft protocol.
     /// Used for both log replication and as heartbeat mechanism.
-    async fn append_entries(&self, request: Request<RaftRequestBytes>) -> Result<Response<RaftReplyBytes>, Status> {
+    async fn append_entries(
+        &self,
+        request: Request<pb::AppendEntriesRequest>,
+    ) -> Result<Response<pb::AppendEntriesResponse>, Status> {
         debug!("Processing append entries request");
-        let req = request.into_inner();
 
-        // Deserialize the append request
-        let append_req = Self::deserialize_request(&req.value)?;
-
-        // Process the append request
         let append_resp = self
             .raft_node
-            .append_entries(append_req)
+            .append_entries(request.into_inner().into())
             .await
             .map_err(|e| Status::internal(format!("Append entries operation failed: {}", e)))?;
 
         debug!("Append entries request processed successfully");
-        Self::create_response(append_resp)
+        Ok(Response::new(append_resp.into()))
     }
 
     /// Handles snapshot installation requests for state transfer using streaming.
@@ -129,39 +101,49 @@ impl InternalService for InternalServiceImpl {
     /// # Returns
     /// * `Ok(Response)` - Response indicating success/failure of snapshot installation
     /// * `Err(Status)` - Error status if the snapshot operation fails
-    async fn snapshot(&self, request: Request<Streaming<SnapshotRequest>>) -> Result<Response<RaftReplyBytes>, Status> {
+    async fn snapshot(
+        &self,
+        request: Request<Streaming<pb::SnapshotRequest>>,
+    ) -> Result<Response<pb::SnapshotResponse>, Status> {
         debug!("Processing streaming snapshot installation request");
         let mut stream = request.into_inner();
 
         // Get the first chunk which contains metadata
         let first_chunk = stream.next().await.ok_or_else(|| Status::invalid_argument("Empty snapshot stream"))??;
 
-        // Deserialize the metadata from the first chunk
-        let (vote, snapshot_meta) = Self::deserialize_request(&first_chunk.rpc_meta)?;
+        let vote;
+        let snapshot_meta;
+        {
+            let meta = first_chunk
+                .into_meta()
+                .ok_or_else(|| Status::invalid_argument("First snapshot chunk must be metadata"))?;
 
-        // Prepare to collect snapshot data
-        let mut snapshot_data_bytes = Vec::new();
+            debug!("Received snapshot metadata chunk: {:?}", meta);
 
-        // Collect remaining chunks
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.map_err(|e| Status::internal(format!("Failed to receive snapshot chunk: {}", e)))?;
+            vote = meta.vote.unwrap();
 
-            // Append non-empty chunks to snapshot data
-            if !chunk.chunk.is_empty() {
-                snapshot_data_bytes.extend_from_slice(&chunk.chunk);
-            }
+            snapshot_meta = SnapshotMeta {
+                last_log_id: meta.last_log_id.map(|log_id| log_id.into()),
+                last_membership: StoredMembership::new(
+                    meta.last_membership_log_id.map(|x| x.into()),
+                    meta.last_membership.unwrap().into(),
+                ),
+                snapshot_id: meta.snapshot_id,
+            };
         }
 
-        // Reconstruct StateMachineData from bytes
-        let snapshot_data = match StateMachineData::from_bytes(&snapshot_data_bytes) {
-            Ok(data) => data,
-            Err(e) => return Err(Status::internal(format!("Failed to reconstruct snapshot data: {}", e))),
-        };
+        // Collect snapshot data
+        let mut snapshot_data_bytes = Vec::new();
 
-        // Create snapshot from collected data
+        while let Some(chunk) = stream.next().await {
+            let data =
+                chunk?.into_data_chunk().ok_or_else(|| Status::invalid_argument("Snapshot chunk must be data"))?;
+            snapshot_data_bytes.extend_from_slice(&data);
+        }
+
         let snapshot = Snapshot {
             meta: snapshot_meta,
-            snapshot: Box::new(snapshot_data),
+            snapshot: Box::new(snapshot_data_bytes),
         };
 
         // Install the full snapshot
@@ -172,6 +154,8 @@ impl InternalService for InternalServiceImpl {
             .map_err(|e| Status::internal(format!("Snapshot installation failed: {}", e)))?;
 
         debug!("Streaming snapshot installation request processed successfully");
-        Self::create_response(snapshot_resp)
+        Ok(Response::new(pb::SnapshotResponse {
+            vote: Some(snapshot_resp.vote),
+        }))
     }
 }

--- a/examples/raft-kv-memstore-grpc/src/network/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/network/mod.rs
@@ -1,19 +1,16 @@
-use bincode::deserialize;
-use bincode::serialize;
 use openraft::error::NetworkError;
 use openraft::error::Unreachable;
 use openraft::network::v2::RaftNetworkV2;
 use openraft::network::RPCOption;
+use openraft::AnyError;
 use openraft::RaftNetworkFactory;
+use tonic::codegen::tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::Channel;
 
 use crate::protobuf as pb;
 use crate::protobuf::internal_service_client::InternalServiceClient;
-use crate::protobuf::RaftRequestBytes;
-use crate::protobuf::SnapshotRequest;
 use crate::protobuf::VoteRequest as PbVoteRequest;
 use crate::protobuf::VoteResponse as PbVoteResponse;
-use crate::typ::RPCError;
 use crate::typ::*;
 use crate::NodeId;
 use crate::TypeConfig;
@@ -60,17 +57,17 @@ impl RaftNetworkV2<TypeConfig> for NetworkConnection {
         let channel = match Channel::builder(format!("http://{}", server_addr).parse().unwrap()).connect().await {
             Ok(channel) => channel,
             Err(e) => {
-                return Err(openraft::error::RPCError::Unreachable(Unreachable::new(&e)));
+                return Err(RPCError::Unreachable(Unreachable::new(&e)));
             }
         };
         let mut client = InternalServiceClient::new(channel);
 
-        let value = serialize(&req).map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
-        let request = RaftRequestBytes { value };
-        let response = client.append_entries(request).await.map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
-        let message = response.into_inner();
-        let result = deserialize(&message.value).map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
-        Ok(result)
+        let response = client
+            .append_entries(pb::AppendEntriesRequest::from(req))
+            .await
+            .map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
+        let response = response.into_inner();
+        Ok(AppendEntriesResponse::from(response))
     }
 
     async fn full_snapshot(
@@ -84,45 +81,51 @@ impl RaftNetworkV2<TypeConfig> for NetworkConnection {
         let channel = match Channel::builder(format!("http://{}", server_addr).parse().unwrap()).connect().await {
             Ok(channel) => channel,
             Err(e) => {
-                return Err(openraft::error::RPCError::Unreachable(Unreachable::new(&e)).into());
+                return Err(RPCError::Unreachable(Unreachable::new(&e)).into());
             }
         };
+
+        let (tx, rx) = tokio::sync::mpsc::channel(1024);
+        let strm = ReceiverStream::new(rx);
+
         let mut client = InternalServiceClient::new(channel);
-        // Serialize the vote and snapshot metadata
-        let rpc_meta =
-            serialize(&(vote, snapshot.meta.clone())).map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
+        let response = client.snapshot(strm).await.map_err(|e| NetworkError::new(&e))?;
 
-        // Convert snapshot data to bytes
-        let snapshot_bytes = snapshot.snapshot.to_bytes();
+        // 1. Send meta chunk
 
-        // Create a stream of snapshot requests
-        let mut requests = Vec::new();
+        let meta = &snapshot.meta;
 
-        // First request with metadata
-        requests.push(SnapshotRequest {
-            rpc_meta,
-            chunk: Vec::new(), // First chunk contains only metadata
-        });
+        let request = pb::SnapshotRequest {
+            payload: Some(pb::snapshot_request::Payload::Meta(pb::SnapshotRequestMeta {
+                vote: Some(vote),
+                last_log_id: meta.last_log_id.map(|log_id| log_id.into()),
+                last_membership_log_id: meta.last_membership.log_id().map(|log_id| log_id.into()),
+                last_membership: Some(meta.last_membership.membership().clone().into()),
+                snapshot_id: meta.snapshot_id.to_string(),
+            })),
+        };
 
-        // Add snapshot data chunks
-        let chunk_size = 1024 * 1024; // 1 MB chunks, adjust as needed
-        for chunk in snapshot_bytes.chunks(chunk_size) {
-            requests.push(SnapshotRequest {
-                rpc_meta: Vec::new(), // Subsequent chunks have empty metadata
-                chunk: chunk.to_vec(),
-            });
+        tx.send(request).await.map_err(|e| NetworkError::new(&e))?;
+
+        // 2. Send data chunks
+
+        let chunk_size = 1024 * 1024;
+        for chunk in snapshot.snapshot.as_ref().chunks(chunk_size) {
+            let request = pb::SnapshotRequest {
+                payload: Some(pb::snapshot_request::Payload::Chunk(chunk.to_vec())),
+            };
+            tx.send(request).await.map_err(|e| NetworkError::new(&e))?;
         }
 
-        // Create a stream from the requests
-        let requests_stream = futures::stream::iter(requests);
+        // 3. receive response
 
-        // Send the streaming snapshot request
-        let response = client.snapshot(requests_stream).await.map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
         let message = response.into_inner();
 
-        // Deserialize the response
-        let result = deserialize(&message.value).map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
-        Ok(result)
+        Ok(SnapshotResponse {
+            vote: message
+                .vote
+                .ok_or_else(|| NetworkError::new(&AnyError::error("Missing `vote` in snapshot response")))?,
+        })
     }
 
     async fn vote(&mut self, req: VoteRequest, _option: RPCOption) -> Result<VoteResponse, RPCError> {
@@ -130,7 +133,7 @@ impl RaftNetworkV2<TypeConfig> for NetworkConnection {
         let channel = match Channel::builder(format!("http://{}", server_addr).parse().unwrap()).connect().await {
             Ok(channel) => channel,
             Err(e) => {
-                return Err(openraft::error::RPCError::Unreachable(Unreachable::new(&e)));
+                return Err(RPCError::Unreachable(Unreachable::new(&e)));
             }
         };
         let mut client = InternalServiceClient::new(channel);

--- a/examples/raft-kv-memstore-grpc/src/pb_impl/impl_client_write_response.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/impl_client_write_response.rs
@@ -1,0 +1,22 @@
+use crate::pb;
+use crate::typ::*;
+
+impl From<pb::ClientWriteResponse> for ClientWriteResponse {
+    fn from(r: pb::ClientWriteResponse) -> Self {
+        ClientWriteResponse {
+            log_id: r.log_id.unwrap().into(),
+            data: r.data.unwrap(),
+            membership: r.membership.map(|mem| mem.into()),
+        }
+    }
+}
+
+impl From<ClientWriteResponse> for pb::ClientWriteResponse {
+    fn from(r: ClientWriteResponse) -> Self {
+        pb::ClientWriteResponse {
+            log_id: Some(r.log_id.into()),
+            data: Some(r.data),
+            membership: r.membership.map(|mem| mem.into()),
+        }
+    }
+}

--- a/examples/raft-kv-memstore-grpc/src/pb_impl/impl_entry.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/impl_entry.rs
@@ -1,0 +1,50 @@
+use std::fmt;
+
+use openraft::alias::LogIdOf;
+use openraft::entry::RaftEntry;
+use openraft::entry::RaftPayload;
+use openraft::EntryPayload;
+use openraft::Membership;
+
+use crate::protobuf as pb;
+use crate::TypeConfig;
+
+impl fmt::Display for pb::Entry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Entry{{term={},index={}}}", self.term, self.index)
+    }
+}
+
+impl RaftPayload<TypeConfig> for pb::Entry {
+    fn get_membership(&self) -> Option<Membership<TypeConfig>> {
+        self.membership.clone().map(Into::into)
+    }
+}
+
+impl RaftEntry<TypeConfig> for pb::Entry {
+    fn new(log_id: LogIdOf<TypeConfig>, payload: EntryPayload<TypeConfig>) -> Self {
+        let mut app_data = None;
+        let mut membership = None;
+        match payload {
+            EntryPayload::Blank => {}
+            EntryPayload::Normal(data) => app_data = Some(data),
+            EntryPayload::Membership(m) => membership = Some(m.into()),
+        }
+
+        Self {
+            term: log_id.leader_id,
+            index: log_id.index,
+            app_data,
+            membership,
+        }
+    }
+
+    fn log_id_parts(&self) -> (&u64, u64) {
+        (&self.term, self.index)
+    }
+
+    fn set_log_id(&mut self, new: LogIdOf<TypeConfig>) {
+        self.term = new.leader_id;
+        self.index = new.index;
+    }
+}

--- a/examples/raft-kv-memstore-grpc/src/pb_impl/impl_membership.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/impl_membership.rs
@@ -1,0 +1,35 @@
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use openraft::Membership;
+
+use crate::pb;
+use crate::TypeConfig;
+
+impl From<pb::Membership> for Membership<TypeConfig> {
+    fn from(value: pb::Membership) -> Self {
+        let mut configs = vec![];
+        for c in value.configs {
+            let config: BTreeSet<u64> = c.node_ids.keys().copied().collect();
+            configs.push(config);
+        }
+        let nodes = value.nodes;
+        // TODO: do not unwrap()
+        Membership::new(configs, nodes).unwrap()
+    }
+}
+
+impl From<Membership<TypeConfig>> for pb::Membership {
+    fn from(value: Membership<TypeConfig>) -> Self {
+        let mut configs = vec![];
+        for c in value.get_joint_config() {
+            let mut node_ids = BTreeMap::new();
+            for nid in c.iter() {
+                node_ids.insert(*nid, ());
+            }
+            configs.push(pb::NodeIdSet { node_ids });
+        }
+        let nodes = value.nodes().map(|(nid, n)| (*nid, n.clone())).collect();
+        pb::Membership { configs, nodes }
+    }
+}

--- a/examples/raft-kv-memstore-grpc/src/pb_impl/impl_snapshot_request.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/impl_snapshot_request.rs
@@ -1,0 +1,19 @@
+use crate::pb::snapshot_request::Payload;
+use crate::protobuf as pb;
+impl pb::SnapshotRequest {
+    pub fn into_meta(self) -> Option<pb::SnapshotRequestMeta> {
+        let p = self.payload?;
+        match p {
+            Payload::Meta(meta) => Some(meta),
+            Payload::Chunk(_) => None,
+        }
+    }
+
+    pub fn into_data_chunk(self) -> Option<Vec<u8>> {
+        let p = self.payload?;
+        match p {
+            Payload::Meta(_) => None,
+            Payload::Chunk(chunk) => Some(chunk),
+        }
+    }
+}

--- a/examples/raft-kv-memstore-grpc/src/pb_impl/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/mod.rs
@@ -1,4 +1,8 @@
 //! Implements traits for protobuf types
 
+mod impl_client_write_response;
+mod impl_entry;
 mod impl_leader_id;
+mod impl_membership;
+mod impl_snapshot_request;
 mod impl_vote;

--- a/examples/raft-kv-memstore-singlethreaded/src/store.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/store.rs
@@ -6,7 +6,6 @@ use std::marker::PhantomData;
 use std::ops::RangeBounds;
 use std::rc::Rc;
 
-use openraft::entry::RaftEntry;
 use openraft::storage::RaftLogStorage;
 use openraft::storage::RaftStateMachine;
 use openraft::RaftLogReader;
@@ -308,7 +307,7 @@ impl RaftLogStorage<TypeConfig> for Rc<LogStore> {
         // Simple implementation that calls the flush-before-return `append_to_log`.
         let mut log = self.log.borrow_mut();
         for entry in entries {
-            log.insert(entry.index(), entry);
+            log.insert(entry.log_id.index(), entry);
         }
         callback.io_completed(Ok(()));
 

--- a/examples/utils/declare_types.rs
+++ b/examples/utils/declare_types.rs
@@ -6,8 +6,9 @@ pub type Raft = openraft::Raft<TypeConfig>;
 pub type Vote = <TypeConfig as openraft::RaftTypeConfig>::Vote;
 pub type LeaderId = <TypeConfig as openraft::RaftTypeConfig>::LeaderId;
 pub type LogId = openraft::LogId<TypeConfig>;
-pub type Entry = openraft::Entry<TypeConfig>;
+pub type Entry = <TypeConfig as openraft::RaftTypeConfig>::Entry;
 pub type EntryPayload = openraft::EntryPayload<TypeConfig>;
+pub type Membership = openraft::membership::Membership<TypeConfig>;
 pub type StoredMembership = openraft::StoredMembership<TypeConfig>;
 
 pub type Node = <TypeConfig as openraft::RaftTypeConfig>::Node;

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -42,7 +42,6 @@ use crate::engine::Condition;
 use crate::engine::Engine;
 use crate::engine::ReplicationProgress;
 use crate::engine::Respond;
-use crate::entry::FromAppData;
 use crate::entry::RaftEntry;
 use crate::error::AllowNextRevertError;
 use crate::error::ClientWriteError;
@@ -53,7 +52,7 @@ use crate::error::InitializeError;
 use crate::error::QuorumNotEnough;
 use crate::error::RPCError;
 use crate::error::Timeout;
-use crate::log_id::LogIdOptionExt;
+use crate::log_id::option_raft_log_id_ext::OptionRaftLogIdExt;
 use crate::metrics::HeartbeatMetrics;
 use crate::metrics::RaftDataMetrics;
 use crate::metrics::RaftMetrics;
@@ -831,7 +830,7 @@ where
             session_id,
             self.config.clone(),
             self.engine.state.committed().cloned(),
-            progress_entry.matching().cloned(),
+            progress_entry.matching.clone(),
             network,
             snapshot_network,
             self.log_store.get_log_reader().await,
@@ -1235,7 +1234,7 @@ where
                 self.handle_check_is_leader_request(tx).await;
             }
             RaftMsg::ClientWriteRequest { app_data, tx } => {
-                self.write_entry(C::Entry::from_app_data(app_data), Some(tx));
+                self.write_entry(C::Entry::new_normal(LogIdOf::<C>::default(), app_data), Some(tx));
             }
             RaftMsg::Initialize { members, tx } => {
                 tracing::info!(

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -56,7 +56,6 @@ use crate::vote::RaftTerm;
 use crate::vote::RaftVote;
 use crate::LogIdOptionExt;
 use crate::Membership;
-use crate::RaftLogId;
 use crate::RaftTypeConfig;
 
 /// Raft protocol algorithm.
@@ -191,7 +190,7 @@ where C: RaftTypeConfig
         self.check_initialize()?;
 
         // The very first log id
-        entry.set_log_id(&LogIdOf::<C>::default());
+        entry.set_log_id(LogIdOf::<C>::default());
 
         let m = entry.get_membership().expect("the only log entry for initializing has to be membership log");
         self.check_members_contain_me(&m)?;

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -11,17 +11,17 @@ use crate::engine::Command;
 use crate::engine::Condition;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
+use crate::entry::raft_entry_ext::RaftEntryExt;
 use crate::entry::RaftEntry;
 use crate::entry::RaftPayload;
 use crate::error::RejectAppendEntries;
+use crate::log_id::option_raft_log_id_ext::OptionRaftLogIdExt;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
 use crate::storage::Snapshot;
 use crate::type_config::alias::LogIdOf;
 use crate::vote::committed::CommittedVote;
 use crate::EffectiveMembership;
-use crate::LogIdOptionExt;
-use crate::RaftLogId;
 use crate::RaftState;
 use crate::RaftTypeConfig;
 use crate::StoredMembership;
@@ -144,10 +144,10 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip(self, entries))]
     pub(crate) fn do_append_entries(&mut self, entries: Vec<C::Entry>) {
         debug_assert!(!entries.is_empty());
-        debug_assert_eq!(entries[0].index(), self.state.log_ids.last().cloned().next_index(),);
-        debug_assert!(Some(entries[0].get_log_id()) > self.state.log_ids.last());
+        debug_assert_eq!(entries[0].index(), self.state.log_ids.last().next_index(),);
+        debug_assert!(Some(entries[0].ref_log_id()) > self.state.log_ids.last_ref());
 
-        self.state.extend_log_ids(&entries);
+        self.state.extend_log_ids(entries.iter().map(|ent| ent.ref_log_id()));
         self.append_membership(entries.iter());
 
         self.output.push_command(Command::AppendInputEntries {

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -2,6 +2,7 @@ use crate::engine::handler::replication_handler::ReplicationHandler;
 use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
+use crate::entry::raft_entry_ext::RaftEntryExt;
 use crate::entry::RaftEntry;
 use crate::entry::RaftPayload;
 use crate::proposer::Leader;
@@ -58,7 +59,7 @@ where C: RaftTypeConfig
 
         self.leader.assign_log_ids(&mut entries);
 
-        self.state.extend_log_ids_from_same_leader(&entries);
+        self.state.extend_log_ids_from_same_leader(entries.iter().map(|x| x.ref_log_id()));
 
         let mut membership_entry = None;
         for entry in entries.iter() {

--- a/openraft/src/engine/handler/log_handler/mod.rs
+++ b/openraft/src/engine/handler/log_handler/mod.rs
@@ -2,6 +2,7 @@ use crate::display_ext::DisplayOptionExt;
 use crate::engine::Command;
 use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
+use crate::log_id::option_ref_log_id_ext::OptionRefLogIdExt;
 use crate::raft_state::LogStateReader;
 use crate::type_config::alias::LogIdOf;
 use crate::LogIdOptionExt;
@@ -100,7 +101,7 @@ where C: RaftTypeConfig
             return None;
         }
 
-        let log_id = self.state.log_ids.get(purge_end - 1);
+        let log_id = self.state.log_ids.ref_at(purge_end - 1);
         debug_assert!(
             log_id.is_some(),
             "log id not found at {}, engine.state:{:?}",
@@ -108,6 +109,6 @@ where C: RaftTypeConfig
             st
         );
 
-        log_id
+        log_id.to_log_id()
     }
 }

--- a/openraft/src/engine/tests/log_id_list_test.rs
+++ b/openraft/src/engine/tests/log_id_list_test.rs
@@ -9,13 +9,13 @@ fn test_log_id_list_extend_from_same_leader() -> anyhow::Result<()> {
 
     // Extend one log id to an empty LogIdList: Just store it directly
 
-    ids.extend_from_same_leader(&[log_id(1, 1, 2)]);
+    ids.extend_from_same_leader([log_id(1, 1, 2)]);
     assert_eq!(vec![log_id(1, 1, 2)], ids.key_log_ids());
 
     // Extend two log ids that are adjacent to the last stored one.
     // It should append only one log id as the new ending log id.
 
-    ids.extend_from_same_leader(&[
+    ids.extend_from_same_leader([
         log_id(1, 1, 3), //
         log_id(1, 1, 4),
     ]);
@@ -31,7 +31,7 @@ fn test_log_id_list_extend_from_same_leader() -> anyhow::Result<()> {
     // Extend 3 log id with new leader id.
     // It should just store every log id for each leader, plus one last-log-id.
 
-    ids.extend_from_same_leader(&[
+    ids.extend_from_same_leader([
         log_id(2, 1, 5), //
         log_id(2, 1, 6),
         log_id(2, 1, 7),
@@ -55,13 +55,13 @@ fn test_log_id_list_extend() -> anyhow::Result<()> {
 
     // Extend one log id to an empty LogIdList: Just store it directly
 
-    ids.extend(&[log_id(1, 1, 2)]);
+    ids.extend([log_id(1, 1, 2)]);
     assert_eq!(vec![log_id(1, 1, 2)], ids.key_log_ids());
 
     // Extend two log ids that are adjacent to the last stored one.
     // It should append only one log id as the new ending log id.
 
-    ids.extend(&[
+    ids.extend([
         log_id(1, 1, 3), //
         log_id(1, 1, 4),
     ]);
@@ -77,7 +77,7 @@ fn test_log_id_list_extend() -> anyhow::Result<()> {
     // Extend 3 log id with different leader id.
     // Last two has the same leader id.
 
-    ids.extend(&[
+    ids.extend([
         log_id(1, 1, 5), //
         log_id(2, 1, 6),
         log_id(2, 1, 7),
@@ -95,7 +95,7 @@ fn test_log_id_list_extend() -> anyhow::Result<()> {
     // Extend 3 log id with different leader id.
     // Last two have different leader id.
 
-    ids.extend(&[
+    ids.extend([
         log_id(2, 1, 8), //
         log_id(2, 1, 9),
         log_id(3, 1, 10),

--- a/openraft/src/entry/raft_entry_ext.rs
+++ b/openraft/src/entry/raft_entry_ext.rs
@@ -1,0 +1,20 @@
+use crate::entry::RaftEntry;
+use crate::log_id::ref_log_id::RefLogId;
+use crate::RaftTypeConfig;
+
+pub(crate) trait RaftEntryExt<C>: RaftEntry<C>
+where C: RaftTypeConfig
+{
+    /// Returns a lightweight [`RefLogId`] that contains the log id information.
+    fn ref_log_id(&self) -> RefLogId<'_, C> {
+        let (leader_id, index) = self.log_id_parts();
+        RefLogId::new(leader_id, index)
+    }
+}
+
+impl<C, T> RaftEntryExt<C> for T
+where
+    C: RaftTypeConfig,
+    T: RaftEntry<C>,
+{
+}

--- a/openraft/src/entry/traits.rs
+++ b/openraft/src/entry/traits.rs
@@ -5,8 +5,9 @@ use openraft_macros::since;
 
 use crate::base::finalized::Final;
 use crate::base::OptionalFeatures;
-use crate::log_id::RaftLogId;
+use crate::type_config::alias::CommittedLeaderIdOf;
 use crate::type_config::alias::LogIdOf;
+use crate::EntryPayload;
 use crate::Membership;
 use crate::RaftTypeConfig;
 
@@ -14,7 +15,7 @@ use crate::RaftTypeConfig;
 pub trait RaftPayload<C>
 where C: RaftTypeConfig
 {
-    /// Return `Some(Membership)` if the entry payload is a membership payload.
+    /// Return `Some(Membership)` if the entry payload contains a membership payload.
     fn get_membership(&self) -> Option<Membership<C>>;
 }
 
@@ -23,37 +24,64 @@ pub trait RaftEntry<C>
 where
     C: RaftTypeConfig,
     Self: OptionalFeatures + Debug + Display,
-    Self: RaftPayload<C> + RaftLogId<C>,
+    Self: RaftPayload<C>,
 {
-    /// Create a new blank log entry.
+    /// Create a new log entry with log id and payload of application data or membership config.
+    #[since(version = "0.10.0")]
+    fn new(log_id: LogIdOf<C>, payload: EntryPayload<C>) -> Self;
+
+    /// Returns references to the components of this entry's log ID: the committed leader ID and
+    /// index.
     ///
-    /// The returned instance must return `true` for `Self::is_blank()`.
-    fn new_blank(log_id: LogIdOf<C>) -> Self;
+    /// The returned tuple contains:
+    /// - A reference to the committed leader ID that proposed this log entry.
+    /// - The index position of this entry in the log.
+    ///
+    /// Note: Although these components constitute a `LogId`, this method returns them separately
+    /// rather than as a reference to `LogId`. This allows implementations to store these
+    /// components directly without requiring a `LogId` field in their data structure.
+    #[since(version = "0.10.0")]
+    fn log_id_parts(&self) -> (&CommittedLeaderIdOf<C>, u64);
+
+    /// Set the log ID of this entry.
+    #[since(version = "0.10.0", change = "use owned argument log id")]
+    fn set_log_id(&mut self, new: LogIdOf<C>);
+
+    /// Create a new blank log entry.
+    #[since(version = "0.10.0", change = "become a default method")]
+    fn new_blank(log_id: LogIdOf<C>) -> Self
+    where Self: Final + Sized {
+        Self::new(log_id, EntryPayload::Blank)
+    }
+
+    /// Create a new normal log entry that contains application data.
+    #[since(version = "0.10.0", change = "become a default method")]
+    fn new_normal(log_id: LogIdOf<C>, data: C::D) -> Self
+    where Self: Final + Sized {
+        Self::new(log_id, EntryPayload::Normal(data))
+    }
 
     /// Create a new membership log entry.
     ///
     /// The returned instance must return `Some()` for `Self::get_membership()`.
-    fn new_membership(log_id: LogIdOf<C>, m: Membership<C>) -> Self;
+    #[since(version = "0.10.0", change = "become a default method")]
+    fn new_membership(log_id: LogIdOf<C>, m: Membership<C>) -> Self
+    where Self: Final + Sized {
+        Self::new(log_id, EntryPayload::Membership(m))
+    }
 
     /// Returns the `LogId` of this entry.
     #[since(version = "0.10.0")]
     fn log_id(&self) -> LogIdOf<C>
     where Self: Final {
-        self.get_log_id().clone()
+        let (leader_id, index) = self.log_id_parts();
+        LogIdOf::<C>::new(leader_id.clone(), index)
     }
 
     /// Returns the index of this log entry.
     #[since(version = "0.10.0")]
     fn index(&self) -> u64
     where Self: Final {
-        self.get_log_id().index()
+        self.log_id_parts().1
     }
-}
-
-/// Build a raft log entry from app data.
-///
-/// A concrete Entry should implement this trait to let openraft create an entry when needed.
-pub trait FromAppData<T> {
-    /// Build a raft log entry from app data.
-    fn from_app_data(t: T) -> Self;
 }

--- a/openraft/src/impls/mod.rs
+++ b/openraft/src/impls/mod.rs
@@ -17,6 +17,8 @@ pub mod leader_id_std {
     pub use crate::vote::leader_id::leader_id_std::LeaderId;
 }
 
+/// Default implementation of a raft log identity.
+pub use crate::log_id::LogId;
 /// Default [`RaftVote`] implementation for both standard Raft mode and multi-leader-per-term mode.
 ///
 /// The difference between the two modes is the implementation of [`RaftLeaderId`].

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -105,7 +105,6 @@ pub use crate::instant::TokioInstant;
 pub use crate::log_id::LogId;
 pub use crate::log_id::LogIdOptionExt;
 pub use crate::log_id::LogIndexOptionExt;
-pub use crate::log_id::RaftLogId;
 pub use crate::membership::EffectiveMembership;
 pub use crate::membership::Membership;
 pub use crate::membership::StoredMembership;

--- a/openraft/src/log_id/log_id_option_ext.rs
+++ b/openraft/src/log_id/log_id_option_ext.rs
@@ -1,8 +1,10 @@
-use crate::type_config::alias::LogIdOf;
+use crate::log_id::raft_log_id::RaftLogId;
 use crate::RaftTypeConfig;
 
 /// This helper trait extracts information from an `Option<LogId>`.
-pub trait LogIdOptionExt {
+pub trait LogIdOptionExt<C>
+where C: RaftTypeConfig
+{
     /// Returns the log index if it is not a `None`.
     fn index(&self) -> Option<u64>;
 
@@ -12,26 +14,13 @@ pub trait LogIdOptionExt {
     fn next_index(&self) -> u64;
 }
 
-impl<C> LogIdOptionExt for Option<LogIdOf<C>>
-where C: RaftTypeConfig
+impl<C, T> LogIdOptionExt<C> for Option<T>
+where
+    C: RaftTypeConfig,
+    T: RaftLogId<C>,
 {
     fn index(&self) -> Option<u64> {
         self.as_ref().map(|x| x.index())
-    }
-
-    fn next_index(&self) -> u64 {
-        match self {
-            None => 0,
-            Some(log_id) => log_id.index() + 1,
-        }
-    }
-}
-
-impl<C> LogIdOptionExt for Option<&LogIdOf<C>>
-where C: RaftTypeConfig
-{
-    fn index(&self) -> Option<u64> {
-        self.map(|x| x.index())
     }
 
     fn next_index(&self) -> u64 {

--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -3,15 +3,19 @@
 
 mod log_id_option_ext;
 mod log_index_option_ext;
-mod raft_log_id;
+pub(crate) mod option_raft_log_id_ext;
+pub(crate) mod option_ref_log_id_ext;
+pub(crate) mod raft_log_id;
+pub(crate) mod raft_log_id_ext;
+pub(crate) mod ref_log_id;
 
 use std::fmt::Display;
 use std::fmt::Formatter;
 
 pub use log_id_option_ext::LogIdOptionExt;
 pub use log_index_option_ext::LogIndexOptionExt;
-pub use raft_log_id::RaftLogId;
 
+use crate::log_id::raft_log_id::RaftLogId;
 use crate::type_config::alias::CommittedLeaderIdOf;
 use crate::RaftTypeConfig;
 
@@ -42,12 +46,16 @@ where
 impl<C> RaftLogId<C> for LogId<C>
 where C: RaftTypeConfig
 {
-    fn get_log_id(&self) -> &LogId<C> {
-        self
+    fn new(leader_id: CommittedLeaderIdOf<C>, index: u64) -> Self {
+        LogId { leader_id, index }
     }
 
-    fn set_log_id(&mut self, log_id: &LogId<C>) {
-        *self = log_id.clone()
+    fn committed_leader_id(&self) -> &CommittedLeaderIdOf<C> {
+        &self.leader_id
+    }
+
+    fn index(&self) -> u64 {
+        self.index
     }
 }
 

--- a/openraft/src/log_id/option_raft_log_id_ext.rs
+++ b/openraft/src/log_id/option_raft_log_id_ext.rs
@@ -1,0 +1,53 @@
+use crate::log_id::raft_log_id::RaftLogId;
+use crate::log_id::raft_log_id_ext::RaftLogIdExt;
+use crate::log_id::ref_log_id::RefLogId;
+use crate::type_config::alias::CommittedLeaderIdOf;
+use crate::RaftTypeConfig;
+
+/// This helper trait extracts information from an `Option<T>` where T impls [`RaftLogId`].
+pub(crate) trait OptionRaftLogIdExt<C>
+where C: RaftTypeConfig
+{
+    /// Returns the log index if it is not a `None`.
+    fn index(&self) -> Option<u64>;
+
+    /// Returns the next log index.
+    ///
+    /// If self is `None`, it returns 0.
+    fn next_index(&self) -> u64;
+
+    /// Returns the leader id that proposed this log id.
+    ///
+    /// In standard raft, committed leader id is just `term`.
+    fn committed_leader_id(&self) -> Option<&CommittedLeaderIdOf<C>>;
+
+    /// Converts this `Option<T: RaftLogId>` into a reference-based log ID.
+    ///
+    /// Returns `Some(RefLogId)` if `self` is `Some(T)`, `None` otherwise.
+    fn to_ref(&self) -> Option<RefLogId<'_, C>>;
+}
+
+impl<C, T> OptionRaftLogIdExt<C> for Option<T>
+where
+    C: RaftTypeConfig,
+    T: RaftLogId<C>,
+{
+    fn index(&self) -> Option<u64> {
+        self.as_ref().map(|x| x.index())
+    }
+
+    fn next_index(&self) -> u64 {
+        match self {
+            None => 0,
+            Some(log_id) => log_id.index() + 1,
+        }
+    }
+
+    fn committed_leader_id(&self) -> Option<&CommittedLeaderIdOf<C>> {
+        self.as_ref().map(|x| x.committed_leader_id())
+    }
+
+    fn to_ref(&self) -> Option<RefLogId<'_, C>> {
+        self.as_ref().map(|x| x.to_ref())
+    }
+}

--- a/openraft/src/log_id/option_ref_log_id_ext.rs
+++ b/openraft/src/log_id/option_ref_log_id_ext.rs
@@ -1,0 +1,20 @@
+use crate::log_id::ref_log_id::RefLogId;
+use crate::type_config::alias::LogIdOf;
+use crate::RaftTypeConfig;
+
+pub(crate) trait OptionRefLogIdExt<C>
+where C: RaftTypeConfig
+{
+    /// Creates a new owned [`LogId`] from the reference log ID.
+    ///
+    /// [`LogId`]: crate::log_id::LogId
+    fn to_log_id(&self) -> Option<LogIdOf<C>>;
+}
+
+impl<C> OptionRefLogIdExt<C> for Option<RefLogId<'_, C>>
+where C: RaftTypeConfig
+{
+    fn to_log_id(&self) -> Option<LogIdOf<C>> {
+        self.as_ref().map(|r| r.into_log_id())
+    }
+}

--- a/openraft/src/log_id/raft_log_id.rs
+++ b/openraft/src/log_id/raft_log_id.rs
@@ -1,24 +1,47 @@
+use std::fmt;
+
 use crate::type_config::alias::CommittedLeaderIdOf;
-use crate::type_config::alias::LogIdOf;
 use crate::RaftTypeConfig;
 
-/// Defines API to operate an object that contains a log-id, such as a log entry or a log id.
-pub trait RaftLogId<C>
-where C: RaftTypeConfig
+/// Log id is the globally unique identifier of a log entry.
+///
+/// Equal log id means the same log entry.
+pub(crate) trait RaftLogId<C>
+where
+    C: RaftTypeConfig,
+    Self: Eq + Clone + fmt::Debug + fmt::Display,
 {
+    /// Creates a log id proposed by a committed leader `leader_id` at the given index.
+    // This is only used internally
+    #[allow(dead_code)]
+    fn new(leader_id: CommittedLeaderIdOf<C>, index: u64) -> Self;
+
     /// Returns a reference to the leader id that proposed this log id.  
     ///
     /// When a `LeaderId` is committed, some of its data can be discarded.
     /// For example, a leader id in standard raft is `(term, node_id)`, but a log id does not have
     /// to store the `node_id`, because in standard raft there is at most one leader that can be
     /// established.
-    fn leader_id(&self) -> &CommittedLeaderIdOf<C> {
-        self.get_log_id().committed_leader_id()
+    fn committed_leader_id(&self) -> &CommittedLeaderIdOf<C>;
+
+    /// Returns the index of the log id.
+    fn index(&self) -> u64;
+}
+
+impl<C, T> RaftLogId<C> for &T
+where
+    C: RaftTypeConfig,
+    T: RaftLogId<C>,
+{
+    fn new(_leader_id: CommittedLeaderIdOf<C>, _index: u64) -> Self {
+        unreachable!("This method should not be called on a reference.")
     }
 
-    /// Return a reference to the log-id it stores.
-    fn get_log_id(&self) -> &LogIdOf<C>;
+    fn committed_leader_id(&self) -> &CommittedLeaderIdOf<C> {
+        T::committed_leader_id(self)
+    }
 
-    /// Update the log id it contains.
-    fn set_log_id(&mut self, log_id: &LogIdOf<C>);
+    fn index(&self) -> u64 {
+        T::index(self)
+    }
 }

--- a/openraft/src/log_id/raft_log_id_ext.rs
+++ b/openraft/src/log_id/raft_log_id_ext.rs
@@ -1,0 +1,32 @@
+use crate::log_id::raft_log_id::RaftLogId;
+use crate::log_id::ref_log_id::RefLogId;
+use crate::type_config::alias::LogIdOf;
+use crate::RaftTypeConfig;
+
+pub(crate) trait RaftLogIdExt<C>
+where
+    C: RaftTypeConfig,
+    Self: RaftLogId<C>,
+{
+    /// Creates a new owned [`LogId`] from this log ID implementation.
+    ///
+    /// [`LogId`]: crate::log_id::LogId
+    fn to_log_id(&self) -> LogIdOf<C> {
+        self.to_ref().into_log_id()
+    }
+
+    /// Creates a reference view of this log ID implementation via a [`RefLogId`].
+    fn to_ref(&self) -> RefLogId<'_, C> {
+        RefLogId {
+            leader_id: self.committed_leader_id(),
+            index: self.index(),
+        }
+    }
+}
+
+impl<C, T> RaftLogIdExt<C> for T
+where
+    C: RaftTypeConfig,
+    T: RaftLogId<C>,
+{
+}

--- a/openraft/src/log_id/ref_log_id.rs
+++ b/openraft/src/log_id/ref_log_id.rs
@@ -1,0 +1,65 @@
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use crate::log_id::raft_log_id::RaftLogId;
+use crate::type_config::alias::CommittedLeaderIdOf;
+use crate::LogId;
+use crate::RaftTypeConfig;
+
+/// A reference to a log id, combining a reference to a committed leader ID and an index.
+/// Committed leader ID is the `term` in standard Raft.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct RefLogId<'k, C>
+where C: RaftTypeConfig
+{
+    pub(crate) leader_id: &'k CommittedLeaderIdOf<C>,
+    pub(crate) index: u64,
+}
+
+impl<'l, C> RefLogId<'l, C>
+where C: RaftTypeConfig
+{
+    /// Create a new reference log id.
+    pub(crate) fn new(leader_id: &'l CommittedLeaderIdOf<C>, index: u64) -> Self {
+        RefLogId { leader_id, index }
+    }
+
+    /// Return the committed leader ID of this log id, which is `term` in standard Raft.
+    pub(crate) fn committed_leader_id(&self) -> &'l CommittedLeaderIdOf<C> {
+        self.leader_id
+    }
+
+    /// Return the index of this log id.
+    pub(crate) fn index(&self) -> u64 {
+        self.index
+    }
+
+    /// Convert this reference type to an owned log id.
+    pub(crate) fn into_log_id(self) -> LogId<C> {
+        LogId::<C>::new(self.leader_id.clone(), self.index)
+    }
+}
+
+impl<C> Display for RefLogId<'_, C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.committed_leader_id(), self.index())
+    }
+}
+
+impl<C> RaftLogId<C> for RefLogId<'_, C>
+where C: RaftTypeConfig
+{
+    fn new(_leader_id: CommittedLeaderIdOf<C>, _index: u64) -> Self {
+        unreachable!("RefLogId does not own the leader id, so it cannot be created from it.")
+    }
+
+    fn committed_leader_id(&self) -> &CommittedLeaderIdOf<C> {
+        self.leader_id
+    }
+
+    fn index(&self) -> u64 {
+        self.index
+    }
+}

--- a/openraft/src/log_id_range.rs
+++ b/openraft/src/log_id_range.rs
@@ -5,7 +5,6 @@ use std::fmt::Formatter;
 use validit::Validate;
 
 use crate::display_ext::DisplayOptionExt;
-use crate::type_config::alias::CommittedLeaderIdOf;
 use crate::type_config::alias::LogIdOf;
 use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
@@ -30,7 +29,7 @@ where C: RaftTypeConfig
 impl<C> Copy for LogIdRange<C>
 where
     C: RaftTypeConfig,
-    CommittedLeaderIdOf<C>: Copy,
+    LogIdOf<C>: Copy,
 {
 }
 

--- a/openraft/src/membership/effective_membership.rs
+++ b/openraft/src/membership/effective_membership.rs
@@ -4,7 +4,8 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use crate::display_ext::DisplayOptionExt;
-use crate::log_id::RaftLogId;
+use crate::log_id::raft_log_id::RaftLogId;
+use crate::log_id::raft_log_id_ext::RaftLogIdExt;
 use crate::quorum::Joint;
 use crate::quorum::QuorumSet;
 use crate::type_config::alias::LogIdOf;
@@ -58,7 +59,7 @@ where
     LID: RaftLogId<C>,
 {
     fn from(v: (&LID, Membership<C>)) -> Self {
-        EffectiveMembership::new(Some(v.0.get_log_id().clone()), v.1)
+        EffectiveMembership::new(Some(v.0.to_log_id()), v.1)
     }
 }
 

--- a/openraft/src/progress/entry/tests.rs
+++ b/openraft/src/progress/entry/tests.rs
@@ -2,6 +2,7 @@ use std::borrow::Borrow;
 
 use crate::engine::testing::UTConfig;
 use crate::engine::EngineConfig;
+use crate::log_id::ref_log_id::RefLogId;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::inflight::Inflight;
 use crate::raft_state::LogStateReader;
@@ -116,6 +117,10 @@ impl LogStateReader<UTConfig> for LogState {
         } else {
             None
         }
+    }
+
+    fn ref_log_id(&self, _index: u64) -> Option<RefLogId<'_, UTConfig>> {
+        unimplemented!("testing")
     }
 
     fn last_log_id(&self) -> Option<&LogIdOf<UTConfig>> {

--- a/openraft/src/progress/inflight/mod.rs
+++ b/openraft/src/progress/inflight/mod.rs
@@ -9,7 +9,6 @@ use validit::Validate;
 
 use crate::display_ext::DisplayOptionExt;
 use crate::log_id_range::LogIdRange;
-use crate::type_config::alias::CommittedLeaderIdOf;
 use crate::type_config::alias::LogIdOf;
 use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
@@ -42,7 +41,7 @@ where C: RaftTypeConfig
 impl<C> Copy for Inflight<C>
 where
     C: RaftTypeConfig,
-    CommittedLeaderIdOf<C>: Copy,
+    LogIdOf<C>: Copy,
 {
 }
 

--- a/openraft/src/raft_state/log_state_reader.rs
+++ b/openraft/src/raft_state/log_state_reader.rs
@@ -1,5 +1,9 @@
+use crate::log_id::option_raft_log_id_ext::OptionRaftLogIdExt;
+use crate::log_id::option_ref_log_id_ext::OptionRefLogIdExt;
+use crate::log_id::raft_log_id::RaftLogId;
+use crate::log_id::raft_log_id_ext::RaftLogIdExt;
+use crate::log_id::ref_log_id::RefLogId;
 use crate::type_config::alias::LogIdOf;
-use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
 
 /// APIs to get significant log ids reflecting the raft state.
@@ -20,18 +24,22 @@ where C: RaftTypeConfig
     /// Return if a log id exists.
     ///
     /// It assumes a committed log will always get positive return value, according to raft spec.
-    fn has_log_id(&self, log_id: &LogIdOf<C>) -> bool {
+    fn has_log_id(&self, log_id: impl RaftLogId<C>) -> bool {
         if log_id.index() < self.committed().next_index() {
-            debug_assert!(Some(log_id) <= self.committed());
+            debug_assert!(Some(log_id.to_ref()) <= self.committed().to_ref());
             return true;
         }
 
         // The local log id exists at the index and is same as the input.
-        if let Some(local) = self.get_log_id(log_id.index()) {
-            *log_id == local
+        if let Some(local) = self.ref_log_id(log_id.index()) {
+            log_id.to_ref() == local
         } else {
             false
         }
+    }
+
+    fn get_log_id(&self, index: u64) -> Option<LogIdOf<C>> {
+        self.ref_log_id(index).to_log_id()
     }
 
     /// Get the log id at the specified index.
@@ -39,7 +47,7 @@ where C: RaftTypeConfig
     /// It will return `last_purged_log_id` if index is at the last purged index.
     /// If the log at the specified index is smaller than `last_purged_log_id`, or greater than
     /// `last_log_id`, it returns None.
-    fn get_log_id(&self, index: u64) -> Option<LogIdOf<C>>;
+    fn ref_log_id(&self, index: u64) -> Option<RefLogId<'_, C>>;
 
     /// The last known log id in the store.
     ///

--- a/openraft/src/raft_state/tests/log_state_reader_test.rs
+++ b/openraft/src/raft_state/tests/log_state_reader_test.rs
@@ -43,7 +43,7 @@ fn test_raft_state_prev_log_id() -> anyhow::Result<()> {
 fn test_raft_state_has_log_id_empty() -> anyhow::Result<()> {
     let rs = RaftState::<UTConfig>::default();
 
-    assert!(!rs.has_log_id(&log_id(0, 0)));
+    assert!(!rs.has_log_id(log_id(0, 0)));
 
     Ok(())
 }
@@ -55,9 +55,9 @@ fn test_raft_state_has_log_id_committed_gets_true() -> anyhow::Result<()> {
         ..Default::default()
     };
 
-    assert!(rs.has_log_id(&log_id(0, 0)));
-    assert!(rs.has_log_id(&log_id(2, 1)));
-    assert!(!rs.has_log_id(&log_id(2, 2)));
+    assert!(rs.has_log_id(log_id(0, 0)));
+    assert!(rs.has_log_id(log_id(2, 1)));
+    assert!(!rs.has_log_id(log_id(2, 2)));
 
     Ok(())
 }
@@ -70,14 +70,14 @@ fn test_raft_state_has_log_id_in_log_id_list() -> anyhow::Result<()> {
         ..Default::default()
     };
 
-    assert!(rs.has_log_id(&log_id(0, 0)));
-    assert!(rs.has_log_id(&log_id(2, 1)));
-    assert!(rs.has_log_id(&log_id(1, 3)));
-    assert!(rs.has_log_id(&log_id(3, 4)));
+    assert!(rs.has_log_id(log_id(0, 0)));
+    assert!(rs.has_log_id(log_id(2, 1)));
+    assert!(rs.has_log_id(log_id(1, 3)));
+    assert!(rs.has_log_id(log_id(3, 4)));
 
-    assert!(!rs.has_log_id(&log_id(2, 3)));
-    assert!(!rs.has_log_id(&log_id(2, 4)));
-    assert!(!rs.has_log_id(&log_id(3, 5)));
+    assert!(!rs.has_log_id(log_id(2, 3)));
+    assert!(!rs.has_log_id(log_id(2, 4)));
+    assert!(!rs.has_log_id(log_id(3, 5)));
 
     Ok(())
 }

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -26,6 +26,7 @@ use crate::core::notification::Notification;
 use crate::core::sm::handle::SnapshotReader;
 use crate::display_ext::DisplayInstantExt;
 use crate::display_ext::DisplayOptionExt;
+use crate::entry::raft_entry_ext::RaftEntryExt;
 use crate::entry::RaftEntry;
 use crate::error::HigherVote;
 use crate::error::PayloadTooLarge;
@@ -59,7 +60,6 @@ use crate::type_config::alias::VoteOf;
 use crate::type_config::async_runtime::mutex::Mutex;
 use crate::type_config::TypeConfigExt;
 use crate::vote::raft_vote::RaftVoteExt;
-use crate::RaftLogId;
 use crate::RaftNetworkFactory;
 use crate::RaftTypeConfig;
 use crate::StorageError;
@@ -398,7 +398,7 @@ where
                 // limited_get_log_entries will return logs smaller than the range [start, end).
                 let logs = self.log_reader.limited_get_log_entries(start, end).await?;
 
-                let first = logs.first().map(|ent| ent.get_log_id()).unwrap();
+                let first = logs.first().map(|ent| ent.ref_log_id()).unwrap();
                 let last = logs.last().map(|ent| ent.log_id()).unwrap();
 
                 debug_assert!(

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -27,7 +27,6 @@ use crate::type_config::alias::VoteOf;
 use crate::type_config::TypeConfigExt;
 use crate::vote::raft_vote::RaftVoteExt;
 use crate::vote::RaftLeaderIdExt;
-use crate::LogId;
 use crate::Membership;
 use crate::OptionalSend;
 use crate::RaftLogReader;
@@ -634,7 +633,7 @@ where
     }
 
     pub async fn get_initial_state_log_ids(mut store: LS, mut sm: SM) -> Result<(), StorageError<C>> {
-        let log_id = |t: u64, n: u64, i| LogId::<C>::new(C::LeaderId::new_committed(t.into(), n.into()), i);
+        let log_id = |t: u64, n: u64, i| LogIdOf::<C>::new(C::LeaderId::new_committed(t.into(), n.into()), i);
 
         tracing::info!("--- empty store, expect []");
         {

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -13,7 +13,6 @@ pub use async_runtime::MpscUnbounded;
 pub use async_runtime::OneshotSender;
 pub use util::TypeConfigExt;
 
-use crate::entry::FromAppData;
 use crate::entry::RaftEntry;
 use crate::raft::responder::Responder;
 use crate::vote::raft_vote::RaftVote;
@@ -89,7 +88,7 @@ pub trait RaftTypeConfig:
     type Vote: RaftVote<Self>;
 
     /// Raft log entry, which can be built from an AppData.
-    type Entry: RaftEntry<Self> + FromAppData<Self::D>;
+    type Entry: RaftEntry<Self>;
 
     /// Snapshot data for exposing a snapshot for reading & writing.
     ///

--- a/tests/tests/snapshot_streaming/t30_purge_in_snapshot_logs.rs
+++ b/tests/tests/snapshot_streaming/t30_purge_in_snapshot_logs.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 
 use anyhow::Result;
 use maplit::btreeset;
-use openraft::entry::RaftEntry;
 use openraft::Config;
 use openraft::RaftLogReader;
 use tokio::time::sleep;
@@ -87,7 +86,7 @@ async fn purge_in_snapshot_logs() -> Result<()> {
     let logs = sto0.try_get_log_entries(..).await?;
     assert_eq!(
         log_index + 1 - max_keep,
-        logs[0].index(),
+        logs[0].log_id.index(),
         "leader's local logs are purged"
     );
 


### PR DESCRIPTION

## Changelog

##### Change: Refine Log Entry Traits

This commit refines the `RaftEntry` and related traits, to better
support application defined log `Entry` type.

Key Changes:

1. Remove `FromAppData` trait:
   - The `FromAppData` trait, which was used to create log `Entry` from
     application data, is removed.
   - Applications should now implement the new `RaftEntry::new()` method
     to create log entries directly.

2. Remove `RaftLogId` trait, it becomes an internal trait.

3. Update `RaftEntry` trait:

   - The `RaftEntry` trait no longer requires `RaftLogId` (due to its
     redefinition) and now mandates the implementation of:

     - `new()`: For creating a log `Entry`.
     - `log_id_parts()`: To return references to the log ID's committed
       leader ID(term) and index.
     - `set_log_id()`: To update the log entry's ID.

   - Default methods are provided:

     - `new_blank()`, `new_normal()`, `new_membership()` for creating
       different types of log entries.
     - `log_id()` returns an owned `LogId` instance.
     - `index()` returns the index of the log entry.

4. Introduce `RefLogId`:
   - `RefLogId` is a reference-based representation of a log ID,
     complementing the existing `LogIdOf<C>` (a storage-based
     implementation).
   - `RefLogId` adds system-defined properties (e.g., `Ord`
     implementation) while referencing an existing `LogIdOf<C>`.
   - Internal components now use `RefLogId` where possible, improving
     flexibility and consistency.

5. Update example `raft-kv-memstore-grpc`:
   - Updated to implement log `Entry` and related types using protobuf,
     including state machine and RPC message types.
   - Added snapshot streaming transmission implementation.
   - Removed `serde` dependency from the example.

- Part of #1278.

---

Upgrade tips:

1. For Applications with Custom `RaftEntry` Implementations:
   If you've declared a custom `RaftEntry` (e.g., `declare_raft_types!(MyTypes: Entry = MyEntry)`):
   - Remove the implementation of `FromAppData`.
   - Implement the following new methods:
     - `new()`
     - `log_id_parts()`
     - `set_log_id()`

2. For Applications Using OpenRaft's Default `Entry`:
   - No changes are required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1320)
<!-- Reviewable:end -->
