### PR TITLE
refactor: separate Raft API and impl

### DIFF
--- a/examples/raft-kv-memstore/README.md
+++ b/examples/raft-kv-memstore/README.md
@@ -4,7 +4,13 @@ It is an example of how to build a real-world key-value store with `openraft`.
 Includes:
 - An in-memory `RaftLogStorage` and `RaftStateMachine` implementation [store](./src/store/store.rs).
 
-- A server is based on [actix-web](https://docs.rs/actix-web/4.0.0-rc.2).  
+- A server is based on [actix-web](https://docs.rs/actix-web/4.0.0-rc.2).
+  All service endpoints accept a `Json<I>` input argument,
+  and return a JSON-encoded `Result<T, E>` response,
+  where `T` and `E` are API-specific types.
+  For example, the `/write` endpoint accepts a user-defined `Request`
+  and returns a `Result<WriteResponse, ClientWriteError>`.
+
   Includes:
   - raft-internal network APIs for replication and voting.
   - Admin APIs to add nodes, change-membership etc.

--- a/examples/raft-kv-memstore/src/network/management.rs
+++ b/examples/raft-kv-memstore/src/network/management.rs
@@ -6,6 +6,7 @@ use actix_web::post;
 use actix_web::web::Data;
 use actix_web::web::Json;
 use actix_web::Responder;
+use openraft::error::decompose::DecomposeResult;
 use openraft::error::Infallible;
 use openraft::BasicNode;
 use openraft::RaftMetrics;
@@ -25,14 +26,14 @@ use crate::TypeConfig;
 pub async fn add_learner(app: Data<App>, req: Json<(NodeId, String)>) -> actix_web::Result<impl Responder> {
     let node_id = req.0 .0;
     let node = BasicNode { addr: req.0 .1.clone() };
-    let res = app.raft.add_learner(node_id, node, true).await;
+    let res = app.raft.add_learner(node_id, node, true).await.decompose().unwrap();
     Ok(Json(res))
 }
 
 /// Changes specified learners to members, or remove members.
 #[post("/change-membership")]
 pub async fn change_membership(app: Data<App>, req: Json<BTreeSet<NodeId>>) -> actix_web::Result<impl Responder> {
-    let res = app.raft.change_membership(req.0, false).await;
+    let res = app.raft.change_membership(req.0, false).await.decompose().unwrap();
     Ok(Json(res))
 }
 
@@ -48,7 +49,7 @@ pub async fn init(app: Data<App>, req: Json<Vec<(NodeId, String)>>) -> actix_web
             nodes.insert(id, BasicNode { addr });
         }
     };
-    let res = app.raft.initialize(nodes).await;
+    let res = app.raft.initialize(nodes).await.decompose().unwrap();
     Ok(Json(res))
 }
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1149,7 +1149,7 @@ where
         });
         self.engine.output.push_command(Command::Respond {
             when: condition,
-            resp: Respond::new(Ok(resp), tx),
+            resp: Respond::new(resp, tx),
         });
     }
 

--- a/openraft/src/core/raft_msg/external_command.rs
+++ b/openraft/src/core/raft_msg/external_command.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use crate::core::raft_msg::ResultSender;
 use crate::core::sm;
 use crate::error::AllowNextRevertError;
+use crate::type_config::alias::OneshotSenderOf;
 use crate::RaftTypeConfig;
 use crate::Snapshot;
 
@@ -25,7 +26,9 @@ pub(crate) enum ExternalCommand<C: RaftTypeConfig> {
     Snapshot,
 
     /// Get a snapshot from the state machine, send back via a oneshot::Sender.
-    GetSnapshot { tx: ResultSender<C, Option<Snapshot<C>>> },
+    GetSnapshot {
+        tx: OneshotSenderOf<C, Option<Snapshot<C>>>,
+    },
 
     /// Purge logs covered by a snapshot up to a specified index.
     ///

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -28,10 +28,10 @@ pub(crate) mod external_command;
 pub(crate) type ResultSender<C, T, E = Infallible> = OneshotSenderOf<C, Result<T, E>>;
 
 /// TX for Vote Response
-pub(crate) type VoteTx<C> = ResultSender<C, VoteResponse<C>>;
+pub(crate) type VoteTx<C> = OneshotSenderOf<C, VoteResponse<C>>;
 
 /// TX for Append Entries Response
-pub(crate) type AppendEntriesTx<C> = ResultSender<C, AppendEntriesResponse<C>>;
+pub(crate) type AppendEntriesTx<C> = OneshotSenderOf<C, AppendEntriesResponse<C>>;
 
 /// TX for Linearizable Read Response
 pub(crate) type ClientReadTx<C> = ResultSender<C, (Option<LogIdOf<C>>, Option<LogIdOf<C>>), CheckIsLeaderError<C>>;
@@ -55,7 +55,7 @@ where C: RaftTypeConfig
     InstallFullSnapshot {
         vote: VoteOf<C>,
         snapshot: Snapshot<C>,
-        tx: ResultSender<C, SnapshotResponse<C>>,
+        tx: OneshotSenderOf<C, SnapshotResponse<C>>,
     },
 
     /// Begin receiving a snapshot from the leader.
@@ -65,7 +65,7 @@ where C: RaftTypeConfig
     /// It does not check `Vote` because it is a read operation
     /// and does not break raft protocol.
     BeginReceivingSnapshot {
-        tx: ResultSender<C, SnapshotDataOf<C>, Infallible>,
+        tx: OneshotSenderOf<C, SnapshotDataOf<C>>,
     },
 
     ClientWriteRequest {

--- a/openraft/src/core/sm/command.rs
+++ b/openraft/src/core/sm/command.rs
@@ -4,11 +4,10 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 
 use crate::base::BoxAny;
-use crate::core::raft_msg::ResultSender;
-use crate::error::Infallible;
 use crate::raft_state::IOId;
 use crate::storage::Snapshot;
 use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::SnapshotDataOf;
 use crate::RaftTypeConfig;
@@ -21,10 +20,12 @@ where C: RaftTypeConfig
     BuildSnapshot,
 
     /// Get the latest built snapshot.
-    GetSnapshot { tx: ResultSender<C, Option<Snapshot<C>>> },
+    GetSnapshot {
+        tx: OneshotSenderOf<C, Option<Snapshot<C>>>,
+    },
 
     BeginReceivingSnapshot {
-        tx: ResultSender<C, SnapshotDataOf<C>, Infallible>,
+        tx: OneshotSenderOf<C, SnapshotDataOf<C>>,
     },
 
     InstallFullSnapshot {
@@ -66,11 +67,11 @@ where C: RaftTypeConfig
         Command::BuildSnapshot
     }
 
-    pub(crate) fn get_snapshot(tx: ResultSender<C, Option<Snapshot<C>>>) -> Self {
+    pub(crate) fn get_snapshot(tx: OneshotSenderOf<C, Option<Snapshot<C>>>) -> Self {
         Command::GetSnapshot { tx }
     }
 
-    pub(crate) fn begin_receiving_snapshot(tx: ResultSender<C, SnapshotDataOf<C>, Infallible>) -> Self {
+    pub(crate) fn begin_receiving_snapshot(tx: OneshotSenderOf<C, SnapshotDataOf<C>>) -> Self {
         Command::BeginReceivingSnapshot { tx }
     }
 

--- a/openraft/src/core/sm/handle.rs
+++ b/openraft/src/core/sm/handle.rs
@@ -70,16 +70,13 @@ where C: RaftTypeConfig
         // If fail to send command, cmd is dropped and tx will be dropped.
         let _ = cmd_tx.send(cmd);
 
-        let got = match rx.await {
+        let snapshot = match rx.await {
             Ok(x) => x,
             Err(_e) => {
                 tracing::error!("failed to receive snapshot, sm::Worker may have shutdown");
                 return Err("failed to receive snapshot, sm::Worker may have shutdown");
             }
         };
-
-        // Safe unwrap(): error is Infallible.
-        let snapshot = got.unwrap();
 
         Ok(snapshot)
     }

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -8,7 +8,6 @@ use crate::display_ext::DisplayResultExt;
 use crate::display_ext::DisplaySliceExt;
 use crate::engine::replication_progress::ReplicationProgress;
 use crate::engine::CommandKind;
-use crate::error::Infallible;
 use crate::error::InitializeError;
 use crate::error::InstallSnapshotError;
 use crate::raft::message::TransferLeaderRequest;
@@ -329,11 +328,11 @@ where C: RaftTypeConfig
 pub(crate) enum Respond<C>
 where C: RaftTypeConfig
 {
-    Vote(ValueSender<C, Result<VoteResponse<C>, Infallible>>),
-    AppendEntries(ValueSender<C, Result<AppendEntriesResponse<C>, Infallible>>),
+    Vote(ValueSender<C, VoteResponse<C>>),
+    AppendEntries(ValueSender<C, AppendEntriesResponse<C>>),
     ReceiveSnapshotChunk(ValueSender<C, Result<(), InstallSnapshotError>>),
     InstallSnapshot(ValueSender<C, Result<InstallSnapshotResponse<C>, InstallSnapshotError>>),
-    InstallFullSnapshot(ValueSender<C, Result<SnapshotResponse<C>, Infallible>>),
+    InstallFullSnapshot(ValueSender<C, SnapshotResponse<C>>),
     Initialize(ValueSender<C, Result<(), InitializeError<C>>>),
 }
 
@@ -342,8 +341,8 @@ where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Respond::Vote(vs) => write!(f, "Vote {}", vs.value().display()),
-            Respond::AppendEntries(vs) => write!(f, "AppendEntries {}", vs.value().display()),
+            Respond::Vote(vs) => write!(f, "Vote {}", vs.value()),
+            Respond::AppendEntries(vs) => write!(f, "AppendEntries {}", vs.value()),
             Respond::ReceiveSnapshotChunk(vs) => {
                 write!(
                     f,
@@ -352,7 +351,7 @@ where C: RaftTypeConfig
                 )
             }
             Respond::InstallSnapshot(vs) => write!(f, "InstallSnapshot {}", vs.value().display()),
-            Respond::InstallFullSnapshot(vs) => write!(f, "InstallFullSnapshot {}", vs.value().display()),
+            Respond::InstallFullSnapshot(vs) => write!(f, "InstallFullSnapshot {}", vs.value()),
             Respond::Initialize(vs) => write!(f, "Initialize {}", vs.value().as_ref().map(|_x| "()").display()),
         }
     }

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -11,7 +11,6 @@ use crate::engine::Command;
 use crate::engine::Condition;
 use crate::engine::Engine;
 use crate::engine::Respond;
-use crate::error::Infallible;
 use crate::raft::VoteResponse;
 use crate::raft_state::IOId;
 use crate::type_config::TypeConfigExt;
@@ -25,8 +24,8 @@ fn m01() -> Membership<UTConfig> {
 }
 
 /// Make a sample VoteResponse
-fn mk_res(granted: bool) -> Result<VoteResponse<UTConfig>, Infallible> {
-    Ok::<VoteResponse<UTConfig>, Infallible>(VoteResponse::new(Vote::new(2, 1), None, granted))
+fn mk_res(granted: bool) -> VoteResponse<UTConfig> {
+    VoteResponse::new(Vote::new(2, 1), None, granted)
 }
 
 fn eng() -> Engine<UTConfig> {

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 use std::time::Duration;
 
-use crate::core::raft_msg::ResultSender;
 use crate::display_ext::DisplayOptionExt;
 use crate::engine::handler::leader_handler::LeaderHandler;
 use crate::engine::handler::replication_handler::ReplicationHandler;
@@ -19,6 +18,7 @@ use crate::proposer::LeaderState;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
 use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::VoteOf;
 use crate::type_config::TypeConfigExt;
 use crate::vote::raft_vote::RaftVoteExt;
@@ -61,17 +61,16 @@ where C: RaftTypeConfig
     ///
     /// The `f` is used to create the error response.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn accept_vote<T, E, F>(
+    pub(crate) fn accept_vote<T, F>(
         &mut self,
         vote: &VoteOf<C>,
-        tx: ResultSender<C, T, E>,
+        tx: OneshotSenderOf<C, T>,
         f: F,
-    ) -> Option<ResultSender<C, T, E>>
+    ) -> Option<OneshotSenderOf<C, T>>
     where
         T: Debug + Eq + OptionalSend,
-        E: Debug + Eq + OptionalSend,
-        Respond<C>: From<ValueSender<C, Result<T, E>>>,
-        F: Fn(&RaftState<C>, RejectVoteRequest<C>) -> Result<T, E>,
+        Respond<C>: From<ValueSender<C, T>>,
+        F: Fn(&RaftState<C>, RejectVoteRequest<C>) -> T,
     {
         let vote_res = self.update_vote(vote);
 

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -98,7 +98,7 @@ fn test_handle_install_full_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
             //
             Command::Respond {
                 when: None,
-                resp: Respond::new(Ok(SnapshotResponse::new(curr_vote)), dummy_tx),
+                resp: Respond::new(SnapshotResponse::new(curr_vote), dummy_tx),
             },
         ],
         eng.output.take_commands()
@@ -160,7 +160,7 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
                 when: Some(Condition::Snapshot {
                     log_id: Some(log_id(4, 1, 6))
                 }),
-                resp: Respond::new(Ok(SnapshotResponse::new(curr_vote)), dummy_tx),
+                resp: Respond::new(SnapshotResponse::new(curr_vote), dummy_tx),
             },
         ],
         eng.output.take_commands()

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -3,6 +3,7 @@
 mod allow_next_revert_error;
 pub mod decompose;
 pub mod into_ok;
+pub(crate) mod into_raft_result;
 mod invalid_sm;
 mod membership_error;
 mod node_not_found;
@@ -17,6 +18,7 @@ use std::fmt::Debug;
 use std::time::Duration;
 
 use anyerror::AnyError;
+use openraft_macros::since;
 
 pub use self::allow_next_revert_error::AllowNextRevertError;
 pub use self::invalid_sm::InvalidStateMachineType;
@@ -51,6 +53,17 @@ where C: RaftTypeConfig
     #[cfg_attr(feature = "serde", serde(bound = ""))]
     #[error(transparent)]
     Fatal(#[from] Fatal<C>),
+}
+
+impl<C> RaftError<C, Infallible>
+where C: RaftTypeConfig
+{
+    /// Convert to a [`Fatal`] error if its `APIError` variant is [`Infallible`],
+    /// otherwise panic.
+    #[since(version = "0.10.0")]
+    pub fn unwrap_fatal(self) -> Fatal<C> {
+        self.into_fatal().unwrap()
+    }
 }
 
 impl<C, E> RaftError<C, E>

--- a/openraft/src/error/into_raft_result.rs
+++ b/openraft/src/error/into_raft_result.rs
@@ -1,0 +1,44 @@
+use crate::error::Fatal;
+use crate::error::Infallible;
+use crate::error::RaftError;
+use crate::RaftTypeConfig;
+
+/// Convert a `Result<_, Fatal<C>>` to a `Result<T, RaftError<C, E>>`
+///
+/// This trait is used to convert `Results` from the new nested format(`Result<Result<_,E>,Fatal>`)
+/// to a format that is compatible with the older API version(`Result<_, RaftError<E>>`).
+/// - In the older Result style, both application Error and Fatal Error are wrapped in the one
+///   [`RaftError`] type.
+/// - In the new Result style, application Error and Fatal Error are wrapped in the two different
+///   types(`Result<_,E>` and `Fatal<C>`).
+///
+/// The primary use case is for protocol methods that return `Result<T, Fatal<C>>` to be converted
+/// to the backward compatible `Result<T, RaftError<C, E>>` which can represent both fatal errors
+/// and application-specific errors.
+pub(crate) trait IntoRaftResult<C, T, E>
+where C: RaftTypeConfig
+{
+    /// Convert a `Result<Result<T, E>, Fatal<C>>` or `Result<T, Fatal<C>>` to a
+    /// `Result<T, RaftError<C, E>>`.
+    fn into_raft_result(self) -> Result<T, RaftError<C, E>>;
+}
+
+impl<C, T, E> IntoRaftResult<C, T, E> for Result<Result<T, E>, Fatal<C>>
+where C: RaftTypeConfig
+{
+    fn into_raft_result(self) -> Result<T, RaftError<C, E>> {
+        match self {
+            Ok(Ok(t)) => Ok(t),
+            Ok(Err(e)) => Err(RaftError::APIError(e)),
+            Err(f) => Err(RaftError::Fatal(f)),
+        }
+    }
+}
+
+impl<C, T> IntoRaftResult<C, T, Infallible> for Result<T, Fatal<C>>
+where C: RaftTypeConfig
+{
+    fn into_raft_result(self) -> Result<T, RaftError<C>> {
+        self.map_err(RaftError::Fatal)
+    }
+}

--- a/openraft/src/network/snapshot_transport.rs
+++ b/openraft/src/network/snapshot_transport.rs
@@ -193,7 +193,7 @@ mod tokio_rt {
                 // Changed to another stream. re-init snapshot state.
                 let snapshot_data = raft.begin_receiving_snapshot().await.map_err(|e| {
                     // Safe unwrap: `RaftError<Infallible>` is always a Fatal.
-                    RaftError::Fatal(e.into_fatal().unwrap())
+                    RaftError::Fatal(e.unwrap_fatal())
                 })?;
 
                 *streaming = Some(Streaming::new(snapshot_id.clone(), snapshot_data));

--- a/openraft/src/raft/api/app.rs
+++ b/openraft/src/raft/api/app.rs
@@ -1,0 +1,102 @@
+use std::error::Error;
+use std::future::Future;
+
+use openraft_macros::since;
+
+use crate::core::raft_msg::RaftMsg;
+use crate::error::CheckIsLeaderError;
+use crate::error::ClientWriteError;
+use crate::error::Fatal;
+use crate::metrics::WaitError;
+use crate::raft::raft_inner::RaftInner;
+use crate::raft::responder::Responder;
+use crate::raft::ClientWriteResponse;
+use crate::raft::ClientWriteResult;
+use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::ResponderOf;
+use crate::type_config::alias::ResponderReceiverOf;
+use crate::type_config::TypeConfigExt;
+use crate::LogIdOptionExt;
+use crate::OptionalSend;
+use crate::RaftTypeConfig;
+use crate::ReadPolicy;
+
+#[since(version = "0.10.0")]
+pub(crate) struct AppApi<'a, C>
+where C: RaftTypeConfig
+{
+    inner: &'a RaftInner<C>,
+}
+
+impl<'a, C> AppApi<'a, C>
+where C: RaftTypeConfig
+{
+    pub(in crate::raft) fn new(inner: &'a RaftInner<C>) -> Self {
+        Self { inner }
+    }
+
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(crate) async fn ensure_linearizable(
+        &self,
+        read_policy: ReadPolicy,
+    ) -> Result<Result<Option<LogIdOf<C>>, CheckIsLeaderError<C>>, Fatal<C>> {
+        let res = self.get_read_log_id(read_policy).await?;
+        let (read_log_id, applied) = match res {
+            Ok(x) => x,
+            Err(e) => return Ok(Err(e)),
+        };
+
+        if read_log_id.index() > applied.index() {
+            self.inner
+                .wait(None)
+                .applied_index_at_least(read_log_id.index(), "ensure_linearizable")
+                .await
+                .map_err(|e| match e {
+                    WaitError::Timeout(_, _) => {
+                        unreachable!("did not specify timeout")
+                    }
+                    WaitError::ShuttingDown => Fatal::Stopped,
+                })?;
+        }
+        Ok(Ok(read_log_id))
+    }
+
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(crate) async fn get_read_log_id(
+        &self,
+        read_policy: ReadPolicy,
+    ) -> Result<Result<(Option<LogIdOf<C>>, Option<LogIdOf<C>>), CheckIsLeaderError<C>>, Fatal<C>> {
+        let (tx, rx) = C::oneshot();
+        self.inner.call_core(RaftMsg::CheckIsLeaderRequest { read_policy, tx }, rx).await
+    }
+
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "debug", skip(self, app_data))]
+    pub(crate) async fn client_write<E>(
+        &self,
+        app_data: C::D,
+        // TODO: ClientWriteError can only be ForwardToLeader Error
+    ) -> Result<Result<ClientWriteResponse<C>, ClientWriteError<C>>, Fatal<C>>
+    where
+        ResponderReceiverOf<C>: Future<Output = Result<ClientWriteResult<C>, E>>,
+        E: Error + OptionalSend,
+    {
+        let rx = self.client_write_ff(app_data).await?;
+
+        let res: ClientWriteResult<C> = self.inner.recv_msg(rx).await?;
+
+        Ok(res)
+    }
+
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "debug", skip(self, app_data))]
+    pub(crate) async fn client_write_ff(&self, app_data: C::D) -> Result<ResponderReceiverOf<C>, Fatal<C>> {
+        let (app_data, tx, rx) = ResponderOf::<C>::from_app_data(app_data);
+
+        self.inner.send_msg(RaftMsg::ClientWriteRequest { app_data, tx }).await?;
+
+        Ok(rx)
+    }
+}

--- a/openraft/src/raft/api/management.rs
+++ b/openraft/src/raft/api/management.rs
@@ -1,0 +1,238 @@
+use std::fmt::Debug;
+
+use maplit::btreemap;
+use openraft_macros::since;
+
+use crate::core::raft_msg::RaftMsg;
+use crate::core::replication_lag;
+use crate::display_ext::DisplayResult;
+use crate::display_ext::DisplayResultExt;
+use crate::error::Fatal;
+use crate::error::InitializeError;
+use crate::impls::OneshotResponder;
+use crate::membership::IntoNodes;
+use crate::raft::raft_inner::RaftInner;
+use crate::raft::ClientWriteResult;
+use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::OneshotReceiverOf;
+use crate::type_config::TypeConfigExt;
+use crate::ChangeMembers;
+use crate::LogIdOptionExt;
+use crate::RaftMetrics;
+use crate::RaftTypeConfig;
+
+#[since(version = "0.10.0")]
+pub(crate) struct ManagementApi<'a, C>
+where C: RaftTypeConfig
+{
+    inner: &'a RaftInner<C>,
+}
+
+impl<'a, C> ManagementApi<'a, C>
+where C: RaftTypeConfig
+{
+    pub(in crate::raft) fn new(inner: &'a RaftInner<C>) -> Self {
+        Self { inner }
+    }
+
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(crate) async fn initialize<T>(&self, members: T) -> Result<Result<(), InitializeError<C>>, Fatal<C>>
+    where T: IntoNodes<C::NodeId, C::Node> + Debug {
+        let (tx, rx) = C::oneshot();
+        self.inner
+            .call_core(
+                RaftMsg::Initialize {
+                    members: members.into_nodes(),
+                    tx,
+                },
+                rx,
+            )
+            .await
+    }
+
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "info", skip_all)]
+    pub(crate) async fn change_membership(
+        &self,
+        members: impl Into<ChangeMembers<C>>,
+        retain: bool,
+    ) -> Result<ClientWriteResult<C>, Fatal<C>>
+    where
+        C: RaftTypeConfig<Responder = OneshotResponder<C>>,
+    {
+        let changes: ChangeMembers<C> = members.into();
+
+        tracing::info!(
+            changes = debug(&changes),
+            retain = display(retain),
+            "change_membership: start to commit joint config"
+        );
+
+        let (tx, rx) = oneshot_channel::<C>();
+
+        // res is error if membership can not be changed.
+        // If no error, it will enter a joint state
+        let client_write_result = self
+            .inner
+            .call_core(
+                RaftMsg::ChangeMembership {
+                    changes: changes.clone(),
+                    retain,
+                    tx,
+                },
+                rx,
+            )
+            .await?;
+
+        let resp = match client_write_result {
+            Ok(x) => x,
+            Err(e) => {
+                tracing::error!("the first step error: {}", e);
+                return Ok(Err(e));
+            }
+        };
+
+        tracing::debug!("res of first step: {}", resp);
+
+        let (log_id, joint) = (&resp.log_id, resp.membership.clone().unwrap());
+
+        if joint.get_joint_config().len() == 1 {
+            return Ok(Ok(resp));
+        }
+
+        tracing::debug!("committed a joint config: {} {:?}", log_id, joint);
+        tracing::debug!("the second step is to change to uniform config: {:?}", changes);
+
+        let (tx, rx) = oneshot_channel::<C>();
+
+        let client_write_result = self.inner.call_core(RaftMsg::ChangeMembership { changes, retain, tx }, rx).await?;
+
+        tracing::info!(
+            "result of second step of change_membership: {}",
+            client_write_result.display()
+        );
+
+        if let Err(e) = &client_write_result {
+            tracing::error!("the second step error: {}", e);
+        }
+
+        Ok(client_write_result)
+    }
+
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "debug", skip(self, id), fields(target=display(&id)))]
+    pub(crate) async fn add_learner(
+        &self,
+        id: C::NodeId,
+        node: C::Node,
+        blocking: bool,
+    ) -> Result<ClientWriteResult<C>, Fatal<C>>
+    where
+        C: RaftTypeConfig<Responder = OneshotResponder<C>>,
+    {
+        let (tx, rx) = oneshot_channel::<C>();
+
+        let msg = RaftMsg::ChangeMembership {
+            changes: ChangeMembers::AddNodes(btreemap! {id.clone()=>node}),
+            retain: true,
+            tx,
+        };
+
+        let client_write_result = self.inner.call_core(msg, rx).await?;
+
+        let resp = match client_write_result {
+            Ok(x) => x,
+            Err(e) => return Ok(Err(e)),
+        };
+
+        if !blocking {
+            return Ok(Ok(resp));
+        }
+
+        if self.inner.id == id {
+            return Ok(Ok(resp));
+        }
+
+        // Otherwise, blocks until the replication to the new learner becomes up to date.
+
+        // The log id of the membership that contains the added learner.
+        let membership_log_id = &resp.log_id;
+
+        let wait_res = self
+            .inner
+            .wait(None)
+            .metrics(
+                |metrics| match self.check_replication_upto_date(metrics, &id, Some(membership_log_id)) {
+                    Ok(_matching) => true,
+                    // keep waiting
+                    Err(_) => false,
+                },
+                "wait new learner to become line-rate",
+            )
+            .await;
+
+        tracing::info!(
+            wait_res = display(DisplayResult(&wait_res)),
+            "waiting for replication to new learner"
+        );
+
+        Ok(Ok(resp))
+    }
+
+    #[since(version = "0.10.0")]
+    fn check_replication_upto_date(
+        &self,
+        metrics: &RaftMetrics<C>,
+        node_id: &C::NodeId,
+        membership_log_id: Option<&LogIdOf<C>>,
+    ) -> Result<Option<LogIdOf<C>>, ()> {
+        if metrics.membership_config.log_id().as_ref() < membership_log_id {
+            // Waiting for the latest metrics to report.
+            return Err(());
+        }
+
+        if metrics.membership_config.membership().get_node(node_id).is_none() {
+            // This learner has been removed.
+            return Ok(None);
+        }
+
+        let repl = match &metrics.replication {
+            None => {
+                // This node is no longer a leader.
+                return Ok(None);
+            }
+            Some(x) => x,
+        };
+
+        let replication_metrics = repl;
+        let target_metrics = match replication_metrics.get(node_id) {
+            None => {
+                // Maybe replication is not reported yet. Keep waiting.
+                return Err(());
+            }
+            Some(x) => x,
+        };
+
+        let matched = target_metrics.clone();
+
+        let distance = replication_lag(&matched.index(), &metrics.last_log_index);
+
+        if distance <= self.inner.config.replication_lag_threshold {
+            // replication became up to date.
+            return Ok(matched);
+        }
+
+        // Not up to date, keep waiting.
+        Err(())
+    }
+}
+
+fn oneshot_channel<C>() -> (OneshotResponder<C>, OneshotReceiverOf<C, ClientWriteResult<C>>)
+where C: RaftTypeConfig {
+    let (tx, rx) = C::oneshot();
+
+    let tx = OneshotResponder::new(tx);
+
+    (tx, rx)
+}

--- a/openraft/src/raft/api/mod.rs
+++ b/openraft/src/raft/api/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod app;
+pub(crate) mod management;
+pub(crate) mod protocol;

--- a/openraft/src/raft/api/protocol.rs
+++ b/openraft/src/raft/api/protocol.rs
@@ -1,0 +1,193 @@
+use std::time::Duration;
+
+use openraft_macros::since;
+
+use crate::core::raft_msg::external_command::ExternalCommand;
+use crate::core::raft_msg::RaftMsg;
+use crate::display_ext::DisplayOptionExt;
+#[cfg(doc)]
+use crate::error::into_raft_result::IntoRaftResult;
+use crate::error::Fatal;
+use crate::raft::raft_inner::RaftInner;
+use crate::raft::AppendEntriesRequest;
+use crate::raft::AppendEntriesResponse;
+use crate::raft::SnapshotResponse;
+use crate::raft::TransferLeaderRequest;
+use crate::raft::VoteRequest;
+use crate::raft::VoteResponse;
+use crate::type_config::alias::SnapshotDataOf;
+use crate::type_config::alias::VoteOf;
+use crate::type_config::TypeConfigExt;
+use crate::vote::raft_vote::RaftVoteExt;
+use crate::LogIdOptionExt;
+use crate::LogIndexOptionExt;
+use crate::RaftMetrics;
+use crate::RaftTypeConfig;
+use crate::Snapshot;
+
+/// Handles Raft protocol requests from other nodes in the cluster.
+///
+/// Usage: [`Raft::protocol_api()`](crate::raft::Raft::protocol_api)
+///
+/// This API uses a nested `Result<Result<_,E>,Fatal>` pattern to separate different error types:
+/// - The outer `Result` contains [`Fatal`] errors that indicate the Raft node itself has failed
+/// - The inner `Result` contains application-specific errors that should be handled or forwarded
+///
+/// This separation allows application code to handle fatal errors (typically by terminating or
+/// restarting the node) separately from regular application errors that can be transmitted back
+/// to RPC callers. In most cases, you'll use the `?` operator on the outer result and then
+/// handle the inner result appropriately.
+///
+/// To convert the nested `Result<Result<_,E>,Fatal>` to a single `Result<_,RaftError<C,E>>`,
+/// use the [`into_raft_result()`](IntoRaftResult::into_raft_result) method.
+///
+/// This struct provides methods for processing core Raft protocol messages such as:
+/// - Vote requests (RequestVote RPCs)
+/// - AppendEntries RPCs (for log replication and heartbeats)
+/// - Snapshot-related operations
+///
+/// It acts as an interface between the service layer and the internal Raft core.
+///
+/// For example:
+/// ```test
+///                                 .-> VoteRequest   ---.
+/// Leader --> RaftNetwork -- TCP --+-> AppendEntries ---+-- --> Server --> ProtocolApi -> RaftCore
+///                                 '-> InstallSnapshot -'
+/// ----------------------                                       ----------------------------------
+/// Remote Leader Node                                           Local Follower Node
+/// ```
+#[since(version = "0.10.0")]
+pub(crate) struct ProtocolApi<'a, C>
+where C: RaftTypeConfig
+{
+    inner: &'a RaftInner<C>,
+}
+
+impl<'a, C> ProtocolApi<'a, C>
+where C: RaftTypeConfig
+{
+    pub(in crate::raft) fn new(inner: &'a RaftInner<C>) -> Self {
+        Self { inner }
+    }
+
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "debug", skip(self, rpc))]
+    pub(crate) async fn vote(&self, rpc: VoteRequest<C>) -> Result<VoteResponse<C>, Fatal<C>> {
+        tracing::info!(rpc = display(&rpc), "Raft::vote()");
+
+        let (tx, rx) = C::oneshot();
+        self.inner.call_core(RaftMsg::RequestVote { rpc, tx }, rx).await
+    }
+
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "debug", skip(self, rpc))]
+    pub(crate) async fn append_entries(
+        &self,
+        rpc: AppendEntriesRequest<C>,
+    ) -> Result<AppendEntriesResponse<C>, Fatal<C>> {
+        tracing::debug!(rpc = display(&rpc), "Raft::append_entries");
+
+        let (tx, rx) = C::oneshot();
+        self.inner.call_core(RaftMsg::AppendEntries { rpc, tx }, rx).await
+    }
+
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) async fn get_snapshot(&self) -> Result<Option<Snapshot<C>>, Fatal<C>> {
+        tracing::debug!("Raft::get_snapshot()");
+
+        let (tx, rx) = C::oneshot();
+        let cmd = ExternalCommand::GetSnapshot { tx };
+        self.inner.call_core(RaftMsg::ExternalCommand { cmd }, rx).await
+    }
+
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) async fn begin_receiving_snapshot(&self) -> Result<SnapshotDataOf<C>, Fatal<C>> {
+        tracing::info!("Raft::begin_receiving_snapshot()");
+
+        let (tx, rx) = C::oneshot();
+        self.inner.call_core(RaftMsg::BeginReceivingSnapshot { tx }, rx).await
+    }
+
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) async fn install_full_snapshot(
+        &self,
+        vote: VoteOf<C>,
+        snapshot: Snapshot<C>,
+    ) -> Result<SnapshotResponse<C>, Fatal<C>> {
+        tracing::info!("Raft::install_full_snapshot()");
+
+        let (tx, rx) = C::oneshot();
+        self.inner.call_core(RaftMsg::InstallFullSnapshot { vote, snapshot, tx }, rx).await
+    }
+
+    #[since(version = "0.10.0")]
+    pub(crate) async fn handle_transfer_leader(&self, req: TransferLeaderRequest<C>) -> Result<(), Fatal<C>> {
+        // Reset the Leader lease at once and quit, if this is not the assigned next leader.
+        // Only the assigned next Leader waits for the log to be flushed.
+        if &req.to_node_id == self.inner.id() {
+            self.ensure_log_flushed_for_transfer_leader(&req).await?;
+        }
+
+        let raft_msg = RaftMsg::HandleTransferLeader {
+            from: req.from_leader,
+            to: req.to_node_id,
+        };
+
+        self.inner.send_msg(raft_msg).await?;
+
+        Ok(())
+    }
+
+    /// Wait for the log to be flushed to make sure the RequestVote.last_log_id is upto date, then
+    /// TransferLeader will be able to proceed.
+    async fn ensure_log_flushed_for_transfer_leader(&self, req: &TransferLeaderRequest<C>) -> Result<(), Fatal<C>> {
+        // If the next Leader is this node, wait for the log to be flushed to make sure the
+        // RequestVote.last_log_id is upto date.
+
+        // Condition satisfied to become Leader
+        let ok = |m: &RaftMetrics<C>| {
+            req.from_leader() == &m.vote && m.last_log_index.next_index() >= req.last_log_id().next_index()
+        };
+
+        // Condition failed to become Leader
+        #[allow(clippy::neg_cmp_op_on_partial_ord)]
+        let fail = |m: &RaftMetrics<C>| !(req.from_leader.as_ref_vote() >= m.vote.as_ref_vote());
+
+        let timeout = Some(Duration::from_millis(self.inner.config().election_timeout_min));
+        let metrics_res =
+            self.inner.wait(timeout).metrics(|st| ok(st) || fail(st), "transfer_leader await flushed log").await;
+
+        match metrics_res {
+            Ok(metrics) => {
+                if fail(&metrics) {
+                    tracing::warn!(
+                        "Vote changed, give up Leader-transfer; expected vote: {}, metrics: {}",
+                        req.from_leader,
+                        metrics
+                    );
+                    return Ok(());
+                }
+                tracing::info!(
+                    "Leader-transfer condition satisfied, submit Leader-transfer message; \
+                     expected: (vote: {}, flushed_log: {})",
+                    req.from_leader,
+                    req.last_log_id.display(),
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "Leader-transfer condition fail to satisfy, still submit Leader-transfer; \
+                    expected: (vote: {}; flushed_log: {}), error: {}",
+                    req.from_leader,
+                    req.last_log_id.display(),
+                    err
+                );
+            }
+        };
+
+        Ok(())
+    }
+}


### PR DESCRIPTION

## Changelog

##### refactor: separate Raft API and impl

For development concerns, we've separated the API interface from its implementation.
During this refactoring, we maintained backward compatibility - the user-facing API
remains unchanged. We kept the Raft struct as an API layer providing consistent methods,
while moving all implementation details into several other structures. These implementation
structures focus solely on core functionality, with the Raft API methods calling them and
handling any necessary type conversions. This separation creates a clearer view of the
implementation with a one-way contract, ensuring the user API remains stable and unaffected.




- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1367)
<!-- Reviewable:end -->
