### PR TITLE
fix: client_api: ensure_linearizable_read must respect transfer_to

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -327,8 +327,7 @@ where
         // Setup sentinel values to track when we've received majority confirmation of leadership.
 
         let resp = {
-            let l = self.engine.try_leader_handler();
-            let lh = match l {
+            let lh = match self.ensure_writable_leader_handler() {
                 Ok(leading_handler) => leading_handler,
                 Err(forward) => {
                     tx.send(Err(forward.into())).ok();

--- a/tests/tests/client_api/t14_transfer_leader.rs
+++ b/tests/tests/client_api/t14_transfer_leader.rs
@@ -3,9 +3,13 @@ use std::time::Duration;
 
 use maplit::btreeset;
 use openraft::Config;
+use openraft::ReadPolicy;
 use openraft::ServerState;
 use openraft::async_runtime::WatchReceiver;
+use openraft::errors::LinearizableReadError;
 use openraft::raft::TransferLeaderRequest;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::ut_harness;
@@ -101,6 +105,177 @@ async fn trigger_transfer_leader() -> anyhow::Result<()> {
         n0.wait(timeout()).state(ServerState::Follower, "node-0 become follower").await?;
         n1.wait(timeout()).state(ServerState::Follower, "node-1 become follower").await?;
     }
+
+    Ok(())
+}
+
+/// Reproduces an issue where, after `transfer_leader` is triggered on a leader,
+/// repeated `ensure_linearizable(ReadIndex)` calls on that same node prevent the
+/// cluster from electing a new leader.
+///
+/// Mechanism:
+/// - `transfer_leader` sets `transfer_to` on the source and broadcasts `TransferLeaderRequest`.
+///   Recipients disable their lease, but only the designated target calls `elect()` directly; other
+///   voters must wait for their election timeout to fire.
+/// - `ensure_linearizable(ReadIndex)` on the source emits `AppendEntries`, which bumps
+///   `last_update` on every reachable follower regardless of lease state. Under sustained read
+///   load, the follower's election timeout is perpetually postponed.
+///
+/// Setup:
+/// - 3-voter cluster, n0 leader.
+/// - n1 (the transfer target) is fully isolated, so `TransferLeaderRequest` never reaches it and it
+///   cannot vote in any subsequent election.
+/// - A background task drives `ensure_linearizable(ReadIndex)` on n0 in a tight loop, simulating an
+///   application that keeps issuing reads during the transfer.
+///
+/// After the fix, reads on the source must respect `transfer_to` and return
+/// `ForwardToLeader(target)`, which (a) pins the contract behaviorally and
+/// (b) stops the read-driven `AppendEntries` so n2's lease/election timer
+/// can fire.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn transfer_leader_with_dead_target_does_not_block_election() -> anyhow::Result<()> {
+    let election_timeout_max = 300;
+
+    let config = Arc::new(
+        Config {
+            // The only AE traffic should come from ReadIndex; otherwise heartbeat AE
+            // would also bump follower last_update and the bug is no longer attributable
+            // to ReadIndex specifically.
+            enable_heartbeat: false,
+            election_timeout_min: 150,
+            election_timeout_max,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    router.network_send_delay(0);
+
+    tracing::info!("--- initializing cluster");
+    let _log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    let n2 = router.get_raft_handle(&2)?;
+
+    tracing::info!("--- isolate n1: it cannot receive TransferLeaderRequest or vote");
+    router.set_network_error(1, true);
+
+    tracing::info!("--- background task: drive ReadIndex on n0 in a tight loop");
+    let r = router.clone();
+    TypeConfig::spawn(async move {
+        loop {
+            let _ = r.ensure_linearizable(0, ReadPolicy::ReadIndex).await;
+            TypeConfig::sleep(Duration::from_millis(20)).await;
+        }
+    });
+
+    tracing::info!("--- trigger transfer to n1");
+    n0.trigger().transfer_leader(1).await?;
+
+    tracing::info!("--- ensure_linearizable on n0 must return ForwardToLeader(1) after transfer");
+    {
+        // The transfer command is processed asynchronously by RaftCore; poll briefly.
+        let mut got = false;
+        for _ in 0..20 {
+            let res = n0.ensure_linearizable(ReadPolicy::ReadIndex).await;
+            if let Err(e) = &res
+                && let Some(LinearizableReadError::ForwardToLeader(fwd)) = e.api_error()
+                && fwd.leader_id == Some(1)
+            {
+                got = true;
+                break;
+            }
+            TypeConfig::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(got, "expected ForwardToLeader(1) within 200ms after transfer");
+    }
+
+    tracing::info!("--- n2 must elect within 5 * election_timeout_max despite background reads");
+    n2.wait(Some(Duration::from_millis(5 * election_timeout_max)))
+        .state(ServerState::Leader, "n2 elects after n0 stops emitting read-index AE")
+        .await?;
+
+    Ok(())
+}
+
+/// `ensure_linearizable(LeaseRead)` on a transferring leader must redirect.
+///
+/// Mechanism is different from the `ReadIndex` case:
+/// - `LeaseRead` short-circuits when `last_quorum_acked_time + leader_lease > now` and returns the
+///   cached read without any quorum confirmation.
+/// - `handle_transfer_leader` disables the *vote* lease but does not clear
+///   `last_quorum_acked_time`. So pre-fix, the source keeps returning a successful `LeaseRead`
+///   while a new leader may already be committing fresh entries -- the classic stale-read scenario.
+///
+/// After the fix, the read path checks `transfer_to` regardless of policy and returns
+/// `ForwardToLeader(target)`.
+///
+/// The transfer target (n1) is isolated, mirroring the `ReadIndex` test. If it were
+/// reachable it would elect immediately (the target calls `elect()` directly on
+/// receiving `TransferLeaderRequest`), n0 would demote to follower, and the assertion
+/// would pass for the wrong reason -- a follower's `forward_to_leader` always points
+/// at the current leader independent of the transfer-gate behavior.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn transfer_leader_blocks_lease_read() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            // Large lease so `last_quorum_acked + leader_lease` stays in the future for the
+            // whole test. If the lease lapses, pre-fix `LeaseRead` returns
+            // `ForwardToLeader::empty` for the wrong reason and masks the bug.
+            heartbeat_interval: 1000,
+            election_timeout_min: 1001,
+            election_timeout_max: 1002,
+            enable_heartbeat: false,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    router.network_send_delay(0);
+
+    tracing::info!("--- initializing cluster");
+    router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+
+    // Refresh quorum-acked time before isolating n1, so the lease is comfortably fresh
+    // and `LeaseRead` would succeed if the gate were absent.
+    n0.trigger().heartbeat().await?;
+    n0.wait(Some(Duration::from_millis(500)))
+        .metrics(|m| m.last_quorum_acked.is_some(), "leader has fresh last_quorum_acked")
+        .await?;
+
+    // Sanity: LeaseRead succeeds before the transfer.
+    n0.ensure_linearizable(ReadPolicy::LeaseRead).await.expect("LeaseRead succeeds on healthy leader");
+
+    tracing::info!("--- isolate n1: it cannot receive TransferLeaderRequest or elect");
+    router.set_network_error(1, true);
+
+    tracing::info!("--- trigger transfer to n1");
+    n0.trigger().transfer_leader(1).await?;
+
+    tracing::info!("--- ensure_linearizable(LeaseRead) on n0 must return ForwardToLeader(1)");
+    let mut got = false;
+    for _ in 0..20 {
+        let res = n0.ensure_linearizable(ReadPolicy::LeaseRead).await;
+        if let Err(e) = &res
+            && let Some(LinearizableReadError::ForwardToLeader(fwd)) = e.api_error()
+            && fwd.leader_id == Some(1)
+        {
+            got = true;
+            break;
+        }
+        TypeConfig::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        got,
+        "expected ForwardToLeader(1) for LeaseRead within 200ms after transfer"
+    );
 
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### fix: client_api: ensure_linearizable_read must respect transfer_to
# Summary

Replace `try_leader_handler` with `ensure_writable_leader_handler` at
the top of `handle_ensure_linearizable_read`. The read path now returns
`ForwardToLeader(target)` when `transfer_to` is set, mirroring the
write path. Fixes #1747.

# Details

Before this change, the only gate on the read path was "am I a
leader?". The write path had a stricter "am I a *writable* leader?"
gate that also checks `transfer_to`. The asymmetry caused two bugs:

- `ReadIndex` on the source emits AppendEntries that bump follower
  `last_update` regardless of lease state. Under sustained reads, the
  cluster could not recover from a transfer if the target was
  unreachable -- followers never election-time-out, so no new leader
  was established.
- `LeaseRead` short-circuits on `last_quorum_acked + leader_lease`,
  which `transfer_leader` does not clear. The source kept serving
  cached reads while a new leader could already be committing fresh
  entries -- a stale read.

Both paths now go through the same gate. `ensure_writable_leader_handler`
returns `ForwardToLeader(target)` when transfer is in progress; the
existing `tx.send(Err(forward.into()))` path propagates that to the
client unchanged.

The two reproducer tests added in the previous commit now pass:

- `transfer_leader_with_dead_target_does_not_block_election` --
  the cluster recovers (n2 elects) within `5 * election_timeout_max`,
  because n0 stops emitting AppendEntries for reads.
- `transfer_leader_blocks_lease_read` -- LeaseRead returns
  `ForwardToLeader(target)` immediately; no stale-read window.

- Fix: #1747


##### test: client_api: reproduce read paths bypassing transfer_leader gate
# Summary

Add two reproducers for the read-path side of the transfer-leader gate.
Both fail on current `main` and are expected to pass once
`handle_ensure_linearizable_read` checks `transfer_to`.

# Details

Pre-fix, the gate at the top of the read path uses `try_leader_handler`,
which only checks "am I a leader" -- not "am I a transferring leader".
The write path uses `ensure_writable_leader_handler` which does both.
This asymmetry produces two distinct misbehaviors, one per read policy:

`transfer_leader_with_dead_target_does_not_block_election` (ReadIndex)

- The read path emits AppendEntries which bump follower `last_update`
  regardless of lease state. Under sustained reads on the source, no
  reachable follower's election timer ever fires, so the cluster
  cannot recover from the transfer when the target is unreachable.
- Setup: 3 voters, n1 (target) isolated, background loop driving
  `ensure_linearizable(0, ReadIndex)`. Asserts (a) reads on n0 return
  `ForwardToLeader { leader_id: Some(1) }` and (b) n2 reaches Leader
  within `5 * election_timeout_max`.

`transfer_leader_blocks_lease_read` (LeaseRead)

- LeaseRead short-circuits when `last_quorum_acked + leader_lease >
  now`. `handle_transfer_leader` disables the *vote* lease but does
  not clear `last_quorum_acked`, so the source keeps serving cached
  reads while a new leader may already be committing fresh entries --
  a stale read.
- Setup: same shape, large lease, target n1 isolated. Asserts
  `LeaseRead` on n0 returns `ForwardToLeader { leader_id: Some(1) }`.
  The target must be isolated; otherwise n2 would elect immediately
  and the assertion would pass for the wrong reason -- a follower's
  `forward_to_leader` always points at the current leader, regardless
  of whether the gate exists.

- Reproduces: #1747

---

- Bug Fix
- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1749)
<!-- Reviewable:end -->
