### PR TITLE
ci: cache tests-turmoil workspace to skip cold fuzz rebuilds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -368,6 +368,10 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 'nightly-2026-03-01'
+          # tests-turmoil is excluded from the root workspace, so the default
+          # cache misses its target dir and the fuzz binary recompiles cold
+          # every run. Cache this workspace so warm runs skip the compile.
+          cache-workspaces: tests-turmoil
 
       - name: Run deterministic simulation
         run: cd tests-turmoil && cargo run --bin fuzz -- --iterations 5 --max-steps 10000


### PR DESCRIPTION

## Changelog

##### ci: cache tests-turmoil workspace to skip cold fuzz rebuilds
# Summary

The deterministic simulation job runs a fuzz binary from
`tests-turmoil`, which is excluded from the root workspace. The default
cache only covers the root target dir, so the binary recompiled cold on
every run. Cache the `tests-turmoil` workspace so warm runs skip that
compile.

---

- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1768)
<!-- Reviewable:end -->
