### PR TITLE
ci: use llvm-cov to report test coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,38 +9,33 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true
+          components: llvm-tools-preview
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-fail-fast -p openraft
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+
+      - name: Install cargo-expand
+        run: cargo install cargo-expand
+
+
+      - name: Generate coverage report
+        # To test with all features:
+        # run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
         env:
           RUST_TEST_THREADS: 2
-          CARGO_INCREMENTAL: '0'
-          # RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-          # RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'
-          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'
 
-      - uses: actions-rs/grcov@v0.1
-        id: coverage
 
-      - name: Coveralls upload
-        uses: coverallsapp/github-action@master
+      - name: Upload to Coveralls
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ${{ steps.coverage.outputs.report }}
-
-      - name: Upload artifact for coverage
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          path: |
-            openraft/_log/
-
+          path-to-lcov: lcov.info

--- a/tests/tests/client_api/t11_client_reads.rs
+++ b/tests/tests/client_api/t11_client_reads.rs
@@ -9,6 +9,7 @@ use openraft::error::RPCError;
 use openraft::Config;
 use openraft::LogIdOptionExt;
 use openraft::RPCTypes;
+use openraft::ServerState;
 
 use crate::fixtures::ut_harness;
 use crate::fixtures::RPCRequest;
@@ -122,6 +123,8 @@ async fn get_read_log_id() -> Result<()> {
     let n1 = router.get_raft_handle(&1).unwrap();
     n1.trigger().elect().await?;
 
+    n1.wait(timeout()).state(ServerState::Leader, "node 1 becomes leader").await?;
+
     tracing::info!(log_index = log_index, "--- node 1 appends blank log but can not commit");
     {
         let res = n1.wait(timeout()).applied_index_at_least(Some(log_index + 1), "blank log can not commit").await;
@@ -179,7 +182,7 @@ async fn get_read_log_id() -> Result<()> {
             Some(last_committed),
             "read-log-id is the committed log"
         );
-    }
+    };
 
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### ci: use llvm-cov to report test coverage


##### test: t11_client_reads::get_read_log_id wait for leader to establish




- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1344)
<!-- Reviewable:end -->
