### PR TITLE
fix: turmoil: count crashed voters in quorum check

### DIFF
--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -625,9 +625,12 @@ fn run_single_iteration(
         steps += 1;
 
         // Check invariants
-        let snapshots = cluster_state.lock().unwrap().get_all_full_snapshots();
+        let (snapshots, durable_logs) = {
+            let state = cluster_state.lock().unwrap();
+            (state.get_all_full_snapshots(), state.get_all_durable_log_ids())
+        };
         invariant_checks += 1;
-        let result = invariants.check(&snapshots);
+        let result = invariants.check_with_durable_logs(&snapshots, &durable_logs);
         if !result.violations.is_empty() {
             for v in &result.violations {
                 let msg = format!("Step {steps}: {v:?}");

--- a/tests-turmoil/src/cluster.rs
+++ b/tests-turmoil/src/cluster.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use openraft::alias::LogIdListOf;
 use openraft::async_runtime::WatchReceiver;
 use openraft_rt::deterministic_rng::DeterministicRng;
 use openraft_rt_tokio::TokioRuntime;
@@ -71,6 +72,10 @@ impl ClusterState {
                 (id, FullNodeSnapshot { raft, sm })
             })
             .collect()
+    }
+
+    pub fn get_all_durable_log_ids(&self) -> BTreeMap<NodeId, LogIdListOf<TypeConfig>> {
+        self.log_stores.iter().map(|(&id, log_store)| (id, log_store.log_id_list())).collect()
     }
 
     /// Find a Raft node that is currently the leader.

--- a/tests-turmoil/src/invariants/committed_on_quorum.rs
+++ b/tests-turmoil/src/invariants/committed_on_quorum.rs
@@ -12,19 +12,23 @@
 //! this leader's own id, we check only the entries this leader itself
 //! committed — for which the quorum must reside in the current membership.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
+use openraft::alias::LogIdListOf;
 use openraft::vote::RaftLeaderId;
 
 use super::violation::InvariantViolation;
 use crate::cluster::FullNodeSnapshot;
 use crate::typ::NodeId;
+use crate::typ::TypeConfig;
 
 /// On every current leader, if the newest committed entry is the leader's own,
-/// verify a quorum of voters have that entry in their log.
-pub fn check(snapshots: &[(NodeId, FullNodeSnapshot)], violations: &mut Vec<InvariantViolation>) {
-    let by_id: HashMap<NodeId, &FullNodeSnapshot> = snapshots.iter().map(|(id, s)| (*id, s)).collect();
-
+/// verify a quorum of voters have that entry in durable log storage.
+pub fn check(
+    snapshots: &[(NodeId, FullNodeSnapshot)],
+    durable_logs: &BTreeMap<NodeId, LogIdListOf<TypeConfig>>,
+    violations: &mut Vec<InvariantViolation>,
+) {
     for (leader_id, s) in snapshots {
         if !s.raft.state.is_leader() {
             continue;
@@ -40,8 +44,10 @@ pub fn check(snapshots: &[(NodeId, FullNodeSnapshot)], violations: &mut Vec<Inva
 
         let idx = committed.index();
         let has_entry = |v: &NodeId| -> bool {
-            let Some(vs) = by_id.get(v) else { return false };
-            vs.raft.log_id_list.get(idx).is_some_and(|lid| lid.committed_leader_id() == expected)
+            durable_logs
+                .get(v)
+                .and_then(|logs| logs.get(idx))
+                .is_some_and(|lid| lid.committed_leader_id() == expected)
         };
 
         for voter_set in s.raft.membership_config.membership().get_joint_config() {

--- a/tests-turmoil/src/invariants/mod.rs
+++ b/tests-turmoil/src/invariants/mod.rs
@@ -42,6 +42,8 @@
 //! just `term` — so the same check is correct under both modes: advanced
 //! mode's "different node_ids in the same term" case simply is not flagged.
 
+use std::collections::BTreeMap;
+
 pub mod committed_immutable;
 pub mod committed_on_quorum;
 pub mod election_safety;
@@ -55,10 +57,12 @@ pub mod violation;
 #[cfg(test)]
 mod tests;
 
+use openraft::alias::LogIdListOf;
 pub use violation::InvariantViolation;
 
 use crate::cluster::FullNodeSnapshot;
 use crate::typ::NodeId;
+use crate::typ::TypeConfig;
 
 /// The committed leader id type for this test config.
 ///
@@ -70,6 +74,8 @@ use crate::typ::NodeId;
 /// different `node_id`s to lead in the same `term`, so equality must include
 /// `node_id`.
 pub type CLeaderId = openraft::type_config::alias::CommittedLeaderIdOf<crate::typ::TypeConfig>;
+
+pub type DurableLogIds = BTreeMap<NodeId, LogIdListOf<TypeConfig>>;
 
 /// Result of one invariant check pass.
 #[derive(Debug, Default)]
@@ -91,6 +97,16 @@ pub struct InvariantChecker {
 impl InvariantChecker {
     /// Check every invariant against `snapshots`, updating temporal state.
     pub fn check(&mut self, snapshots: &[(NodeId, FullNodeSnapshot)]) -> InvariantCheckResult {
+        let durable_logs: DurableLogIds = snapshots.iter().map(|(id, s)| (*id, s.raft.log_id_list.clone())).collect();
+
+        self.check_with_durable_logs(snapshots, &durable_logs)
+    }
+
+    pub fn check_with_durable_logs(
+        &mut self,
+        snapshots: &[(NodeId, FullNodeSnapshot)],
+        durable_logs: &DurableLogIds,
+    ) -> InvariantCheckResult {
         let mut violations = Vec::new();
 
         // --- Single-tick per-node checks ---
@@ -101,7 +117,7 @@ impl InvariantChecker {
         // --- Single-tick cross-node checks ---
         election_safety::check(snapshots, &mut violations);
         leader_completeness::check(snapshots, &mut violations);
-        committed_on_quorum::check(snapshots, &mut violations);
+        committed_on_quorum::check(snapshots, durable_logs, &mut violations);
 
         // --- Pairwise cross-node checks ---
         for i in 0..snapshots.len() {

--- a/tests-turmoil/src/invariants/tests.rs
+++ b/tests-turmoil/src/invariants/tests.rs
@@ -13,6 +13,7 @@ use openraft::metrics::RaftMetrics;
 use openraft::vote::RaftLeaderId;
 
 use super::CLeaderId;
+use super::DurableLogIds;
 use super::InvariantChecker;
 use super::InvariantViolation;
 use crate::cluster::FullNodeSnapshot;
@@ -158,6 +159,17 @@ impl SnapshotBuilder {
 
 fn check(snapshots: &[(NodeId, FullNodeSnapshot)]) -> Vec<InvariantViolation> {
     InvariantChecker::default().check(snapshots).violations
+}
+
+fn durable_logs(snapshots: &[(NodeId, FullNodeSnapshot)]) -> DurableLogIds {
+    snapshots.iter().map(|(id, s)| (*id, s.raft.log_id_list.clone())).collect()
+}
+
+fn check_with_durable_logs(
+    snapshots: &[(NodeId, FullNodeSnapshot)],
+    durable_logs: &DurableLogIds,
+) -> Vec<InvariantViolation> {
+    InvariantChecker::default().check_with_durable_logs(snapshots, durable_logs).violations
 }
 
 // --- Helpers for assertions --------------------------------------------
@@ -388,6 +400,31 @@ fn committed_on_quorum_exact_majority_ok() {
     assert!(
         !violations.iter().any(|v| matches!(v, InvariantViolation::CommittedNotOnQuorum { .. })),
         "2-of-3 is a majority and must not be flagged: {violations:?}"
+    );
+}
+
+#[test]
+fn committed_on_quorum_counts_crashed_voter_durable_log() {
+    let entry = log_id(1, 1, 7);
+    let snaps = vec![
+        SnapshotBuilder::new(1)
+            .term(1)
+            .leader(1, 1, true)
+            .state(openraft::ServerState::Leader)
+            .log_entries([entry])
+            .committed(entry)
+            .membership_voters(vec![vec![1, 2, 3, 4]])
+            .build(),
+        SnapshotBuilder::new(3).build(),
+        SnapshotBuilder::new(4).log_entries([entry]).build(),
+    ];
+    let mut logs = durable_logs(&snaps);
+    logs.insert(2, LogIdListOf::<TypeConfig>::new(None, [entry]));
+
+    let violations = check_with_durable_logs(&snaps, &logs);
+    assert!(
+        !violations.iter().any(|v| matches!(v, InvariantViolation::CommittedNotOnQuorum { .. })),
+        "durable log on crashed voter must count toward quorum: {violations:?}"
     );
 }
 

--- a/tests-turmoil/src/store.rs
+++ b/tests-turmoil/src/store.rs
@@ -12,6 +12,7 @@ use std::sync::Mutex;
 use futures::Stream;
 use openraft::EntryPayload;
 use openraft::OptionalSend;
+use openraft::alias::LogIdListOf;
 use openraft::storage::EntryResponder;
 use openraft::storage::IOFlushed;
 use openraft::storage::LogState;
@@ -56,6 +57,13 @@ impl LogStore {
             log: Mutex::new(BTreeMap::new()),
         }
     }
+
+    pub fn log_id_list(&self) -> LogIdListOf<TypeConfig> {
+        let last_purged = *self.last_purged.lock().unwrap();
+        let log = self.log.lock().unwrap();
+
+        LogIdListOf::<TypeConfig>::new(last_purged, log.values().map(|entry| entry.log_id))
+    }
 }
 
 impl RaftLogReader<TypeConfig> for Arc<LogStore> {
@@ -81,9 +89,9 @@ impl RaftLogStorage<TypeConfig> for Arc<LogStore> {
     type LogReader = Self;
 
     async fn get_log_state(&mut self) -> Result<LogState<TypeConfig>, io::Error> {
+        let last_purged = *self.last_purged.lock().unwrap();
         let log = self.log.lock().unwrap();
         let last = log.iter().next_back().map(|(_, e)| e.log_id);
-        let last_purged = *self.last_purged.lock().unwrap();
 
         Ok(LogState {
             last_purged_log_id: last_purged,


### PR DESCRIPTION

## Changelog

##### fix: turmoil: count crashed voters in quorum check
# Summary

Committed-on-quorum now checks voter log presence against durable
turmoil log stores instead of only live raft handles. This avoids
reporting a committed entry as missing just because a voter crashed
after persisting it.

# Details

The fuzzer now passes durable log-id snapshots into the invariant
checker, while the rest of the safety checks still operate on live raft
snapshots. This keeps stale crashed-node metrics out of leader and
pairwise checks.

A regression test covers the case where a crashed voter is absent from
live snapshots but its persisted log still contributes to the commit
quorum.

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1753)
<!-- Reviewable:end -->
