### PR TITLE
feat: add `Raft::get_read_linearizer()`

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -66,6 +66,7 @@ use crate::network::RaftNetworkFactory;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::Progress;
 use crate::quorum::QuorumSet;
+use crate::raft::linearizable_read::Linearizer;
 use crate::raft::message::TransferLeaderRequest;
 use crate::raft::responder::either::OneshotOrUserDefined;
 use crate::raft::responder::Responder;
@@ -268,7 +269,7 @@ where
             //       Fix this when the following heartbeats are replaced with calling RaftNetwork.
             let applied = self.engine.state.io_applied().cloned();
 
-            (read_log_id, applied)
+            Linearizer::new(read_log_id, applied)
         };
 
         if read_policy == ReadPolicy::LeaseRead {

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -7,6 +7,7 @@ use crate::error::CheckIsLeaderError;
 use crate::error::Infallible;
 use crate::error::InitializeError;
 use crate::impls::OneshotResponder;
+use crate::raft::linearizable_read::Linearizer;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::AppendEntriesResponse;
 use crate::raft::ReadPolicy;
@@ -14,7 +15,6 @@ use crate::raft::SnapshotResponse;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::storage::Snapshot;
-use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::ResponderOf;
 use crate::type_config::alias::SnapshotDataOf;
@@ -35,7 +35,7 @@ pub(crate) type VoteTx<C> = OneshotSenderOf<C, VoteResponse<C>>;
 pub(crate) type AppendEntriesTx<C> = OneshotSenderOf<C, AppendEntriesResponse<C>>;
 
 /// TX for Linearizable Read Response
-pub(crate) type ClientReadTx<C> = ResultSender<C, (Option<LogIdOf<C>>, Option<LogIdOf<C>>), CheckIsLeaderError<C>>;
+pub(crate) type ClientReadTx<C> = ResultSender<C, Linearizer<C>, CheckIsLeaderError<C>>;
 
 /// A message sent by application to the [`RaftCore`].
 ///

--- a/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
+++ b/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
@@ -55,14 +55,14 @@ fn test_get_read_log_id() -> anyhow::Result<()> {
     let mut eng = eng();
 
     eng.state.apply_progress_mut().accept(log_id(0, 1, 0));
-    eng.leader.as_mut().unwrap().noop_log_id = Some(log_id(1, 1, 2));
+    eng.leader.as_mut().unwrap().noop_log_id = log_id(1, 1, 2);
 
     let got = eng.leader_handler()?.get_read_log_id();
-    assert_eq!(Some(log_id(1, 1, 2)), got);
+    assert_eq!(log_id(1, 1, 2), got);
 
     eng.state.apply_progress_mut().accept(log_id(2, 1, 3));
     let got = eng.leader_handler()?.get_read_log_id();
-    assert_eq!(Some(log_id(2, 1, 3)), got);
+    assert_eq!(log_id(2, 1, 3), got);
 
     Ok(())
 }

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -109,8 +109,12 @@ where C: RaftTypeConfig
     /// Get the log id for a linearizable read.
     ///
     /// See: [Read Operation](crate::docs::protocol::read)
-    pub(crate) fn get_read_log_id(&self) -> Option<LogIdOf<C>> {
+    pub(crate) fn get_read_log_id(&self) -> LogIdOf<C> {
         let committed = self.state.committed().cloned();
+        let Some(committed) = committed else {
+            return self.leader.noop_log_id.clone();
+        };
+
         // noop log id is the first log this leader proposed.
         std::cmp::max(self.leader.noop_log_id.clone(), committed)
     }

--- a/openraft/src/engine/handler/vote_handler/become_leader_test.rs
+++ b/openraft/src/engine/handler/vote_handler/become_leader_test.rs
@@ -52,7 +52,7 @@ fn test_become_leader() -> anyhow::Result<()> {
     eng.vote_handler().become_leader();
 
     let leader = eng.leader.as_ref().unwrap();
-    assert_eq!(leader.noop_log_id, Some(log_id(2, 1, 0)));
+    assert_eq!(leader.noop_log_id, log_id(2, 1, 0));
     assert_eq!(leader.last_log_id(), Some(&log_id(2, 1, 0)));
     assert_eq!(*leader.committed_vote_ref(), Vote::new(2, 1).into_committed());
 

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -194,7 +194,7 @@ where C: RaftTypeConfig
 
         let (last_log_id, noop_log_id) = {
             let leader = self.leader.as_ref().unwrap();
-            (leader.last_log_id().cloned(), leader.noop_log_id().cloned())
+            (leader.last_log_id().cloned(), leader.noop_log_id().clone())
         };
 
         self.state.accept_log_io(IOId::new_log_io(leader_vote.clone(), last_log_id.clone()));
@@ -211,7 +211,7 @@ where C: RaftTypeConfig
 
         // If the leader has not yet proposed any log, propose a blank log and initiate replication;
         // Otherwise, just initiate replication.
-        if last_log_id < noop_log_id {
+        if last_log_id.as_ref() < Some(&noop_log_id) {
             self.leader_handler().leader_append_entries(vec![C::Entry::new_blank(LogIdOf::<C>::default())]);
         } else {
             self.replication_handler().initiate_replication();

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -185,7 +185,7 @@ fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
 
         assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref(),);
 
-        assert_eq!(Some(log_id(2, 1, 1)), eng.leader.as_ref().unwrap().noop_log_id);
+        assert_eq!(log_id(2, 1, 1), eng.leader.as_ref().unwrap().noop_log_id);
         assert_eq!(
             Some(log_id(2, 1, 1)),
             eng.leader.as_ref().unwrap().last_log_id().copied()

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -66,7 +66,7 @@ fn test_startup_as_leader_without_logs() -> anyhow::Result<()> {
 
     assert_eq!(ServerState::Leader, eng.state.server_state);
     let leader = eng.leader_ref().unwrap();
-    assert_eq!(leader.noop_log_id(), Some(&log_id(2, 2, 4)));
+    assert_eq!(leader.noop_log_id(), &log_id(2, 2, 4));
     assert_eq!(leader.last_log_id(), Some(&log_id(2, 2, 4)));
     assert_eq!(
         vec![
@@ -118,7 +118,7 @@ fn test_startup_as_leader_with_proposed_logs() -> anyhow::Result<()> {
 
     assert_eq!(ServerState::Leader, eng.state.server_state);
     let leader = eng.leader_ref().unwrap();
-    assert_eq!(leader.noop_log_id(), Some(&log_id(1, 2, 4)));
+    assert_eq!(leader.noop_log_id(), &log_id(1, 2, 4));
     assert_eq!(leader.last_log_id(), Some(&log_id(1, 2, 6)));
     assert_eq!(
         vec![

--- a/openraft/src/raft/linearizable_read/linearize_state.rs
+++ b/openraft/src/raft/linearizable_read/linearize_state.rs
@@ -1,0 +1,105 @@
+use std::fmt;
+
+use openraft_macros::since;
+
+use crate::display_ext::DisplayOptionExt;
+use crate::LogId;
+use crate::RaftTypeConfig;
+
+/// LinearizeState represents the state after await the applied log entries for a linearizable read.
+///
+/// This is returned by [`Linearizer::await_applied()`] after waiting for the state
+/// machine to apply all necessary log entries for a linearizable read.
+///
+/// This struct contains the log IDs that were used to ensure linearizability:
+/// - `read_log_id`: the log ID that was required to be applied before reading
+/// - `applied`: the actual log ID that was applied to satisfy the linearizability requirement
+///
+/// If the state is ready, it is guaranteed `applied >= read_log_id`.
+/// If the state is not ready(timeout waiting for the applied log entries), it is guaranteed
+/// `applied < read_log_id`.
+///
+/// [`Linearizer::await_applied()`]: crate::raft::linearizable_read::Linearizer::await_applied
+#[since(version = "0.10.0")]
+#[derive(Debug, Clone)]
+pub struct LinearizeState<C>
+where C: RaftTypeConfig
+{
+    read_log_id: LogId<C>,
+    applied: Option<LogId<C>>,
+}
+
+impl<C> fmt::Display for LinearizeState<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ready = if self.is_ready() { "ready" } else { "not_ready" };
+        write!(
+            f,
+            "LinearizeState({ready}){{ read_log_id: {}, applied: {} }}",
+            self.read_log_id,
+            self.applied.display()
+        )
+    }
+}
+
+impl<C> LinearizeState<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(read_log_id: LogId<C>, applied: Option<LogId<C>>) -> Self {
+        Self { read_log_id, applied }
+    }
+
+    /// Updates the applied log ID and returns the modified state.
+    pub(crate) fn with_applied(mut self, applied: Option<LogId<C>>) -> Self {
+        self.applied = applied;
+        self
+    }
+
+    /// Returns whether the linearizable read is ready to be performed.
+    ///
+    /// This method checks if the state machine has applied enough log entries to satisfy
+    /// the linearizability requirement. It returns `true` when `applied >= read_log_id`,
+    /// meaning the state machine has caught up to the point where a linearizable read
+    /// can be safely performed.
+    #[since(version = "0.10.0")]
+    pub fn is_ready(&self) -> bool {
+        self.applied.as_ref() >= Some(&self.read_log_id)
+    }
+
+    /// Return the `read_log_id` of this read operation.
+    ///
+    /// It is the max of the current leader noop-log-id and the last committed log id.
+    /// See: [`read` docs](crate::docs::protocol::read).
+    #[since(version = "0.10.0")]
+    pub fn read_log_id(&self) -> &LogId<C> {
+        &self.read_log_id
+    }
+
+    /// The last applied log ID.
+    #[since(version = "0.10.0")]
+    pub fn applied(&self) -> Option<&LogId<C>> {
+        self.applied.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::testing::log_id;
+
+    #[test]
+    fn test_display() {
+        let state = LinearizeState::new(log_id(1, 1, 1), Some(log_id(1, 1, 0)));
+        assert_eq!(
+            format!("{}", state),
+            "LinearizeState(not_ready){ read_log_id: T1-N1.1, applied: T1-N1.0 }"
+        );
+
+        let state = state.with_applied(Some(log_id(3, 3, 3)));
+        assert_eq!(
+            format!("{}", state),
+            "LinearizeState(ready){ read_log_id: T1-N1.1, applied: T3-N3.3 }"
+        );
+    }
+}

--- a/openraft/src/raft/linearizable_read/linearizer.rs
+++ b/openraft/src/raft/linearizable_read/linearizer.rs
@@ -1,0 +1,115 @@
+use std::ops::Deref;
+use std::time::Duration;
+
+use openraft_macros::since;
+
+use crate::async_runtime::watch::WatchReceiver;
+use crate::error::Fatal;
+use crate::metrics::WaitError;
+use crate::raft::linearizable_read::LinearizeState;
+use crate::LogId;
+use crate::Raft;
+use crate::RaftTypeConfig;
+
+/// Linearizer represents a linearization operation for read.
+///
+/// See the [read protocol documentation](crate::docs::protocol::read) for more details.
+///
+/// This struct is the result returned from [`Raft::get_read_linearizer()`],
+/// which is the implementation of awaiting the applied log entries.
+/// The application calls [`Linearizer::await_applied()`](Self::await_applied) to ensure its
+/// following reads are linearized.
+///
+/// It contains:
+/// - a `read_log_id`: the log ID that must be applied before reading to ensure linearizability
+/// - a `applied`: the last known log ID that has been applied to the state machine
+///
+/// [`Raft::get_read_linearizer()`]: Raft::get_read_linearizer
+#[since(version = "0.10.0")]
+#[must_use = "call `await_applied()` to ensure linearizability"]
+#[derive(Debug, Clone)]
+pub struct Linearizer<C>
+where C: RaftTypeConfig
+{
+    /// The state containing the read log ID and last applied log ID for linearizable reads.
+    state: LinearizeState<C>,
+}
+
+impl<C> Deref for Linearizer<C>
+where C: RaftTypeConfig
+{
+    type Target = LinearizeState<C>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+impl<C> Linearizer<C>
+where C: RaftTypeConfig
+{
+    #[since(version = "0.10.0")]
+    pub fn new(read_log_id: LogId<C>, applied: Option<LogId<C>>) -> Self {
+        Self {
+            state: LinearizeState::new(read_log_id, applied),
+        }
+    }
+
+    /// Waits for the state machine to apply all required log entries for linearizable reads.
+    ///
+    /// This method ensures linearizability by waiting for the state machine to apply all log
+    /// entries up to the `read_log_id`.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(Ok(LinearizeState))` once `applied >= read_log_id`, indicating it's safe to
+    /// perform linearizable reads.
+    ///
+    /// If `timeout` is provided and expires, returns `Ok(Err(LinearizeState))` where
+    /// `applied < read_log_id`, indicating the read cannot be performed yet.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let linearizer = raft.get_read_linearizer().await?;
+    /// let state = linearizer.await_applied(&raft, Some(Duration::from_secs(1))).await??;
+    /// // Now safe to perform linearizable reads
+    /// ```
+    #[since(version = "0.10.0")]
+    pub async fn await_applied(
+        self,
+        raft: &Raft<C>,
+        timeout: Option<Duration>,
+    ) -> Result<Result<LinearizeState<C>, LinearizeState<C>>, Fatal<C>> {
+        // TODO: test timeout
+        if self.state.is_ready() {
+            return Ok(Ok(self.state));
+        }
+
+        let expected = Some(self.state.read_log_id().index());
+
+        let res = raft.inner.wait(timeout).applied_index_at_least(expected, "Linearizer::await_applied").await;
+
+        match res {
+            Ok(metrics) => Ok(Ok(self.state.with_applied(metrics.last_applied))),
+            Err(e) => match e {
+                WaitError::Timeout(_, _) => {
+                    let metrics_rx = raft.metrics();
+                    let ref_metrics = metrics_rx.borrow_watched();
+                    let applied = ref_metrics.last_applied.clone();
+
+                    let state = self.state.with_applied(applied);
+                    if state.is_ready() {
+                        Ok(Ok(state))
+                    } else {
+                        Ok(Err(state))
+                    }
+                }
+                WaitError::ShuttingDown => {
+                    let err = raft.inner.get_core_stop_error().await;
+                    Err(err)
+                }
+            },
+        }
+    }
+}

--- a/openraft/src/raft/linearizable_read/mod.rs
+++ b/openraft/src/raft/linearizable_read/mod.rs
@@ -1,0 +1,5 @@
+mod linearize_state;
+mod linearizer;
+
+pub use linearize_state::LinearizeState;
+pub use linearizer::Linearizer;


### PR DESCRIPTION
## Changelog

### feat: add `Raft::get_read_linearizer()`

Add new API `Raft::get_read_linearizer()` to implement linearizable
reads. It provides a clearer API and gives users intuitive guidance
on how to perform local linearizable reads or follower reads, i.e.,
get `read_log_id` from a remote leader but read the local state machine.

`Raft::get_read_linearizer()` ensures leadership and returns a
`Linearizer` instance containing `read_log_id` and the last `applied`
log ID in the state machine. The caller, either on the local node or on
a remote follower, calls `Linearizer::await_applied()` to block until
the state machine applies up to `read_log_id` to assert linearizability.

A typical usage of follower read:

```rust,ignore
// Application defined RPC to get the `read_log_id` from the remote leader
let leader_id = my_raft.current_leader().await?.unwrap();
let linearizer = my_app_rpc.get_read_linearizer(leader_id, ReadPolicy::ReadIndex).await?;

// Block waiting local state machine to apply up to the `read_log_id`
let _ = linearizer.await_applied(&my_raft, None).await?.unwrap();

// Following read from state machine is linearized across the cluster
let val = my_raft.with_state_machine(|sm| { sm.read("foo") }).await?;
```
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1371)
<!-- Reviewable:end -->
