### PR TITLE
refactor: config: split clap parsing and RuntimeConfig into separate files

### DIFF
--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -1,13 +1,8 @@
 //! Raft runtime configuration.
 
 use std::ops::Deref;
-#[cfg(feature = "clap")]
-use std::str::FromStr;
-use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
-#[cfg(feature = "clap")]
-use anyerror::AnyError;
 use backoff_series::BackoffSeries;
 #[cfg(feature = "clap")]
 use clap::Parser;
@@ -18,6 +13,10 @@ use crate::AsyncRuntime;
 use crate::LogId;
 use crate::LogIdOptionExt;
 use crate::config::error::ConfigError;
+#[cfg(feature = "clap")]
+use crate::config::parser::parse_bytes_with_unit;
+#[cfg(feature = "clap")]
+use crate::config::parser::parse_snapshot_policy;
 use crate::network::Backoff;
 use crate::raft_state::LogStateReader;
 use crate::vote::RaftCommittedLeaderId;
@@ -116,45 +115,6 @@ impl SnapshotPolicy {
             SnapshotPolicy::Never => None,
         }
     }
-}
-
-/// Parse number with unit such as 5.3 KB
-#[cfg(feature = "clap")]
-fn parse_bytes_with_unit(src: &str) -> Result<u64, ConfigError> {
-    let res = byte_unit::Byte::from_str(src).map_err(|e| ConfigError::InvalidNumber {
-        invalid: src.to_string(),
-        reason: e.to_string(),
-    })?;
-
-    Ok(res.as_u64())
-}
-
-#[cfg(feature = "clap")]
-fn parse_snapshot_policy(src: &str) -> Result<SnapshotPolicy, ConfigError> {
-    if src == "never" {
-        return Ok(SnapshotPolicy::Never);
-    }
-
-    let elts = src.split(':').collect::<Vec<_>>();
-    if elts.len() != 2 {
-        return Err(ConfigError::InvalidSnapshotPolicy {
-            syntax: "never|since_last:<num>".to_string(),
-            invalid: src.to_string(),
-        });
-    }
-
-    if elts[0] != "since_last" {
-        return Err(ConfigError::InvalidSnapshotPolicy {
-            syntax: "never|since_last:<num>".to_string(),
-            invalid: src.to_string(),
-        });
-    }
-
-    let n_logs = elts[1].parse::<u64>().map_err(|e| ConfigError::InvalidNumber {
-        invalid: src.to_string(),
-        reason: e.to_string(),
-    })?;
-    Ok(SnapshotPolicy::LogsSinceLast(n_logs))
 }
 
 /// Runtime configuration for a Raft node.
@@ -454,21 +414,6 @@ pub struct Config {
     pub allow_log_reversion: Option<bool>,
 }
 
-/// Updatable config for a raft runtime.
-pub(crate) struct RuntimeConfig {
-    pub(crate) enable_heartbeat: AtomicBool,
-    pub(crate) enable_elect: AtomicBool,
-}
-
-impl RuntimeConfig {
-    pub(crate) fn new(config: &Config) -> Self {
-        Self {
-            enable_heartbeat: AtomicBool::from(config.enable_heartbeat),
-            enable_elect: AtomicBool::from(config.enable_elect),
-        }
-    }
-}
-
 impl Default for Config {
     #[allow(deprecated)]
     fn default() -> Self {
@@ -567,33 +512,6 @@ impl Config {
     /// Defaults to 4096 if not specified.
     pub(crate) fn max_append_entries(&self) -> u64 {
         self.max_append_entries.unwrap_or(4096)
-    }
-
-    /// Build a `Config` instance from a series of command line arguments.
-    ///
-    /// The first element in `args` must be the application name.
-    ///
-    /// Only available when the `clap` feature is enabled (default).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use openraft::Config;
-    ///
-    /// let config = Config::build(&[
-    ///     "myapp",
-    ///     "--election-timeout-min", "300",
-    ///     "--election-timeout-max", "500",
-    /// ])?;
-    /// # Ok::<(), openraft::ConfigError>(())
-    /// ```
-    #[cfg(feature = "clap")]
-    pub fn build(args: &[&str]) -> Result<Config, ConfigError> {
-        let config = <Self as Parser>::try_parse_from(args).map_err(|e| ConfigError::ParseError {
-            source: AnyError::from(&e),
-            args: args.iter().map(|x| x.to_string()).collect(),
-        })?;
-        config.validate()
     }
 
     /// Validate the state of this config.

--- a/openraft/src/config/mod.rs
+++ b/openraft/src/config/mod.rs
@@ -38,6 +38,9 @@
 #[allow(clippy::module_inception)]
 mod config;
 mod error;
+#[cfg(feature = "clap")]
+mod parser;
+mod runtime_config;
 
 #[cfg(test)]
 mod config_test;
@@ -46,6 +49,6 @@ mod config_test;
 mod config_clap_test;
 
 pub use config::Config;
-pub(crate) use config::RuntimeConfig;
 pub use config::SnapshotPolicy;
 pub use error::ConfigError;
+pub(crate) use runtime_config::RuntimeConfig;

--- a/openraft/src/config/parser.rs
+++ b/openraft/src/config/parser.rs
@@ -1,0 +1,78 @@
+//! Clap-based parsing for [`Config`].
+//!
+//! Gated behind `feature = "clap"` in [`super`]; functions and the
+//! [`Config::build`] method here are only compiled when that feature is on.
+
+use std::str::FromStr;
+
+use anyerror::AnyError;
+use clap::Parser;
+
+use crate::Config;
+use crate::SnapshotPolicy;
+use crate::config::error::ConfigError;
+
+/// Parse number with unit such as 5.3 KB
+pub(super) fn parse_bytes_with_unit(src: &str) -> Result<u64, ConfigError> {
+    let res = byte_unit::Byte::from_str(src).map_err(|e| ConfigError::InvalidNumber {
+        invalid: src.to_string(),
+        reason: e.to_string(),
+    })?;
+
+    Ok(res.as_u64())
+}
+
+pub(super) fn parse_snapshot_policy(src: &str) -> Result<SnapshotPolicy, ConfigError> {
+    if src == "never" {
+        return Ok(SnapshotPolicy::Never);
+    }
+
+    let elts = src.split(':').collect::<Vec<_>>();
+    if elts.len() != 2 {
+        return Err(ConfigError::InvalidSnapshotPolicy {
+            syntax: "never|since_last:<num>".to_string(),
+            invalid: src.to_string(),
+        });
+    }
+
+    if elts[0] != "since_last" {
+        return Err(ConfigError::InvalidSnapshotPolicy {
+            syntax: "never|since_last:<num>".to_string(),
+            invalid: src.to_string(),
+        });
+    }
+
+    let n_logs = elts[1].parse::<u64>().map_err(|e| ConfigError::InvalidNumber {
+        invalid: src.to_string(),
+        reason: e.to_string(),
+    })?;
+    Ok(SnapshotPolicy::LogsSinceLast(n_logs))
+}
+
+impl Config {
+    /// Build a `Config` instance from a series of command line arguments.
+    ///
+    /// The first element in `args` must be the application name.
+    ///
+    /// Only available when the `clap` feature is enabled (default).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use openraft::Config;
+    ///
+    /// let config = Config::build(&[
+    ///     "myapp",
+    ///     "--election-timeout-min", "300",
+    ///     "--election-timeout-max", "500",
+    /// ])?;
+    /// # Ok::<(), openraft::ConfigError>(())
+    /// ```
+    pub fn build(args: &[&str]) -> Result<Config, ConfigError> {
+        let config = <Self as Parser>::try_parse_from(args).map_err(|e| ConfigError::ParseError {
+            source: AnyError::from(&e),
+            args: args.iter().map(|x| x.to_string()).collect(),
+        })?;
+        config.validate()
+    }
+}

--- a/openraft/src/config/runtime_config.rs
+++ b/openraft/src/config/runtime_config.rs
@@ -1,0 +1,20 @@
+//! Updatable config for a raft runtime.
+
+use std::sync::atomic::AtomicBool;
+
+use crate::Config;
+
+/// Updatable config for a raft runtime.
+pub(crate) struct RuntimeConfig {
+    pub(crate) enable_heartbeat: AtomicBool,
+    pub(crate) enable_elect: AtomicBool,
+}
+
+impl RuntimeConfig {
+    pub(crate) fn new(config: &Config) -> Self {
+        Self {
+            enable_heartbeat: AtomicBool::from(config.enable_heartbeat),
+            enable_elect: AtomicBool::from(config.enable_elect),
+        }
+    }
+}


### PR DESCRIPTION

## Changelog

##### refactor: config: split clap parsing and RuntimeConfig into separate files
`config.rs` mixed three concerns: the `Config` struct itself, the
`RuntimeConfig` runtime-mutable subset, and clap-driven CLI parsing
(`parse_bytes_with_unit`, `parse_snapshot_policy`, `Config::build`).
Splitting them per the project's "one main type per file" rule isolates
the clap surface as a single feature-gated module rather than scattering
`#[cfg(feature = "clap")]` gates through the file, and moves
`RuntimeConfig` to its own file.

The `crate::config::RuntimeConfig` re-export is preserved via `mod.rs`,
so the three call sites (`raft_core.rs`, `raft_inner.rs`,
`raft/mod.rs`) need no edits.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1745)
<!-- Reviewable:end -->
