### PR TITLE
docs: clarify `leader_lease` and `clock_progress` mechanisms

### DIFF
--- a/openraft/src/engine/time_state.rs
+++ b/openraft/src/engine/time_state.rs
@@ -15,10 +15,16 @@ pub(crate) struct Config {
     /// Note that this value should be greater than the `election_timeout` of every other node.
     pub(crate) smaller_log_timeout: Duration,
 
-    /// The duration of an active leader's lease.
+    /// The duration of an active leader's lease for a follower.
     ///
     /// When a follower or learner perceives an active leader, such as by receiving an AppendEntries
-    /// message, it should not grant another candidate to become the leader during this period.
+    /// message(including heartbeat), it should not grant vote to another candidate during this
+    /// period. This prevents unnecessary elections when the leader is still active and helps
+    /// maintain cluster stability.
+    ///
+    /// The leader uses this value to determine how long it can safely assume leadership without
+    /// sending heartbeats. A leader tracks the clock time acknowledged by followers to establish
+    /// a quorum-acknowledged time, ensuring no new leader can be elected before this lease expires.
     pub(crate) leader_lease: Duration,
 }
 

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -65,6 +65,14 @@ where C: RaftTypeConfig
 
     /// Tracks the clock time acknowledged by other nodes.
     ///
+    /// Tracks the sending time(not receiving time) of the last heartbeat RPC to each follower.
+    /// The leader's own entry is always updated with the current time when calculating
+    /// the quorum-acknowledged time, as the leader is assumed to have the most up-to-date
+    /// clock time. When a follower receives a heartbeat RPC, it resets its election timeout
+    /// and won't start an election for at least the duration of `leader_lease`. If we denote
+    /// the sending time of the heartbeat as `t`, then the leader can be sure that no follower
+    /// can become a leader until `t + leader_lease`. This is the basis for the leader lease
+    ///
     /// See [`docs::leader_lease`] for more details.
     ///
     /// [`docs::leader_lease`]: `crate::docs::protocol::replication::leader_lease`


### PR DESCRIPTION

## Changelog

##### docs: clarify `leader_lease` and `clock_progress` mechanisms

Improve documentation explaining two critical timing mechanisms:

- `leader_lease`: Defines the period during which a follower will not
  initiate an election, preventing unnecessary leadership challenges

- `clock_progress`: Tracks the latest timestamp when a heartbeat sending
  time was acknowledged by a quorum of nodes, allowing the leader to
  maintain its authority

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1363)
<!-- Reviewable:end -->
