### PR TITLE
refactor: tolerate leader state reversion upon restart

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -102,7 +102,6 @@ use crate::vote::RaftVote;
 use crate::ChangeMembers;
 use crate::Instant;
 use crate::Membership;
-use crate::OptionalSend;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 
@@ -677,23 +676,6 @@ where
     pub(crate) fn trigger_snapshot(&mut self) {
         tracing::debug!("{}", func_name!());
         self.engine.snapshot_handler().trigger_snapshot();
-    }
-
-    /// Reject a request due to the Raft node being in a state which prohibits the request.
-    #[tracing::instrument(level = "trace", skip(self, tx))]
-    pub(crate) fn reject_with_forward_to_leader<T: OptionalSend, E>(&self, tx: ResultSender<C, T, E>)
-    where E: From<ForwardToLeader<C>> + OptionalSend {
-        let mut leader_id = self.current_leader();
-        let leader_node = self.get_leader_node(leader_id.clone());
-
-        // Leader is no longer a node in the membership config.
-        if leader_node.is_none() {
-            leader_id = None;
-        }
-
-        let err = ForwardToLeader { leader_id, leader_node };
-
-        let _ = tx.send(Err(err.into()));
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -1008,6 +1008,7 @@ impl TypedRaftRouter {
         Ok(())
     }
 
+    #[allow(clippy::result_large_err)]
     #[tracing::instrument(level = "debug", skip(self))]
     pub fn emit_rpc_error(&self, id: MemNodeId, target: MemNodeId) -> Result<(), RPCError<MemConfig>> {
         let fails = self.fail_rpc.lock().unwrap();


### PR DESCRIPTION

## Changelog

##### refactor: tolerate leader state reversion upon restart

When a leader restarted and its log reverted, and tried to re-elect
itself as leader:

And when vote request is rejected and see a greater vote,
it should only update to the non-committed version of the responded vote
to its local state:

This prevents a dangerous scenario when state reversion is allowed:
1. A node was a leader but its state reverted to a previous version;
2. The node restarts and begins election;
3. It receives a vote response containing its own previous leader vote;
4. Without this protection, it would update to that committed vote and
   become leader again;
5. However, it lacks the necessary logs, causing committed entries to be
   lost or inconsistent;

By using the non-committed version, we prevent this reverted node from
becoming leader while still allowing proper vote updates for legitimate
cases.




- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1385)
<!-- Reviewable:end -->
