### PR TITLE
chore: makefile: clean all crates and tests/_log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,18 +183,20 @@ clean:
 	cargo clean --manifest-path rt-tokio/Cargo.toml
 	cargo clean --manifest-path metrics-otel/Cargo.toml
 	cargo clean --manifest-path benchmarks/minimal/Cargo.toml
+	cargo clean --manifest-path tests-turmoil/Cargo.toml
 	cargo clean --manifest-path examples/client-http/Cargo.toml
 	cargo clean --manifest-path examples/network-v1-http/Cargo.toml
 	cargo clean --manifest-path examples/log-mem/Cargo.toml
 	cargo clean --manifest-path examples/sm-mem/Cargo.toml
 	cargo clean --manifest-path examples/rocksstore/Cargo.toml
+	cargo clean --manifest-path examples/types-kv/Cargo.toml
 	cargo clean --manifest-path examples/raft-kv-memstore-grpc/Cargo.toml
 	cargo clean --manifest-path examples/raft-kv-memstore-network-v2/Cargo.toml
 	cargo clean --manifest-path examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
 	cargo clean --manifest-path examples/raft-kv-memstore-single-threaded/Cargo.toml
 	cargo clean --manifest-path examples/raft-kv-memstore/Cargo.toml
 	cargo clean --manifest-path examples/raft-kv-rocksdb/Cargo.toml
-	cargo clean --manifest-path examples/rocksstore/Cargo.toml
 	cargo clean --manifest-path examples/multi-raft-kv/Cargo.toml
+	rm -rf tests/_log
 
 .PHONY: test fmt lint clean doc guide detsim


### PR DESCRIPTION

## Changelog

##### chore: makefile: clean all crates and tests/_log
# Summary

`make clean` now wipes build artifacts for every workspace crate and
every excluded crate, and removes the `tests/_log` scratch directory.
Previously it skipped two excluded crates and left `tests/_log` behind.

# Details

- Add `tests-turmoil` and `examples/types-kv`, which are listed in
  `[workspace].exclude` but were never cleaned.
- Drop the duplicate `examples/rocksstore` invocation.
- Remove `tests/_log`, a gitignored scratch dir of test logs that can
  grow to several GB.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1757)
<!-- Reviewable:end -->
