### PR TITLE
feat: turmoil: crash window with crash + delayed bounce for real outages

### DIFF
--- a/openraft/src/core/raft_msg/raft_msg_name.rs
+++ b/openraft/src/core/raft_msg/raft_msg_name.rs
@@ -94,6 +94,7 @@ impl RaftMsgName {
     /// All variants in canonical order.
     ///
     /// ExternalCommand variants are expanded to include all ExternalCommandName variants.
+    #[allow(dead_code)]
     pub const ALL: &'static [RaftMsgName] = &[
         RaftMsgName::AppendEntries,
         RaftMsgName::RequestVote,

--- a/openraft/src/core/runtime_stats/runtime_stats_display.rs
+++ b/openraft/src/core/runtime_stats/runtime_stats_display.rs
@@ -86,6 +86,7 @@ where C: RaftTypeConfig
 impl<C> RuntimeStatsDisplay<C>
 where C: RaftTypeConfig
 {
+    #[allow(dead_code)]
     fn fmt_compact(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -157,6 +158,7 @@ where C: RaftTypeConfig
         write!(f, "}} }}")
     }
 
+    #[allow(dead_code)]
     fn fmt_multiline(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "RuntimeStats:")?;
         writeln!(f, "  apply_batch: {}", self.apply_batch)?;
@@ -215,6 +217,7 @@ where C: RaftTypeConfig
         Ok(())
     }
 
+    #[allow(dead_code)]
     #[cfg(feature = "runtime-stats")]
     fn fmt_human_readable(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Batch sizes table
@@ -393,6 +396,7 @@ where C: RaftTypeConfig
     }
 
     /// Fallback when tabled is not available.
+    #[allow(dead_code)]
     #[cfg(not(feature = "runtime-stats"))]
     fn fmt_human_readable(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_multiline(f)

--- a/openraft/src/engine/command_name.rs
+++ b/openraft/src/engine/command_name.rs
@@ -84,6 +84,7 @@ impl CommandName {
     /// All variants in canonical order.
     ///
     /// StateMachine variants are expanded to include all SMCommandName variants.
+    #[allow(dead_code)]
     pub const ALL: &'static [CommandName] = &[
         CommandName::UpdateIOProgress,
         CommandName::AppendEntries,

--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -340,18 +340,22 @@ async fn workload_loop(cluster_state: Arc<Mutex<ClusterState>>, seed: u64) -> Re
     }
 }
 
-fn step_until_quiescent(sim: &mut turmoil::Sim) -> Result<(), String> {
-    loop {
-        match sim.step() {
-            Ok(true) => continue,
-            Ok(false) => return Ok(()),
-            Err(e) => {
-                let msg = e.to_string();
-                return if msg.contains("duration") || msg.contains("without completing") {
-                    Err("Simulation duration reached".to_string())
-                } else {
-                    Err(format!("Simulation error: {e}"))
-                };
+/// Advance the simulation by one tick.
+///
+/// `Sim::step()` returns `Ok(true)` when all client hosts have exited. Our
+/// fuzz clients (`workload`, `membership-agent`, `chaos-agent`) run forever,
+/// so that case should be impossible; if it ever happens, the fuzz harness
+/// has lost its drivers and we must abort rather than keep spinning.
+fn step_tick(sim: &mut turmoil::Sim) -> Result<(), String> {
+    match sim.step() {
+        Ok(false) => Ok(()),
+        Ok(true) => Err("All fuzz clients exited unexpectedly".to_string()),
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("duration") || msg.contains("without completing") {
+                Err("Simulation duration reached".to_string())
+            } else {
+                Err(format!("Simulation error: {e}"))
             }
         }
     }
@@ -456,7 +460,7 @@ fn run_single_iteration(
             }
         }
 
-        if let Err(msg) = step_until_quiescent(&mut sim) {
+        if let Err(msg) = step_tick(&mut sim) {
             println!("{msg} at step {steps}");
             return FuzzResult {
                 steps_completed: steps,

--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -20,9 +20,10 @@ use rand::rngs::SmallRng;
 use rand::rngs::StdRng;
 use serde::Serialize;
 use tests_turmoil::cluster::ClusterState;
+use tests_turmoil::cluster::bounce_node;
+use tests_turmoil::cluster::crash_node;
 use tests_turmoil::cluster::host_name;
 use tests_turmoil::cluster::register_node_storage;
-use tests_turmoil::cluster::restart_node;
 use tests_turmoil::cluster::spawn_host;
 use tests_turmoil::invariants::InvariantChecker;
 use tests_turmoil::typ::*;
@@ -454,6 +455,11 @@ fn run_single_iteration(
     let mut next_node_id = (derived.num_initial_nodes as u64) + 1;
     let mut invariants = InvariantChecker::default();
 
+    // Pending bounces: (node_id, step_at_which_to_bounce). When a crash is
+    // triggered, we push an entry here and later bounce the node when the
+    // simulation reaches the scheduled step.
+    let mut pending_bounces: Vec<(NodeId, u64)> = Vec::new();
+
     println!("Starting simulation...");
 
     while running.load(Ordering::Relaxed) && steps < max_steps {
@@ -475,12 +481,34 @@ fn run_single_iteration(
             }
         }
 
-        // Crash restarts
+        // Bounce any nodes whose crash window has expired.
+        pending_bounces.retain(|(id, bounce_at)| {
+            if steps >= *bounce_at {
+                bounce_node(&mut sim, *id);
+                false
+            } else {
+                true
+            }
+        });
+
+        // Crash a random voter for a bounded downtime, then schedule its
+        // bounce. We pick the window to straddle `election_timeout_max` so
+        // the fuzz mixes "short outage, no re-election" with "long outage,
+        // leader churn / quorum loss".
         if steps > 0 && steps.is_multiple_of(derived.chaos_interval) && chaos_rng.gen_bool(derived.restart_chance) {
-            let voters: Vec<_> = active_voters.iter().collect();
-            if !voters.is_empty() {
-                let victim = **voters.get(chaos_rng.gen_range(0..voters.len())).unwrap();
-                restart_node(&mut sim, victim);
+            let crashable: Vec<_> =
+                active_voters.iter().copied().filter(|id| !pending_bounces.iter().any(|(p, _)| p == id)).collect();
+            if !crashable.is_empty() {
+                let victim = crashable[chaos_rng.gen_range(0..crashable.len())];
+                let min_downtime = derived.election_timeout_max / 2;
+                let max_downtime = derived.election_timeout_max * 2;
+                let downtime = chaos_rng.gen_range(min_downtime..=max_downtime);
+                crash_node(&mut sim, victim);
+                pending_bounces.push((victim, steps + downtime));
+                println!(
+                    "CRASH: node {victim} for {downtime} ticks (bounce at step {})",
+                    steps + downtime
+                );
             }
         }
 

--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -300,6 +300,7 @@ async fn chaos_agent_loop(seed: u64, max_nodes: u64) -> Result<(), Box<dyn std::
 async fn membership_agent_loop(
     cluster_state: Arc<Mutex<ClusterState>>,
     next_membership: Arc<Mutex<Option<HashSet<NodeId>>>>,
+    potential_nodes: BTreeMap<NodeId, Node>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     loop {
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -309,14 +310,25 @@ async fn membership_agent_loop(
         };
 
         let leader = cluster_state.lock().unwrap().find_leader();
-        if let Some(raft) = leader {
-            println!("MEMBERSHIP-AGENT: executing change to {new_set:?}");
-            let _ = raft.change_membership(new_set, false).await;
-        } else {
+        let Some(raft) = leader else {
             // No leader found; put the membership change back for retry.
             next_membership.lock().unwrap().get_or_insert(new_set);
             tokio::time::sleep(Duration::from_millis(500)).await;
+            continue;
+        };
+
+        // openraft requires a node to be a learner before promotion to voter.
+        // Add each target as learner; ignore "already known" errors — we do
+        // not track membership here and prefer idempotent retries.
+        for id in &new_set {
+            let Some(node) = potential_nodes.get(id).cloned() else {
+                continue;
+            };
+            let _ = raft.add_learner(*id, node, true).await;
         }
+
+        println!("MEMBERSHIP-AGENT: executing change to {new_set:?}");
+        let _ = raft.change_membership(new_set, false).await;
     }
 }
 
@@ -385,12 +397,24 @@ fn run_single_iteration(
     let cluster_state = Arc::new(Mutex::new(ClusterState::new()));
     let next_membership = Arc::new(Mutex::new(None::<HashSet<NodeId>>));
 
-    let all_nodes: BTreeMap<_, _> = (1..=derived.max_potential_nodes)
+    // Potential cluster members: every host we spawn has an entry here so the
+    // membership agent can construct a `Node` when adding a new learner.
+    let potential_nodes: BTreeMap<NodeId, Node> = (1..=derived.max_potential_nodes)
         .map(|id| {
             (id, Node {
                 addr: format!("{}:9000", host_name(id)),
             })
         })
+        .collect();
+
+    // Initial cluster members: only these are passed to `raft.initialize()` so
+    // the bootstrap membership matches `num_initial_nodes`. Non-initial hosts
+    // still come up, run uninitialized, and join later via add_learner +
+    // change_membership.
+    let initial_nodes: BTreeMap<NodeId, Node> = potential_nodes
+        .iter()
+        .take(derived.num_initial_nodes)
+        .map(|(id, node)| (*id, node.clone()))
         .collect();
 
     for id in 1..=derived.max_potential_nodes {
@@ -401,7 +425,7 @@ fn run_single_iteration(
             raft_config.clone(),
             cluster_state.clone(),
             iteration_seed,
-            all_nodes.clone(),
+            initial_nodes.clone(),
         );
     }
 
@@ -413,7 +437,7 @@ fn run_single_iteration(
     }
     sim.client(
         "membership-agent",
-        membership_agent_loop(cluster_state.clone(), next_membership.clone()),
+        membership_agent_loop(cluster_state.clone(), next_membership.clone(), potential_nodes.clone()),
     );
     sim.client(
         "workload",

--- a/tests-turmoil/src/cluster.rs
+++ b/tests-turmoil/src/cluster.rs
@@ -97,12 +97,12 @@ pub fn spawn_host(
     raft_config: Arc<openraft::Config>,
     cluster_state: Arc<std::sync::Mutex<ClusterState>>,
     seed: u64,
-    all_nodes: BTreeMap<NodeId, Node>,
+    initial_nodes: BTreeMap<NodeId, Node>,
 ) {
     let host_name = host_name(node_id);
     sim.host(host_name, move || {
         let raft_config = raft_config.clone();
-        let all_nodes = all_nodes.clone();
+        let initial_nodes = initial_nodes.clone();
         let cluster_state = cluster_state.clone();
         let node_seed = seed.wrapping_add(node_id);
 
@@ -137,7 +137,7 @@ pub fn spawn_host(
                         if !is_initialized {
                             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                             tracing::info!("Initializing cluster on node {}", node_id);
-                            raft.initialize(all_nodes.clone()).await.expect("Failed to initialize");
+                            raft.initialize(initial_nodes.clone()).await.expect("Failed to initialize");
                         }
                     }
 

--- a/tests-turmoil/src/cluster.rs
+++ b/tests-turmoil/src/cluster.rs
@@ -163,9 +163,21 @@ pub fn spawn_host(
     });
 }
 
-/// Restart a node by bouncing it.
-pub fn restart_node(sim: &mut Sim, node_id: NodeId) {
+/// Crash a node's software; it will stay down until `bounce_node` is called.
+///
+/// Use this together with a delayed `bounce_node` to model a downtime window
+/// — `sim.bounce()` alone is an instant restart that only exercises the
+/// software-restart / persistence-recovery path, not the "node unreachable
+/// long enough to lose quorum" case.
+pub fn crash_node(sim: &mut Sim, node_id: NodeId) {
     let host_name = host_name(node_id);
-    tracing::info!("RESTART: bouncing {}", host_name);
+    tracing::info!("CRASH: {}", host_name);
+    sim.crash(host_name);
+}
+
+/// Restart a previously crashed node's software.
+pub fn bounce_node(sim: &mut Sim, node_id: NodeId) {
+    let host_name = host_name(node_id);
+    tracing::info!("BOUNCE: {}", host_name);
     sim.bounce(host_name);
 }


### PR DESCRIPTION

## Changelog

##### feat: turmoil: crash window with crash + delayed bounce for real outages
The previous `restart_node` was an instant `sim.bounce()`, which only
exercises software restart / persistence recovery. It does not model
a node being unreachable long enough to cause leader churn or quorum
loss.

Split into `crash_node` and `bounce_node`. The fuzz loop tracks
`pending_bounces: Vec<(NodeId, u64)>` and bounces each entry when the
simulation reaches its scheduled step. Downtime is drawn from
`[election_timeout_max/2, election_timeout_max*2]` so the window
straddles the election timeout: the fuzz mixes short outages that
don't trigger re-election with long outages that force it.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


##### fix: turmoil: bootstrap with num_initial_nodes; add_learner on join
The fuzzer reported "initial 3-5 nodes" but actually initialized the
cluster with all 10 potential nodes, because `raft.initialize()`
received `max_potential_nodes`. The first "add node N" membership
change then implicitly *removed* nodes N+1..=10 instead of growing the
cluster.

Split the node map in two: `potential_nodes` (full 1..=10, used by
the membership agent to construct `Node` for `add_learner`), and
`initial_nodes` (only 1..=num_initial_nodes, passed to `initialize()`).

Non-initial hosts are still spawned but stay uninitialized until the
membership agent joins them via `add_learner` + `change_membership`,
which matches how openraft requires new voters to be promoted.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


##### fix: turmoil: step_tick uses correct Sim::step() semantics
`Sim::step()` returns `Ok(true)` when all client hosts have completed
and `Ok(false)` while work remains. The previous `step_until_quiescent`
had the two branches inverted, treating "all done" as "keep stepping"
and "still busy" as "quiescent". With three infinite-loop fuzz clients
(workload, membership-agent, chaos-agent), `Ok(true)` can never happen,
so the outer loop was advancing exactly one tick per iteration despite
the name promising a drain-to-idle.

Rename to `step_tick` and make the semantics explicit: one tick per
call, and treat `Ok(true)` as a hard error since it means the fuzz
harness has lost its drivers.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1736)
<!-- Reviewable:end -->
