### PR TITLE
Test: Wait until `last-applied` is updated before proceeding with the following read-log-id test

### DIFF
--- a/tests/tests/client_api/t11_client_reads.rs
+++ b/tests/tests/client_api/t11_client_reads.rs
@@ -149,6 +149,7 @@ async fn get_read_log_id() -> Result<()> {
         log_index += 1;
 
         log_index += router.client_request_many(1, "foo", 1).await?;
+        n1.wait(timeout()).applied_index(Some(log_index), "log applied to state-machine").await?;
 
         let (read_log_id, applied) = n1.get_read_log_id().await?;
         assert_eq!(read_log_id.index(), Some(log_index), "read-log-id is the committed log");


### PR DESCRIPTION

## Changelog

##### Test: Wait until `last-applied` is updated before proceeding with the following read-log-id test

This ensures the `last-applied` log id is updated.
Since `last-applied` may not be updated when the client-write response
is received, the following `get_read_log_id()` may return a stale
`last-applied` value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1338)
<!-- Reviewable:end -->
