### PR TITLE
test: turmoil: route openraft RNG and spawn through DeterministicRng

### DIFF
--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -5,7 +5,7 @@
 //!   Reproduce mode: fuzz --reproduce <ITERATION_SEED> --max-steps <N> [--crash-file <PATH>]
 
 use std::collections::BTreeMap;
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fs;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -340,7 +340,7 @@ async fn chaos_agent_loop(
                 let minority_size = rng.gen_range(1..=max_nodes / 2);
                 let mut all: Vec<u64> = (1..=max_nodes).collect();
                 all.shuffle(&mut rng);
-                let minority: std::collections::HashSet<u64> = all.into_iter().take(minority_size as usize).collect();
+                let minority: BTreeSet<u64> = all.into_iter().take(minority_size as usize).collect();
                 for &a in &minority {
                     for b in 1..=max_nodes {
                         if !minority.contains(&b) {
@@ -367,7 +367,7 @@ async fn chaos_agent_loop(
                 };
                 let mut others: Vec<u64> = (1..=max_nodes).filter(|n| *n != leader_id).collect();
                 others.shuffle(&mut rng);
-                let mut minority: std::collections::HashSet<u64> = others.into_iter().take(extra as usize).collect();
+                let mut minority: BTreeSet<u64> = others.into_iter().take(extra as usize).collect();
                 minority.insert(leader_id);
                 for &a in &minority {
                     for b in 1..=max_nodes {
@@ -384,7 +384,7 @@ async fn chaos_agent_loop(
 
 async fn membership_agent_loop(
     cluster_state: Arc<Mutex<ClusterState>>,
-    next_membership: Arc<Mutex<Option<HashSet<NodeId>>>>,
+    next_membership: Arc<Mutex<Option<BTreeSet<NodeId>>>>,
     potential_nodes: BTreeMap<NodeId, Node>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     loop {
@@ -483,7 +483,7 @@ fn run_single_iteration(
     });
 
     let cluster_state = Arc::new(Mutex::new(ClusterState::new()));
-    let next_membership = Arc::new(Mutex::new(None::<HashSet<NodeId>>));
+    let next_membership = Arc::new(Mutex::new(None::<BTreeSet<NodeId>>));
 
     // Potential cluster members: every host we spawn has an entry here so the
     // membership agent can construct a `Node` when adding a new learner.
@@ -542,7 +542,7 @@ fn run_single_iteration(
     let mut violations: Vec<String> = Vec::new();
     let mut chaos_rng = StdRng::seed_from_u64(iteration_seed.wrapping_add(3000));
     let mut member_rng = StdRng::seed_from_u64(iteration_seed.wrapping_add(5000));
-    let mut active_voters: HashSet<NodeId> = (1..=derived.num_initial_nodes as u64).collect();
+    let mut active_voters: BTreeSet<NodeId> = (1..=derived.num_initial_nodes as u64).collect();
     let mut next_node_id = (derived.num_initial_nodes as u64) + 1;
     let mut invariants = InvariantChecker::default();
 
@@ -565,7 +565,8 @@ fn run_single_iteration(
                     *next_membership.lock().unwrap() = Some(active_voters.clone());
                 }
             } else if active_voters.len() > 3 {
-                let victim = *active_voters.iter().next().unwrap();
+                let voters: Vec<NodeId> = active_voters.iter().copied().collect();
+                let victim = voters[member_rng.gen_range(0..voters.len())];
                 println!("MEMBERSHIP: Requesting remove node {victim}...");
                 active_voters.remove(&victim);
                 *next_membership.lock().unwrap() = Some(active_voters.clone());
@@ -585,13 +586,11 @@ fn run_single_iteration(
         // Crash a random voter and schedule its bounce after a downtime
         // window. Two flavors:
         //
-        // - Short outage (majority case): window straddles
-        //   `election_timeout_max`, mixing "no re-election" with "leader
-        //   churn / quorum loss" on restart.
-        // - Long outage (rare, `long_outage_chance`): 5k-15k ticks, so
-        //   the crashed node falls behind by more than
-        //   `replication_lag_threshold` and must receive a snapshot
-        //   install instead of log shipping when it rejoins.
+        // - Short outage (majority case): window straddles `election_timeout_max`, mixing "no re-election"
+        //   with "leader churn / quorum loss" on restart.
+        // - Long outage (rare, `long_outage_chance`): 5k-15k ticks, so the crashed node falls behind by
+        //   more than `replication_lag_threshold` and must receive a snapshot install instead of log
+        //   shipping when it rejoins.
         if steps > 0 && steps.is_multiple_of(derived.chaos_interval) && chaos_rng.gen_bool(derived.restart_chance) {
             let crashable: Vec<_> =
                 active_voters.iter().copied().filter(|id| !pending_bounces.iter().any(|(p, _)| p == id)).collect();
@@ -608,7 +607,10 @@ fn run_single_iteration(
                 crash_node(&mut sim, victim, &cluster_state);
                 pending_bounces.push((victim, steps + downtime));
                 let kind = if is_long_outage { "CRASH(long)" } else { "CRASH" };
-                println!("{kind}: node {victim} for {downtime} ticks (bounce at step {})", steps + downtime);
+                println!(
+                    "{kind}: node {victim} for {downtime} ticks (bounce at step {})",
+                    steps + downtime
+                );
             }
         }
 

--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -49,6 +49,14 @@ struct DerivedConfig {
     /// Switch a follower from log-shipping to snapshot install when it
     /// falls this far behind the leader. Must exceed `snapshot_logs_threshold`.
     replication_lag_threshold: u64,
+    /// Probability a crash becomes a long outage instead of a short bounce.
+    /// Long outages let the follower fall far enough behind to require
+    /// snapshot install when it rejoins.
+    long_outage_chance: f64,
+    /// Minimum downtime (in ticks) for a long outage.
+    long_outage_min_ticks: u64,
+    /// Maximum downtime (in ticks) for a long outage.
+    long_outage_max_ticks: u64,
 }
 
 impl DerivedConfig {
@@ -71,6 +79,9 @@ impl DerivedConfig {
             snapshot_logs_threshold,
             max_in_snapshot_log_to_keep: rng.gen_range(30..=80),
             replication_lag_threshold: snapshot_logs_threshold * 2,
+            long_outage_chance: rng.gen_range(0.1..=0.3), // 10-30% of crashes
+            long_outage_min_ticks: 5000,
+            long_outage_max_ticks: 15000,
         }
     }
 }
@@ -90,7 +101,10 @@ impl std::fmt::Display for DerivedConfig {
         writeln!(f, "  membership_interval: {}", self.membership_interval)?;
         writeln!(f, "  snapshot_logs_threshold: {}", self.snapshot_logs_threshold)?;
         writeln!(f, "  max_in_snapshot_log_to_keep: {}", self.max_in_snapshot_log_to_keep)?;
-        write!(f, "  replication_lag_threshold: {}", self.replication_lag_threshold)
+        writeln!(f, "  replication_lag_threshold: {}", self.replication_lag_threshold)?;
+        writeln!(f, "  long_outage_chance: {:.4}", self.long_outage_chance)?;
+        writeln!(f, "  long_outage_min_ticks: {}", self.long_outage_min_ticks)?;
+        write!(f, "  long_outage_max_ticks: {}", self.long_outage_max_ticks)
     }
 }
 
@@ -510,24 +524,33 @@ fn run_single_iteration(
             }
         });
 
-        // Crash a random voter for a bounded downtime, then schedule its
-        // bounce. We pick the window to straddle `election_timeout_max` so
-        // the fuzz mixes "short outage, no re-election" with "long outage,
-        // leader churn / quorum loss".
+        // Crash a random voter and schedule its bounce after a downtime
+        // window. Two flavors:
+        //
+        // - Short outage (majority case): window straddles
+        //   `election_timeout_max`, mixing "no re-election" with "leader
+        //   churn / quorum loss" on restart.
+        // - Long outage (rare, `long_outage_chance`): 5k-15k ticks, so
+        //   the crashed node falls behind by more than
+        //   `replication_lag_threshold` and must receive a snapshot
+        //   install instead of log shipping when it rejoins.
         if steps > 0 && steps.is_multiple_of(derived.chaos_interval) && chaos_rng.gen_bool(derived.restart_chance) {
             let crashable: Vec<_> =
                 active_voters.iter().copied().filter(|id| !pending_bounces.iter().any(|(p, _)| p == id)).collect();
             if !crashable.is_empty() {
                 let victim = crashable[chaos_rng.gen_range(0..crashable.len())];
-                let min_downtime = derived.election_timeout_max / 2;
-                let max_downtime = derived.election_timeout_max * 2;
-                let downtime = chaos_rng.gen_range(min_downtime..=max_downtime);
+                let is_long_outage = chaos_rng.gen_bool(derived.long_outage_chance);
+                let downtime = if is_long_outage {
+                    chaos_rng.gen_range(derived.long_outage_min_ticks..=derived.long_outage_max_ticks)
+                } else {
+                    let min_downtime = derived.election_timeout_max / 2;
+                    let max_downtime = derived.election_timeout_max * 2;
+                    chaos_rng.gen_range(min_downtime..=max_downtime)
+                };
                 crash_node(&mut sim, victim, &cluster_state);
                 pending_bounces.push((victim, steps + downtime));
-                println!(
-                    "CRASH: node {victim} for {downtime} ticks (bounce at step {})",
-                    steps + downtime
-                );
+                let kind = if is_long_outage { "CRASH(long)" } else { "CRASH" };
+                println!("{kind}: node {victim} for {downtime} ticks (bounce at step {})", steps + downtime);
             }
         }
 

--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -18,6 +18,7 @@ use rand::Rng;
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
 use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
 use serde::Serialize;
 use tests_turmoil::cluster::ClusterState;
 use tests_turmoil::cluster::bounce_node;
@@ -286,12 +287,18 @@ fn run_fuzz_loop(base_seed: u64, max_steps: u64, iterations: u64, crash_file: Op
     println!("Status: PASSED");
 }
 
-async fn chaos_agent_loop(seed: u64, max_nodes: u64) -> Result<(), Box<dyn std::error::Error>> {
+async fn chaos_agent_loop(
+    seed: u64,
+    max_nodes: u64,
+    cluster_state: Arc<Mutex<ClusterState>>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut rng = StdRng::seed_from_u64(seed);
     loop {
         tokio::time::sleep(Duration::from_millis(rng.gen_range(1000..5000))).await;
-        match rng.gen_range(0..5) {
+        match rng.gen_range(0..6) {
             0 => {
+                // Single-node isolation: one node unreachable from all others.
+                // Does not threaten quorum in 3+ clusters on its own.
                 let victim = rng.gen_range(1..=max_nodes);
                 for i in 1..=max_nodes {
                     if i != victim {
@@ -300,6 +307,7 @@ async fn chaos_agent_loop(seed: u64, max_nodes: u64) -> Result<(), Box<dyn std::
                 }
             }
             1 => {
+                // Global repair: undo all partitions.
                 for i in 1..=max_nodes {
                     for j in (i + 1)..=max_nodes {
                         turmoil::repair(host_name(i), host_name(j));
@@ -307,6 +315,7 @@ async fn chaos_agent_loop(seed: u64, max_nodes: u64) -> Result<(), Box<dyn std::
                 }
             }
             2 => {
+                // One-way hold on a single pair (delivers later).
                 let a = rng.gen_range(1..=max_nodes);
                 let mut b = rng.gen_range(1..=max_nodes);
                 while b == a {
@@ -315,6 +324,7 @@ async fn chaos_agent_loop(seed: u64, max_nodes: u64) -> Result<(), Box<dyn std::
                 turmoil::hold(host_name(a), host_name(b));
             }
             3 => {
+                // Global release: flush all held messages.
                 for i in 1..=max_nodes {
                     for j in 1..=max_nodes {
                         if i != j {
@@ -323,7 +333,51 @@ async fn chaos_agent_loop(seed: u64, max_nodes: u64) -> Result<(), Box<dyn std::
                     }
                 }
             }
-            _ => {} // no-op: let system stabilize
+            4 => {
+                // Minority partition: split the cluster into a minority side
+                // (size 1..=max_nodes/2) vs the rest. The majority side
+                // retains quorum; the minority cannot commit until repaired.
+                let minority_size = rng.gen_range(1..=max_nodes / 2);
+                let mut all: Vec<u64> = (1..=max_nodes).collect();
+                all.shuffle(&mut rng);
+                let minority: std::collections::HashSet<u64> = all.into_iter().take(minority_size as usize).collect();
+                for &a in &minority {
+                    for b in 1..=max_nodes {
+                        if !minority.contains(&b) {
+                            turmoil::partition(host_name(a), host_name(b));
+                        }
+                    }
+                }
+            }
+            5 => {
+                // Leader-in-minority partition: isolate the current leader
+                // together with a random subset of peers on the minority side,
+                // forcing the majority to re-elect while the old leader may
+                // still believe it leads — this is where stale-leader bugs
+                // and dueling-term scenarios live.
+                let Some(leader_id) = cluster_state.lock().unwrap().find_leader_id() else {
+                    continue;
+                };
+                let majority_needed = (max_nodes / 2) + 1;
+                // Leader plus 0..=(max_nodes - majority_needed) peers → minority.
+                let extra = if max_nodes > majority_needed {
+                    rng.gen_range(0..=(max_nodes - majority_needed))
+                } else {
+                    0
+                };
+                let mut others: Vec<u64> = (1..=max_nodes).filter(|n| *n != leader_id).collect();
+                others.shuffle(&mut rng);
+                let mut minority: std::collections::HashSet<u64> = others.into_iter().take(extra as usize).collect();
+                minority.insert(leader_id);
+                for &a in &minority {
+                    for b in 1..=max_nodes {
+                        if !minority.contains(&b) {
+                            turmoil::partition(host_name(a), host_name(b));
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
         }
     }
 }
@@ -466,7 +520,11 @@ fn run_single_iteration(
     if derived.enable_chaos {
         sim.client(
             "chaos-agent",
-            chaos_agent_loop(iteration_seed.wrapping_add(1000), derived.max_potential_nodes),
+            chaos_agent_loop(
+                iteration_seed.wrapping_add(1000),
+                derived.max_potential_nodes,
+                cluster_state.clone(),
+            ),
         );
     }
     sim.client(

--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -40,6 +40,15 @@ struct DerivedConfig {
     restart_chance: f64,
     chaos_interval: u64,
     membership_interval: u64,
+    /// Take a snapshot after this many new committed logs.
+    snapshot_logs_threshold: u64,
+    /// Keep at most this many applied logs around after a snapshot.
+    /// Smaller = more aggressive purging = snapshot install is more likely
+    /// when a lagging follower returns.
+    max_in_snapshot_log_to_keep: u64,
+    /// Switch a follower from log-shipping to snapshot install when it
+    /// falls this far behind the leader. Must exceed `snapshot_logs_threshold`.
+    replication_lag_threshold: u64,
 }
 
 impl DerivedConfig {
@@ -47,6 +56,7 @@ impl DerivedConfig {
         let mut rng = StdRng::seed_from_u64(seed);
         let heartbeat_interval = 50 + rng.gen_range(0..100);
         let election_timeout_min = heartbeat_interval * rng.gen_range(2..4);
+        let snapshot_logs_threshold = rng.gen_range(100..=250);
         Self {
             num_initial_nodes: 3 + rng.gen_range(0..3), // 3-5
             max_potential_nodes: 10,
@@ -58,6 +68,9 @@ impl DerivedConfig {
             restart_chance: rng.gen_range(0.01..0.05), // 1-5%
             chaos_interval: rng.gen_range(2000..5000),
             membership_interval: rng.gen_range(10000..25000),
+            snapshot_logs_threshold,
+            max_in_snapshot_log_to_keep: rng.gen_range(30..=80),
+            replication_lag_threshold: snapshot_logs_threshold * 2,
         }
     }
 }
@@ -74,7 +87,10 @@ impl std::fmt::Display for DerivedConfig {
         writeln!(f, "  enable_chaos: {}", self.enable_chaos)?;
         writeln!(f, "  restart_chance: {:.4}", self.restart_chance)?;
         writeln!(f, "  chaos_interval: {}", self.chaos_interval)?;
-        write!(f, "  membership_interval: {}", self.membership_interval)
+        writeln!(f, "  membership_interval: {}", self.membership_interval)?;
+        writeln!(f, "  snapshot_logs_threshold: {}", self.snapshot_logs_threshold)?;
+        writeln!(f, "  max_in_snapshot_log_to_keep: {}", self.max_in_snapshot_log_to_keep)?;
+        write!(f, "  replication_lag_threshold: {}", self.replication_lag_threshold)
     }
 }
 
@@ -392,6 +408,9 @@ fn run_single_iteration(
         heartbeat_interval: derived.heartbeat_interval,
         election_timeout_min: derived.election_timeout_min,
         election_timeout_max: derived.election_timeout_max,
+        snapshot_policy: openraft::SnapshotPolicy::LogsSinceLast(derived.snapshot_logs_threshold),
+        max_in_snapshot_log_to_keep: derived.max_in_snapshot_log_to_keep,
+        replication_lag_threshold: derived.replication_lag_threshold,
         ..Default::default()
     });
 

--- a/tests-turmoil/src/cluster.rs
+++ b/tests-turmoil/src/cluster.rs
@@ -80,7 +80,10 @@ impl ClusterState {
 
     /// Return the node id of the current leader, if any.
     pub fn find_leader_id(&self) -> Option<NodeId> {
-        self.rafts.iter().find(|(_, raft)| raft.metrics().borrow_watched().state.is_leader()).map(|(id, _)| *id)
+        self.rafts
+            .iter()
+            .find(|(_, raft)| raft.metrics().borrow_watched().state.is_leader())
+            .map(|(id, _)| *id)
     }
 
     /// Register a freshly started Raft instance as live.

--- a/tests-turmoil/src/cluster.rs
+++ b/tests-turmoil/src/cluster.rs
@@ -78,6 +78,11 @@ impl ClusterState {
         self.rafts.values().find(|raft| raft.metrics().borrow_watched().state.is_leader()).cloned()
     }
 
+    /// Return the node id of the current leader, if any.
+    pub fn find_leader_id(&self) -> Option<NodeId> {
+        self.rafts.iter().find(|(_, raft)| raft.metrics().borrow_watched().state.is_leader()).map(|(id, _)| *id)
+    }
+
     /// Register a freshly started Raft instance as live.
     pub fn register_raft(&mut self, node_id: NodeId, raft: Arc<Raft>) {
         self.rafts.insert(node_id, raft);

--- a/tests-turmoil/src/typ.rs
+++ b/tests-turmoil/src/typ.rs
@@ -49,6 +49,7 @@ openraft::declare_raft_types!(
         D = Request,
         R = Response,
         Node = Node,
+        AsyncRuntime = openraft_rt::deterministic_rng::DeterministicRng<openraft_rt_tokio::TokioRuntime>,
 );
 
 pub type Raft = openraft::Raft<TypeConfig, std::sync::Arc<crate::store::StateMachine>>;


### PR DESCRIPTION

## Changelog

##### test: turmoil: route openraft RNG and spawn through DeterministicRng
Override `AsyncRuntime` in the test's `TypeConfig` so openraft's
internal randomness honors the per-host deterministic seed already
set up by `cluster.rs`.

`declare_raft_types!` defaults `AsyncRuntime` to plain `TokioRuntime`,
whose `thread_rng()` is `rand::rng()` (OS-seeded) and whose `spawn`
is `tokio::spawn`. Each host enters `DeterministicRng::scope`, but
plain runtime calls bypass the task-local `DETSIM_SEED` entirely —
election timeouts and child-task seeds came from the OS RNG, so the
cluster diverged across runs even after the prior fuzz-driver
determinism fix.

`DeterministicRng<TokioRuntime>` routes both `thread_rng()` and
`spawn` through the wrapper that consults `DETSIM_SEED`.


##### test: turmoil: deterministic fuzz scheduling via BTreeSet
`HashSet` re-seeds its `RandomState` from the OS RNG on every process
launch, so iteration order varies across runs. The fuzz driver's
scheduling decisions — minority/leader-targeted partition membership,
the next membership change set, and the victim picked when shrinking
voters — all depended on that order, breaking `--reproduce` even
though per-node openraft RNG and turmoil-sim RNG were both already
seeded.

The voter-removal path used `active_voters.iter().next().unwrap()`,
which under `HashSet` happens to pick an "arbitrary" voter but under
`BTreeSet` would always pick the smallest id — a fixed bias, not
randomness. Switched it to draw from `member_rng`, the existing
membership-decisions RNG, so we keep seed-deterministic random-looking
choice.

Verified: three back-to-back runs of
`--reproduce 509 --max-steps 50000` now produce byte-identical output.
Previously the same seed could yield PASS, FAIL with `matching: [1, 2]`,
or FAIL with `matching: [1, 4]`.

This unblocks deterministic investigation of the
`CommittedNotOnQuorum` violation captured in `tests-turmoil/ISSUES.md`,
which previously could not be pinned to a specific seed for follow-up.


##### feat: turmoil: minority and leader-targeted network partitions
The existing chaos agent had one partition fault (option 0: isolate a
single node from all others). In a 3+-node cluster that never
threatens quorum on its own, and the previous option 4 was a literal
no-op, wasting 20% of chaos events.

Add two new chaos fault modes:

- Minority partition (option 4): split the cluster into a minority
  side (size 1..=n/2) vs the rest. The majority retains quorum; the
  minority cannot commit until the partition is repaired.
- Leader-in-minority partition (option 5): isolate the current
  leader together with a random peer subset so the majority is
  forced to re-elect while the old leader may still think it leads.
  This is where stale-leader and dueling-term bugs live.

The chaos agent now takes `cluster_state` so it can look up the
current leader for option 5. `ClusterState::find_leader_id` is a new
helper that returns just the node id.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


##### feat: turmoil: long-outage crash variant to exercise snapshot install
Existing crash windows are short (election_timeout_max/2 ..= *2,
typically 250-1500ms). A crashed node comes back with only a few logs
of lag, which the leader trivially catches up via log shipping. The
install-snapshot path is never exercised under a simple restart.

Add a `long_outage_chance` (10-30%) that promotes a crash to a long
outage with 5000-15000 ticks of downtime. After that long, the
returning node's `next_index` is far behind the leader's log tail and
more than `replication_lag_threshold` behind — forcing the leader to
send a snapshot install instead of log entries.

Paired with the snapshot config from the previous commit, this is the
path that covers the `install_snapshot` RPC end-to-end, a dense bug
area previously untested.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


##### feat: turmoil: enable snapshots via SnapshotPolicy::LogsSinceLast
The default openraft Config has `SnapshotPolicy::LogsSinceLast(5000)`
plus `max_in_snapshot_log_to_keep=1000`, so within a 100k-step fuzz
run the snapshot path is never triggered and `install_snapshot`
(a dense bug area) never goes across the wire.

Derive three new fields per iteration:

- `snapshot_logs_threshold` (100..=250): `LogsSinceLast(N)` — take a
  snapshot every ~100-250 committed logs.
- `max_in_snapshot_log_to_keep` (30..=80): aggressively purge
  post-snapshot logs so a lagging follower must be sent a snapshot.
- `replication_lag_threshold` (2 * threshold): switch a follower
  from log-shipping to snapshot install when it falls this far behind.

This is a prerequisite for exercising the install-snapshot path under
network faults and long outages (next commits).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1741)
<!-- Reviewable:end -->
