### PR TITLE
Fix: prevent panic in runtime-stats when recording duplicate log stage

### DIFF
--- a/openraft/src/core/runtime_stats/log_stage/lifecycle_latency.rs
+++ b/openraft/src/core/runtime_stats/log_stage/lifecycle_latency.rs
@@ -79,7 +79,24 @@ where I: Instant
     }
 
     pub(crate) fn record_stage(&mut self, stage: Stage, right: u64, value: I) {
-        if let Some(evicted) = self.inner.get_mut(stage.index()).record(right, value) {
+        let range_map = self.inner.get_mut(stage.index());
+
+        // Defensive check: in low-latency environments, the same stage for the same
+        // log index may be recorded multiple times in quick succession.
+        // Skip recording if there's no new progress (right boundary not increasing).
+        if let Some(prev_end) = range_map.end() {
+            if right <= prev_end {
+                tracing::debug!(
+                    "LogStages::record_stage: skipping non-increasing boundary, stage={:?}, right={}, prev_end={}",
+                    stage,
+                    right,
+                    prev_end
+                );
+                return;
+            }
+        }
+
+        if let Some(evicted) = range_map.record(right, value) {
             self.begin = self.begin.max(evicted);
         }
     }

--- a/openraft/src/core/runtime_stats/log_stage/lifecycle_latency.rs
+++ b/openraft/src/core/runtime_stats/log_stage/lifecycle_latency.rs
@@ -88,10 +88,8 @@ where I: Instant
             && right <= prev_end
         {
             tracing::debug!(
-                "LogStages::record_stage: skipping non-increasing boundary, stage={:?}, right={}, prev_end={}",
-                stage,
-                right,
-                prev_end
+                "LogStages::record_stage: skipping non-increasing boundary, \
+                stage={stage:?}, right={right}, prev_end={prev_end}"
             );
             return;
         }

--- a/openraft/src/core/runtime_stats/log_stage/lifecycle_latency.rs
+++ b/openraft/src/core/runtime_stats/log_stage/lifecycle_latency.rs
@@ -84,16 +84,16 @@ where I: Instant
         // Defensive check: in low-latency environments, the same stage for the same
         // log index may be recorded multiple times in quick succession.
         // Skip recording if there's no new progress (right boundary not increasing).
-        if let Some(prev_end) = range_map.end() {
-            if right <= prev_end {
-                tracing::debug!(
-                    "LogStages::record_stage: skipping non-increasing boundary, stage={:?}, right={}, prev_end={}",
-                    stage,
-                    right,
-                    prev_end
-                );
-                return;
-            }
+        if let Some(prev_end) = range_map.end()
+            && right <= prev_end
+        {
+            tracing::debug!(
+                "LogStages::record_stage: skipping non-increasing boundary, stage={:?}, right={}, prev_end={}",
+                stage,
+                right,
+                prev_end
+            );
+            return;
         }
 
         if let Some(evicted) = range_map.record(right, value) {


### PR DESCRIPTION
In low-latency environments (e.g., in-memory simulated clusters), the same log index's lifecycle stage may be recorded multiple times in quick succession. This caused a panic in `RangeMap::record` due to its strict monotonicity assertion (`right_boundary > prev`).

The fix adds a defensive check in `LogStages::record_stage` to skip recording when there's no new progress (i.e., `right <= prev_end`), preventing the panic while maintaining correct statistics.

Fixes #1710

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1711)
<!-- Reviewable:end -->
