### PR TITLE
refactor: drop unused PartialEq/Eq derives from proposer state

### DIFF
--- a/openraft/src/progress/vec_progress.rs
+++ b/openraft/src/progress/vec_progress.rs
@@ -15,7 +15,6 @@ use crate::quorum::QuorumSet;
 ///
 /// Suitable for a small quorum set.
 #[derive(Clone, Debug)]
-#[derive(PartialEq, Eq)]
 pub(crate) struct VecProgress<ID, Ent, Prog, QS>
 where
     ID: 'static,

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -18,7 +18,6 @@ use crate::vote::raft_vote::RaftVoteExt;
 
 /// Candidate: voting state.
 #[derive(Clone, Debug)]
-#[derive(PartialEq, Eq)]
 pub(crate) struct Candidate<C, QS>
 where
     C: RaftTypeConfig,

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -32,7 +32,6 @@ use crate::vote::raft_vote::RaftVoteExt;
 /// a higher `leader_id`(roughly the `term` in original raft) is seen.
 /// But instead it will be able to upgrade its `leader_id` without losing leadership.
 #[derive(Clone, Debug)]
-#[derive(PartialEq, Eq)]
 pub(crate) struct Leader<C, QS: QuorumSet<C::NodeId>>
 where C: RaftTypeConfig
 {


### PR DESCRIPTION

## Changelog

##### refactor: drop unused PartialEq/Eq derives from proposer state
# Summary

Candidate, Leader, and their embedded VecProgress are mutable runtime
state rather than value types, and nothing compares them for equality.
Remove the now-dead PartialEq/Eq derives to shrink their trait surface.

# Details

The three derives were coupled: Candidate and Leader each embed
VecProgress, so the proposers could only derive PartialEq/Eq while
VecProgress also did. Dropping all three together keeps them consistent.

All three structs are pub(crate), so this carries no public API or
#[since] impact.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1773)
<!-- Reviewable:end -->
