### PR TITLE
Change: Add: `RaftStateMachine::save_snapshot()`

### DIFF
--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -123,20 +123,14 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
             snapshot_id: snapshot_id.clone(),
         };
 
-        let snapshot = StoredSnapshot {
-            meta: meta.clone(),
-            data: snapshot_id.clone(),
-        };
-
-        {
-            let mut current_snapshot = self.current_snapshot.lock().unwrap();
-            *current_snapshot = Some(snapshot);
-        }
-
-        Ok(Snapshot {
+        let snapshot = Snapshot {
             meta,
             snapshot: snapshot_id,
-        })
+        };
+
+        self.save_snapshot(&snapshot).await?;
+
+        Ok(snapshot)
     }
 }
 
@@ -201,9 +195,26 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
             *state_machine = updated_state_machine;
         }
 
-        // Update current snapshot.
-        let mut current_snapshot = self.current_snapshot.lock().unwrap();
-        *current_snapshot = Some(new_snapshot);
+        Ok(())
+    }
+
+    async fn save_snapshot(&mut self, snapshot: &Snapshot) -> Result<(), StorageError> {
+        let new_snapshot = StoredSnapshot {
+            meta: snapshot.meta.clone(),
+            data: snapshot.snapshot.clone(),
+        };
+
+        let mut current = self.current_snapshot.lock().unwrap();
+
+        // Only save it if the new snapshot contains more recent data than the current snapshot.
+
+        let current_last = current.as_ref().and_then(|s| s.meta.last_log_id.clone());
+
+        if new_snapshot.meta.last_log_id <= current_last {
+            return Ok(());
+        }
+
+        *current = Some(new_snapshot);
         Ok(())
     }
 

--- a/examples/raft-kv-memstore-singlethreaded/src/store.rs
+++ b/examples/raft-kv-memstore-singlethreaded/src/store.rs
@@ -157,20 +157,14 @@ impl RaftSnapshotBuilder<TypeConfig> for Rc<StateMachineStore> {
             snapshot_id,
         };
 
-        let snapshot = StoredSnapshot {
-            meta: meta.clone(),
-            data: data.clone(),
-        };
-
-        {
-            let mut current_snapshot = self.current_snapshot.borrow_mut();
-            *current_snapshot = Some(snapshot);
-        }
-
-        Ok(Snapshot {
+        let snapshot = Snapshot {
             meta,
             snapshot: Cursor::new(data),
-        })
+        };
+
+        self.save_snapshot(&snapshot).await?;
+
+        Ok(snapshot)
     }
 }
 
@@ -238,9 +232,26 @@ impl RaftStateMachine<TypeConfig> for Rc<StateMachineStore> {
             *state_machine = updated_state_machine;
         }
 
-        // Update current snapshot.
-        let mut current_snapshot = self.current_snapshot.borrow_mut();
-        *current_snapshot = Some(new_snapshot);
+        Ok(())
+    }
+
+    async fn save_snapshot(&mut self, snapshot: &Snapshot) -> Result<(), StorageError> {
+        let new_snapshot = StoredSnapshot {
+            meta: snapshot.meta.clone(),
+            data: snapshot.snapshot.clone().into_inner(),
+        };
+
+        let mut current = self.current_snapshot.borrow_mut();
+
+        // Only save it if the new snapshot contains more recent data than the current snapshot.
+
+        let current_last = current.as_ref().and_then(|s| s.meta.last_log_id.clone());
+        if new_snapshot.meta.last_log_id <= current_last {
+            return Ok(());
+        }
+
+        *current = Some(new_snapshot);
+
         Ok(())
     }
 

--- a/openraft/src/core/sm/worker.rs
+++ b/openraft/src/core/sm/worker.rs
@@ -124,7 +124,19 @@ where
                     // GetSnapshot does not respond to RaftCore
                 }
                 Command::InstallFullSnapshot { io_id, snapshot } => {
-                    tracing::info!("{}: install complete snapshot", func_name!());
+                    tracing::info!(
+                        "{}: install snapshot step-1(save): save snapshot: {}",
+                        func_name!(),
+                        snapshot.meta
+                    );
+
+                    self.state_machine.save_snapshot(&snapshot).await?;
+
+                    tracing::info!(
+                        "{}: install snapshot step-2(install): replace state machine with snapshot: {}",
+                        func_name!(),
+                        snapshot.meta
+                    );
 
                     let meta = snapshot.meta.clone();
                     self.state_machine.install_snapshot(&meta, snapshot.snapshot).await?;

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -282,12 +282,13 @@ where C: RaftTypeConfig
         tracing::info!("install_full_snapshot: meta:{:?}", meta);
 
         let snap_last_log_id = meta.last_log_id.clone();
+        let committed = self.state.committed().cloned();
 
-        if snap_last_log_id.as_ref() <= self.state.committed() {
+        if snap_last_log_id <= committed {
             tracing::info!(
                 "No need to install snapshot; snapshot last_log_id({}) <= committed({})",
                 snap_last_log_id.display(),
-                self.state.committed().display()
+                committed.display()
             );
             return None;
         }
@@ -309,7 +310,7 @@ where C: RaftTypeConfig
         if let Some(local) = local {
             if local != snap_last_log_id {
                 // Conflict, delete all non-committed logs.
-                self.truncate_logs(self.state.committed().next_index());
+                self.truncate_logs(committed.next_index());
             }
         }
 

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -1333,15 +1333,19 @@ where
         );
 
         tracing::info!("--- install snapshot on follower state machine");
-        sm_f.install_snapshot(&ss1_cur.meta, ss1_cur.snapshot).await?;
+        sm_f.save_snapshot(&ss1_cur).await?;
 
-        tracing::info!("--- check correctness of installed snapshot");
+        tracing::info!("--- check correctness of saved snapshot");
         // ... by requesting whole snapshot
         let ss2 = sm_f.get_current_snapshot().await?.expect("uninitialized snapshot");
         assert_eq!(
             ss2.meta, ss1.meta,
             "snapshot metadata not updated correctly on follower sm"
         );
+
+        // Replace the state machine with the snapshot
+        sm_f.install_snapshot(&ss1_cur.meta, ss1_cur.snapshot).await?;
+
         // ... by checking smstore state
         assert_eq!(sm_f.applied_state().await?, snapshot_applied_state);
         Ok(())

--- a/tests/tests/client_api/t16_with_state_machine.rs
+++ b/tests/tests/client_api/t16_with_state_machine.rs
@@ -126,6 +126,10 @@ async fn with_state_machine_wrong_sm_type() -> Result<()> {
                 todo!()
             }
 
+            async fn save_snapshot(&mut self, _snapshot: &Snapshot<TC>) -> Result<(), StorageError<TC>> {
+                todo!()
+            }
+
             async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot<TC>>, Err> {
                 todo!()
             }


### PR DESCRIPTION

## Changelog

##### Change: Add: `RaftStateMachine::save_snapshot()`

Before this commit, `RaftStateMachine::install_snapshot()` is
responsible to 1) replace the state machine with the provided snapshot
and 2) persist the snapshot on disk.
Since this commit, a new method `RaftStateMachine::save_snapshot()` is
responsible to persist a snapshot. `install_snapshot()` does not have to
do this. But doing this has no harm.

- Part of #1333

Upgrade tip:

Implement persisting snapshot in `save_snapshot()` and it is recommended
to remove persisting snpashot from `install_snapshot()`.