### PR TITLE
refactor: no more `C::Responder = OneshotResponder` for `change_membership()`

### DIFF
--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -6,6 +6,7 @@ use crate::core::raft_msg::external_command::ExternalCommand;
 use crate::error::CheckIsLeaderError;
 use crate::error::Infallible;
 use crate::error::InitializeError;
+use crate::impls::OneshotResponder;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::AppendEntriesResponse;
 use crate::raft::ReadPolicy;
@@ -90,7 +91,7 @@ where C: RaftTypeConfig
         /// config will be converted into learners, otherwise they will be removed.
         retain: bool,
 
-        tx: ResponderOf<C>,
+        tx: OneshotResponder<C>,
     },
 
     ExternalCoreRequest {

--- a/openraft/src/core/sm/command.rs
+++ b/openraft/src/core/sm/command.rs
@@ -4,11 +4,11 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 
 use crate::base::BoxAny;
+use crate::raft::responder::either::OneshotOrUserDefined;
 use crate::raft_state::IOId;
 use crate::storage::Snapshot;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::OneshotSenderOf;
-use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::SnapshotDataOf;
 use crate::RaftTypeConfig;
 
@@ -45,7 +45,7 @@ where C: RaftTypeConfig
         /// The last log id to apply, inclusive.
         last: LogIdOf<C>,
 
-        client_resp_channels: BTreeMap<u64, ResponderOf<C>>,
+        client_resp_channels: BTreeMap<u64, OneshotOrUserDefined<C>>,
     },
 
     /// Apply a custom function to the state machine.
@@ -83,7 +83,7 @@ where C: RaftTypeConfig
     pub(crate) fn apply(
         first: LogIdOf<C>,
         last: LogIdOf<C>,
-        client_resp_channels: BTreeMap<u64, ResponderOf<C>>,
+        client_resp_channels: BTreeMap<u64, OneshotOrUserDefined<C>>,
     ) -> Self {
         Command::Apply {
             first,

--- a/openraft/src/core/sm/worker.rs
+++ b/openraft/src/core/sm/worker.rs
@@ -17,6 +17,7 @@ use crate::display_ext::DisplayOptionExt;
 use crate::display_ext::DisplaySliceExt;
 use crate::entry::RaftEntry;
 use crate::entry::RaftPayload;
+use crate::raft::responder::either::OneshotOrUserDefined;
 use crate::raft::responder::Responder;
 use crate::raft::ClientWriteResponse;
 #[cfg(doc)]
@@ -28,7 +29,6 @@ use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::MpscUnboundedReceiverOf;
 use crate::type_config::alias::MpscUnboundedSenderOf;
 use crate::type_config::alias::OneshotSenderOf;
-use crate::type_config::alias::ResponderOf;
 use crate::type_config::TypeConfigExt;
 use crate::RaftLogReader;
 use crate::RaftSnapshotBuilder;
@@ -173,7 +173,7 @@ where
         &mut self,
         first: LogIdOf<C>,
         last: LogIdOf<C>,
-        client_resp_channels: &mut BTreeMap<u64, ResponderOf<C>>,
+        client_resp_channels: &mut BTreeMap<u64, OneshotOrUserDefined<C>>,
     ) -> Result<ApplyResult<C>, StorageError<C>> {
         // TODO: prepare response before apply,
         //       so that an Entry does not need to be Clone,

--- a/openraft/src/raft/api/app.rs
+++ b/openraft/src/raft/api/app.rs
@@ -21,6 +21,10 @@ use crate::OptionalSend;
 use crate::RaftTypeConfig;
 use crate::ReadPolicy;
 
+/// Provides application-facing APIs for interacting with the Raft system.
+///
+/// This module contains methods for client operations such as linearizable reads
+/// and writes to the replicated state machine.
 #[since(version = "0.10.0")]
 pub(crate) struct AppApi<'a, C>
 where C: RaftTypeConfig

--- a/openraft/src/raft/api/app.rs
+++ b/openraft/src/raft/api/app.rs
@@ -23,8 +23,8 @@ use crate::ReadPolicy;
 
 /// Provides application-facing APIs for interacting with the Raft system.
 ///
-/// This module contains methods for client operations such as linearizable reads
-/// and writes to the replicated state machine.
+/// This struct contains methods for client operations such as linearizable reads
+/// and writes.
 #[since(version = "0.10.0")]
 pub(crate) struct AppApi<'a, C>
 where C: RaftTypeConfig

--- a/openraft/src/raft/api/management.rs
+++ b/openraft/src/raft/api/management.rs
@@ -21,6 +21,10 @@ use crate::LogIdOptionExt;
 use crate::RaftMetrics;
 use crate::RaftTypeConfig;
 
+/// Provides management APIs for the Raft system.
+///
+/// This module contains methods for managing the Raft cluster, including
+/// membership changes and node additions.
 #[since(version = "0.10.0")]
 pub(crate) struct ManagementApi<'a, C>
 where C: RaftTypeConfig

--- a/openraft/src/raft/api/management.rs
+++ b/openraft/src/raft/api/management.rs
@@ -23,7 +23,7 @@ use crate::RaftTypeConfig;
 
 /// Provides management APIs for the Raft system.
 ///
-/// This module contains methods for managing the Raft cluster, including
+/// This struct contains methods for managing the Raft cluster, including
 /// membership changes and node additions.
 #[since(version = "0.10.0")]
 pub(crate) struct ManagementApi<'a, C>
@@ -61,10 +61,7 @@ where C: RaftTypeConfig
         &self,
         members: impl Into<ChangeMembers<C>>,
         retain: bool,
-    ) -> Result<ClientWriteResult<C>, Fatal<C>>
-    where
-        C: RaftTypeConfig<Responder = OneshotResponder<C>>,
-    {
+    ) -> Result<ClientWriteResult<C>, Fatal<C>> {
         let changes: ChangeMembers<C> = members.into();
 
         tracing::info!(
@@ -131,10 +128,7 @@ where C: RaftTypeConfig
         id: C::NodeId,
         node: C::Node,
         blocking: bool,
-    ) -> Result<ClientWriteResult<C>, Fatal<C>>
-    where
-        C: RaftTypeConfig<Responder = OneshotResponder<C>>,
-    {
+    ) -> Result<ClientWriteResult<C>, Fatal<C>> {
         let (tx, rx) = oneshot_channel::<C>();
 
         let msg = RaftMsg::ChangeMembership {

--- a/openraft/src/raft/impl_raft_blocking_write.rs
+++ b/openraft/src/raft/impl_raft_blocking_write.rs
@@ -5,7 +5,6 @@
 use crate::error::into_raft_result::IntoRaftResult;
 use crate::error::ClientWriteError;
 use crate::error::RaftError;
-use crate::raft::responder::OneshotResponder;
 use crate::raft::ClientWriteResponse;
 #[cfg(doc)]
 use crate::raft::ManagementApi;
@@ -16,7 +15,7 @@ use crate::RaftTypeConfig;
 /// Implement blocking mode write operations those reply on oneshot channel for communication
 /// between Raft core and client.
 impl<C> Raft<C>
-where C: RaftTypeConfig<Responder = OneshotResponder<C>>
+where C: RaftTypeConfig
 {
     /// Propose a cluster configuration change.
     ///
@@ -67,7 +66,7 @@ where C: RaftTypeConfig<Responder = OneshotResponder<C>>
     ///
     /// If the node to add is already a voter or learner, it will still re-add it.
     ///
-    /// A `node` is able to store the network address of a node. Thus an application does not
+    /// A `node` is able to store the network address of a node. Thus, an application does not
     /// need another store for mapping node-id to ip-addr when implementing the RaftNetwork.
     #[tracing::instrument(level = "debug", skip(self, id), fields(target=display(&id)))]
     pub async fn add_learner(

--- a/openraft/src/raft/responder/either.rs
+++ b/openraft/src/raft/responder/either.rs
@@ -1,0 +1,32 @@
+use crate::impls::OneshotResponder;
+use crate::raft::responder::Responder;
+use crate::raft::ClientWriteResult;
+use crate::RaftTypeConfig;
+
+/// Either an oneshot responder or a user-defined responder.
+///
+/// It is used in RaftCore to enqueue responder to client.
+pub(crate) enum OneshotOrUserDefined<C>
+where C: RaftTypeConfig
+{
+    Oneshot(OneshotResponder<C>),
+    UserDefined(C::Responder),
+}
+
+impl<C> Responder<C> for OneshotOrUserDefined<C>
+where C: RaftTypeConfig
+{
+    fn send(self, res: ClientWriteResult<C>) {
+        match self {
+            Self::Oneshot(responder) => responder.send(res),
+            Self::UserDefined(responder) => responder.send(res),
+        }
+    }
+
+    type Receiver = ();
+
+    fn from_app_data(_app_data: <C as RaftTypeConfig>::D) -> (<C as RaftTypeConfig>::D, Self, Self::Receiver)
+    where Self: Sized {
+        unimplemented!("OneshotOrUserDefined is just a wrapper and does not support building from app_data")
+    }
+}

--- a/openraft/src/raft/responder/mod.rs
+++ b/openraft/src/raft/responder/mod.rs
@@ -1,5 +1,6 @@
 //! API to consumer a response when a client write request is completed.
 
+pub(crate) mod either;
 pub(crate) mod impls;
 pub use impls::OneshotResponder;
 


### PR DESCRIPTION

## Changelog

##### refactor: no more `C::Responder = OneshotResponder` for `change_membership()`

Before this commit, calling `change_membership()` required the
`RaftTypeConfig::Responder` to be configured with `OneshotResponder`.
This unnecessarily limited applications from using alternative
`Responder` types.

In this commit, we've removed this restriction from the
`change_membership()` method, allowing applications to use any responder
type they prefer. Internally, we now store different types of responders
for `change_membership()` and `client_write()` operations in an enum.


##### chore: add comment




- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1368)
<!-- Reviewable:end -->
