### PR TITLE
Fix: accept no-op re-snapshot at the same last_applied log id

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1393,10 +1393,10 @@ where
                         // In-memory state should always be ahead or equal to the io state.
 
                         let last_log_id = meta.last_log_id.clone();
-                        self.engine.finish_building_snapshot(meta);
-
-                        let st = self.engine.state.io_state_mut();
-                        st.update_snapshot(last_log_id);
+                        if self.engine.finish_building_snapshot(meta) {
+                            let st = self.engine.state.io_state_mut();
+                            st.update_snapshot(last_log_id);
+                        }
                     }
                     sm::Response::InstallSnapshot(meta) => {
                         tracing::info!(

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -545,8 +545,16 @@ where C: RaftTypeConfig
     /// This is all right because:
     /// - Engine only keeps the snapshot meta with the greatest last-log-id;
     /// - and a snapshot smaller than last-committed is not allowed to be installed.
+    ///
+    /// Returns `true` if the engine's snapshot state was actually advanced by `meta`.
+    /// Returns `false` when `meta` is not newer than the current snapshot (a duplicate
+    /// `Raft::trigger().snapshot()` at the same `last_applied` can produce this), in which
+    /// case the caller must not propagate `meta.last_log_id` to dependent state (e.g.
+    /// `IOState::snapshot`), since that cursor must advance strictly monotonically.
+    #[must_use = "caller must branch on whether the snapshot advanced before propagating \
+                  `meta.last_log_id` to dependent state such as `IOState::snapshot`"]
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn finish_building_snapshot(&mut self, meta: SnapshotMeta<C::NodeId, C::Node>) {
+    pub(crate) fn finish_building_snapshot(&mut self, meta: SnapshotMeta<C::NodeId, C::Node>) -> bool {
         tracing::info!(snapshot_meta = display(&meta), "{}", func_name!());
 
         self.state.io_state_mut().set_building_snapshot(false);
@@ -555,11 +563,12 @@ where C: RaftTypeConfig
 
         let updated = h.update_snapshot(meta);
         if !updated {
-            return;
+            return false;
         }
 
         self.log_handler().schedule_policy_based_purge();
         self.try_purge_log();
+        true
     }
 
     /// Try to purge logs up to the expected position.

--- a/tests/tests/snapshot_building/main.rs
+++ b/tests/tests/snapshot_building/main.rs
@@ -6,6 +6,7 @@
 mod fixtures;
 
 mod t10_build_snapshot;
+mod t11_trigger_snapshot_twice;
 mod t35_building_snapshot_does_not_block_append;
 mod t35_building_snapshot_does_not_block_apply;
 mod t60_snapshot_policy_never;

--- a/tests/tests/snapshot_building/t11_trigger_snapshot_twice.rs
+++ b/tests/tests/snapshot_building/t11_trigger_snapshot_twice.rs
@@ -1,0 +1,85 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::CommittedLeaderId;
+use openraft::Config;
+use openraft::LogId;
+
+use crate::fixtures::init_default_ut_tracing;
+use crate::fixtures::RaftRouter;
+
+/// Two back-to-back `Raft::trigger().snapshot()` calls targeting the same
+/// `last_applied` must not panic on the monotonic-advancement invariant of
+/// `IOState::update_snapshot`.
+///
+/// Regression for the path where:
+///
+/// 1. First trigger builds a snapshot at log id `X` and completes. The engine's `building_snapshot`
+///    flag is cleared and `IOState::snapshot` is updated to `X`.
+/// 2. A second trigger arrives before any new entry is applied. A new `BuildSnapshot` command is
+///    queued at the same `last_applied == X`.
+/// 3. When that second build completes, `SnapshotHandler::update_snapshot` correctly returns
+///    `false` (equal log id, no advancement), but `raft_core` previously called
+///    `IOState::update_snapshot(X)` unconditionally, tripping `debug_assert!(log_id >
+///    self.snapshot)` in debug builds.
+///
+/// With the fix, `raft_core` honors the `bool` returned by
+/// `Engine::finish_building_snapshot` and only updates the io-state snapshot
+/// cursor when the engine actually advanced.
+#[async_entry::test(worker_threads = 8, init = "init_default_ut_tracing()", tracing_span = "debug")]
+async fn trigger_snapshot_twice_at_same_last_applied() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_tick: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing single-node cluster");
+    let log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+
+    let snap_at = LogId::new(CommittedLeaderId::new(1, 0), log_index);
+
+    tracing::info!(log_index, "--- first trigger().snapshot(): build at {}", snap_at);
+    n0.trigger().snapshot().await?;
+    router.wait(&0, timeout()).snapshot(snap_at, "first snapshot built").await?;
+
+    tracing::info!(
+        log_index,
+        "--- second trigger().snapshot() at the same last_applied: must not panic"
+    );
+    n0.trigger().snapshot().await?;
+
+    // The second build produces the same snapshot meta, so the snapshot metric
+    // never changes. Wait a generous window for the second build to complete —
+    // if the regression is present, `IOState::update_snapshot` panics in the
+    // raft core task during this window.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Prove the raft core task is still alive: issue a client write and wait
+    // for it to be applied. A panicked core would leave this hanging until the
+    // test timeout.
+    tracing::info!(
+        log_index,
+        "--- client write after duplicate snapshot: proves raft core survived"
+    );
+    router.client_request_many(0, "after_dup_snap", 1).await?;
+    let log_index = log_index + 1;
+    router
+        .wait(&0, timeout())
+        .applied_index(Some(log_index), "client write applied after duplicate snapshot")
+        .await?;
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}


### PR DESCRIPTION
### Fix: accept no-op re-snapshot at the same last_applied log id

#### Summary

`IOState::update_snapshot` panics in debug builds when two back-to-back `Raft::trigger().snapshot()` calls land on the same `last_applied` without a new log entry being applied in between. The assertion `debug_assert!(log_id > self.snapshot)` fires with `current == update`, even though the state is already consistent and the update is a logical no-op. This PR relaxes the guard to allow an equal log id (early-return no-op) and keeps a `debug_assert_eq!` to still catch a real regression.

#### Root cause

In `openraft/src/raft_state/io_state.rs:101` (on `release-0.9`):

```rust
pub(crate) fn update_snapshot(&mut self, log_id: Option<LogId<NID>>) {
    tracing::debug!(snapshot = display(DisplayOption(&log_id)), "{}", func_name!());

    debug_assert!(
        log_id > self.snapshot,
        "snapshot log id should be monotonically increasing: current: {:?}, update: {:?}",
        self.snapshot,
        log_id
    );

    self.snapshot = log_id;
}
```

Call path that hits `log_id == self.snapshot`:

1. `Raft::trigger().snapshot()` posts a `BuildSnapshot` to the SM worker. The engine sets `io_state.building_snapshot = true`.
2. SM finishes. `raft_core` receives `sm::Response::BuildSnapshot(meta)` and calls `engine.finish_building_snapshot(meta)`, which clears `building_snapshot` and calls `SnapshotHandler::update_snapshot(meta)`. That handler already guards:
   ```rust
   if meta.last_log_id <= self.state.snapshot_last_log_id().cloned() {
       return false;
   }
   ```
   so it returns `true` only when the snapshot strictly advances.
3. `raft_core.rs` then calls `io_state.update_snapshot(last_log_id)` (unconditional of the handler's return value) — **this is where the panic fires**.
4. Meanwhile, a second `trigger().snapshot()` arrives after step 2 cleared `building_snapshot` but before any new log entry is applied. It queues another `BuildSnapshot` at the same `last_applied`.
5. When that second build finishes, step 3 runs again with `last_log_id == io_state.snapshot`, and the strict `>` guard panics.

Release builds strip the `debug_assert!` and perform a redundant `snapshot = snapshot` self-assignment, so this is debug-only, but it makes `debug_assertions = on` CI/test environments flaky for any application that triggers snapshots on a bursty workload.

#### Fix

```rust
if log_id <= self.snapshot {
    debug_assert_eq!(
        log_id, self.snapshot,
        "snapshot log id must not regress: current: {:?}, update: {:?}",
        self.snapshot, log_id
    );
    return;
}

self.snapshot = log_id;
```

- Equal log id → early return (no-op), matching what `SnapshotHandler::update_snapshot` already enforces at the caller side and what release builds already do in practice.
- A strictly regressing log id still trips the `debug_assert_eq!` — that would be a real invariant violation (the snapshot cursor going backward on the io-state side), so the safety check is preserved.

The change is structurally the same pattern as #1729 ("Fix: allow newer snapshot in `Inflight::Snapshot` ack"), where an overly strict `debug_assert_eq!` was relaxed to a `>=` check with an explanatory comment.

#### Testing

**Unit tests** (co-located in `openraft/src/raft_state/io_state.rs`):

- `update_snapshot_accepts_equal_log_id` — call `update_snapshot(id)` twice with the same id, assert no panic, final value equals `id`.
- `update_snapshot_advances_monotonically` — three strictly increasing ids advance `self.snapshot` each time.
- `update_snapshot_rejects_regressing_log_id` (`#[should_panic]`) — update to `index: 10`, then update to `index: 5`; the `debug_assert_eq!` fires as expected.

Local run:

```
running 3 tests
test raft_state::io_state::tests::update_snapshot_advances_monotonically ... ok
test raft_state::io_state::tests::update_snapshot_accepts_equal_log_id ... ok
test raft_state::io_state::tests::update_snapshot_rejects_regressing_log_id - should panic ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 182 filtered out
```

Full `cargo test --manifest-path openraft/Cargo.toml --lib`: **185 passed; 0 failed**. `cargo clippy --no-deps --manifest-path openraft/Cargo.toml --all-targets -- -D warnings` clean.

**External reproducer** — a 100-line single-node Raft + vendored memstore that calls `trigger().snapshot()` twice in quick succession on a burst of committed entries:

- `openraft = "=0.9.22"` (pristine): panics in ~2s every run (5/5), exit 134, with the exact message `snapshot log id should be monotonically increasing: current: Some(LogId { ... index: 6 }), update: Some(LogId { ... index: 6 })`.
- Same reproducer with `[patch.crates-io] openraft = { path = "..." }` pointed at this branch: prints `no panic (unexpected on debug build)` and exits 0.

The reproducer is available as a gist: https://gist.github.com/youichi-uda/fbf585dd60346b476981332b9ab8874c

#### Environment where this was first observed

- openraft `0.9.22`
- rustc `1.95.0` (stable)
- `aarch64-apple-darwin`
- 3-node controller integration test for a Kafka-compatible broker, calling `trigger().snapshot()` eagerly on every committed metadata command under burst load

I've already changed the application side to stop trigger-per-commit, so this doesn't block me downstream — but the upstream invariant violation seemed worth fixing so the next user who hits this doesn't spend hours bisecting.

#### Alternatives considered

1. **Dedup triggers in `SnapshotHandler::trigger_snapshot`** (skip a trigger if `snapshot_last_log_id == last_applied`). Would also avoid the panic, but tightens the semantics of `trigger().snapshot()` in a user-visible way (some callers may reasonably expect an idempotent re-build, e.g. for a fresh on-disk artifact) and needs a broader design discussion.
2. **Relax the io_state assertion** (this PR). Minimum sufficient change; preserves all current caller semantics; preserves the monotonic-non-regressing invariant that `IOState::snapshot` actually needs.
3. **Document the panic as user-facing contract and fix callers.** Would require auditing every caller of `trigger().snapshot()` across downstream crates and is strictly weaker than (2); the io_state `>` check was never part of the documented contract.

(2) is the smallest change that eliminates the panic without changing any caller-visible semantics. The stricter guard it replaces was redundant with the equality check already present one level up in `SnapshotHandler::update_snapshot`.

#### Targeting

This PR targets `release-0.9` since that is where the bug lives. On `main` and `release-0.10` the `IOState::update_snapshot` function has already been replaced by the `IOProgress`-based `snapshot` field with `try_update_all`, which handles the equal case safely by construction — so no forward-port is needed.

---

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- No user-facing API change; no guide update needed. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1733)
<!-- Reviewable:end -->
