### PR TITLE
Refactor: Fix: impl XX for associated type conflict in another crate

### DIFF
--- a/examples/raft-kv-memstore-grpc/src/pb_impl/impl_vote.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/impl_vote.rs
@@ -2,12 +2,13 @@ use std::fmt;
 
 use openraft::vote::RaftVote;
 
-use crate::typ::*;
+use crate::pb;
+use crate::typ::LeaderId;
 use crate::TypeConfig;
 
-impl RaftVote<TypeConfig> for Vote {
+impl RaftVote<TypeConfig> for pb::Vote {
     fn from_leader_id(leader_id: LeaderId, committed: bool) -> Self {
-        Vote {
+        pb::Vote {
             leader_id: Some(leader_id),
             committed,
         }
@@ -22,7 +23,7 @@ impl RaftVote<TypeConfig> for Vote {
     }
 }
 
-impl fmt::Display for Vote {
+impl fmt::Display for pb::Vote {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,

--- a/openraft/src/storage/snapshot_meta.rs
+++ b/openraft/src/storage/snapshot_meta.rs
@@ -49,7 +49,7 @@ where C: RaftTypeConfig
     pub fn signature(&self) -> SnapshotSignature<C> {
         SnapshotSignature {
             last_log_id: self.last_log_id.clone(),
-            last_membership_log_id: self.last_membership.log_id().clone(),
+            last_membership_log_id: self.last_membership.log_id().as_ref().map(|x| Box::new(x.clone())),
             snapshot_id: self.snapshot_id.clone(),
         }
     }

--- a/openraft/src/storage/snapshot_signature.rs
+++ b/openraft/src/storage/snapshot_signature.rs
@@ -17,3 +17,28 @@ where C: RaftTypeConfig
     /// To identify a snapshot when transferring.
     pub snapshot_id: SnapshotId,
 }
+
+#[cfg(test)]
+mod tests {
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_snapshot_signature_serde() {
+        use super::SnapshotSignature;
+        use crate::engine::testing::log_id;
+        use crate::engine::testing::UTConfig;
+
+        let sig = SnapshotSignature {
+            last_log_id: Some(log_id(1, 2, 3)),
+            last_membership_log_id: Some(log_id(4, 5, 6)),
+            snapshot_id: "test".to_string(),
+        };
+        let s = serde_json::to_string(&sig).unwrap();
+        assert_eq!(
+            s,
+            r#"{"last_log_id":{"leader_id":{"term":1,"node_id":2},"index":3},"last_membership_log_id":{"leader_id":{"term":4,"node_id":5},"index":6},"snapshot_id":"test"}"#
+        );
+        let sig2: SnapshotSignature<UTConfig> = serde_json::from_str(&s).unwrap();
+        assert_eq!(sig, sig2);
+    }
+}

--- a/openraft/src/storage/snapshot_signature.rs
+++ b/openraft/src/storage/snapshot_signature.rs
@@ -12,7 +12,7 @@ where C: RaftTypeConfig
     pub last_log_id: Option<LogIdOf<C>>,
 
     /// The last applied membership log id.
-    pub last_membership_log_id: Option<LogIdOf<C>>,
+    pub last_membership_log_id: Option<Box<LogIdOf<C>>>,
 
     /// To identify a snapshot when transferring.
     pub snapshot_id: SnapshotId,
@@ -30,7 +30,7 @@ mod tests {
 
         let sig = SnapshotSignature {
             last_log_id: Some(log_id(1, 2, 3)),
-            last_membership_log_id: Some(log_id(4, 5, 6)),
+            last_membership_log_id: Some(Box::new(log_id(4, 5, 6))),
             snapshot_id: "test".to_string(),
         };
         let s = serde_json::to_string(&sig).unwrap();

--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -113,7 +113,7 @@ where C: RaftTypeConfig
 {
     subject: ErrorSubject<C>,
     verb: ErrorVerb,
-    source: AnyError,
+    source: Box<AnyError>,
     backtrace: Option<String>,
 }
 
@@ -132,7 +132,7 @@ where C: RaftTypeConfig
         Self {
             subject,
             verb,
-            source: source.into(),
+            source: Box::new(source.into()),
             backtrace: anyerror::backtrace_str(),
         }
     }

--- a/openraft/src/storage_error.rs
+++ b/openraft/src/storage_error.rs
@@ -195,3 +195,23 @@ where C: RaftTypeConfig
         Self::new(ErrorSubject::Store, ErrorVerb::Write, source)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_storage_error_serde() {
+        use super::StorageError;
+        use crate::engine::testing::log_id;
+        use crate::engine::testing::UTConfig;
+
+        let err = StorageError::write_log_entry(log_id(1, 2, 3), super::AnyError::error("test"));
+        let s = serde_json::to_string(&err).unwrap();
+        assert_eq!(
+            s,
+            r#"{"subject":{"Log":{"leader_id":{"term":1,"node_id":2},"index":3}},"verb":"Write","source":{"typ":null,"msg":"test","source":null,"context":[],"backtrace":null},"backtrace":null}"#
+        );
+        let err2: StorageError<UTConfig> = serde_json::from_str(&s).unwrap();
+        assert_eq!(err, err2);
+    }
+}


### PR DESCRIPTION
## Changelog

##### Refactor: Fix: impl XX for associated type conflict in another crate

This commit addressed an issue of implementing trait for associated
types, by replacing implementation for associated type with concrete
type `pb::Vote`.

- Related issues: https://github.com/rust-lang/rust/issues/51445

- The minimized reproduce repo is:
  https://github.com/drmingdrmer/conflict-trait-in-main

Explanation:

If one crate `lib.rs` implements a trait(`Default`) for an associated
type(`<() as Container>::Item`, which is `Foo`), in another crate
`main.rs`, it seems the compiler treats the associated type(`<() as
Container>::Item`) as a generic type `T` and assumes `T` would
be any type and results in the conflict with a local type that tries to
implement `Default`, while actually `Foo` and `Wow` are actually
different types.

```
▾ src/
    lib.rs
    main.rs
```

`lib.rs`:

```rust
pub trait Container {
    type Item;
}

impl Container for () {
    type Item = Foo;
}

pub struct Foo;

impl Default for <() as Container>::Item {
    fn default() -> Self { Foo }
}
```

`main.rs`:

```rust
// Make main.rs depends on lib.rs
use t_conflict::Container as _;

struct Wow;
impl Default for Wow {
    fn default() -> Self { Wow }
}

fn main() {}
```

`cargo build` yield this error:
```
error[E0119]: conflicting implementations of trait `Default` for type `Wow`
 --> t-conflict/src/main.rs:7:1
  |
7 | impl Default for Wow {
  | ^^^^^^^^^^^^^^^^^^^^
  |
  = note: conflicting implementation in crate `t_conflict`:
          - impl Default for <() as Container>::Item;
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1331)
<!-- Reviewable:end -->
