### PR TITLE
feat: config: Make fast path re-elect configurable

### DIFF
--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -465,6 +465,44 @@ pub struct Config {
            default_missing_value = "true"
     ))]
     pub allow_log_reversion: Option<bool>,
+
+    /// Whether to allow a restarted leader to restore leadership without a vote.
+    ///
+    /// When enabled (`true`), if a node that was leader before a restart comes back quickly
+    /// enough, before any other node triggers and election, it can continue serving as leader
+    /// without re-election. This differs from standard Raft, but can help improve availability
+    /// after a leader restart.
+    ///
+    /// When disabled (`false`), a restarted leader must always trigger a new election to become
+    /// leader again.
+    ///
+    /// **Important**: When this setting is enabled, it can introduce inconsistencies when the
+    /// following conditions are true:
+    ///
+    /// - The state machine does not flush state to disk before returning from
+    ///   [`openraft::storage::RaftLogStorage::apply`].
+    /// - The last committed log id is not persisted.
+    ///
+    /// When the above conditions are met and this setting is enabled, then a leader can restart
+    /// with a stale state machine and restore itself as leader without any mechanism to detect
+    /// the staleness.
+    ///
+    /// When the above conditions are met and this setting is disabled, then a restarted leader can
+    /// learn the current commit log id by participating in a new election or receiving a message
+    /// from the new leader.
+    ///
+    /// See: [`docs::data::log_pointers`].
+    ///
+    /// [`docs::data::log_pointers`]: `crate::docs::data::log_pointers#optionally-persisted-committed`
+    // clap 4 requires `num_args = 0..=1`, or it complains about missing arg error
+    // https://github.com/clap-rs/clap/discussions/4374
+    #[since(version = "0.10.0")]
+    #[cfg_attr(feature = "clap", clap(long,
+           action = clap::ArgAction::Set,
+           num_args = 0..=1,
+           default_missing_value = "true"
+    ))]
+    pub enable_leader_restore: Option<bool>,
 }
 
 impl Default for Config {
@@ -496,6 +534,7 @@ impl Default for Config {
             removed_leader_step_down: DEFAULTS.removed_leader_step_down.clone(),
             backoff: DEFAULTS.backoff.to_string(),
             allow_log_reversion: None,
+            enable_leader_restore: None,
         }
     }
 }
@@ -532,6 +571,15 @@ impl Config {
     #[since(version = "0.10.0")]
     pub(crate) fn get_allow_log_reversion(&self) -> bool {
         self.allow_log_reversion.unwrap_or(false)
+    }
+
+    /// Whether a node that was a leader before a restart restores leadership at startup, without
+    /// an election.
+    ///
+    /// By default, it restores leadership at once for better availability.
+    #[since(version = "0.10.0")]
+    pub(crate) fn enable_leader_restore(&self) -> bool {
+        self.enable_leader_restore.unwrap_or(true)
     }
 
     /// Get the API channel size for bounded MPSC channel.

--- a/openraft/src/config/config_clap_test.rs
+++ b/openraft/src/config/config_clap_test.rs
@@ -183,6 +183,34 @@ fn test_config_allow_log_reversion() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_config_enable_leader_restore() -> anyhow::Result<()> {
+    let config = Config::build(&["foo", "--enable-leader-restore=false"])?;
+    assert_eq!(Some(false), config.enable_leader_restore);
+
+    let config = Config::build(&["foo", "--enable-leader-restore=true"])?;
+    assert_eq!(Some(true), config.enable_leader_restore);
+
+    let config = Config::build(&["foo", "--enable-leader-restore"])?;
+    assert_eq!(Some(true), config.enable_leader_restore);
+
+    let mut config = Config::build(&["foo"])?;
+    assert_eq!(None, config.enable_leader_restore);
+
+    // test enable_leader_restore method
+
+    config.enable_leader_restore = None;
+    assert_eq!(true, config.enable_leader_restore());
+
+    config.enable_leader_restore = Some(true);
+    assert_eq!(true, config.enable_leader_restore());
+
+    config.enable_leader_restore = Some(false);
+    assert_eq!(false, config.enable_leader_restore());
+
+    Ok(())
+}
+
+#[test]
 fn test_config_api_channel_size() -> anyhow::Result<()> {
     // Test default value
     let config = Config::build(&["foo"])?;

--- a/openraft/src/engine/engine_config.rs
+++ b/openraft/src/engine/engine_config.rs
@@ -24,6 +24,8 @@ pub(crate) struct EngineConfig<C: RaftTypeConfig> {
     pub(crate) allow_log_reversion: bool,
 
     pub(crate) timer_config: time_state::Config,
+
+    pub(crate) enable_leader_restore: bool,
 }
 
 impl<C> EngineConfig<C>
@@ -43,6 +45,8 @@ where C: RaftTypeConfig
                 smaller_log_timeout: Duration::from_millis(config.election_timeout_max * 2),
                 leader_lease: Duration::from_millis(config.election_timeout_max),
             },
+
+            enable_leader_restore: config.enable_leader_restore(),
         }
     }
 
@@ -55,6 +59,7 @@ where C: RaftTypeConfig
             max_payload_entries: 300,
             allow_log_reversion: false,
             timer_config: time_state::Config::default(),
+            enable_leader_restore: true,
         }
     }
 }

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -144,10 +144,26 @@ where C: RaftTypeConfig
         );
 
         // TODO: replace all the following codes with one update_internal_server_state;
-        // Previously it is a leader. restore it as leader at once
+        // Previously it is a leader. restore it as leader at once if leader restore enabled.
         if self.state.is_leader(&self.config.id) {
-            self.vote_handler().update_internal_server_state();
-            return;
+            if self.config.enable_leader_restore {
+                self.vote_handler().update_internal_server_state();
+                return;
+            } else {
+                // Demote the vote in memory only; do not persist it.
+                //
+                // Saving a non-committed vote would revert the vote value in storage
+                // (non-committed < committed for the same leader), breaking the
+                // monotonicity invariant of vote storage and of IO progress tracking.
+                //
+                // Keeping the committed vote in storage is safe: there is no vote `x`
+                // such that `(term, node, non-committed) < x < (term, node, committed)`,
+                // so any vote accepted later is also greater than the stored one and
+                // the next `SaveVote` automatically heals the divergence.
+                let uncommitted: VoteOf<C> = self.state.vote.to_non_committed().into_vote();
+                self.state.vote.update(C::now(), Duration::default(), uncommitted);
+                debug_assert!(!self.state.is_leader(&self.config.id))
+            }
         }
 
         let server_state = if self.state.membership_state.effective().is_voter(&self.config.id) {

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -239,3 +239,34 @@ fn test_startup_as_learner() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_startup_as_leader_leader_restore_disabled() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.config.enable_leader_restore = false;
+
+    // self.id==2 is a voter:
+    eng.state.membership_state.set_effective(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        Some(log_id(1, 1, 3)),
+        m23(),
+    )));
+    eng.state.log_ids = LogIdList::new(None, [log_id(1, 1, 3)]);
+    // Committed vote would normally make it a leader at startup.
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 2),
+    );
+
+    eng.startup();
+
+    // It does not re-elect itself; as a voter it becomes a Follower.
+    assert_eq!(ServerState::Follower, eng.state.server_state);
+    assert!(eng.leader_ref().is_none());
+    assert!(!eng.state.is_leader(&eng.config.id));
+    // The demotion is in-memory only: no command is emitted; the committed vote stays in storage.
+    assert_eq!(eng.output.take_commands(), vec![]);
+    assert_eq!(eng.state.vote_ref(), &Vote::new(2, 2));
+
+    Ok(())
+}

--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -60,6 +60,7 @@ struct DerivedConfig {
     long_outage_min_ticks: u64,
     /// Maximum downtime (in ticks) for a long outage.
     long_outage_max_ticks: u64,
+    enable_leader_restore: bool,
 }
 
 impl DerivedConfig {
@@ -72,6 +73,7 @@ impl DerivedConfig {
         let fail_rate = rng.gen_range(0.0..0.002);
         let election_timeout_max = election_timeout_min + rng.gen_range(100..500);
         let enable_chaos = rng.gen_bool(0.8);
+        let enable_leader_restore = rng.gen_bool(0.5);
         Self {
             num_initial_nodes,
             max_potential_nodes: 10,
@@ -89,6 +91,7 @@ impl DerivedConfig {
             long_outage_chance: rng.gen_range(0.1..=0.3), // 10-30% of crashes
             long_outage_min_ticks: 5000,
             long_outage_max_ticks: 15000,
+            enable_leader_restore,
         }
     }
 }
@@ -111,7 +114,8 @@ impl std::fmt::Display for DerivedConfig {
         writeln!(f, "  replication_lag_threshold: {}", self.replication_lag_threshold)?;
         writeln!(f, "  long_outage_chance: {:.4}", self.long_outage_chance)?;
         writeln!(f, "  long_outage_min_ticks: {}", self.long_outage_min_ticks)?;
-        write!(f, "  long_outage_max_ticks: {}", self.long_outage_max_ticks)
+        writeln!(f, "  long_outage_max_ticks: {}", self.long_outage_max_ticks)?;
+        write!(f, "  enable_leader_restore: {}", self.enable_leader_restore)
     }
 }
 
@@ -261,12 +265,13 @@ fn run_fuzz_loop(base_seed: u64, max_steps: u64, iterations: u64, crash_file: Op
         let derived = DerivedConfig::from_seed(iteration_seed);
 
         println!(
-            "--- Iteration {} (seed: {}, nodes: {}, fail_rate: {:.2}%, chaos: {}) ---",
+            "--- Iteration {} (seed: {}, nodes: {}, fail_rate: {:.2}%, chaos: {}, leader_restore: {}) ---",
             iteration + 1,
             iteration_seed,
             derived.num_initial_nodes,
             derived.fail_rate * 100.0,
-            derived.enable_chaos
+            derived.enable_chaos,
+            derived.enable_leader_restore,
         );
 
         let result = run_single_iteration(iteration_seed, &derived, max_steps, running.clone());
@@ -593,6 +598,7 @@ fn run_single_iteration(
         snapshot_policy: openraft::SnapshotPolicy::LogsSinceLast(derived.snapshot_logs_threshold),
         max_in_snapshot_log_to_keep: derived.max_in_snapshot_log_to_keep,
         replication_lag_threshold: derived.replication_lag_threshold,
+        enable_leader_restore: Some(derived.enable_leader_restore),
         ..Default::default()
     });
 

--- a/tests/tests/life_cycle/main.rs
+++ b/tests/tests/life_cycle/main.rs
@@ -11,6 +11,7 @@ mod t10_initialization;
 mod t11_shutdown;
 mod t50_follower_restart_does_not_interrupt;
 mod t50_leader_restart_clears_state;
+mod t50_leader_restart_leader_restore_disabled;
 mod t50_single_follower_restart;
 mod t50_single_leader_restart_re_apply_logs;
 mod t90_issue_607_single_restart;

--- a/tests/tests/life_cycle/t50_leader_restart_leader_restore_disabled.rs
+++ b/tests/tests/life_cycle/t50_leader_restart_leader_restore_disabled.rs
@@ -1,0 +1,66 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::Config;
+use openraft::ServerState;
+use openraft::Vote;
+
+use crate::fixtures::MemLogStore;
+use crate::fixtures::MemRaft;
+use crate::fixtures::MemStateMachine;
+use crate::fixtures::RaftRouter;
+use crate::fixtures::ut_harness;
+
+/// With `enable_leader_restore=false`, a restarted leader must not restore leadership
+/// from the persisted committed vote. It restarts as a follower and re-acquires
+/// leadership through a normal election at a higher term.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn leader_restart_leader_restore_disabled() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_leader_restore: Some(false),
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- bring up cluster of 1 node");
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- write 1 log");
+    {
+        log_index += router.client_request_many(0, "foo", 1).await?;
+    }
+
+    tracing::info!(log_index, "--- stop and restart node-0");
+    {
+        let (node, ls, sm): (MemRaft, MemLogStore, MemStateMachine) = router.remove_node(0).unwrap();
+        node.shutdown().await?;
+
+        router.new_raft_node_with_sto(0, ls, sm).await;
+    }
+
+    tracing::info!(log_index, "--- node-0 must re-elect instead of restoring leadership");
+    {
+        router.wait(&0, timeout()).state(ServerState::Leader, "leader again via election").await?;
+
+        // Term 2 proves a real election happened: restoring leadership would have
+        // kept the committed vote at term 1.
+        router.wait(&0, timeout()).vote(Vote::new_committed(2, 0), "vote moved to term 2").await?;
+
+        // The new leader appends a blank log entry for its term.
+        log_index += 1;
+        router.wait(&0, timeout()).applied_index(Some(log_index), "logs re-applied, plus the noop").await?;
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}


### PR DESCRIPTION
Previously, when a leader restarted fast enough, it would re-elect itself as a leader without an election. This behavior improves availability but differs from standard Raft and introduces potential inconsistencies.

This change adds a configuration that allows users to disable this behavior.

Fixes #1511




**Checklist**

- [X] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [X] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [X] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1771)
<!-- Reviewable:end -->
