### PR TITLE
refactor: not exposing the lock

### DIFF
--- a/examples/raft-kv-memstore/src/lib.rs
+++ b/examples/raft-kv-memstore/src/lib.rs
@@ -47,9 +47,9 @@ pub async fn start_example_raft_node(node_id: NodeId, http_addr: String) -> std:
 
     let config = Arc::new(config.validate().unwrap());
 
-    // Create a instance of where the Raft logs will be stored.
+    // Create an instance of where the Raft logs will be stored.
     let log_store = LogStore::default();
-    // Create a instance of where the Raft data will be stored.
+    // Create an instance of where the Raft data will be stored.
     let state_machine_store = StateMachineStore::default();
 
     // Create the network layer that will connect and communicate the raft instances and

--- a/examples/raft-kv-memstore/src/network/api.rs
+++ b/examples/raft-kv-memstore/src/network/api.rs
@@ -31,9 +31,8 @@ pub async fn write(app: Data<App>, req: Json<types_kv::Request>) -> actix_web::R
 
 #[post("/read")]
 pub async fn read(app: Data<App>, req: Json<String>) -> actix_web::Result<impl Responder> {
-    let inner = app.state_machine_store.inner().lock().await;
     let key = req.0;
-    let value = inner.state_machine.data.get(&key).cloned();
+    let value = app.state_machine_store.get(&key).await;
 
     let res: Result<String, Infallible> = Ok(value.unwrap_or_default());
     Ok(Json(res))

--- a/examples/sm-mem/src/lib.rs
+++ b/examples/sm-mem/src/lib.rs
@@ -97,6 +97,12 @@ impl<C: RaftTypeConfig> StateMachineStore<C> {
     pub fn inner(&self) -> &Arc<Mutex<StateMachineStoreInner<C>>> {
         &self.0
     }
+
+    /// Get a value from the state machine by key, locking the state machine.
+    pub async fn get(&self, key: &str) -> Option<String> {
+        let inner = self.0.lock().await;
+        inner.state_machine.data.get(key).cloned()
+    }
 }
 
 impl<C> RaftSnapshotBuilder<C> for StateMachineStore<C>


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

I opened this PR, but it's more asking for "feedback" and to check if you prefer this approach.
The idea of this PR is not to expose the "lock" in `StateMachineStore` by adding a method `get` that internally does the mutex locking and return the value.

What do you think about this? If you don't like it, or prefer the current approach, let me know, if not I can try to "deprecate" the `inner` method and use only `get`.


**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

PS: I am trying to learn about Raft and distributed systems, and I am really enjoying the examples. Thanks a lot!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1751)
<!-- Reviewable:end -->
