### PR TITLE
Chore: rename consistent_read() to linearizable_read() for examples

### DIFF
--- a/examples/raft-kv-memstore/src/app.rs
+++ b/examples/raft-kv-memstore/src/app.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use crate::LogStore;
 use crate::NodeId;
 use crate::Raft;
 use crate::StateMachineStore;
@@ -11,7 +10,5 @@ pub struct App {
     pub id: NodeId,
     pub addr: String,
     pub raft: Raft,
-    pub log_store: LogStore,
     pub state_machine_store: Arc<StateMachineStore>,
-    pub config: Arc<openraft::Config>,
 }

--- a/examples/raft-kv-memstore/src/client.rs
+++ b/examples/raft-kv-memstore/src/client.rs
@@ -60,8 +60,8 @@ impl ExampleClient {
     /// Consistent Read value by key, in an inconsistent mode.
     ///
     /// This method MUST return consistent value or CheckIsLeaderError.
-    pub async fn consistent_read(&self, req: &String) -> Result<String, RPCError<RaftError<CheckIsLeaderError>>> {
-        self.do_send_rpc_to_leader("consistent_read", Some(req)).await
+    pub async fn linearizable_read(&self, req: &String) -> Result<String, RPCError<RaftError<CheckIsLeaderError>>> {
+        self.do_send_rpc_to_leader("linearizable_read", Some(req)).await
     }
 
     // --- Cluster management API

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -99,7 +99,7 @@ pub async fn start_example_raft_node(node_id: NodeId, http_addr: String) -> std:
             // application API
             .service(api::write)
             .service(api::read)
-            .service(api::consistent_read)
+            .service(api::linearizable_read)
     });
 
     let x = server.bind(http_addr)?;

--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -77,9 +77,7 @@ pub async fn start_example_raft_node(node_id: NodeId, http_addr: String) -> std:
         id: node_id,
         addr: http_addr.clone(),
         raft,
-        log_store,
         state_machine_store,
-        config,
     });
 
     // Start the actix-web server.

--- a/examples/raft-kv-memstore/src/network/api.rs
+++ b/examples/raft-kv-memstore/src/network/api.rs
@@ -36,8 +36,8 @@ pub async fn read(app: Data<App>, req: Json<String>) -> actix_web::Result<impl R
     Ok(Json(res))
 }
 
-#[post("/consistent_read")]
-pub async fn consistent_read(app: Data<App>, req: Json<String>) -> actix_web::Result<impl Responder> {
+#[post("/linearizable_read")]
+pub async fn linearizable_read(app: Data<App>, req: Json<String>) -> actix_web::Result<impl Responder> {
     let ret = app.raft.ensure_linearizable().await;
 
     match ret {

--- a/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_cluster.rs
@@ -224,12 +224,12 @@ async fn test_cluster() -> anyhow::Result<()> {
     let x = client3.read(&("foo".to_string())).await?;
     assert_eq!("wow", x);
 
-    println!("=== consistent_read `foo` on node 1");
-    let x = client.consistent_read(&("foo".to_string())).await?;
+    println!("=== linearizable_read `foo` on node 1");
+    let x = client.linearizable_read(&("foo".to_string())).await?;
     assert_eq!("wow", x);
 
-    println!("=== consistent_read `foo` on node 2 MUST return CheckIsLeaderError");
-    let x = client2.consistent_read(&("foo".to_string())).await;
+    println!("=== linearizable_read `foo` on node 2 MUST return CheckIsLeaderError");
+    let x = client2.linearizable_read(&("foo".to_string())).await;
     match x {
         Err(e) => {
             let s = e.to_string();

--- a/examples/raft-kv-rocksdb/src/client.rs
+++ b/examples/raft-kv-rocksdb/src/client.rs
@@ -58,8 +58,8 @@ impl ExampleClient {
     /// Consistent Read value by key, in an inconsistent mode.
     ///
     /// This method MUST return consistent value or CheckIsLeaderError.
-    pub async fn consistent_read(&self, req: &String) -> Result<String, RPCError<RaftError<CheckIsLeaderError>>> {
-        self.do_send_rpc_to_leader("api/consistent_read", Some(req)).await
+    pub async fn linearizable_read(&self, req: &String) -> Result<String, RPCError<RaftError<CheckIsLeaderError>>> {
+        self.do_send_rpc_to_leader("api/linearizable_read", Some(req)).await
     }
 
     // --- Cluster management API

--- a/examples/raft-kv-rocksdb/src/network/api.rs
+++ b/examples/raft-kv-rocksdb/src/network/api.rs
@@ -14,7 +14,7 @@ pub fn rest(app: &mut Server) {
     let mut api = app.at("/api");
     api.at("/write").post(write);
     api.at("/read").post(read);
-    api.at("/consistent_read").post(consistent_read);
+    api.at("/linearizable_read").post(linearizable_read);
 }
 /**
  * Application API
@@ -40,7 +40,7 @@ async fn read(mut req: Request<Arc<App>>) -> tide::Result {
     Ok(Response::builder(StatusCode::Ok).body(Body::from_json(&res)?).build())
 }
 
-async fn consistent_read(mut req: Request<Arc<App>>) -> tide::Result {
+async fn linearizable_read(mut req: Request<Arc<App>>) -> tide::Result {
     let ret = req.state().raft.ensure_linearizable().await;
 
     match ret {

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -221,12 +221,12 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
     let x = client3.read(&("foo".to_string())).await?;
     assert_eq!("wow", x);
 
-    println!("=== consistent_read `foo` on node 1");
-    let x = leader.consistent_read(&("foo".to_string())).await?;
+    println!("=== linearizable_read `foo` on node 1");
+    let x = leader.linearizable_read(&("foo".to_string())).await?;
     assert_eq!("wow", x);
 
-    println!("=== consistent_read `foo` on node 2 MUST return CheckIsLeaderError");
-    let x = client2.consistent_read(&("foo".to_string())).await;
+    println!("=== linearizable_read `foo` on node 2 MUST return CheckIsLeaderError");
+    let x = client2.linearizable_read(&("foo".to_string())).await;
     match x {
         Err(e) => {
             let s = e.to_string();


### PR DESCRIPTION

## Changelog

##### Chore: rename consistent_read() to linearizable_read() for examples


##### Chore: remove unused field from example raft-kv-memstore

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1323)
<!-- Reviewable:end -->
