### PR TITLE
Change: Remove Box from `Snapshot::snapshot`

### DIFF
--- a/cluster_benchmark/tests/benchmark/store.rs
+++ b/cluster_benchmark/tests/benchmark/store.rs
@@ -176,7 +176,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
 
         Ok(Snapshot {
             meta,
-            snapshot: Box::new(Cursor::new(data)),
+            snapshot: Cursor::new(data),
         })
     }
 }
@@ -281,15 +281,15 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<TypeConfig>> {
-        Ok(Box::new(Cursor::new(Vec::new())))
+    async fn begin_receiving_snapshot(&mut self) -> Result<SnapshotDataOf<TypeConfig>, StorageError<TypeConfig>> {
+        Ok(Cursor::new(Vec::new()))
     }
 
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<TypeConfig>,
-        snapshot: Box<SnapshotDataOf<TypeConfig>>,
+        snapshot: SnapshotDataOf<TypeConfig>,
     ) -> Result<(), StorageError<TypeConfig>> {
         let new_snapshot = StoredSnapshot {
             meta: meta.clone(),
@@ -317,7 +317,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
                 let data = snapshot.data.clone();
                 Ok(Some(Snapshot {
                     meta: snapshot.meta.clone(),
-                    snapshot: Box::new(Cursor::new(data)),
+                    snapshot: Cursor::new(data),
                 }))
             }
             None => Ok(None),

--- a/examples/raft-kv-memstore-grpc/src/grpc/raft_service.rs
+++ b/examples/raft-kv-memstore-grpc/src/grpc/raft_service.rs
@@ -143,7 +143,7 @@ impl RaftService for RaftServiceImpl {
 
         let snapshot = Snapshot {
             meta: snapshot_meta,
-            snapshot: Box::new(snapshot_data_bytes),
+            snapshot: snapshot_data_bytes,
         };
 
         // Install the full snapshot

--- a/examples/raft-kv-memstore-grpc/src/network/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/network/mod.rs
@@ -110,7 +110,7 @@ impl RaftNetworkV2<TypeConfig> for NetworkConnection {
         // 2. Send data chunks
 
         let chunk_size = 1024 * 1024;
-        for chunk in snapshot.snapshot.as_ref().chunks(chunk_size) {
+        for chunk in snapshot.snapshot.chunks(chunk_size) {
             let request = pb::SnapshotRequest {
                 payload: Some(pb::snapshot_request::Payload::Chunk(chunk.to_vec())),
             };

--- a/examples/raft-kv-memstore-network-v2/src/api.rs
+++ b/examples/raft-kv-memstore-network-v2/src/api.rs
@@ -51,7 +51,7 @@ pub async fn snapshot(app: &mut App, req: String) -> String {
     let (vote, snapshot_meta, snapshot_data): (Vote, SnapshotMeta, SnapshotData) = decode(&req);
     let snapshot = Snapshot {
         meta: snapshot_meta,
-        snapshot: Box::new(snapshot_data),
+        snapshot: snapshot_data,
     };
     let res = app.raft.install_full_snapshot(vote, snapshot).await.map_err(RaftError::<Infallible>::Fatal);
     encode(res)

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/api.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/api.rs
@@ -51,7 +51,7 @@ pub async fn snapshot(app: &mut App, req: String) -> String {
     let (vote, snapshot_meta, snapshot_data): (Vote, SnapshotMeta, SnapshotData) = decode(&req);
     let snapshot = Snapshot {
         meta: snapshot_meta,
-        snapshot: Box::new(snapshot_data),
+        snapshot: snapshot_data,
     };
     let res = app.raft.install_full_snapshot(vote, snapshot).await.map_err(RaftError::<Infallible>::Fatal);
     encode(res)

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -40,7 +40,7 @@ pub struct StoredSnapshot {
     pub meta: SnapshotMeta,
 
     /// The data of the state machine at the time of this snapshot.
-    pub data: Box<SnapshotData>,
+    pub data: SnapshotData,
 }
 
 /// Data contained in the Raft state machine.
@@ -125,7 +125,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
 
         let snapshot = StoredSnapshot {
             meta: meta.clone(),
-            data: Box::new(snapshot_id.clone()),
+            data: snapshot_id.clone(),
         };
 
         {
@@ -135,7 +135,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
 
         Ok(Snapshot {
             meta,
-            snapshot: Box::new(snapshot_id),
+            snapshot: snapshot_id,
         })
     }
 }
@@ -180,12 +180,12 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotData>, StorageError> {
-        Ok(Box::default())
+    async fn begin_receiving_snapshot(&mut self) -> Result<SnapshotData, StorageError> {
+        Ok(Default::default())
     }
 
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
-    async fn install_snapshot(&mut self, meta: &SnapshotMeta, snapshot: Box<SnapshotData>) -> Result<(), StorageError> {
+    async fn install_snapshot(&mut self, meta: &SnapshotMeta, snapshot: SnapshotData) -> Result<(), StorageError> {
         tracing::info!("install snapshot");
 
         let new_snapshot = StoredSnapshot {

--- a/examples/raft-kv-memstore-singlethreaded/src/store.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/store.rs
@@ -169,7 +169,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Rc<StateMachineStore> {
 
         Ok(Snapshot {
             meta,
-            snapshot: Box::new(Cursor::new(data)),
+            snapshot: Cursor::new(data),
         })
     }
 }
@@ -214,12 +214,12 @@ impl RaftStateMachine<TypeConfig> for Rc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotData>, StorageError> {
-        Ok(Box::new(Cursor::new(Vec::new())))
+    async fn begin_receiving_snapshot(&mut self) -> Result<SnapshotData, StorageError> {
+        Ok(Cursor::new(Vec::new()))
     }
 
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
-    async fn install_snapshot(&mut self, meta: &SnapshotMeta, snapshot: Box<SnapshotData>) -> Result<(), StorageError> {
+    async fn install_snapshot(&mut self, meta: &SnapshotMeta, snapshot: SnapshotData) -> Result<(), StorageError> {
         tracing::info!(
             { snapshot_size = snapshot.get_ref().len() },
             "decoding snapshot for installation"
@@ -251,7 +251,7 @@ impl RaftStateMachine<TypeConfig> for Rc<StateMachineStore> {
                 let data = snapshot.data.clone();
                 Ok(Some(Snapshot {
                     meta: snapshot.meta.clone(),
-                    snapshot: Box::new(Cursor::new(data)),
+                    snapshot: Cursor::new(data),
                 }))
             }
             None => Ok(None),

--- a/examples/raft-kv-memstore/src/store/mod.rs
+++ b/examples/raft-kv-memstore/src/store/mod.rs
@@ -125,7 +125,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
 
         Ok(Snapshot {
             meta,
-            snapshot: Box::new(Cursor::new(data)),
+            snapshot: Cursor::new(data),
         })
     }
 }
@@ -172,15 +172,15 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<TypeConfig>> {
-        Ok(Box::new(Cursor::new(Vec::new())))
+    async fn begin_receiving_snapshot(&mut self) -> Result<SnapshotDataOf<TypeConfig>, StorageError<TypeConfig>> {
+        Ok(Cursor::new(Vec::new()))
     }
 
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<TypeConfig>,
-        snapshot: Box<SnapshotDataOf<TypeConfig>>,
+        snapshot: SnapshotDataOf<TypeConfig>,
     ) -> Result<(), StorageError<TypeConfig>> {
         tracing::info!(
             { snapshot_size = snapshot.get_ref().len() },
@@ -220,7 +220,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
                 let data = snapshot.data.clone();
                 Ok(Some(Snapshot {
                     meta: snapshot.meta.clone(),
-                    snapshot: Box::new(Cursor::new(data)),
+                    snapshot: Cursor::new(data),
                 }))
             }
             None => Ok(None),

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -109,7 +109,7 @@ impl RaftSnapshotBuilder<TypeConfig> for StateMachineStore {
 
         Ok(Snapshot {
             meta,
-            snapshot: Box::new(Cursor::new(kv_json)),
+            snapshot: Cursor::new(kv_json),
         })
     }
 }
@@ -217,11 +217,11 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
         self.clone()
     }
 
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<Cursor<Vec<u8>>>, StorageError> {
-        Ok(Box::new(Cursor::new(Vec::new())))
+    async fn begin_receiving_snapshot(&mut self) -> Result<Cursor<Vec<u8>>, StorageError> {
+        Ok(Cursor::new(Vec::new()))
     }
 
-    async fn install_snapshot(&mut self, meta: &SnapshotMeta, snapshot: Box<SnapshotData>) -> Result<(), StorageError> {
+    async fn install_snapshot(&mut self, meta: &SnapshotMeta, snapshot: SnapshotData) -> Result<(), StorageError> {
         let new_snapshot = StoredSnapshot {
             meta: meta.clone(),
             data: snapshot.into_inner(),
@@ -238,7 +238,7 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
         let x = self.get_current_snapshot_()?;
         Ok(x.map(|s| Snapshot {
             meta: s.meta.clone(),
-            snapshot: Box::new(Cursor::new(s.data.clone())),
+            snapshot: Cursor::new(s.data.clone()),
         }))
     }
 }

--- a/examples/rocksstore/src/lib.rs
+++ b/examples/rocksstore/src/lib.rs
@@ -155,7 +155,7 @@ impl RaftSnapshotBuilder<TypeConfig> for RocksStateMachine {
 
         Ok(Snapshot {
             meta,
-            snapshot: Box::new(Cursor::new(data)),
+            snapshot: Cursor::new(data),
         })
     }
 }
@@ -204,14 +204,14 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
         self.clone()
     }
 
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<TypeConfig>> {
-        Ok(Box::new(Cursor::new(Vec::new())))
+    async fn begin_receiving_snapshot(&mut self) -> Result<SnapshotDataOf<TypeConfig>, StorageError<TypeConfig>> {
+        Ok(Cursor::new(Vec::new()))
     }
 
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<TypeConfig>,
-        snapshot: Box<SnapshotDataOf<TypeConfig>>,
+        snapshot: SnapshotDataOf<TypeConfig>,
     ) -> Result<(), StorageError<TypeConfig>> {
         tracing::info!(
             { snapshot_size = snapshot.get_ref().len() },
@@ -260,7 +260,7 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
 
         Ok(Some(Snapshot {
             meta: snapshot.meta,
-            snapshot: Box::new(Cursor::new(data)),
+            snapshot: Cursor::new(data),
         }))
     }
 }

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -64,7 +64,7 @@ where C: RaftTypeConfig
     /// It does not check `Vote` because it is a read operation
     /// and does not break raft protocol.
     BeginReceivingSnapshot {
-        tx: ResultSender<C, Box<SnapshotDataOf<C>>, Infallible>,
+        tx: ResultSender<C, SnapshotDataOf<C>, Infallible>,
     },
 
     ClientWriteRequest {

--- a/openraft/src/core/sm/command.rs
+++ b/openraft/src/core/sm/command.rs
@@ -22,7 +22,7 @@ where C: RaftTypeConfig
     GetSnapshot { tx: ResultSender<C, Option<Snapshot<C>>> },
 
     BeginReceivingSnapshot {
-        tx: ResultSender<C, Box<SnapshotDataOf<C>>, Infallible>,
+        tx: ResultSender<C, SnapshotDataOf<C>, Infallible>,
     },
 
     InstallFullSnapshot {
@@ -66,7 +66,7 @@ where C: RaftTypeConfig
         Command::GetSnapshot { tx }
     }
 
-    pub(crate) fn begin_receiving_snapshot(tx: ResultSender<C, Box<SnapshotDataOf<C>>, Infallible>) -> Self {
+    pub(crate) fn begin_receiving_snapshot(tx: ResultSender<C, SnapshotDataOf<C>, Infallible>) -> Self {
         Command::BeginReceivingSnapshot { tx }
     }
 

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -484,7 +484,7 @@ where C: RaftTypeConfig
 
     /// Install a completely received snapshot on a follower.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn handle_begin_receiving_snapshot(&mut self, tx: ResultSender<C, Box<SnapshotDataOf<C>>, Infallible>) {
+    pub(crate) fn handle_begin_receiving_snapshot(&mut self, tx: ResultSender<C, SnapshotDataOf<C>, Infallible>) {
         tracing::info!("{}", func_name!());
         self.output.push_command(Command::from(sm::Command::begin_receiving_snapshot(tx)));
     }

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -69,7 +69,7 @@ fn test_install_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
             last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
             snapshot_id: "1-2-3-4".to_string(),
         },
-        snapshot: Box::new(Cursor::new(vec![0u8])),
+        snapshot: Cursor::new(vec![0u8]),
     });
 
     assert_eq!(None, cond);
@@ -101,7 +101,7 @@ fn test_install_snapshot_lt_committed() -> anyhow::Result<()> {
             last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
             snapshot_id: "1-2-3-4".to_string(),
         },
-        snapshot: Box::new(Cursor::new(vec![0u8])),
+        snapshot: Cursor::new(vec![0u8]),
     });
 
     assert_eq!(None, cond);
@@ -130,7 +130,7 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
             last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
             snapshot_id: "1-2-3-4".to_string(),
         },
-        snapshot: Box::new(Cursor::new(vec![0u8])),
+        snapshot: Cursor::new(vec![0u8]),
     });
 
     assert_eq!(
@@ -164,7 +164,7 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
                         last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
                         snapshot_id: "1-2-3-4".to_string(),
                     },
-                    snapshot: Box::new(Cursor::new(vec![0u8])),
+                    snapshot: Cursor::new(vec![0u8]),
                 },
                 IOId::new_log_io(Vote::new(2, 1).into_committed(), Some(log_id(4, 1, 6))),
             )),
@@ -215,7 +215,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
             last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
             snapshot_id: "1-2-3-4".to_string(),
         },
-        snapshot: Box::new(Cursor::new(vec![0u8])),
+        snapshot: Cursor::new(vec![0u8]),
     });
 
     assert_eq!(
@@ -250,7 +250,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
                         last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
                         snapshot_id: "1-2-3-4".to_string(),
                     },
-                    snapshot: Box::new(Cursor::new(vec![0u8])),
+                    snapshot: Cursor::new(vec![0u8]),
                 },
                 IOId::new_log_io(Vote::new(2, 1).into_committed(), Some(log_id(5, 1, 6)))
             )),
@@ -273,7 +273,7 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
             last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
             snapshot_id: "1-2-3-4".to_string(),
         },
-        snapshot: Box::new(Cursor::new(vec![0u8])),
+        snapshot: Cursor::new(vec![0u8]),
     });
 
     assert_eq!(
@@ -310,7 +310,7 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
                         last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
                         snapshot_id: "1-2-3-4".to_string(),
                     },
-                    snapshot: Box::new(Cursor::new(vec![0u8])),
+                    snapshot: Cursor::new(vec![0u8]),
                 },
                 IOId::new_log_io(Vote::new(2, 1).into_committed(), Some(log_id(100, 1, 100)))
             )),
@@ -335,7 +335,7 @@ fn test_install_snapshot_update_accepted() -> anyhow::Result<()> {
             last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
             snapshot_id: "1-2-3-4".to_string(),
         },
-        snapshot: Box::new(Cursor::new(vec![0u8])),
+        snapshot: Cursor::new(vec![0u8]),
     });
 
     assert_eq!(

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -78,7 +78,7 @@ fn test_handle_install_full_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
                 last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
                 snapshot_id: "1-2-3-4".to_string(),
             },
-            snapshot: Box::new(Cursor::new(vec![0u8])),
+            snapshot: Cursor::new(vec![0u8]),
         },
         tx,
     );
@@ -126,7 +126,7 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
                 last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
                 snapshot_id: "1-2-3-4".to_string(),
             },
-            snapshot: Box::new(Cursor::new(vec![0u8])),
+            snapshot: Cursor::new(vec![0u8]),
         },
         tx,
     );
@@ -151,7 +151,7 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
                         last_membership: StoredMembership::new(Some(log_id(1, 1, 1)), m1234()),
                         snapshot_id: "1-2-3-4".to_string(),
                     },
-                    snapshot: Box::new(Cursor::new(vec![0u8])),
+                    snapshot: Cursor::new(vec![0u8]),
                 },
                 IOId::new_log_io(Vote::new(2, 1).into_committed(), Some(log_id(4, 1, 6)))
             )),

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -411,8 +411,9 @@ where C: RaftTypeConfig
     }
 
     /// Get a snapshot data for receiving snapshot from the leader.
+    #[since(version = "0.10.0", change = "SnapshotData without Box")]
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn begin_receiving_snapshot(&self) -> Result<Box<SnapshotDataOf<C>>, RaftError<C, Infallible>> {
+    pub async fn begin_receiving_snapshot(&self) -> Result<SnapshotDataOf<C>, RaftError<C, Infallible>> {
         tracing::info!("Raft::begin_receiving_snapshot()");
 
         let (tx, rx) = C::oneshot();

--- a/openraft/src/storage/snapshot.rs
+++ b/openraft/src/storage/snapshot.rs
@@ -1,9 +1,12 @@
 use std::fmt;
 
+use openraft_macros::since;
+
 use crate::storage::SnapshotMeta;
 use crate::RaftTypeConfig;
 
 /// The data associated with the current snapshot.
+#[since(version = "0.10.0", change = "SnapshotData without Box")]
 #[derive(Debug, Clone)]
 pub struct Snapshot<C>
 where C: RaftTypeConfig
@@ -12,14 +15,14 @@ where C: RaftTypeConfig
     pub meta: SnapshotMeta<C>,
 
     /// A read handle to the associated snapshot.
-    pub snapshot: Box<C::SnapshotData>,
+    pub snapshot: C::SnapshotData,
 }
 
 impl<C> Snapshot<C>
 where C: RaftTypeConfig
 {
     #[allow(dead_code)]
-    pub(crate) fn new(meta: SnapshotMeta<C>, snapshot: Box<C::SnapshotData>) -> Self {
+    pub(crate) fn new(meta: SnapshotMeta<C>, snapshot: C::SnapshotData) -> Self {
         Self { meta, snapshot }
     }
 }

--- a/openraft/src/storage/v2/raft_state_machine.rs
+++ b/openraft/src/storage/v2/raft_state_machine.rs
@@ -1,4 +1,5 @@
 use openraft_macros::add_async_trait;
+use openraft_macros::since;
 
 use crate::storage::Snapshot;
 use crate::storage::SnapshotMeta;
@@ -86,7 +87,8 @@ where C: RaftTypeConfig
     /// See the [storage chapter of the guide][sto] for details on log compaction / snapshotting.
     ///
     /// [sto]: crate::docs::getting_started#3-implement-raftlogstorage-and-raftstatemachine
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<C::SnapshotData>, StorageError<C>>;
+    #[since(version = "0.10.0", change = "SnapshotData without Box")]
+    async fn begin_receiving_snapshot(&mut self) -> Result<C::SnapshotData, StorageError<C>>;
 
     /// Install a snapshot which has finished streaming from the leader.
     ///
@@ -99,10 +101,11 @@ where C: RaftTypeConfig
     ///
     /// A snapshot created from an earlier call to `begin_receiving_snapshot` which provided the
     /// snapshot.
+    #[since(version = "0.10.0", change = "SnapshotData without Box")]
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<C>,
-        snapshot: Box<C::SnapshotData>,
+        snapshot: C::SnapshotData,
     ) -> Result<(), StorageError<C>>;
 
     /// Get a readable handle to the current snapshot.

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -1333,10 +1333,7 @@ where
         );
 
         tracing::info!("--- install snapshot on follower state machine");
-        let mut ss2_box = sm_f.begin_receiving_snapshot().await?;
-        *ss2_box = *ss1_cur.snapshot;
-
-        sm_f.install_snapshot(&ss1_cur.meta, ss2_box).await?;
+        sm_f.install_snapshot(&ss1_cur.meta, ss1_cur.snapshot).await?;
 
         tracing::info!("--- check correctness of installed snapshot");
         // ... by requesting whole snapshot

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -319,7 +319,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<MemStateMachine> {
 
         Ok(Snapshot {
             meta,
-            snapshot: Box::new(Cursor::new(data)),
+            snapshot: Cursor::new(data),
         })
     }
 }
@@ -489,15 +489,15 @@ impl RaftStateMachine<TypeConfig> for Arc<MemStateMachine> {
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
-    async fn begin_receiving_snapshot(&mut self) -> Result<Box<SnapshotDataOf<TypeConfig>>, StorageError<TypeConfig>> {
-        Ok(Box::new(Cursor::new(Vec::new())))
+    async fn begin_receiving_snapshot(&mut self) -> Result<SnapshotDataOf<TypeConfig>, StorageError<TypeConfig>> {
+        Ok(Cursor::new(Vec::new()))
     }
 
     #[tracing::instrument(level = "trace", skip(self, snapshot))]
     async fn install_snapshot(
         &mut self,
         meta: &SnapshotMeta<TypeConfig>,
-        snapshot: Box<SnapshotDataOf<TypeConfig>>,
+        snapshot: SnapshotDataOf<TypeConfig>,
     ) -> Result<(), StorageError<TypeConfig>> {
         tracing::info!(
             { snapshot_size = snapshot.get_ref().len() },
@@ -537,7 +537,7 @@ impl RaftStateMachine<TypeConfig> for Arc<MemStateMachine> {
                 let data = snapshot.data.clone();
                 Ok(Some(Snapshot {
                     meta: snapshot.meta.clone(),
-                    snapshot: Box::new(Cursor::new(data)),
+                    snapshot: Cursor::new(data),
                 }))
             }
             None => Ok(None),

--- a/tests/tests/client_api/t16_with_state_machine.rs
+++ b/tests/tests/client_api/t16_with_state_machine.rs
@@ -114,14 +114,14 @@ async fn with_state_machine_wrong_sm_type() -> Result<()> {
                 todo!()
             }
 
-            async fn begin_receiving_snapshot(&mut self) -> Result<Box<<TC as RaftTypeConfig>::SnapshotData>, Err> {
+            async fn begin_receiving_snapshot(&mut self) -> Result<<TC as RaftTypeConfig>::SnapshotData, Err> {
                 todo!()
             }
 
             async fn install_snapshot(
                 &mut self,
                 _meta: &SnapshotMeta<TC>,
-                _snapshot: Box<<TC as RaftTypeConfig>::SnapshotData>,
+                _snapshot: <TC as RaftTypeConfig>::SnapshotData,
             ) -> Result<(), Err> {
                 todo!()
             }

--- a/tests/tests/snapshot_streaming/t10_api_install_snapshot_with_lower_vote.rs
+++ b/tests/tests/snapshot_streaming/t10_api_install_snapshot_with_lower_vote.rs
@@ -81,7 +81,7 @@ async fn install_snapshot_lower_vote() -> Result<()> {
         let got = n0
             .install_full_snapshot(Vote::new_committed(1, 1), Snapshot {
                 meta: Default::default(),
-                snapshot: Box::new(Cursor::new(vec![])),
+                snapshot: Cursor::new(vec![]),
             })
             .await?;
         assert_eq!(Vote::new_committed(2, 1), got.vote);


### PR DESCRIPTION

## Changelog

##### Change: Remove Box from `Snapshot::snapshot`

Currently, `Snapshot` is defined as:

```
struct Snapshot<C> {
    pub meta: SnapshotMeta<C>,
    pub snapshot: Box<C::SnapshotData>,
}
```

The `Box` wrapping `snapshot` should be removed because:
1. Memory management of large `SnapshotData` should be handled by the
   application.
2. If needed, applications can still implement `C::SnapshotData` using
   `Box` or other pointer types.
3. OpenRaft should not make assumptions about the size of `SnapshotData`.

This commit change `Snapshot` to:

```rust
struct Snapshot<C> {
    pub meta: SnapshotMeta<C>,
    pub snapshot: C::SnapshotData,
}
```

By removing the `Box`, it also saves troubles converting the `inner` to
`Box` and vice versa.

- Fix: #1322

Upgrade tip:

Remove `Box<>` when using `Snapshot::snapshot`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1327)
<!-- Reviewable:end -->
