### PR TITLE
Fix: in 0.10, auto `NodeId` impl should not include `Copy`

### DIFF
--- a/openraft/src/node.rs
+++ b/openraft/src/node.rs
@@ -33,7 +33,6 @@ impl<T> NodeId for T where T: Sized
         + Debug
         + Display
         + Hash
-        + Copy
         + Clone
         + Default
         + 'static
@@ -99,5 +98,31 @@ impl BasicNode {
 impl Display for BasicNode {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.addr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt;
+
+    use crate::NodeId;
+
+    #[test]
+    fn node_id_default_impl() {
+        /// Automatically implemented trait [`NodeId`] for this struct.
+        #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Ord, PartialOrd)]
+        struct AutoNodeId;
+
+        impl fmt::Display for AutoNodeId {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "FooNodeId")
+            }
+        }
+
+        /// Assert a value implements the trait [`NodeId`].
+        fn assert_node_id<NID: NodeId>(_nid: &NID) {}
+
+        assert_node_id(&AutoNodeId);
     }
 }


### PR DESCRIPTION

## Changelog

##### Fix: in 0.10, auto `NodeId` impl should not include `Copy`

`NodeId` does not require `Copy` in release 0.10 . But the auto `NodeId`
trait implementation still require `T` to be `Copy`, i.e.:

`impl NodeId for T where T: Copy + ..`.

This `Copy` trait bound should be removed according to the `NodeId`
trait definition change.

- Fix: ##1382

Thanks to @tvsfx !

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1383)
<!-- Reviewable:end -->
