### PR TITLE
CI: add API key to increase rate limit of installing protoc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -434,6 +434,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           version: '23.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Run the following steps in the exmple dir in order to reuse the `./target` dir.
 


### PR DESCRIPTION

## Changelog

##### CI: add API key to increase rate limit of installing protoc

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1396)
<!-- Reviewable:end -->
