### PR TITLE
Change: Remove `RemoteError` variant from `StreamingError`

### DIFF
--- a/openraft/src/error/decompose.rs
+++ b/openraft/src/error/decompose.rs
@@ -1,11 +1,9 @@
 use std::error::Error;
 
 use crate::error::into_ok::into_ok;
-use crate::error::Fatal;
 use crate::error::Infallible;
 use crate::error::RPCError;
 use crate::error::RaftError;
-use crate::error::StreamingError;
 use crate::error::Unreachable;
 use crate::RaftTypeConfig;
 
@@ -68,27 +66,6 @@ where
                     RaftError::APIError(e) => Ok(Err(e)),
                     RaftError::Fatal(e) => Err(RPCError::Unreachable(Unreachable::new(&e))),
                 },
-            },
-        }
-    }
-}
-
-impl<C, R> DecomposeResult<C, R, StreamingError<C>> for Result<R, StreamingError<C, Fatal<C>>>
-where C: RaftTypeConfig
-{
-    type InnerError = Infallible;
-
-    /// `Fatal` is considered as `RPCError::Unreachable`.
-    fn decompose(self) -> Result<Result<R, Self::InnerError>, StreamingError<C>> {
-        match self {
-            Ok(r) => Ok(Ok(r)),
-            Err(e) => match e {
-                StreamingError::Closed(e) => Err(StreamingError::Closed(e)),
-                StreamingError::StorageError(e) => Err(StreamingError::StorageError(e)),
-                StreamingError::Timeout(e) => Err(StreamingError::Timeout(e)),
-                StreamingError::Unreachable(e) => Err(StreamingError::Unreachable(e)),
-                StreamingError::Network(e) => Err(StreamingError::Network(e)),
-                StreamingError::RemoteError(e) => Err(StreamingError::Unreachable(Unreachable::new(&e.source))),
             },
         }
     }

--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -18,7 +18,6 @@ mod tokio_rt {
     use super::Chunked;
     use super::SnapshotTransport;
     use super::Streaming;
-    use crate::error::Fatal;
     use crate::error::InstallSnapshotError;
     use crate::error::RPCError;
     use crate::error::RaftError;
@@ -50,7 +49,7 @@ mod tokio_rt {
             mut snapshot: Snapshot<C>,
             mut cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
             option: RPCOption,
-        ) -> Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>
+        ) -> Result<SnapshotResponse<C>, StreamingError<C>>
         where
             Net: RaftNetwork<C> + ?Sized,
         {
@@ -264,7 +263,6 @@ use std::future::Future;
 
 use openraft_macros::add_async_trait;
 
-use crate::error::Fatal;
 use crate::error::InstallSnapshotError;
 use crate::error::RaftError;
 use crate::error::ReplicationClosed;
@@ -304,7 +302,7 @@ pub trait SnapshotTransport<C: RaftTypeConfig> {
         snapshot: Snapshot<C>,
         cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
         option: RPCOption,
-    ) -> Result<SnapshotResponse<C>, StreamingError<C, Fatal<C>>>
+    ) -> Result<SnapshotResponse<C>, StreamingError<C>>
     where
         Net: RaftNetwork<C> + ?Sized;
 

--- a/openraft/src/network/v2/adapt_v1.rs
+++ b/openraft/src/network/v2/adapt_v1.rs
@@ -46,7 +46,7 @@ where
         use crate::network::snapshot_transport::Chunked;
         use crate::network::snapshot_transport::SnapshotTransport;
 
-        let resp = Chunked::send_snapshot(self, vote, snapshot, cancel, option).await.decompose_infallible()?;
+        let resp = Chunked::send_snapshot(self, vote, snapshot, cancel, option).await?;
         Ok(resp)
     }
 


### PR DESCRIPTION

## Changelog

##### Change: Remove `RemoteError` variant from `StreamingError`

`StreamingError` is intended to represent non-logic errors that occur
while streaming data to a remote peer. A `RemoteError` does not belong
in a stream RPC error and should instead be included as part of a
non-error response.

Upgrade tip:

No modifications are required for this change, as no related API
utilized the `RemoteError` variant.


##### Change: Simplify `send_snapshot()` error type in `Chunked`

The return error type of
`openraft::network::snapshot_transport::Chunked::send_snapshot()` is
simplified from `StreamingError<_, Fatal>` to `StreamingError<_>`. This
change is made because the remote `Fatal` error cannot be handled by the
sending end and should not be produced at all.

Upgrade Tip:

If `Chunked` is used in a `RaftNetworkV2` implementation to adapt the v1
`RaftNetwork`, simply remove the error handling for `Fatal`. Otherwise,
no changes are required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1325)
<!-- Reviewable:end -->
