### PR TITLE
Change: Track commit and apply progress with `io_state.apply_progress`

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -543,7 +543,7 @@ where
 
             // --- data ---
             current_term: st.vote_ref().term(),
-            vote: st.io_state().io_progress.flushed().map(|io_id| io_id.to_vote()).unwrap_or_default(),
+            vote: st.io_state().log_progress.flushed().map(|io_id| io_id.to_vote()).unwrap_or_default(),
             last_log_index: st.last_log_id().index(),
             last_applied: st.io_applied().cloned(),
             snapshot: st.io_snapshot_last_log_id().cloned(),
@@ -575,7 +575,7 @@ where
 
         let server_metrics = RaftServerMetrics {
             id: self.id.clone(),
-            vote: st.io_state().io_progress.flushed().map(|io_id| io_id.to_vote()).unwrap_or_default(),
+            vote: st.io_state().log_progress.flushed().map(|io_id| io_id.to_vote()).unwrap_or_default(),
             state: st.server_state,
             current_leader,
             membership_config,
@@ -861,7 +861,7 @@ where
             tracing::debug!(
                 "RAFT_stats id={:<2} log_io: {}",
                 self.id,
-                self.engine.state.io_state.io_progress
+                self.engine.state.io_state.log_progress
             );
 
             // In each loop, it does not have to check rx_shutdown and flush metrics for every RaftMsg
@@ -1368,7 +1368,7 @@ where
             }
 
             Notification::LocalIO { io_id } => {
-                self.engine.state.io_state.io_progress.flush(io_id.clone());
+                self.engine.state.io_state.log_progress.flush(io_id.clone());
 
                 match io_id {
                     IOId::Log(log_io_id) => {
@@ -1448,7 +1448,7 @@ where
                             func_name!()
                         );
 
-                        self.engine.state.io_state_mut().io_progress.flush(io_id);
+                        self.engine.state.io_state_mut().log_progress.flush(io_id);
 
                         if let Some(meta) = meta {
                             let st = self.engine.state.io_state_mut();
@@ -1613,7 +1613,7 @@ where
         if let Some(condition) = condition {
             match condition {
                 Condition::IOFlushed { io_id } => {
-                    let curr = self.engine.state.io_state().io_progress.flushed();
+                    let curr = self.engine.state.io_state().log_progress.flushed();
                     if curr < Some(&io_id) {
                         tracing::debug!(
                             "io_id: {} has not yet flushed, currently flushed: {} postpone cmd: {}",
@@ -1625,7 +1625,7 @@ where
                     }
                 }
                 Condition::LogFlushed { log_id } => {
-                    let curr = self.engine.state.io_state().io_progress.flushed();
+                    let curr = self.engine.state.io_state().log_progress.flushed();
                     let curr = curr.and_then(|x| x.last_log_id());
                     if curr < log_id.as_ref() {
                         tracing::debug!(
@@ -1664,7 +1664,7 @@ where
 
         match cmd {
             Command::UpdateIOProgress { io_id, .. } => {
-                self.engine.state.io_state.io_progress.submit(io_id.clone());
+                self.engine.state.io_state.log_progress.submit(io_id.clone());
 
                 let notify = Notification::LocalIO { io_id: io_id.clone() };
 
@@ -1689,13 +1689,13 @@ where
                 //
                 // The `submit` state must be updated before calling `append()`,
                 // because `append()` may call the callback before returning.
-                self.engine.state.io_state.io_progress.submit(io_id);
+                self.engine.state.io_state.log_progress.submit(io_id);
 
                 // Submit IO request, do not wait for the response.
                 self.log_store.append(entries, callback).await?;
             }
             Command::SaveVote { vote } => {
-                self.engine.state.io_state_mut().io_progress.submit(IOId::new(&vote));
+                self.engine.state.io_state_mut().log_progress.submit(IOId::new(&vote));
                 self.log_store.save_vote(&vote).await?;
 
                 let _ = self.tx_notification.send(Notification::LocalIO {
@@ -1758,6 +1758,7 @@ where
                 already_committed,
                 upto,
             } => {
+                self.engine.state.io_state.apply_progress.submit(upto.clone());
                 let first = self.engine.state.get_log_id(already_committed.next_index()).unwrap();
                 self.apply_to_state_machine(first, upto).await?;
             }
@@ -1788,7 +1789,12 @@ where
                 let io_id = command.get_submit_io();
 
                 if let Some(io_id) = io_id {
-                    self.engine.state.io_state.io_progress.submit(io_id);
+                    self.engine.state.io_state.log_progress.submit(io_id);
+                }
+
+                // If this command update the last-applied log id, mark it as submitted(to state machine).
+                if let Some(log_id) = command.get_apply_progress() {
+                    self.engine.state.io_state.apply_progress.submit(log_id);
                 }
 
                 // Just forward a state machine command to the worker.

--- a/openraft/src/core/sm/command.rs
+++ b/openraft/src/core/sm/command.rs
@@ -102,6 +102,22 @@ where C: RaftTypeConfig
             Command::Func { .. } => None,
         }
     }
+
+    /// Return the last applied log id if this command updates the `last_applied` of the state
+    /// machine.
+    ///
+    /// The caller can use this information to update the `apply_progress.submitted()` in `IOState`,
+    /// which tracks the highest log id that has been submitted to be applied to the state machine.
+    pub(crate) fn get_apply_progress(&self) -> Option<LogIdOf<C>> {
+        match self {
+            Command::BuildSnapshot => None,
+            Command::GetSnapshot { .. } => None,
+            Command::BeginReceivingSnapshot { .. } => None,
+            Command::InstallFullSnapshot { io_id, .. } => io_id.last_log_id().cloned(),
+            Command::Apply { last, .. } => Some(last.clone()),
+            Command::Func { .. } => None,
+        }
+    }
 }
 
 impl<C> Debug for Command<C>

--- a/openraft/src/engine/handler/following_handler/commit_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/commit_entries_test.rs
@@ -8,7 +8,6 @@ use crate::engine::testing::UTConfig;
 use crate::engine::Command;
 use crate::engine::Engine;
 use crate::raft_state::IOId;
-use crate::raft_state::LogStateReader;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::vote::raft_vote::RaftVoteExt;
@@ -34,7 +33,7 @@ fn eng() -> Engine<UTConfig> {
         Duration::from_millis(500),
         Vote::new_committed(2, 1),
     );
-    eng.state.committed = Some(log_id(1, 1, 1));
+    eng.state.io_state.update_committed(log_id(1, 1, 1));
     eng.state.membership_state = MembershipState::new(
         Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())),
         Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m23())),
@@ -65,7 +64,7 @@ fn test_following_handler_commit_entries_empty() -> anyhow::Result<()> {
 fn test_following_handler_commit_entries_ge_accepted() -> anyhow::Result<()> {
     let mut eng = eng();
     let committed_vote = eng.state.vote_ref().into_committed();
-    eng.state.io_state.io_progress.accept(IOId::new_log_io(committed_vote, Some(log_id(1, 1, 2))));
+    eng.state.io_state.log_progress.accept(IOId::new_log_io(committed_vote, Some(log_id(1, 1, 2))));
 
     eng.following_handler().commit_entries(Some(log_id(2, 1, 3)));
 
@@ -97,7 +96,7 @@ fn test_following_handler_commit_entries_ge_accepted() -> anyhow::Result<()> {
 fn test_following_handler_commit_entries_le_accepted() -> anyhow::Result<()> {
     let mut eng = eng();
     let committed_vote = eng.state.vote_ref().into_committed();
-    eng.state.io_state.io_progress.accept(IOId::new_log_io(committed_vote, Some(log_id(3, 1, 4))));
+    eng.state.io_state.log_progress.accept(IOId::new_log_io(committed_vote, Some(log_id(3, 1, 4))));
 
     eng.following_handler().commit_entries(Some(log_id(2, 1, 3)));
 

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -13,7 +13,6 @@ use crate::engine::Condition;
 use crate::engine::Engine;
 use crate::engine::LogIdList;
 use crate::raft_state::IOId;
-use crate::raft_state::LogStateReader;
 use crate::storage::Snapshot;
 use crate::storage::SnapshotMeta;
 use crate::type_config::alias::VoteOf;
@@ -39,7 +38,7 @@ fn eng() -> Engine<UTConfig> {
     let now = UTConfig::<()>::now();
     let vote = VoteOf::<UTConfig>::new_committed(2, 1);
     eng.state.vote.update(now, Duration::from_millis(500), vote);
-    eng.state.committed = Some(log_id(4, 1, 5));
+    eng.state.io_state_mut().update_committed(log_id(4, 1, 5));
     eng.state.log_ids = LogIdList::new(vec![
         //
         log_id(2, 1, 2),
@@ -189,7 +188,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
             Duration::from_millis(500),
             Vote::new_committed(2, 1),
         );
-        eng.state.committed = Some(log_id(2, 1, 3));
+        eng.state.io_state_mut().update_committed(log_id(2, 1, 3));
         eng.state.log_ids = LogIdList::new(vec![
             //
             log_id(2, 1, 2),

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -315,7 +315,7 @@ where C: RaftTypeConfig
 
         let io_id = IOId::new_log_io(self.leader_vote.clone(), Some(snap_last_log_id.clone()));
         self.state.accept_io(io_id.clone());
-        self.state.committed = Some(snap_last_log_id.clone());
+        self.state.io_state.update_committed(snap_last_log_id.clone());
         self.update_committed_membership(EffectiveMembership::new_from_stored_membership(
             meta.last_membership.clone(),
         ));

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -52,7 +52,7 @@ fn eng() -> Engine<UTConfig> {
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 1;
-    eng.state.committed = Some(log_id(0, 1, 0));
+    eng.state.io_state_mut().update_committed(log_id(0, 1, 0));
     eng.state.vote = Leased::new(
         UTConfig::<()>::now(),
         Duration::from_millis(500),

--- a/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
+++ b/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
@@ -32,7 +32,7 @@ fn eng() -> Engine<UTConfig> {
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 1;
-    eng.state.committed = Some(log_id(0, 1, 0));
+    eng.state.io_state_mut().update_committed(log_id(0, 1, 0));
     eng.state.vote = Leased::new(
         UTConfig::<()>::now(),
         Duration::from_millis(500),
@@ -54,13 +54,13 @@ fn eng() -> Engine<UTConfig> {
 fn test_get_read_log_id() -> anyhow::Result<()> {
     let mut eng = eng();
 
-    eng.state.committed = Some(log_id(0, 1, 0));
+    eng.state.io_state_mut().update_committed(log_id(0, 1, 0));
     eng.leader.as_mut().unwrap().noop_log_id = Some(log_id(1, 1, 2));
 
     let got = eng.leader_handler()?.get_read_log_id();
     assert_eq!(Some(log_id(1, 1, 2)), got);
 
-    eng.state.committed = Some(log_id(2, 1, 3));
+    eng.state.io_state_mut().update_committed(log_id(2, 1, 3));
     let got = eng.leader_handler()?.get_read_log_id();
     assert_eq!(Some(log_id(2, 1, 3)), got);
 

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -9,7 +9,6 @@ use crate::proposer::Leader;
 use crate::proposer::LeaderQuorumSet;
 use crate::raft::message::TransferLeaderRequest;
 use crate::raft_state::IOId;
-use crate::raft_state::LogStateReader;
 use crate::replication::ReplicationSessionId;
 use crate::type_config::alias::LogIdOf;
 use crate::RaftState;

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -30,7 +30,7 @@ fn eng() -> Engine<UTConfig> {
     eng.state.enable_validation(false); // Disable validation for incomplete state
 
     eng.config.id = 1;
-    eng.state.committed = Some(log_id(0, 1, 0));
+    eng.state.io_state_mut().update_committed(log_id(0, 1, 0));
     eng.state.vote = Leased::new(
         UTConfig::<()>::now(),
         Duration::from_millis(500),

--- a/openraft/src/engine/handler/replication_handler/update_matching_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_matching_test.rs
@@ -10,7 +10,6 @@ use crate::engine::Command;
 use crate::engine::Engine;
 use crate::progress::Inflight;
 use crate::progress::Progress;
-use crate::raft_state::LogStateReader;
 use crate::type_config::TypeConfigExt;
 use crate::utime::Leased;
 use crate::EffectiveMembership;

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -44,7 +44,7 @@ fn eng() -> Engine<UTConfig> {
     eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(2, 1));
     eng.state.log_ids.append(log_id(1, 1, 1));
     eng.state.log_ids.append(log_id(2, 1, 3));
-    eng.state.committed = Some(log_id(0, 1, 0));
+    eng.state.io_state_mut().update_committed(log_id(0, 1, 0));
     eng.state.membership_state = MembershipState::new(
         Arc::new(EffectiveMembership::new(Some(log_id(1, 1, 1)), m01())),
         Arc::new(EffectiveMembership::new(Some(log_id(2, 1, 3)), m23())),

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -39,7 +39,7 @@ fn eng() -> Engine<UTConfig> {
         Duration::from_millis(500),
         Vote::new_committed(2, 1),
     );
-    eng.state.committed = Some(log_id(4, 1, 5));
+    eng.state.io_state_mut().update_committed(log_id(4, 1, 5));
     eng.state.log_ids = LogIdList::new(vec![
         //
         log_id(2, 1, 2),

--- a/openraft/src/raft_state/io_state.rs
+++ b/openraft/src/raft_state/io_state.rs
@@ -9,6 +9,7 @@ use crate::raft_state::io_state::io_progress::IOProgress;
 use crate::raft_state::IOId;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
+use crate::LogId;
 use crate::RaftTypeConfig;
 
 pub(crate) mod io_id;
@@ -65,11 +66,27 @@ where C: RaftTypeConfig
     /// Whether it is building a snapshot
     building_snapshot: bool,
 
-    /// Tracks the accepted, submitted and flushed IO to local storage.
-    pub(crate) io_progress: Valid<IOProgress<IOId<C>>>,
+    /// Tracks the accepted, submitted and flushed log I/O to the local storage.
+    ///
+    /// Note that log I/O also includes the vote state, which is persisted alongside log entries.
+    pub(crate) log_progress: Valid<IOProgress<IOId<C>>>,
 
-    /// The last log id that has been applied to state machine.
-    pub(crate) applied: Option<LogIdOf<C>>,
+    /// The io progress of applying log to state machine.
+    ///
+    /// - The `apply_progress.accepted()` log id is also the committed, i.e., persisted in a quorum
+    ///   and can be chosen by next Leader. A quorum is either a uniform quorum or a joint quorum.
+    ///   This is the highest log id that is safe to apply to the state machine.
+    ///
+    /// - The `apply_progress.submitted()` is the last log id that has been sent to state machine
+    ///   task to apply.
+    ///
+    /// - The `apply_progress.flushed()` is the last log id that has been already applied to state
+    ///   machine.
+    ///
+    /// Note that depending on the implementation of the state machine,
+    /// the `flushed()` log id may not be persisted in storage(the state machine may periodically
+    /// build a snapshot to persist the state).
+    pub(crate) apply_progress: Valid<IOProgress<LogId<C>>>,
 
     /// The last log id in the currently persisted snapshot.
     pub(crate) snapshot: Option<LogIdOf<C>>,
@@ -86,14 +103,14 @@ impl<C> Validate for IOState<C>
 where C: RaftTypeConfig
 {
     fn validate(&self) -> Result<(), Box<dyn Error>> {
-        self.io_progress.validate()?;
+        self.log_progress.validate()?;
 
         // TODO: enable this when get_initial_state() initialize the log io progress correctly
         // let a = &self.append_log;
         // Applied does not have to be flushed in local store.
         // less_equal!(self.applied.as_ref(), a.submitted().and_then(|x| x.last_log_id()));
 
-        less_equal!(&self.snapshot, &self.applied);
+        less_equal!(self.snapshot.as_ref(), self.applied());
         less_equal!(&self.purged, &self.snapshot);
         Ok(())
     }
@@ -108,19 +125,23 @@ where C: RaftTypeConfig
         snapshot: Option<LogIdOf<C>>,
         purged: Option<LogIdOf<C>>,
     ) -> Self {
-        let mut io_progress = Valid::new(IOProgress::default());
-
-        io_progress.accept(IOId::new(vote));
-        io_progress.submit(IOId::new(vote));
-        io_progress.flush(IOId::new(vote));
-
         Self {
             building_snapshot: false,
-            io_progress,
-            applied,
+            log_progress: Valid::new(IOProgress::new_synchronized(Some(IOId::new(vote)))),
+            apply_progress: Valid::new(IOProgress::new_synchronized(applied)),
             snapshot,
             purged,
         }
+    }
+
+    pub(crate) fn update_committed(&mut self, log_id: LogId<C>) {
+        // The committed log id represents the highest log entry that is safe to apply to the state machine.
+        // Here we update the accepted cursor in apply_progress to track this commitment point.
+        self.apply_progress.accept(log_id);
+    }
+
+    pub(crate) fn committed(&self) -> Option<&LogIdOf<C>> {
+        self.apply_progress.accepted()
     }
 
     pub(crate) fn update_applied(&mut self, log_id: Option<LogIdOf<C>>) {
@@ -128,17 +149,18 @@ where C: RaftTypeConfig
 
         // TODO: should we update flushed if applied is newer?
         debug_assert!(
-            log_id > self.applied,
+            log_id.as_ref() > self.applied(),
             "applied log id should be monotonically increasing: current: {:?}, update: {:?}",
-            self.applied,
+            self.applied(),
             log_id
         );
 
-        self.applied = log_id;
+        // Safe unwrap(): log_id > self.applied(), implies it can not be None
+        self.apply_progress.flush(log_id.unwrap());
     }
 
     pub(crate) fn applied(&self) -> Option<&LogIdOf<C>> {
-        self.applied.as_ref()
+        self.apply_progress.flushed()
     }
 
     pub(crate) fn update_snapshot(&mut self, log_id: Option<LogIdOf<C>>) {

--- a/openraft/src/raft_state/io_state/io_progress.rs
+++ b/openraft/src/raft_state/io_state/io_progress.rs
@@ -77,6 +77,21 @@ where
     T: PartialOrd + fmt::Debug,
     T: fmt::Display,
 {
+    /// Create a new IOProgress with all three cursors (accepted, submitted, flushed) set to the
+    /// same value.
+    ///
+    /// This creates a synchronized state where all IO operations (accepted, submitted, and flushed)
+    /// are considered complete up to the specified point. This is typically used for initialization
+    /// or when a snapshot is installed, ensuring all IO tracking is aligned.
+    pub(crate) fn new_synchronized(v: Option<T>) -> Self
+    where T: Clone {
+        Self {
+            accepted: v.clone(),
+            submitted: v.clone(),
+            flushed: v.clone(),
+        }
+    }
+
     /// Update the `accept` cursor of the I/O progress.
     pub(crate) fn accept(&mut self, new_accepted: T) {
         debug_assert!(

--- a/openraft/src/raft_state/tests/log_state_reader_test.rs
+++ b/openraft/src/raft_state/tests/log_state_reader_test.rs
@@ -50,10 +50,9 @@ fn test_raft_state_has_log_id_empty() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_has_log_id_committed_gets_true() -> anyhow::Result<()> {
-    let rs = RaftState::<UTConfig> {
-        committed: Some(log_id(2, 1)),
-        ..Default::default()
-    };
+    let mut rs = RaftState::<UTConfig>::default();
+
+    rs.io_state_mut().update_committed(log_id(2, 1));
 
     assert!(rs.has_log_id(log_id(0, 0)));
     assert!(rs.has_log_id(log_id(2, 1)));
@@ -64,11 +63,12 @@ fn test_raft_state_has_log_id_committed_gets_true() -> anyhow::Result<()> {
 
 #[test]
 fn test_raft_state_has_log_id_in_log_id_list() -> anyhow::Result<()> {
-    let rs = RaftState::<UTConfig> {
-        committed: Some(log_id(2, 1)),
+    let mut rs = RaftState::<UTConfig> {
         log_ids: LogIdList::new(vec![log_id(1, 2), log_id(3, 4)]),
         ..Default::default()
     };
+
+    rs.io_state_mut().update_committed(log_id(2, 1));
 
     assert!(rs.has_log_id(log_id(0, 0)));
     assert!(rs.has_log_id(log_id(2, 1)));

--- a/openraft/src/raft_state/tests/validate_test.rs
+++ b/openraft/src/raft_state/tests/validate_test.rs
@@ -15,14 +15,15 @@ fn test_raft_state_validate_snapshot_is_none() -> anyhow::Result<()> {
     // Some app does not persist snapshot, when restarted, purged is not None but snapshot_last_log_id
     // is None. This is a valid state and should not emit error.
 
-    let rs = RaftState::<UTConfig> {
+    let mut rs = RaftState::<UTConfig> {
         log_ids: LogIdList::new(vec![log_id(1, 1), log_id(3, 4)]),
         purged_next: 2,
         purge_upto: Some(log_id(1, 1)),
-        committed: Some(log_id(1, 1)),
         snapshot_meta: SnapshotMeta::default(),
         ..Default::default()
     };
+
+    rs.io_state_mut().update_committed(log_id(1, 1));
 
     assert!(rs.validate().is_ok());
 

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -153,7 +153,6 @@ where
         let now = C::now();
 
         Ok(RaftState {
-            committed: last_applied,
             // The initial value for `vote` is the minimal possible value.
             // See: [Conditions for initialization][precondition]
             //

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -467,9 +467,9 @@ where
             Duration::default(),
             VoteOf::<C>::default(),
         );
-        want.io_state.io_progress.accept(IOId::new(&VoteOf::<C>::default()));
-        want.io_state.io_progress.submit(IOId::new(&VoteOf::<C>::default()));
-        want.io_state.io_progress.flush(IOId::new(&VoteOf::<C>::default()));
+        want.io_state.log_progress.accept(IOId::new(&VoteOf::<C>::default()));
+        want.io_state.log_progress.submit(IOId::new(&VoteOf::<C>::default()));
+        want.io_state.log_progress.flush(IOId::new(&VoteOf::<C>::default()));
 
         assert_eq!(want, initial, "uninitialized state");
         Ok(())

--- a/tests/tests/client_api/t16_with_raft_state.rs
+++ b/tests/tests/client_api/t16_with_raft_state.rs
@@ -28,13 +28,13 @@ async fn with_raft_state() -> Result<()> {
 
     let n0 = router.get_raft_handle(&0)?;
 
-    let committed = n0.with_raft_state(|st| st.committed).await?;
+    let committed = n0.with_raft_state(|st| st.committed().cloned()).await?;
     assert_eq!(committed, Some(log_id(1, 0, log_index)));
 
     tracing::info!("--- shutting down node 0");
     n0.shutdown().await?;
 
-    let res = n0.with_raft_state(|st| st.committed).await;
+    let res = n0.with_raft_state(|st| st.committed().cloned()).await;
     assert_eq!(Err(Fatal::Stopped), res);
 
     Ok(())


### PR DESCRIPTION

## Changelog

##### Change: Track commit and apply progress with `io_state.apply_progress`

This commit updates `RaftState` to track the committed and applied log
IDs using `io_state.apply_progress`, which is now an
`IOProgress<LogId>`. This approach aligns the apply progress tracking
with the log I/O progress mechanism.

- `apply_progress.accepted()`: Represents the committed log ID (the log
  ID accepted for applying).

- `apply_progress.submitted()`: Represents the log ID that has been
  submitted to the state machine for application, or the last log ID of
  a snapshot being installed.

- `apply_progress.flushed()`: Represents the log ID that has already
  been applied to the state machine.

- Refactor: rename `io_progress` to `log_progress` to distinguish it
  from the `apply_progress`.

Upgrade tip:

Replace usages of the `RaftState.committed` field with the `RaftState::committed()` method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1337)
<!-- Reviewable:end -->
