### PR TITLE
docs: Add example/network-v1 example crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
 exclude = [
     "cluster_benchmark",
     "examples/memstore",
+    "examples/network-v1",
     "examples/rocksstore",
     "examples/raft-kv-memstore",
     "examples/raft-kv-memstore-grpc",

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,49 @@
+# OpenRaft Examples
+
+This directory contains example applications demonstrating different implementation approaches for OpenRaft components.
+
+## Complete Applications
+
+### Component Overview
+
+- **Log**: LogStore implementation for storing raft logs
+- **State Machine**: StateMachine implementation for application state
+- **RaftNetwork Impl**: Transport protocol and client library used
+- **RaftNetwork**: Interface version (RaftNetwork vs RaftNetworkV2)
+- **Client**: HTTP/gRPC client library for application requests
+- **Server**: Web framework for handling incoming requests
+- **Special Features**: Unique characteristics of each example
+
+| Example | Log | State Machine | RaftNetwork Impl | RaftNetwork | Client | Server | Special Features |
+|---------|-----|---------------|------------------|-------------|--------|--------|------------------|
+| [raft-kv-memstore] | [memstore] | in-memory | HTTP/reqwest | RaftNetwork | reqwest | actix-web | Basic example |
+| [raft-kv-rocksdb] | [rocksstore] | [rocksstore] | HTTP/reqwest([network-v1]) | RaftNetwork | reqwest | actix-web | Persistent storage |
+| [raft-kv-memstore-network-v2] | [memstore] | in-memory | HTTP/reqwest | RaftNetworkV2 | reqwest | actix-web | Network V2 interface |
+| [raft-kv-memstore-grpc] | [memstore] | in-memory | gRPC/tonic | RaftNetwork | tonic | tonic | gRPC transport |
+| [raft-kv-memstore-singlethreaded] | memstore | in-memory | HTTP/reqwest | RaftNetwork | reqwest | actix-web | Single-threaded runtime |
+| [raft-kv-memstore-opendal-snapshot-data] | [memstore] | in-memory+OpenDAL | HTTP/reqwest | RaftNetwork | reqwest | actix-web | OpenDAL snapshot storage |
+
+
+## Component Implementations
+
+### Storage Implementations
+- **[memstore]** - In-memory LogStore and StateMachine using `std::collections::HashMap` and `Vec`
+- **[rocksstore]** - RocksDB-based persistent storage using `rocksdb` crate
+
+### Network Implementations
+- **[network-v1]** - HTTP-based RaftNetwork interface V1 using `reqwest` crate
+
+### Utilities
+- **[utils]** - Shared type declarations and utilities
+
+<!-- Reference Links -->
+[raft-kv-memstore]: raft-kv-memstore/
+[raft-kv-rocksdb]: raft-kv-rocksdb/
+[raft-kv-memstore-network-v2]: raft-kv-memstore-network-v2/
+[raft-kv-memstore-grpc]: raft-kv-memstore-grpc/
+[raft-kv-memstore-singlethreaded]: raft-kv-memstore-singlethreaded/
+[raft-kv-memstore-opendal-snapshot-data]: raft-kv-memstore-opendal-snapshot-data/
+[memstore]: memstore/
+[rocksstore]: rocksstore/
+[network-v1]: network-v1/
+[utils]: utils/

--- a/examples/network-v1/Cargo.toml
+++ b/examples/network-v1/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "network-v1"
+version = "0.1.0"
+readme = "README.md"
+
+edition = "2021"
+authors = [
+  "drdr xp <drdr.xp@gmail.com>",
+]
+categories = ["algorithms", "asynchronous", "data-structures"]
+description = "An example network implementation v1 built upon `openraft`."
+homepage = "https://github.com/databendlabs/openraft"
+keywords = ["raft", "consensus", "network"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/databendlabs/openraft"
+
+[dependencies]
+openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
+
+reqwest = { version = "0.12.5", features = ["json"] }
+serde = { version = "1.0.114", features = ["derive"] }
+serde_json = "1.0.57"
+tokio = { version = "1.35.1", features = ["full"] }
+tracing = "0.1.40"
+
+[features]
+default = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/examples/network-v1/README.md
+++ b/examples/network-v1/README.md
@@ -1,0 +1,225 @@
+# Network-v1
+
+An OpenRaft network layer implementation example that demonstrates the **RaftNetwork interface V1** using HTTP and `reqwest` as the transport mechanism.
+
+## Role and Position in OpenRaft
+
+`network-v1` demonstrates how to implement `RaftNetwork` and `RaftNetworkFactory` traits (**interface V1**) to **enable Raft nodes to establish connections and exchange messages with other nodes** for consensus operations.
+
+### Position in OpenRaft Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Application Layer                        │
+│                (Business Applications)                      │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+┌─────────────────────────▼───────────────────────────────────┐
+│                Complete Example Applications                │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+┌─────────────────────────▼───────────────────────────────────┐
+│                   OpenRaft Core                             │
+│              (consensus algorithm & coordinator)            │
+│                                                             │
+│  ┌─────────────────┐                    ┌─────────────────┐ │
+│  │   Storage       │                    │    Network      │ │
+│  │  Management     │◄──────────────────►│   Management    │ │
+│  │                 │                    │                 │ │
+│  └────────┬────────┘                    └────────┬────────┘ │
+└───────────│──────────────────────────────────────│──────────┘
+            │                                      │
+            ▼                                      ▼
+┌─────────────────────┐                 ┌─────────────────────┐
+│   Storage Layer     │                 │   Network Layer     │
+│                     │                 │                     │
+│ • LogStore          │                 │ • RaftNetwork       │
+│ • StateMachine      │                 │ • RaftNetworkFactory│
+│ • SnapshotStore     │                 │                     │
+│                     │                 │ ┌─────────────────┐ │
+│ Implementations:    │                 │ │   network-v1    │ │
+│ • RocksDB           │                 │ │ (Interface v1)  │ │
+│ • Memory            │                 │ │                 │ │
+│ • Custom stores     │                 │ │   network-v2    │ │
+│                     │                 │ │ (Interface v2)  │ │
+│                     │                 │ └─────────────────┘ │
+└─────────────────────┘                 └─────────────────────┘
+```
+
+### Core Functions
+
+- **Send three RPCs to other nodes**: vote, append_entries, and install_snapshot
+- **Demonstrate Interface V1**: Shows how to implement the RaftNetwork V1 programming interface
+
+### Core Technology Stack
+
+- **HTTP Protocol**: Implemented using `reqwest`
+- **Serialization**: Uses `serde` + JSON
+
+### Implemented Traits
+
+#### 1. `RaftNetworkFactory<C>`
+```rust
+impl<C> RaftNetworkFactory<C> for NetworkFactory
+where
+    C: RaftTypeConfig<Node = BasicNode>,
+    <C as RaftTypeConfig>::SnapshotData: AsyncRead + AsyncWrite + AsyncSeek + Unpin,
+{
+    type Network = Network<C>;
+
+    async fn new_client(&mut self, target: C::NodeId, node: &BasicNode) -> Self::Network;
+}
+```
+
+**Responsibilities**:
+- **Create network client instances for each target node** that this Raft node needs to communicate with
+- **Enable the Raft node to establish outbound connections** to specific remote nodes in the cluster
+- Manage HTTP client configuration and initialization **for inter-node communication**
+
+#### 2. `RaftNetwork<C>`
+```rust
+impl<C> RaftNetwork<C> for Network<C>
+where C: RaftTypeConfig
+{
+    async fn append_entries(&mut self, req: AppendEntriesRequest<C>, option: RPCOption) -> Result<...>;
+    async fn install_snapshot(&mut self, req: InstallSnapshotRequest<C>, option: RPCOption) -> Result<...>;
+    async fn vote(&mut self, req: VoteRequest<C>, option: RPCOption) -> Result<...>;
+}
+```
+
+**Responsibilities**:
+- **Send raft protocol messages from this node to a specific remote node**
+- Implement the three core RPC calls of the raft protocol **for inter-node communication**
+- Handle network errors and retry logic **when communicating with remote nodes**
+
+### Error Handling
+
+The implementation properly handles network errors and maps them to OpenRaft's error types:
+
+```rust
+let resp = self.client.post(url).json(&req).send().await.map_err(|e| {
+    if e.is_connect() {
+        // Connection errors trigger OpenRaft's backoff mechanism
+        RPCError::Unreachable(Unreachable::new(&e))
+    } else {
+        // Other network errors
+        RPCError::Network(NetworkError::new(&e))
+    }
+})?;
+```
+
+**Error Types**:
+- `Unreachable`: Connection failures (triggers backoff retry)
+- `NetworkError`: Other HTTP/network errors
+
+### HTTP Protocol Requirements
+
+#### Protocol Description
+
+This implementation expects the remote server to implement these HTTP endpoints:
+
+| Raft RPC Method | HTTP Endpoint | Request Type | Response Type | Description |
+|-----------------|---------------|--------------|---------------|-------------|
+| `append_entries` | `POST /append` | `AppendEntriesRequest` | `Result<AppendEntriesResponse, Error>` | **Node-to-node** log replication and heartbeat messages |
+| `vote` | `POST /vote` | `VoteRequest` | `Result<VoteResponse, Error>` | **Node-to-node** leader election voting requests |
+| `install_snapshot` | `POST /snapshot` | `InstallSnapshotRequest` | `Result<InstallSnapshotResponse, Error>` | **Node-to-node** snapshot installation for catching up lagging nodes |
+
+**Requirements:**
+- All requests: JSON-serialized POST with `Content-Type: application/json`
+- All responses: HTTP 200 OK with JSON-serialized `Result<T, E>` body
+- Raft-level errors in response body, not HTTP status codes
+
+#### Protocol Examples
+
+**Request Examples:**
+
+```bash
+# append_entries request
+POST http://127.0.0.1:21001/append
+Content-Type: application/json
+
+{
+  "vote": {"term": 1, "node_id": 1},
+  "prev_log_id": {"term": 0, "index": 0},
+  "entries": [...],
+  "leader_commit": {"term": 1, "index": 5}
+}
+```
+
+```bash
+# vote request
+POST http://127.0.0.1:21002/vote
+Content-Type: application/json
+
+{
+  "vote": {"term": 2, "node_id": 1},
+  "last_log_id": {"term": 1, "index": 10}
+}
+```
+
+```bash
+# install_snapshot request
+POST http://127.0.0.1:21003/snapshot
+Content-Type: application/json
+
+{
+  "vote": {"term": 3, "node_id": 1},
+  "meta": {...},
+  "offset": 0,
+  "data": [...]
+}
+```
+
+**Response Examples:**
+
+```json
+// Success response
+{
+  "Ok": {
+    "vote": {"term": 1, "node_id": 2},
+    "success": true,
+    "conflict": false
+  }
+}
+```
+
+```json
+// Error response
+{
+  "Err": {
+    "error_type": "SomeRaftError",
+    "message": "Error description"
+  }
+}
+```
+
+## Usage
+
+### Add Dependency
+
+```toml
+[dependencies]
+network-v1 = { path = "../network-v1" }
+```
+
+### Use in Application
+
+```rust
+use network_v1::NetworkFactory;
+
+// Create network factory
+let network = NetworkFactory {};
+
+// Create raft instance
+let raft = openraft::Raft::new(
+    node_id,
+    config,
+    network,        // Use network-v1
+    log_store,
+    state_machine
+).await?;
+```
+
+### Example Application
+
+See [`raft-kv-rocksdb`](../raft-kv-rocksdb/) for a complete example of using this network implementation.

--- a/examples/network-v1/src/lib.rs
+++ b/examples/network-v1/src/lib.rs
@@ -1,45 +1,64 @@
 use std::fmt::Display;
 
+use openraft::error::Infallible;
 use openraft::error::InstallSnapshotError;
 use openraft::error::NetworkError;
+use openraft::error::RPCError;
+use openraft::error::RaftError;
 use openraft::error::RemoteError;
 use openraft::error::Unreachable;
 use openraft::network::RPCOption;
 use openraft::network::RaftNetwork;
 use openraft::network::RaftNetworkFactory;
+use openraft::raft::AppendEntriesRequest;
+use openraft::raft::AppendEntriesResponse;
+use openraft::raft::InstallSnapshotRequest;
+use openraft::raft::InstallSnapshotResponse;
+use openraft::raft::VoteRequest;
+use openraft::raft::VoteResponse;
+use openraft::BasicNode;
+use openraft::RaftTypeConfig;
 use reqwest::Client;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncSeek;
+use tokio::io::AsyncWrite;
 
-use crate::typ::*;
-use crate::Node;
-use crate::NodeId;
-use crate::TypeConfig;
+pub struct NetworkFactory {}
 
-pub struct Network {}
-
-// NOTE: This could be implemented also on `Arc<ExampleNetwork>`, but since it's empty, implemented
-// directly.
-impl RaftNetworkFactory<TypeConfig> for Network {
-    type Network = NetworkConnection;
+impl<C> RaftNetworkFactory<C> for NetworkFactory
+where
+    C: RaftTypeConfig<Node = BasicNode>,
+    // RaftNetworkV2 is implemented automatically for RaftNetwork, but requires the following trait bounds.
+    // In V2 network, the snapshot has no constraints, but RaftNetwork assumes a Snapshot is a file-like
+    // object that can be seeked, read from, and written to.
+    <C as RaftTypeConfig>::SnapshotData: AsyncRead + AsyncWrite + AsyncSeek + Unpin,
+{
+    type Network = Network<C>;
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn new_client(&mut self, target: NodeId, node: &Node) -> Self::Network {
+    async fn new_client(&mut self, target: C::NodeId, node: &BasicNode) -> Self::Network {
         let addr = node.addr.clone();
 
         let client = Client::builder().no_proxy().build().unwrap();
 
-        NetworkConnection { addr, client, target }
+        Network { addr, client, target }
     }
 }
 
-pub struct NetworkConnection {
+pub struct Network<C>
+where C: RaftTypeConfig
+{
     addr: String,
     client: Client,
-    target: NodeId,
+    target: C::NodeId,
 }
-impl NetworkConnection {
-    async fn request<Req, Resp, Err>(&mut self, uri: impl Display, req: Req) -> Result<Result<Resp, Err>, RPCError>
+
+impl<C> Network<C>
+where C: RaftTypeConfig
+{
+    async fn request<Req, Resp, Err>(&mut self, uri: impl Display, req: Req) -> Result<Result<Resp, Err>, RPCError<C>>
     where
         Req: Serialize + 'static,
         Resp: Serialize + DeserializeOwned,
@@ -55,12 +74,13 @@ impl NetworkConnection {
         let resp = self.client.post(url.clone()).json(&req).send().await.map_err(|e| {
             if e.is_connect() {
                 // `Unreachable` informs the caller to backoff for a short while to avoid error log flush.
-                return RPCError::Unreachable(Unreachable::new(&e));
+                RPCError::Unreachable(Unreachable::new(&e))
+            } else {
+                RPCError::Network(NetworkError::new(&e))
             }
-            RPCError::Network(NetworkError::new(&e))
         })?;
 
-        let res: Result<Resp, Err> = resp.json().await.map_err(|e| RPCError::Network(NetworkError::new(&e)))?;
+        let res: Result<Resp, Err> = resp.json().await.map_err(|e| NetworkError::new(&e))?;
         // println!(
         //     "<<< network recv reply from {}: {}",
         //     url,
@@ -72,13 +92,15 @@ impl NetworkConnection {
 }
 
 #[allow(clippy::blocks_in_conditions)]
-impl RaftNetwork<TypeConfig> for NetworkConnection {
+impl<C> RaftNetwork<C> for Network<C>
+where C: RaftTypeConfig
+{
     #[tracing::instrument(level = "debug", skip_all, err(Debug))]
     async fn append_entries(
         &mut self,
-        req: AppendEntriesRequest,
+        req: AppendEntriesRequest<C>,
         _option: RPCOption,
-    ) -> Result<AppendEntriesResponse, RPCError<RaftError>> {
+    ) -> Result<AppendEntriesResponse<C>, RPCError<C, RaftError<C>>> {
         let res = self.request::<_, _, Infallible>("append", req).await.map_err(RPCError::with_raft_error)?;
         Ok(res.unwrap())
     }
@@ -86,21 +108,25 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
     #[tracing::instrument(level = "debug", skip_all, err(Debug))]
     async fn install_snapshot(
         &mut self,
-        req: InstallSnapshotRequest,
+        req: InstallSnapshotRequest<C>,
         _option: RPCOption,
-    ) -> Result<InstallSnapshotResponse, RPCError<RaftError<InstallSnapshotError>>> {
+    ) -> Result<InstallSnapshotResponse<C>, RPCError<C, RaftError<C, InstallSnapshotError>>> {
         let res = self.request("snapshot", req).await.map_err(RPCError::with_raft_error)?;
         match res {
             Ok(resp) => Ok(resp),
             Err(e) => Err(RPCError::RemoteError(RemoteError::new(
-                self.target,
+                self.target.clone(),
                 RaftError::APIError(e),
             ))),
         }
     }
 
     #[tracing::instrument(level = "debug", skip_all, err(Debug))]
-    async fn vote(&mut self, req: VoteRequest, _option: RPCOption) -> Result<VoteResponse, RPCError<RaftError>> {
+    async fn vote(
+        &mut self,
+        req: VoteRequest<C>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<C>, RPCError<C, RaftError<C>>> {
         let res = self.request::<_, _, Infallible>("vote", req).await.map_err(RPCError::with_raft_error)?;
         Ok(res.unwrap())
     }

--- a/examples/raft-kv-rocksdb/Cargo.toml
+++ b/examples/raft-kv-rocksdb/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/bin/main.rs"
 [dependencies]
 openraft = { path = "../../openraft", features = ["serde", "type-alias"] }
 openraft-rocksstore = { path = "../rocksstore" }
+network-v1 = { path = "../network-v1" }
 
 actix-web = "4.0.0-rc.2"
 tokio = { version = "1.35.1", features = ["full"] }
@@ -32,14 +33,6 @@ reqwest = { version = "0.12.5", features = ["json"] }
 rocksdb = "0.22.0"
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.57"
-# for toy-rpc, use `serde_json` instead of the default `serde_bincode`:
-# bincode which enabled by default by toy-rpc, does not support `#[serde(flatten)]`: https://docs.rs/bincode/2.0.0-alpha.1/bincode/serde/index.html#known-issues
-toy-rpc = { version = "0.10.0", features = [
-  "ws_tokio",
-  "server",
-  "client",
-  "tokio_runtime",
-] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }
 

--- a/examples/raft-kv-rocksdb/src/network/management.rs
+++ b/examples/raft-kv-rocksdb/src/network/management.rs
@@ -11,7 +11,6 @@ use openraft::error::Infallible;
 
 use crate::app::App;
 use crate::typ::*;
-use crate::Node;
 use crate::NodeId;
 
 // --- Cluster management

--- a/examples/raft-kv-rocksdb/src/network/mod.rs
+++ b/examples/raft-kv-rocksdb/src/network/mod.rs
@@ -1,7 +1,3 @@
 pub mod api;
 pub mod management;
 pub mod raft;
-mod raft_network_impl;
-
-pub use raft_network_impl::Network;
-pub use raft_network_impl::NetworkConnection;

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -6,10 +6,10 @@ use std::time::Duration;
 
 use maplit::btreemap;
 use maplit::btreeset;
+use openraft::BasicNode;
 use raft_kv_rocksdb::client::ExampleClient;
 use raft_kv_rocksdb::start_example_raft_node;
 use raft_kv_rocksdb::store::Request;
-use raft_kv_rocksdb::Node;
 use tokio::runtime::Handle;
 use tracing_subscriber::EnvFilter;
 
@@ -121,9 +121,9 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
         x.membership_config.nodes().map(|(nid, node)| (*nid, node.clone())).collect::<BTreeMap<_, _>>();
     assert_eq!(
         btreemap! {
-            1 => Node{addr: get_addr(1)},
-            2 => Node{addr: get_addr(2)},
-            3 => Node{addr: get_addr(3)},
+            1 => BasicNode::new(get_addr(1)),
+            2 => BasicNode::new(get_addr(2)),
+            3 => BasicNode::new(get_addr(3)),
         },
         nodes_in_cluster
     );
@@ -224,7 +224,7 @@ async fn test_cluster() -> Result<(), Box<dyn std::error::Error>> {
         Err(e) => {
             let s = e.to_string();
             let expect_err: String =
-                "has to forward request to: Some(1), Some(Node { addr: \"127.0.0.1:31001\" })".to_string();
+                "has to forward request to: Some(1), Some(BasicNode { addr: \"127.0.0.1:31001\" })".to_string();
 
             assert_eq!(s, expect_err);
         }


### PR DESCRIPTION

## Changelog

##### docs: Add example/network-v1 example crate

Add a complete OpenRaft network layer implementation example that demonstrates
the RaftNetwork interface V1 using HTTP and `reqwest` as transport mechanism.

Features:
- Implements `RaftNetworkFactory` and `RaftNetwork` traits (interface V1)
- HTTP-based transport using `reqwest` client
- JSON serialization with serde

This serves as a reference implementation for developers who want to
understand or implement custom network layers for OpenRaft.