### PR TITLE
docs: annotate 0.10.0 public fields and variants with #[since]

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -147,6 +147,21 @@ fn add_send_bounds(item: TokenStream) -> TokenStream {
 /// /// Since: 1.0.0
 /// fn foo() {}
 /// ```
+///
+/// ### Fields and variants
+///
+/// Rust forbids attribute macros directly on struct fields, so annotate the enclosing `struct` /
+/// `enum` with `#[since]` (with or without its own `version`) to enable `#[since(...)]` markers on
+/// its fields or variants:
+///
+/// ```rust,ignore
+/// #[since]
+/// struct Config {
+///     /// The batch capacity.
+///     #[since(version = "1.0.0")]
+///     capacity: u64,
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn since(args: TokenStream, item: TokenStream) -> TokenStream {
     let tokens = do_since(args, item.clone());
@@ -157,6 +172,12 @@ pub fn since(args: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 fn do_since(args: TokenStream, item: TokenStream) -> Result<TokenStream, syn::Error> {
+    // `#[since]` on a struct/enum also rewrites `#[since(...)]` markers on its fields/variants,
+    // the only way to attach `Since:` docs to fields (attribute macros cannot sit on fields).
+    if let Some(tokens) = since::try_expand_container(args.clone(), item.clone())? {
+        return Ok(tokens);
+    }
+
     let since = Since::new(args)?;
     let tokens = since.append_since_doc(item)?;
     Ok(tokens)

--- a/macros/src/since.rs
+++ b/macros/src/since.rs
@@ -18,6 +18,14 @@ pub struct Since {
 impl Since {
     /// Build a `Since` struct from the given attribute arguments.
     pub(crate) fn new(args: TokenStream) -> Result<Since, syn::Error> {
+        Self::from_tokens(args.into())
+    }
+
+    /// Build a `Since` struct from `proc_macro2` attribute arguments.
+    ///
+    /// Shared by the attribute-macro entry point and by `#[since(...)]` markers found on struct
+    /// fields or enum variants.
+    pub(crate) fn from_tokens(args: proc_macro2::TokenStream) -> Result<Since, syn::Error> {
         let mut since = Since {
             version: None,
             date: None,
@@ -26,7 +34,7 @@ impl Since {
 
         type AttributeArgs = syn::punctuated::Punctuated<syn::Meta, syn::Token![,]>;
 
-        let parsed_args = AttributeArgs::parse_terminated.parse(args.clone())?;
+        let parsed_args = AttributeArgs::parse_terminated.parse2(args.clone())?;
 
         for arg in parsed_args {
             match arg {
@@ -67,10 +75,7 @@ impl Since {
         }
 
         if since.version.is_none() {
-            return Err(syn::Error::new_spanned(
-                proc_macro2::TokenStream::from(args),
-                "Missing `version` attribute",
-            ));
+            return Err(syn::Error::new_spanned(args, "Missing `version` attribute"));
         }
 
         Ok(since)
@@ -126,6 +131,30 @@ impl Since {
             #other
         };
         Ok(tokens.into())
+    }
+
+    /// Build a `Since` from a `#[since(...)]` attribute marker.
+    fn from_attr(attr: &syn::Attribute) -> Result<Since, syn::Error> {
+        Self::from_tokens(attr.meta.require_list()?.tokens.clone())
+    }
+
+    /// Insert the `Since:` doc line(s) into an attribute list, after any leading doc attrs.
+    ///
+    /// The attribute-list counterpart of [`Self::append_since_doc`], used by the syn-based
+    /// struct / enum field path.
+    fn append_since_doc_attrs(&self, attrs: &mut Vec<syn::Attribute>) {
+        let lead_docs = attrs.iter().take_while(|a| a.path().is_ident("doc")).count();
+
+        // If there are already docs, insert a blank line before the `Since:` line.
+        let blank = if lead_docs > 0 { quote!(#[doc = ""]) } else { quote!() };
+        let line = format!(" {}", self.to_doc_string());
+        let new_docs = syn::Attribute::parse_outer
+            .parse2(quote!(#blank #[doc = #line]))
+            .expect("since doc attributes are well-formed");
+
+        for (offset, attr) in new_docs.into_iter().enumerate() {
+            attrs.insert(lead_docs + offset, attr);
+        }
     }
 
     /// Build doc string: `Since: 1.0.0, Date(2021-01-01)` or  `Since: 1.0.0`
@@ -214,4 +243,78 @@ impl Since {
         };
         Ok(s)
     }
+}
+
+/// Expand `#[since]` on a `struct`/`enum`/`union` that carries `#[since(...)]` markers on its
+/// fields or variants.
+///
+/// Rust forbids attribute macros directly on fields, so a field-level `#[since]` is reachable only
+/// when the enclosing container is annotated with `#[since]`: that invocation expands first and
+/// rewrites the markers here. Returns `Ok(None)` when `item` is not such a container, so the caller
+/// falls back to the plain item-level expansion.
+pub(crate) fn try_expand_container(args: TokenStream, item: TokenStream) -> Result<Option<TokenStream>, syn::Error> {
+    let Ok(mut input) = syn::parse2::<syn::DeriveInput>(item.into()) else {
+        return Ok(None);
+    };
+
+    if !rewrite_field_since(&mut input)? {
+        return Ok(None);
+    }
+
+    // Args on the container document the container itself; empty args only enable field rewriting.
+    let args = proc_macro2::TokenStream::from(args);
+    if !args.is_empty() {
+        Since::from_tokens(args)?.append_since_doc_attrs(&mut input.attrs);
+    }
+
+    Ok(Some(quote!(#input).into()))
+}
+
+/// Rewrite every `#[since(...)]` marker on the fields / variants of `input` into a `Since:` doc.
+///
+/// Returns whether any marker was found.
+fn rewrite_field_since(input: &mut syn::DeriveInput) -> Result<bool, syn::Error> {
+    let mut found = false;
+    match &mut input.data {
+        syn::Data::Struct(data) => {
+            for field in &mut data.fields {
+                found |= rewrite_attrs_since(&mut field.attrs)?;
+            }
+        }
+        syn::Data::Enum(data) => {
+            for variant in &mut data.variants {
+                found |= rewrite_attrs_since(&mut variant.attrs)?;
+                for field in &mut variant.fields {
+                    found |= rewrite_attrs_since(&mut field.attrs)?;
+                }
+            }
+        }
+        syn::Data::Union(data) => {
+            for field in &mut data.fields.named {
+                found |= rewrite_attrs_since(&mut field.attrs)?;
+            }
+        }
+    }
+    Ok(found)
+}
+
+/// Replace each `#[since(...)]` attribute in `attrs` with its `Since:` doc, preserving order.
+fn rewrite_attrs_since(attrs: &mut Vec<syn::Attribute>) -> Result<bool, syn::Error> {
+    let sinces = attrs.iter().filter(|a| is_since(a)).map(Since::from_attr).collect::<Result<Vec<_>, _>>()?;
+
+    if sinces.is_empty() {
+        return Ok(false);
+    }
+
+    attrs.retain(|a| !is_since(a));
+    for since in &sinces {
+        since.append_since_doc_attrs(attrs);
+    }
+
+    Ok(true)
+}
+
+/// Whether `attr` is a `#[since(...)]` marker, matching both `since` and `openraft_macros::since`.
+fn is_since(attr: &syn::Attribute) -> bool {
+    attr.path().segments.last().is_some_and(|s| s.ident == "since")
 }

--- a/macros/tests/since/expand/on_field.expanded.rs
+++ b/macros/tests/since/expand/on_field.expanded.rs
@@ -1,0 +1,16 @@
+struct Foo {
+    /// Field a.
+    ///
+    /// Since: 1.0.0
+    a: i32,
+    /// Since: 1.1.0, Date(2021-01-01)
+    b: i32,
+}
+/// Since: 2.0.0
+enum Bar {
+    /// Variant X.
+    ///
+    /// Since: 1.5.0
+    X,
+    Y,
+}

--- a/macros/tests/since/expand/on_field.rs
+++ b/macros/tests/since/expand/on_field.rs
@@ -1,0 +1,19 @@
+// `#[since]` on a container rewrites `#[since(...)]` markers on its fields / variants.
+
+#[openraft_macros::since]
+struct Foo {
+    /// Field a.
+    #[openraft_macros::since(version = "1.0.0")]
+    a: i32,
+
+    #[openraft_macros::since(version = "1.1.0", date = "2021-01-01")]
+    b: i32,
+}
+
+#[openraft_macros::since(version = "2.0.0")]
+enum Bar {
+    /// Variant X.
+    #[openraft_macros::since(version = "1.5.0")]
+    X,
+    Y,
+}

--- a/openraft/src/change_members.rs
+++ b/openraft/src/change_members.rs
@@ -79,6 +79,7 @@ where
     ///
     /// The changes are applied in the order they are given.
     /// And it still finishes in a two-step joint config change.
+    #[since(version = "0.10.0")]
     Batch(Vec<ChangeMembers<NID, N>>),
 }
 

--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -159,6 +159,7 @@ impl SnapshotPolicy {
 /// - [`SnapshotPolicy`] for snapshot triggering strategies
 ///
 /// [`Raft::new`]: crate::Raft::new
+#[since]
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "clap", derive(Parser))]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -257,11 +258,13 @@ pub struct Config {
 
     /// `RaftMsg::ClientWrite` batch before it is processed.
     /// Then the batched `ClientWrite` requests will be submitted to `RaftStorage` in one shot.
+    #[since(version = "0.10.0")]
     #[cfg_attr(feature = "clap", clap(long, default_value = "4096"))]
     pub api_batch_capacity: u64,
 
     /// Maximum amount of milliseconds to wait for additional client requests before
     /// flushing a partially filled batch.
+    #[since(version = "0.10.0")]
     #[cfg_attr(feature = "clap", clap(long, default_value = "0"))]
     pub api_batch_linger_ms: u64,
     /// The size of the bounded notification channel for internal events.

--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -214,6 +214,7 @@ pub struct Config {
     /// Storage typically has higher throughput than network, so this value can be larger.
     ///
     /// Defaults to 4096.
+    #[since(version = "0.10.0")]
     #[cfg_attr(feature = "clap", clap(long, default_value = "4096"))]
     pub max_append_entries: Option<u64>,
 
@@ -253,6 +254,7 @@ pub struct Config {
     ///
     /// This controls backpressure for client requests. When the channel is full,
     /// new API calls will block until space becomes available.
+    #[since(version = "0.10.0")]
     #[cfg_attr(feature = "clap", clap(long, default_value = "65536"))]
     pub api_channel_size: Option<u64>,
 
@@ -271,6 +273,7 @@ pub struct Config {
     ///
     /// This channel carries internal notifications like IO completion, replication progress,
     /// and tick events. When full, internal components will block until space is available.
+    #[since(version = "0.10.0")]
     #[cfg_attr(feature = "clap", clap(long, default_value = "65536"))]
     pub notification_channel_size: Option<u64>,
 
@@ -279,6 +282,7 @@ pub struct Config {
     /// This channel carries commands like Apply, BuildSnapshot, and InstallSnapshot.
     /// When full, RaftCore will block until space becomes available, providing backpressure
     /// when the state machine is slow.
+    #[since(version = "0.10.0")]
     #[cfg_attr(feature = "clap", clap(long, default_value = "1024"))]
     pub state_machine_channel_size: Option<u64>,
 
@@ -289,6 +293,7 @@ pub struct Config {
     /// Only used when the `runtime-stats` feature is enabled.
     ///
     /// Defaults to 1024 if not specified.
+    #[since(version = "0.10.0")]
     #[cfg_attr(feature = "clap", clap(long))]
     pub log_stage_capacity: Option<u64>,
 
@@ -404,8 +409,7 @@ pub struct Config {
     ///
     /// Because only the last few explicit delays shape what follows, you can prepend any
     /// number of custom warm-up values without changing the long-run behavior.
-    ///
-    /// Since: 0.10.0
+    #[since(version = "0.10.0")]
     #[cfg_attr(feature = "clap", clap(long, default_value = DEFAULTS.backoff))]
     pub backoff: String,
 
@@ -420,8 +424,7 @@ pub struct Config {
     ///
     /// For one-shot log reversion, use
     /// [`Raft::trigger().allow_next_revert()`](crate::raft::trigger::Trigger::allow_next_revert).
-    ///
-    /// Since: 0.10.0
+    #[since(version = "0.10.0")]
     #[cfg_attr(feature = "clap", clap(long,
            action = clap::ArgAction::Set,
            num_args = 0..=1,

--- a/openraft/src/config/error.rs
+++ b/openraft/src/config/error.rs
@@ -1,7 +1,9 @@
 use anyerror::AnyError;
 use backoff_series::ParseError as BackoffParseError;
+use openraft_macros::since;
 
 /// Error variants related to configuration.
+#[since]
 #[derive(Debug, thiserror::Error)]
 #[derive(PartialEq, Eq)]
 pub enum ConfigError {
@@ -57,8 +59,7 @@ pub enum ConfigError {
     /// Invalid backoff policy string.
     ///
     /// See [`backoff_series::BackoffSeries::parse`] for the expected format.
-    ///
-    /// Since: 0.10.0
+    #[since(version = "0.10.0")]
     #[error(transparent)]
     InvalidBackoff(#[from] BackoffParseError),
 }

--- a/openraft/src/core/merged_raft_msg_receiver.rs
+++ b/openraft/src/core/merged_raft_msg_receiver.rs
@@ -144,7 +144,7 @@ where C: RaftTypeConfig
         &mut self,
         deadline: <C::AsyncRuntime as AsyncRuntime>::Instant,
     ) -> Result<Option<RaftMsg<C>>, Fatal<C>> {
-        match C::AsyncRuntime::mpsc_recv_timeout_at(&mut self.inner, deadline).await {
+        match C::AsyncRuntime::mpsc_recv_deadline(&mut self.inner, deadline).await {
             Ok(value) => Ok(Some(value)),
             Err(TryRecvError::Empty) => {
                 tracing::debug!("all RaftMsg are processed, wait for more");

--- a/openraft/src/core/runtime_stats/runtime_stats_display.rs
+++ b/openraft/src/core/runtime_stats/runtime_stats_display.rs
@@ -19,7 +19,7 @@ use crate::core::runtime_stats::log_stage::LogStages;
 use crate::engine::CommandName;
 use crate::type_config::alias::InstantOf;
 
-/// Precomputed display data for [`RuntimeStats`].
+/// Precomputed display data for [`RuntimeStats`](super::RuntimeStats).
 ///
 /// All values are computed upfront so `Display::fmt()` is cheap.
 /// Use [`DisplayMode`] to control the output format.

--- a/openraft/src/display_ext/display_btreemap_opt_value.rs
+++ b/openraft/src/display_ext/display_btreemap_opt_value.rs
@@ -8,7 +8,7 @@ use display_more::DisplayOptionExt;
 /// It formats a key-value pair in a string like "{key}:{opt_value}" and
 /// concatenates the key-value pairs with comma.
 ///
-/// For how to format the `opt_value`, see [`DisplayOption`].
+/// For how to format the `opt_value`, see [`DisplayOptionExt`].
 pub(crate) struct DisplayBTreeMapOptValue<'a, K: fmt::Display, V: fmt::Display>(pub &'a BTreeMap<K, Option<V>>);
 
 impl<K: fmt::Display, V: fmt::Display> fmt::Display for DisplayBTreeMapOptValue<'_, K, V> {

--- a/openraft/src/metrics/metric.rs
+++ b/openraft/src/metrics/metric.rs
@@ -1,5 +1,7 @@
 use std::cmp::Ordering;
 
+use openraft_macros::since;
+
 use crate::LogIdOptionExt;
 use crate::RaftMetrics;
 use crate::RaftTypeConfig;
@@ -11,6 +13,7 @@ use crate::vote::raft_vote::RaftVoteExt;
 /// A metric entry of a Raft node.
 ///
 /// This is used to specify which metric to observe.
+#[since]
 #[derive(Debug)]
 pub enum Metric<C>
 where C: RaftTypeConfig
@@ -22,6 +25,7 @@ where C: RaftTypeConfig
     /// The index of the last log entry.
     LastLogIndex(Option<u64>),
     /// The last committed log ID (accepted by a quorum).
+    #[since(version = "0.10.0")]
     Committed(Option<LogIdOf<C>>),
     /// The last applied log ID.
     Applied(Option<LogIdOf<C>>),

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use display_more::DisplayOptionExt;
+use openraft_macros::since;
 
 use crate::Instant;
 use crate::RaftTypeConfig;
@@ -70,6 +71,7 @@ use crate::vote::raft_vote::RaftVoteExt;
 /// - [`RaftServerMetrics`] for server operational metrics
 ///
 /// [`Raft::metrics`]: crate::Raft::metrics
+#[since]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct RaftMetrics<C: RaftTypeConfig> {
@@ -99,6 +101,7 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     /// delivery. See [`commit`] for the full explanation of the distinction.
     ///
     /// [`commit`]: crate::docs::protocol::commit
+    #[since(version = "0.10.0")]
     pub committed: Option<LogIdOf<C>>,
 
     /// The last log index has been applied to this Raft node's state machine.
@@ -117,6 +120,7 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     /// The list of log IDs, one per leader, tracking the last log entry from each leader.
     ///
     /// Only available when the `metrics-logids` feature is enabled.
+    #[since(version = "0.10.0")]
     #[cfg(feature = "metrics-logids")]
     #[cfg_attr(feature = "serde", serde(skip))]
     pub log_id_list: LogIdListOf<C>,
@@ -162,6 +166,7 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     /// lost synchronization with the cluster.
     /// An older value may suggest a higher probability of the leader being partitioned from the
     /// cluster.
+    #[since(version = "0.10.0")]
     pub last_quorum_acked: Option<SerdeInstantOf<C>>,
 
     /// The current membership config of the cluster.
@@ -175,6 +180,7 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     /// This duration since the recorded time can be used by applications to
     /// guess if a follower/learner node is offline, longer duration suggests
     /// a higher possibility of that.
+    #[since(version = "0.10.0")]
     pub heartbeat: Option<HeartbeatMetrics<C>>,
 
     // ---
@@ -264,6 +270,7 @@ where C: RaftTypeConfig
 }
 
 /// Subset of RaftMetrics, only include data-related metrics
+#[since]
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct RaftDataMetrics<C: RaftTypeConfig> {
@@ -275,6 +282,7 @@ pub struct RaftDataMetrics<C: RaftTypeConfig> {
     /// cluster-committed.
     ///
     /// [`commit`]: crate::docs::protocol::commit
+    #[since(version = "0.10.0")]
     pub committed: Option<LogIdOf<C>>,
     /// The last applied log id.
     pub last_applied: Option<LogIdOf<C>>,
@@ -286,6 +294,7 @@ pub struct RaftDataMetrics<C: RaftTypeConfig> {
     /// The list of log IDs, one per leader, tracking the last log entry from each leader.
     ///
     /// Only available when the `metrics-logids` feature is enabled.
+    #[since(version = "0.10.0")]
     #[cfg(feature = "metrics-logids")]
     #[cfg_attr(feature = "serde", serde(skip))]
     pub log_id_list: LogIdListOf<C>,
@@ -318,6 +327,7 @@ pub struct RaftDataMetrics<C: RaftTypeConfig> {
     /// lost synchronization with the cluster.
     /// An older value may suggest a higher probability of the leader being partitioned from the
     /// cluster.
+    #[since(version = "0.10.0")]
     pub last_quorum_acked: Option<SerdeInstant<InstantOf<C>>>,
 
     /// Replication metrics for each node, available only on the leader.
@@ -331,6 +341,7 @@ pub struct RaftDataMetrics<C: RaftTypeConfig> {
     /// This duration since the recorded time can be used by applications to
     /// guess if a follower/learner node is offline, longer duration suggests
     /// a higher possibility of that.
+    #[since(version = "0.10.0")]
     pub heartbeat: Option<HeartbeatMetrics<C>>,
 }
 

--- a/openraft/src/network/rpc_type.rs
+++ b/openraft/src/network/rpc_type.rs
@@ -1,6 +1,9 @@
 use std::fmt;
 
+use openraft_macros::since;
+
 /// Types of RPC requests in the Raft protocol.
+#[since]
 #[derive(Debug, Clone, Copy)]
 #[derive(PartialEq, Eq)]
 #[derive(Hash)]
@@ -13,6 +16,7 @@ pub enum RPCTypes {
     /// InstallSnapshot request RPC.
     InstallSnapshot,
     /// TransferLeader request RPC.
+    #[since(version = "0.10.0")]
     TransferLeader,
 }
 

--- a/openraft/src/network/v2/network.rs
+++ b/openraft/src/network/v2/network.rs
@@ -44,7 +44,7 @@ use crate::type_config::alias::VoteOf;
 /// It remains **compatible** with the stream-oriented API, however: if an application only
 /// implements the unary `append_entries`, Openraft adapts it into a stream by calling it
 /// sequentially via the default [`stream_append`](Self::stream_append) implementation
-/// (see [`stream_append_sequential`](crate::network::stream_append_sequential)). This is
+/// (see [`stream_append_sequential`]). This is
 /// convenient but not optimal for throughput.
 ///
 /// For true streaming performance while keeping the unified interface, an application can

--- a/rt/src/async_runtime.rs
+++ b/rt/src/async_runtime.rs
@@ -9,6 +9,8 @@ use std::future::Future;
 use std::io;
 use std::time::Duration;
 
+use openraft_macros::since;
+
 use crate::Instant;
 use crate::Mpsc;
 use crate::MpscReceiver;
@@ -163,6 +165,7 @@ pub trait AsyncRuntime: Debug + OptionalSend + OptionalSync + 'static {
     /// If not, it uses the AsyncRuntime timeout mechanism to wait until:
     /// - a new element arrives
     /// - the deadline is reached
+    #[since(version = "0.10.0")]
     fn mpsc_recv_timeout_at<T: OptionalSend>(
         receiver: &mut <Self::Mpsc as Mpsc>::Receiver<T>,
         deadline: Self::Instant,

--- a/rt/src/async_runtime.rs
+++ b/rt/src/async_runtime.rs
@@ -166,7 +166,7 @@ pub trait AsyncRuntime: Debug + OptionalSend + OptionalSync + 'static {
     /// - a new element arrives
     /// - the deadline is reached
     #[since(version = "0.10.0")]
-    fn mpsc_recv_timeout_at<T: OptionalSend>(
+    fn mpsc_recv_deadline<T: OptionalSend>(
         receiver: &mut <Self::Mpsc as Mpsc>::Receiver<T>,
         deadline: Self::Instant,
     ) -> impl Future<Output = Result<T, TryRecvError>> + OptionalSend {


### PR DESCRIPTION

## Changelog

##### docs: annotate 0.10.0 public fields and variants with #[since]
# Summary

Record the introducing version of every public field and enum variant added to
a pre-existing public type during the 0.10.0 cycle. These members were left
unmarked because the `#[since]` macro could not annotate fields or variants
until recently; this fills that gap so the generated docs show when each first
appeared.

# Details

- Add `#[since(version = "0.10.0")]` to the new members of `Config`,
  `ConfigError`, `ChangeMembers`, `Metric`, `RaftMetrics`, `RaftDataMetrics`,
  and `RPCTypes`.
- Convert the hand-written `Since: 0.10.0` doc lines on `Config::backoff`,
  `Config::allow_log_reversion`, and `ConfigError::InvalidBackoff` into the
  `#[since]` attribute now that member-level support exists.
- Give the types that lacked one a container-level `#[since]` (plus the macro
  import); the container attribute is what lets the macro rewrite the
  member-level markers.


##### refactor: rename mpsc_recv_timeout_at to mpsc_recv_deadline
# Summary

`AsyncRuntime::mpsc_recv_timeout_at` is renamed to `mpsc_recv_deadline`, a
clearer name for receiving from an mpsc channel until a given deadline. Pure
rename of the default trait method and its only call site, with no behavior
change.


##### feat: support #[since] on struct fields and enum variants
# Summary

Rust forbids attribute macros on struct fields, so `#[since]` could previously
annotate only items. A container's `#[since]` now rewrites `#[since(...)]`
markers on its fields and enum variants into `Since:` doc lines, which lets the
new batch-API surface carry version annotations. Also repairs three unrelated
broken intra-doc links surfaced while building docs.

# Details

- `#[since]` on a `struct`/`enum` rewrites `#[since(...)]` markers on its fields
  and variants into doc lines; non-container items and marker-free containers
  keep the original token-level behavior, so existing usages are unchanged. An
  expansion test covers the new path.
- Annotate the new public API with `#[since(version = "0.10.0")]`:
  `Config::api_batch_capacity`, `Config::api_batch_linger_ms`, and
  `AsyncRuntime::mpsc_recv_timeout_at`.
- Fix three broken intra-doc links (`RuntimeStats`, `DisplayOptionExt`, and a
  redundant `stream_append_sequential` target) so the docs build clean under
  `-D warnings`.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1765)
<!-- Reviewable:end -->
