### PR TITLE
ci: link system RocksDB in examples instead of compiling it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -420,14 +420,14 @@ jobs:
 
   examples:
     runs-on: ubuntu-latest
-    # RocksDB-backed examples (raft-kv-rocksdb, rocksstore) compile RocksDB's
-    # bundled C++ from source — the slowest step in CI. Route that C/C++ build
-    # through sccache (object-level cache, shared across jobs) so a cold target
-    # rebuild reuses the .o files. `cc` recognizes sccache as a known wrapper.
+    # RocksDB-backed examples (raft-kv-rocksdb, rocksstore) were the slowest CI
+    # jobs because librocksdb-sys compiles bundled RocksDB (8.10) C++ from
+    # source. Link the system librocksdb instead so it is not compiled at all;
+    # ROCKSDB_INCLUDE_DIR points bindgen at the system headers so the generated
+    # bindings match the installed lib version (no ABI skew).
     env:
-      SCCACHE_GHA_ENABLED: 'true'
-      CC: 'sccache cc'
-      CXX: 'sccache c++'
+      ROCKSDB_LIB_DIR: /usr/lib/x86_64-linux-gnu
+      ROCKSDB_INCLUDE_DIR: /usr/include
     strategy:
       fail-fast: false
       matrix:
@@ -453,12 +453,13 @@ jobs:
           toolchain: '${{ matrix.toolchain }}'
           components: rustfmt, clippy
           # Examples are separate workspaces; the default cache only covers the
-          # repo-root target, so examples/*/target (incl. the built RocksDB lib)
-          # was never cached. Point the cache at this example's own workspace.
+          # repo-root target, so examples/*/target was never cached. Point the
+          # cache at this example's own workspace.
           cache-workspaces: examples/${{ matrix.example }}
 
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+      - name: Install system RocksDB
+        if: matrix.example == 'raft-kv-rocksdb' || matrix.example == 'rocksstore'
+        run: sudo apt-get update && sudo apt-get install -y librocksdb-dev
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3


### PR DESCRIPTION

## Changelog

##### ci: link system RocksDB in examples instead of compiling it
# Summary

The RocksDB-backed example jobs (`raft-kv-rocksdb`, `rocksstore`) spent
most of their CI time compiling librocksdb-sys's bundled RocksDB 8.10
C++ from source. Install and link the distro's prebuilt
`librocksdb-dev` so that compile is skipped entirely.

# Details

- Add an Install system RocksDB step, gated to the two RocksDB examples,
  that installs `librocksdb-dev` via apt.
- Set `ROCKSDB_LIB_DIR` and `ROCKSDB_INCLUDE_DIR` so librocksdb-sys
  links the system library and bindgen generates bindings against the
  installed headers, keeping bindings in lockstep with the linked lib
  version (no ABI skew).
- Drop the sccache compile-caching (compiler env wrappers and Setup
  sccache step) from the previous approach. Linking a prebuilt library
  removes the compile rather than caching it.

---

- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1767)
<!-- Reviewable:end -->
