### PR TITLE
test: detsim: Drop stale raft handles on crash

### DIFF
--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -503,7 +503,7 @@ fn run_single_iteration(
                 let min_downtime = derived.election_timeout_max / 2;
                 let max_downtime = derived.election_timeout_max * 2;
                 let downtime = chaos_rng.gen_range(min_downtime..=max_downtime);
-                crash_node(&mut sim, victim);
+                crash_node(&mut sim, victim, &cluster_state);
                 pending_bounces.push((victim, steps + downtime));
                 println!(
                     "CRASH: node {victim} for {downtime} ticks (bounce at step {})",

--- a/tests-turmoil/src/cluster.rs
+++ b/tests-turmoil/src/cluster.rs
@@ -22,7 +22,12 @@ pub fn host_name(id: NodeId) -> String {
 
 /// Shared state for observing nodes from outside the simulation.
 pub struct ClusterState {
-    /// Raft instances for each node (keyed by node ID).
+    /// Live Raft instances for each node (keyed by node ID).
+    ///
+    /// A crashed host's handle is removed from this map so external observers
+    /// and simulated clients do not keep treating its last metrics snapshot as
+    /// live state. When the host is bounced, `spawn_host()` recreates the Raft
+    /// instance and re-inserts it.
     pub rafts: BTreeMap<NodeId, Arc<Raft>>,
     /// Log stores for each node.
     pub log_stores: BTreeMap<NodeId, Arc<LogStore>>,
@@ -71,6 +76,16 @@ impl ClusterState {
     /// Find a Raft node that is currently the leader.
     pub fn find_leader(&self) -> Option<Arc<Raft>> {
         self.rafts.values().find(|raft| raft.metrics().borrow_watched().state.is_leader()).cloned()
+    }
+
+    /// Register a freshly started Raft instance as live.
+    pub fn register_raft(&mut self, node_id: NodeId, raft: Arc<Raft>) {
+        self.rafts.insert(node_id, raft);
+    }
+
+    /// Drop the live handle for a crashed node.
+    pub fn unregister_raft(&mut self, node_id: NodeId) {
+        self.rafts.remove(&node_id);
     }
 }
 
@@ -126,7 +141,7 @@ pub fn spawn_host(
 
                     let raft = Arc::new(raft);
 
-                    cluster_state.lock().unwrap().rafts.insert(node_id, raft.clone());
+                    cluster_state.lock().unwrap().register_raft(node_id, raft.clone());
 
                     // Node 1 initializes if needed
                     if node_id == 1 {
@@ -169,10 +184,11 @@ pub fn spawn_host(
 /// — `sim.bounce()` alone is an instant restart that only exercises the
 /// software-restart / persistence-recovery path, not the "node unreachable
 /// long enough to lose quorum" case.
-pub fn crash_node(sim: &mut Sim, node_id: NodeId) {
+pub fn crash_node(sim: &mut Sim, node_id: NodeId, cluster_state: &Arc<std::sync::Mutex<ClusterState>>) {
     let host_name = host_name(node_id);
     tracing::info!("CRASH: {}", host_name);
     sim.crash(host_name);
+    cluster_state.lock().unwrap().unregister_raft(node_id);
 }
 
 /// Restart a previously crashed node's software.


### PR DESCRIPTION

## Changelog

##### test: detsim: Drop stale raft handles on crash

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1737)
<!-- Reviewable:end -->
