### PR TITLE
refactor: replace inner for get

### DIFF
--- a/examples/multi-raft-kv/src/api.rs
+++ b/examples/multi-raft-kv/src/api.rs
@@ -28,9 +28,7 @@ pub async fn read(app: &mut GroupApp, req: String) -> String {
     let res = match ret {
         Ok(linearizer) => {
             linearizer.await_ready(&app.raft).await.unwrap();
-
-            let inner = app.state_machine.inner().lock().await;
-            let value = inner.state_machine.data.get(&key).cloned();
+            let value = app.state_machine.get(&key).await;
 
             let res: Result<String, RaftError<LinearizableReadError>> = Ok(value.unwrap_or_default());
             res

--- a/examples/raft-kv-memstore-network-v2/src/api.rs
+++ b/examples/raft-kv-memstore-network-v2/src/api.rs
@@ -27,9 +27,7 @@ pub async fn read(app: &mut App, req: String) -> String {
     let res = match ret {
         Ok(linearizer) => {
             linearizer.await_ready(&app.raft).await.unwrap();
-
-            let inner = app.state_machine.inner().lock().await;
-            let value = inner.state_machine.data.get(&key).cloned();
+            let value = app.state_machine.get(&key).await;
 
             let res: Result<String, RaftError<LinearizableReadError>> = Ok(value.unwrap_or_default());
             res

--- a/examples/raft-kv-memstore/src/network/api.rs
+++ b/examples/raft-kv-memstore/src/network/api.rs
@@ -45,10 +45,8 @@ pub async fn linearizable_read(app: Data<App>, req: Json<String>) -> actix_web::
     match ret {
         Ok(linearizer) => {
             linearizer.await_ready(&app.raft).await.unwrap();
-
-            let inner = app.state_machine_store.inner().lock().await;
             let key = req.0;
-            let value = inner.state_machine.data.get(&key).cloned();
+            let value = app.state_machine_store.get(&key).await;
 
             let res: Result<String, LinearizableReadError<TypeConfig>> = Ok(value.unwrap_or_default());
             Ok(Json(res))
@@ -136,9 +134,8 @@ pub async fn follower_read(app: Data<App>, req: Json<String>) -> actix_web::Resu
     }
 
     // 5. Read from local state machine
-    let inner = app.state_machine_store.inner().lock().await;
     let key = req.0;
-    let value = inner.state_machine.data.get(&key).cloned();
+    let value = app.state_machine_store.get(&key).await;
 
     Ok(Json(Ok(value.unwrap_or_default())))
 }

--- a/examples/sm-mem/src/lib.rs
+++ b/examples/sm-mem/src/lib.rs
@@ -76,9 +76,9 @@ impl<C: RaftTypeConfig> StateMachineStoreInner<C> {
 
 /// Defines a state machine for the Raft cluster.
 ///
-/// This is a newtype wrapper around `Arc<Mutex<StateMachineStoreInner<C>>>` to satisfy
+/// This is a new type wrapper around `Arc<Mutex<StateMachineStoreInner<C>>>` to satisfy
 /// Rust's orphan rules when implementing foreign traits.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct StateMachineStore<C: RaftTypeConfig>(Arc<Mutex<StateMachineStoreInner<C>>>);
 
 impl<C: RaftTypeConfig> Default for StateMachineStore<C> {
@@ -87,17 +87,7 @@ impl<C: RaftTypeConfig> Default for StateMachineStore<C> {
     }
 }
 
-impl<C: RaftTypeConfig> Clone for StateMachineStore<C> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
 impl<C: RaftTypeConfig> StateMachineStore<C> {
-    pub fn inner(&self) -> &Arc<Mutex<StateMachineStoreInner<C>>> {
-        &self.0
-    }
-
     /// Get a value from the state machine by key, locking the state machine.
     pub async fn get(&self, key: &str) -> Option<String> {
         let inner = self.0.lock().await;


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

Continuation of the previous PR #1751 to replace `inner` for `get` to not to expose the locking.

I also removed the method `clone` in `StateMachineStore` and added it as a macro.


**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

PS: I promise this is the last one, and thanks again!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1752)
<!-- Reviewable:end -->
