### PR TITLE
ci: cache examples job builds with sccache and workspaces

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -420,6 +420,14 @@ jobs:
 
   examples:
     runs-on: ubuntu-latest
+    # RocksDB-backed examples (raft-kv-rocksdb, rocksstore) compile RocksDB's
+    # bundled C++ from source — the slowest step in CI. Route that C/C++ build
+    # through sccache (object-level cache, shared across jobs) so a cold target
+    # rebuild reuses the .o files. `cc` recognizes sccache as a known wrapper.
+    env:
+      SCCACHE_GHA_ENABLED: 'true'
+      CC: 'sccache cc'
+      CXX: 'sccache c++'
     strategy:
       fail-fast: false
       matrix:
@@ -444,6 +452,13 @@ jobs:
         with:
           toolchain: '${{ matrix.toolchain }}'
           components: rustfmt, clippy
+          # Examples are separate workspaces; the default cache only covers the
+          # repo-root target, so examples/*/target (incl. the built RocksDB lib)
+          # was never cached. Point the cache at this example's own workspace.
+          cache-workspaces: examples/${{ matrix.example }}
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3


### PR DESCRIPTION

## Changelog

##### ci: cache examples job builds with sccache and workspaces
# Summary

The `examples` CI job recompiles RocksDB's bundled C++ from source on
every run, the slowest step in the pipeline. Cache that work so reruns
reuse prior build artifacts instead of starting cold.

# Details

- Route the C/C++ compiler through sccache (`CC`/`CXX` wrappers with the
  GitHub Actions backend) and add a Setup sccache step. RocksDB object
  files are then cached at object granularity and shared across matrix
  jobs.
- Point `cache-workspaces` at `examples/${{ matrix.example }}`. Each
  example is its own workspace, so the default repo-root target cache
  never covered `examples/*/target` — including the built RocksDB
  library — leaving it rebuilt cold on every run.

---

- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1766)
<!-- Reviewable:end -->
