### PR TITLE
fix: match on uninhabited types at compile time

### DIFF
--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -321,7 +321,6 @@ where C: RaftTypeConfig
             RPCError::Unreachable(e) => RPCError::Unreachable(e),
             RPCError::PayloadTooLarge(e) => RPCError::PayloadTooLarge(e),
             RPCError::Network(e) => RPCError::Network(e),
-            RPCError::RemoteError(_infallible) => unreachable!(),
         }
     }
 }

--- a/openraft/src/error/into_ok.rs
+++ b/openraft/src/error/into_ok.rs
@@ -11,7 +11,11 @@ where E: Into<Infallible>
     fn into_ok(self) -> T {
         match self {
             Ok(t) => t,
-            Err(_) => unreachable!(),
+            Err(e) => {
+                // NOTE: `allow` required because of buggy reachability detection by rust compiler
+                #[allow(unreachable_code)]
+                match e.into() {}
+            }
         }
     }
 }

--- a/openraft/src/error/streaming_error.rs
+++ b/openraft/src/error/streaming_error.rs
@@ -48,7 +48,6 @@ impl<C: RaftTypeConfig> From<StreamingError<C>> for ReplicationError<C> {
 
 impl<C: RaftTypeConfig> From<RPCError<C>> for StreamingError<C> {
     fn from(value: RPCError<C>) -> Self {
-        #[allow(unreachable_patterns)]
         match value {
             RPCError::Timeout(e) => StreamingError::Timeout(e),
             RPCError::Unreachable(e) => StreamingError::Unreachable(e),
@@ -56,9 +55,6 @@ impl<C: RaftTypeConfig> From<RPCError<C>> for StreamingError<C> {
                 unreachable!("PayloadTooLarge should not be converted to StreamingError")
             }
             RPCError::Network(e) => StreamingError::Network(e),
-            RPCError::RemoteError(_e) => {
-                unreachable!("Infallible error should not be produced at all")
-            }
         }
     }
 }

--- a/rt-monoio/src/lib.rs
+++ b/rt-monoio/src/lib.rs
@@ -74,11 +74,8 @@ impl AsyncRuntime for MonoioRuntime {
     }
 
     #[inline]
-    fn is_panic(_join_error: &Self::JoinError) -> bool {
-        // Given that joining a task will never fail, i.e., `Self::JoinError`
-        // will never be constructed, and it is impossible to construct an
-        // enum like `Infallible`, this function could never be invoked.
-        unreachable!("unreachable since argument `join_error` could never be constructed")
+    fn is_panic(join_error: &Self::JoinError) -> bool {
+        match *join_error {}
     }
 
     #[inline]


### PR DESCRIPTION
uninhabited types should be dealt with at compile time, not through the runtime panic that `unreachable!` throws
since rust 1.82, Rust has better ergonomics for matching on uninhabited enum variants, which makes this easier for owned types (https://github.com/rust-lang/rust/pull/122792)

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1401)
<!-- Reviewable:end -->
