### PR TITLE
fix(example): remove route prefixes to maintain consistency with test_cluster.rs

### DIFF
--- a/examples/raft-kv-rocksdb/test-cluster.sh
+++ b/examples/raft-kv-rocksdb/test-cluster.sh
@@ -75,7 +75,7 @@ sleep 1
 echo "Initialize server 1 as a single-node cluster"
 sleep 2
 echo
-rpc 21001/cluster/init '{}'
+rpc 21001/init '[]'
 
 echo "Server 1 is a leader now"
 
@@ -84,7 +84,7 @@ sleep 2
 echo "Get metrics from the leader"
 sleep 2
 echo
-rpc 21001/cluster/metrics
+rpc 21001/metrics
 sleep 1
 
 
@@ -92,23 +92,23 @@ echo "Adding node 2 and node 3 as learners, to receive log from leader node 1"
 
 sleep 1
 echo
-rpc 21001/cluster/add-learner       '[2, "127.0.0.1:21002", "127.0.0.1:22002"]'
+rpc 21001/add-learner       '[2, "127.0.0.1:21002"]'
 echo "Node 2 added as leaner"
 sleep 1
 echo
-rpc 21001/cluster/add-learner       '[3, "127.0.0.1:21003", "127.0.0.1:22003"]'
+rpc 21001/add-learner       '[3, "127.0.0.1:21003"]'
 echo "Node 3 added as leaner"
 sleep 1
 
 echo "Get metrics from the leader, after adding 2 learners"
 sleep 2
 echo
-rpc 21001/cluster/metrics
+rpc 21001/metrics
 sleep 1
 
 echo "Changing membership from [1] to 3 nodes cluster: [1, 2, 3]"
 echo
-rpc 21001/cluster/change-membership '[1, 2, 3]'
+rpc 21001/change-membership '[1, 2, 3]'
 sleep 1
 echo "Membership changed"
 sleep 1
@@ -116,13 +116,13 @@ sleep 1
 echo "Get metrics from the leader again"
 sleep 1
 echo
-rpc 21001/cluster/metrics
+rpc 21001/metrics
 sleep 1
 
 echo "Write data on leader"
 sleep 1
 echo
-rpc 21001/api/write '{"Set":{"key":"foo","value":"bar"}}'
+rpc 21001/write '{"Set":{"key":"foo","value":"bar"}}'
 sleep 1
 echo "Data written"
 sleep 1
@@ -131,13 +131,13 @@ echo "Read on every node, including the leader"
 sleep 1
 echo "Read from node 1"
 echo
-rpc 21001/api/read  '"foo"'
+rpc 21001/read  '"foo"'
 echo "Read from node 2"
 echo
-rpc 21002/api/read  '"foo"'
+rpc 21002/read  '"foo"'
 echo "Read from node 3"
 echo
-rpc 21003/api/read  '"foo"'
+rpc 21003/read  '"foo"'
 
 echo "Kill Node 1"
 kill -9 $PID1
@@ -145,20 +145,20 @@ sleep 1
 
 echo "Read from node 3"
 echo
-rpc 21003/api/read  '"foo"'
+rpc 21003/read  '"foo"'
 sleep 1
 
 
 echo "Get metrics from node 2"
 sleep 1
 echo
-rpc 21002/cluster/metrics
+rpc 21002/metrics
 sleep 1
 
 echo "Write data on node 2"
 sleep 1
 echo
-rpc 21002/api/write '{"Set":{"key":"foo","value":"badger"}}'
+rpc 21002/write '{"Set":{"key":"foo","value":"badger"}}'
 sleep 1
 echo "Data written"
 sleep 1
@@ -166,7 +166,7 @@ sleep 1
 echo "Write data on node 3"
 sleep 1
 echo
-rpc 21003/api/write '{"Set":{"key":"foo","value":"badger"}}'
+rpc 21003/write '{"Set":{"key":"foo","value":"badger"}}'
 sleep 1
 echo "Data written"
 sleep 1
@@ -175,13 +175,13 @@ sleep 1
 echo "Get metrics from node 2"
 sleep 1
 echo
-rpc 21002/cluster/metrics
+rpc 21002/metrics
 sleep 1
 
 
 echo "Read from node 3"
 echo
-rpc 21003/api/read  '"foo"'
+rpc 21003/read  '"foo"'
 sleep 1
 
 
@@ -194,13 +194,13 @@ echo "Server 1 started"
 
 echo "Read from node 1"
 echo
-rpc 21001/api/read  '"foo"'
+rpc 21001/read  '"foo"'
 sleep 1
 
 echo "Get metrics from node 1"
 sleep 1
 echo
-rpc 21001/cluster/metrics
+rpc 21001/metrics
 sleep 1
 
 


### PR DESCRIPTION
remove route prefixes to maintain consistency with test_cluster.rs

- Remove  prefix from management endpoints
- Remove  prefix from application endpoints

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)
