### PR TITLE
change: make default backoff configurable via `Config::backoff`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ repository = "https://github.com/databendlabs/openraft"
 [workspace.dependencies]
 anyerror           = { version = "0.1.10" }
 anyhow             = { version = "1.0.63" }
+backoff-series     = { version = "0.1.1" }
 byte-unit          = { version = "5.1.4" }
 bytes              = { version = "1.0" }
 chrono             = { version = "0.4" }

--- a/examples/multi-raft-kv/src/network.rs
+++ b/examples/multi-raft-kv/src/network.rs
@@ -71,8 +71,8 @@ impl GroupRouter<TypeConfig, GroupId> for Router {
         self.send(target, &group_id, "/raft/transfer_leader", req).await.map_err(RPCError::Unreachable)
     }
 
-    fn backoff(&self) -> Backoff {
-        Backoff::new(std::iter::repeat(std::time::Duration::from_millis(500)))
+    fn backoff(&self) -> Option<Backoff> {
+        Some(Backoff::new(std::iter::repeat(std::time::Duration::from_millis(500))))
     }
 }
 

--- a/examples/raft-kv-memstore-grpc/src/network/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/network/mod.rs
@@ -206,8 +206,8 @@ impl NetSnapshot<TypeConfig> for NetworkConnection {
 }
 
 impl NetBackoff<TypeConfig> for NetworkConnection {
-    fn backoff(&self) -> Backoff {
-        Backoff::new(std::iter::repeat(Duration::from_millis(200)))
+    fn backoff(&self) -> Option<Backoff> {
+        Some(Backoff::new(std::iter::repeat(Duration::from_millis(200))))
     }
 }
 

--- a/legacy/src/network_v1/adapter.rs
+++ b/legacy/src/network_v1/adapter.rs
@@ -108,7 +108,7 @@ where
         Sender::<C>::send_snapshot(&mut self.network, vote, snapshot, cancel, option).await
     }
 
-    fn backoff(&self) -> Backoff {
-        RaftNetwork::<C>::backoff(&self.network)
+    fn backoff(&self) -> Option<Backoff> {
+        Some(RaftNetwork::<C>::backoff(&self.network))
     }
 }

--- a/multiraft/src/network.rs
+++ b/multiraft/src/network.rs
@@ -8,7 +8,6 @@
 //! See `examples/multi-raft-kv` for usage.
 
 use std::future::Future;
-use std::time::Duration;
 
 use openraft::OptionalSend;
 use openraft::OptionalSync;
@@ -81,9 +80,10 @@ where C: RaftTypeConfig
         }
     }
 
-    /// Backoff strategy for retries. Default: 500ms constant.
-    fn backoff(&self) -> Backoff {
-        Backoff::new(std::iter::repeat(Duration::from_millis(500)))
+    /// Backoff strategy for retries. Default: `None`, delegating to
+    /// [`Config::backoff`](openraft::Config::backoff).
+    fn backoff(&self) -> Option<Backoff> {
+        None
     }
 }
 
@@ -183,7 +183,7 @@ where
         self.router.transfer_leader(self.target.clone(), self.group_id.clone(), req, option).await
     }
 
-    fn backoff(&self) -> Backoff {
+    fn backoff(&self) -> Option<Backoff> {
         self.router.backoff()
     }
 }

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -21,6 +21,7 @@ openraft-macros = { path = "../macros", version = "0.10.0-alpha.18" }
 
 anyerror        = { workspace = true }
 anyhow          = { workspace = true, optional = true }
+backoff-series  = { workspace = true }
 base2histogram  = { workspace = true }
 byte-unit       = { workspace = true }
 chrono          = { workspace = true }

--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
 use anyerror::AnyError;
+use backoff_series::BackoffSeries;
 use clap::Parser;
 use openraft_macros::since;
 use rand::RngExt;
@@ -14,6 +15,7 @@ use crate::AsyncRuntime;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::config::error::ConfigError;
+use crate::network::Backoff;
 use crate::raft_state::LogStateReader;
 use crate::vote::RaftCommittedLeaderId;
 
@@ -319,6 +321,62 @@ pub struct Config {
     )]
     pub enable_elect: bool,
 
+    /// Default backoff policy used when
+    /// [`RaftNetworkV2::backoff`](crate::network::RaftNetworkV2::backoff) returns `None`.
+    ///
+    /// The string lists the first few retry delays explicitly. After those, the sequence
+    /// continues automatically — smoothly extended from **at most the last three explicit
+    /// delays** by either an exponential `k · aˣ + t` or linear `k · x + t` form, whichever
+    /// fits the tail. A trailing `..<max>` or `...<max>` caps every extrapolated delay at
+    /// `<max>` (defaults to `1000ms`).
+    ///
+    /// # Syntax
+    ///
+    /// `<dur>` values separated by `,` or whitespace; an optional `..` or `...` before the
+    /// last value marks it as the **max cap**. `<dur>` is a number with a unit suffix:
+    /// `ns`, `us`, `ms`, `s`, `m`, `h`.
+    ///
+    /// # Examples
+    ///
+    /// **Doubling from a single anchor** — this is the default, `"200ms"`:
+    ///
+    /// ```text
+    /// 200  400  800  1000  1000  1000  …    (ms; cap = 1000)
+    /// ```
+    ///
+    /// **Exponential growth**, `"100ms 200ms 400ms ...5s"`:
+    ///
+    /// ```text
+    /// 100  200  400  800  1600  3200  5000  5000  …    (ms; cap = 5000)
+    /// ```
+    ///
+    /// **Linear growth**, `"1ms 2ms 3ms ...1500ms"` — the tail has constant difference, so the
+    /// sequence continues that line until it hits the cap:
+    ///
+    /// ```text
+    /// 1  2  3  4  5  6  …  1499  1500  1500  1500  …    (ms; cap = 1500)
+    /// ```
+    ///
+    /// **Constant delay**, `"500ms 500ms 500ms"` — a flat tail stays flat:
+    ///
+    /// ```text
+    /// 500  500  500  500  …    (ms)
+    /// ```
+    ///
+    /// **Short warm-up, then extrapolate**, `"10ms 20ms ...2s"` — two anchors imply a doubling
+    /// rate, extended automatically:
+    ///
+    /// ```text
+    /// 10  20  40  80  160  320  640  1280  2000  2000  …    (ms; cap = 2000)
+    /// ```
+    ///
+    /// Because only the last few explicit delays shape what follows, you can prepend any
+    /// number of custom warm-up values without changing the long-run behavior.
+    ///
+    /// Since: 0.10.0
+    #[clap(long, default_value = "200ms")]
+    pub backoff: String,
+
     /// Whether to allow to reset the replication progress to `None`, when the
     /// follower's log is found reverted to an early state. **Do not enable this in production**
     /// unless you know what you are doing.
@@ -475,6 +533,19 @@ impl Config {
             return Err(ConfigError::MaxPayloadIs0);
         }
 
+        // Validate the backoff policy string up-front so build_backoff() can assume it parses.
+        BackoffSeries::parse(&self.backoff)?;
+
         Ok(self)
+    }
+
+    /// Build a [`Backoff`] iterator from the [`backoff`](Self::backoff) policy string.
+    ///
+    /// Panics if the policy is invalid — callers should obtain `Config` through [`Config::build`]
+    /// or [`Config::validate`], which reject invalid policies up-front.
+    #[since(version = "0.10.0")]
+    pub fn build_backoff(&self) -> Backoff {
+        let series = BackoffSeries::parse(&self.backoff).expect("backoff policy must be validated by Config::validate");
+        Backoff::new(series.build())
     }
 }

--- a/openraft/src/config/error.rs
+++ b/openraft/src/config/error.rs
@@ -1,4 +1,5 @@
 use anyerror::AnyError;
+use backoff_series::ParseError as BackoffParseError;
 
 /// Error variants related to configuration.
 #[derive(Debug, thiserror::Error)]
@@ -52,4 +53,12 @@ pub enum ConfigError {
         /// The reason for the parse failure.
         reason: String,
     },
+
+    /// Invalid backoff policy string.
+    ///
+    /// See [`backoff_series::BackoffSeries::parse`] for the expected format.
+    ///
+    /// Since: 0.10.0
+    #[error(transparent)]
+    InvalidBackoff(#[from] BackoffParseError),
 }

--- a/openraft/src/network/backoff_trait.rs
+++ b/openraft/src/network/backoff_trait.rs
@@ -1,5 +1,7 @@
 //! Defines the [`NetBackoff`] trait for network backoff behavior.
 
+use openraft_macros::since;
+
 use crate::OptionalSend;
 use crate::OptionalSync;
 use crate::RaftTypeConfig;
@@ -26,5 +28,12 @@ where C: RaftTypeConfig
     ///
     /// The backoff is an infinite iterator that returns the ith sleep interval before the ith
     /// retry. The returned instance will be dropped if a successful RPC is made.
-    fn backoff(&self) -> Backoff;
+    ///
+    /// Return `None` to use the default backoff configured in
+    /// [`Config::backoff`](crate::Config::backoff).
+    #[since(
+        version = "0.10.0",
+        change = "changed return type to Option<Backoff>; None delegates to Config::backoff"
+    )]
+    fn backoff(&self) -> Option<Backoff>;
 }

--- a/openraft/src/network/v2/network.rs
+++ b/openraft/src/network/v2/network.rs
@@ -1,5 +1,4 @@
 use std::future::Future;
-use std::time::Duration;
 
 use anyerror::AnyError;
 use futures_util::Stream;
@@ -159,9 +158,14 @@ where C: RaftTypeConfig
     /// The backoff is an infinite iterator that returns the ith sleep interval before the ith
     /// retry. The returned instance will be dropped if a successful RPC is made.
     ///
-    /// By default, it returns a constant backoff of 500 ms.
-    fn backoff(&self) -> Backoff {
-        Backoff::new(std::iter::repeat(Duration::from_millis(200)))
+    /// Return `None` (the default) to use the backoff configured in
+    /// [`Config::backoff`](crate::Config::backoff).
+    #[since(
+        version = "0.10.0",
+        change = "changed return type to Option<Backoff>; None delegates to Config::backoff"
+    )]
+    fn backoff(&self) -> Option<Backoff> {
+        None
     }
 }
 
@@ -199,7 +203,7 @@ where
     C: RaftTypeConfig,
     T: RaftNetworkV2<C> + ?Sized,
 {
-    fn backoff(&self) -> Backoff {
+    fn backoff(&self) -> Option<Backoff> {
         RaftNetworkV2::backoff(self)
     }
 }

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -213,7 +213,9 @@ where
 
             // Kept separate from `on_error` because only this scope holds a reference
             // to `network`, which is needed to construct the `Backoff` iterator.
-            self.backoff_state.reconcile(|| network.backoff());
+            // If the network returns None, fall back to the policy configured in `Config::backoff`.
+            let config = self.replication_context.config.clone();
+            self.backoff_state.reconcile(|| network.backoff().unwrap_or_else(|| config.build_backoff()));
 
             if self.next_action.is_none() {
                 self.drain_events().await?;

--- a/openraft/src/replication/snapshot_transmitter.rs
+++ b/openraft/src/replication/snapshot_transmitter.rs
@@ -141,7 +141,11 @@ where
                             // period of time. Backoff will be reset if there is a
                             // successful RPC is sent.
                             if self.backoff.is_none() {
-                                self.backoff = Some(self.network.backoff());
+                                self.backoff = Some(
+                                    self.network
+                                        .backoff()
+                                        .unwrap_or_else(|| self.replication_context.config.build_backoff()),
+                                );
                             }
                         }
                         RPCError::Timeout(_) | RPCError::Network(_) | RPCError::RemoteError(_) => {

--- a/tests/tests/snapshot_streaming/t90_issue_808_snapshot_to_unreachable_node_should_not_block.rs
+++ b/tests/tests/snapshot_streaming/t90_issue_808_snapshot_to_unreachable_node_should_not_block.rs
@@ -19,6 +19,10 @@ async fn snapshot_to_unreachable_node_should_not_block() -> Result<()> {
             max_in_snapshot_log_to_keep: 0,
             enable_heartbeat: false,
             enable_elect: false,
+            // Constant 10ms backoff: with two equal anchors the fit is `k · aˣ` with `a = 1`,
+            // so the sequence is `10ms, 10ms, …`. The default grows to a 1s cap, which is too
+            // slow for this test's 2s budget on loaded CI.
+            backoff: "10ms, 10ms".to_string(),
             ..Default::default()
         }
         .validate()?,


### PR DESCRIPTION

## Changelog

##### change: make default backoff configurable via `Config::backoff`
Previously, when a peer was unreachable and the application did not
override `RaftNetworkV2::backoff`, the library retried with a hardcoded
200 ms constant. There was no way to tune the default without
implementing the trait.

This change:

1. Adds `Config::backoff` (default `"200ms"`), a policy string parsed
   via the external `backoff-series` crate. The string lists the first
   retry delays explicitly and optionally sets a max cap; beyond the
   series, the sequence is extended by fitting the last anchors to an
   exponential `k·aˣ + t` or a linear `k·x + t` tail — whichever
   matches the shape of the tail.

2. Adds `Config::build_backoff()` returning a `Backoff` iterator built
   from the policy string. The string is validated in
   `Config::validate()` so `build_backoff()` is infallible.

3. Changes `RaftNetworkV2::backoff` (and `NetBackoff::backoff`) to
   return `Option<Backoff>`. `None` — the new default — delegates to
   `Config::backoff`; `Some(_)` lets an implementation override on a
   per-target basis.

The parser, iterator, and extrapolation logic live in `backoff-series`
(published separately on crates.io), so they are reusable outside
openraft and can evolve independently. The openraft side keeps only
the `Backoff` wrapper needed by the network trait plus the thin
adapters in `Config` and `ConfigError`.

Example:

    # default: double from 200ms, cap at 1000ms
    --backoff "200ms"

    # explicit series, extended to a 1500ms cap
    --backoff "1ms, 2ms, 3ms, ...1500ms"

    # two anchors imply doubling; capped at 2s
    --backoff "10ms 20ms ...2s"

Separators are `,` and/or whitespace; `..` or `...` marks the cap.

Upgrade tip:

If you implement `RaftNetworkV2::backoff`, change the return type from
`Backoff` to `Option<Backoff>` and wrap the existing value in `Some`:

    // before
    fn backoff(&self) -> Backoff {
        Backoff::new(std::iter::repeat(Duration::from_millis(500)))
    }

    // after
    fn backoff(&self) -> Option<Backoff> {
        Some(Backoff::new(std::iter::repeat(Duration::from_millis(500))))
    }

Return `None` to accept the configured `Config::backoff` default.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1734)
<!-- Reviewable:end -->
