### PR TITLE
feat: Add impl `IntoNodes<NID, EmptyNode>` for `BTreeSet<NID>`

### DIFF
--- a/openraft/src/membership/into_nodes.rs
+++ b/openraft/src/membership/into_nodes.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use maplit::btreemap;
 
+use crate::EmptyNode;
 use crate::Node;
 use crate::NodeId;
 
@@ -34,6 +35,14 @@ where NID: NodeId
 {
     fn into_nodes(self) -> BTreeMap<NID, ()> {
         self.into_iter().map(|node_id| (node_id, ())).collect()
+    }
+}
+
+impl<NID> IntoNodes<NID, EmptyNode> for BTreeSet<NID>
+where NID: NodeId
+{
+    fn into_nodes(self) -> BTreeMap<NID, EmptyNode> {
+        self.into_iter().map(|node_id| (node_id, EmptyNode {})).collect()
     }
 }
 


### PR DESCRIPTION

## Changelog

##### feat: Add impl `IntoNodes<NID, EmptyNode>` for `BTreeSet<NID>`

EmptyNode can be created directly thus a BTreeSet can be used to build a
nodes map

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1346)
<!-- Reviewable:end -->
