### PR TITLE
Change: Remove type parameter from `RaftCommittedLeaderId`(added in 0.10)

### DIFF
--- a/openraft/src/vote/leader_id/raft_committed_leader_id.rs
+++ b/openraft/src/vote/leader_id/raft_committed_leader_id.rs
@@ -1,8 +1,9 @@
 use std::fmt::Debug;
 use std::fmt::Display;
 
+use openraft_macros::since;
+
 use crate::base::OptionalFeatures;
-use crate::RaftTypeConfig;
 
 /// A Leader identifier that has been granted and committed by a quorum of the cluster.
 ///
@@ -37,16 +38,10 @@ use crate::RaftTypeConfig;
 ///   dropped since it's no longer needed for ordering)
 ///
 /// [`RaftLeaderId`]: crate::vote::RaftLeaderId
-pub trait RaftCommittedLeaderId<C>
-where
-    C: RaftTypeConfig,
-    Self: OptionalFeatures + Ord + Clone + Debug + Display + Default + 'static,
+#[since(version = "0.10.0")]
+pub trait RaftCommittedLeaderId
+where Self: OptionalFeatures + Ord + Clone + Debug + Display + Default + 'static
 {
 }
 
-impl<C, T> RaftCommittedLeaderId<C> for T
-where
-    C: RaftTypeConfig,
-    T: OptionalFeatures + Ord + Clone + Debug + Display + Default + 'static,
-{
-}
+impl<T> RaftCommittedLeaderId for T where T: OptionalFeatures + Ord + Clone + Debug + Display + Default + 'static {}

--- a/openraft/src/vote/leader_id/raft_leader_id.rs
+++ b/openraft/src/vote/leader_id/raft_leader_id.rs
@@ -30,7 +30,7 @@ where
     /// The committed version of this leader ID.
     ///
     /// A simple implementation of this trait would return `Self` as the committed version.
-    type Committed: RaftCommittedLeaderId<C>;
+    type Committed: RaftCommittedLeaderId;
 
     fn new(term: C::Term, node_id: C::NodeId) -> Self;
 


### PR DESCRIPTION

## Changelog

##### Change: Remove type parameter from `RaftCommittedLeaderId`(added in 0.10)

`RaftCommittedLeaderId` does not need a `RaftTypeConfig` parameter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1347)
<!-- Reviewable:end -->
