### PR TITLE
refactor: make Membership implement QuorumSet directly

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use display_more::DisplayOptionExt;
@@ -123,7 +124,7 @@ where C: RaftTypeConfig
             now,
             vote,
             last_log_id,
-            membership.to_quorum_set(),
+            Arc::new((*membership).clone()),
             membership.learner_ids(),
             self.state.progress_id_gen.clone(),
         ));

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use display_more::DisplayOptionExt;
 use display_more::DisplayResultExt;
 
@@ -112,14 +114,14 @@ where C: RaftTypeConfig
             };
 
             self.leader.progress =
-                old_progress.upgrade_quorum_set(em.membership().to_quorum_set(), learner_ids.clone(), default_v);
+                old_progress.upgrade_quorum_set(Arc::new((*em.membership()).clone()), learner_ids.clone(), default_v);
         }
 
         {
             let old_progress = self.leader.clock_progress.clone();
 
             self.leader.clock_progress =
-                old_progress.upgrade_quorum_set(em.membership().to_quorum_set(), learner_ids, || None);
+                old_progress.upgrade_quorum_set(Arc::new((*em.membership()).clone()), learner_ids, || None);
         }
     }
 

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -411,15 +411,6 @@ where
             }
         }
     }
-
-    /// Build a QuorumSet from current joint config
-    pub(crate) fn to_quorum_set(&self) -> Joint<NID, Vec<NID>, Vec<Vec<NID>>> {
-        let mut qs = vec![];
-        for c in self.get_joint_config().iter() {
-            qs.push(c.iter().cloned().collect::<Vec<_>>());
-        }
-        Joint::new(qs)
-    }
 }
 
 #[cfg(test)]

--- a/openraft/src/membership/membership_impl_quorum_set.rs
+++ b/openraft/src/membership/membership_impl_quorum_set.rs
@@ -1,0 +1,91 @@
+use std::collections::BTreeSet;
+
+use crate::Membership;
+use crate::node::Node;
+use crate::node::NodeId;
+use crate::quorum::QuorumSet;
+
+impl<NID, N> QuorumSet<NID> for Membership<NID, N>
+where
+    NID: NodeId,
+    N: Node,
+{
+    type Iter = std::collections::btree_set::IntoIter<NID>;
+
+    fn is_quorum<'a, I>(&self, ids: I) -> bool
+    where I: Iterator<Item = &'a NID> + Clone {
+        for config in &self.configs {
+            if !config.is_quorum(ids.clone()) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn ids(&self) -> Self::Iter {
+        let mut ids = BTreeSet::new();
+        for config in &self.configs {
+            ids.extend(config.iter().cloned());
+        }
+        ids.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use maplit::btreemap;
+    use maplit::btreeset;
+
+    use crate::Membership;
+    use crate::quorum::QuorumSet;
+
+    // `Membership` is the joint of its `configs`. `is_quorum`/`ids` read only `configs`,
+    // so `nodes` is left empty in the quorum-set tests below.
+
+    #[test]
+    fn test_membership_is_quorum() -> anyhow::Result<()> {
+        // Single config: simple majority.
+        {
+            let m12345 = Membership::<u64, ()> {
+                configs: vec![btreeset! {1,2,3,4,5}],
+                nodes: btreemap! {},
+            };
+
+            assert!(!m12345.is_quorum([0].iter()));
+            assert!(!m12345.is_quorum([0, 1, 2].iter()));
+            assert!(!m12345.is_quorum([6, 7, 8].iter()));
+            assert!(m12345.is_quorum([1, 2, 3].iter()));
+            assert!(m12345.is_quorum([3, 4, 5].iter()));
+            assert!(m12345.is_quorum([1, 3, 4, 5].iter()));
+        }
+
+        // Joint config: must be a majority in every config.
+        {
+            let m12345_678 = Membership::<u64, ()> {
+                configs: vec![btreeset! {1,2,3,4,5}, btreeset! {6,7,8}],
+                nodes: btreemap! {},
+            };
+
+            assert!(!m12345_678.is_quorum([0].iter()));
+            assert!(!m12345_678.is_quorum([0, 1, 2].iter()));
+            assert!(!m12345_678.is_quorum([6, 7, 8].iter()));
+            assert!(!m12345_678.is_quorum([1, 2, 3].iter()));
+            assert!(m12345_678.is_quorum([1, 2, 3, 6, 7].iter()));
+            assert!(m12345_678.is_quorum([1, 2, 3, 4, 7, 8].iter()));
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_membership_ids() -> anyhow::Result<()> {
+        let m12345_678 = Membership::<u64, ()> {
+            configs: vec![btreeset! {1,2,3,4,5}, btreeset! {4,5,6,7,8}],
+            nodes: btreemap! {},
+        };
+
+        assert_eq!(btreeset! {1,2,3,4,5,6,7,8}, m12345_678.ids().collect());
+
+        Ok(())
+    }
+}

--- a/openraft/src/membership/mod.rs
+++ b/openraft/src/membership/mod.rs
@@ -25,6 +25,7 @@ mod effective_membership;
 mod into_nodes;
 #[allow(clippy::module_inception)]
 mod membership;
+mod membership_impl_quorum_set;
 mod stored_membership;
 
 #[cfg(feature = "bench")]

--- a/openraft/src/proposer/leader_state.rs
+++ b/openraft/src/proposer/leader_state.rs
@@ -1,10 +1,13 @@
+use std::sync::Arc;
+
+use crate::Membership;
 use crate::proposer::Candidate;
 use crate::proposer::Leader;
-use crate::quorum::Joint;
 use crate::type_config::alias::NodeIdOf;
+use crate::type_config::alias::NodeOf;
 
 /// The quorum set type used by `Leader`.
-pub(crate) type LeaderQuorumSet<C> = Joint<NodeIdOf<C>, Vec<NodeIdOf<C>>, Vec<Vec<NodeIdOf<C>>>>;
+pub(crate) type LeaderQuorumSet<C> = Arc<Membership<NodeIdOf<C>, NodeOf<C>>>;
 
 pub(crate) type LeaderState<C> = Option<Box<Leader<C, LeaderQuorumSet<C>>>>;
 pub(crate) type CandidateState<C> = Option<Candidate<C, LeaderQuorumSet<C>>>;

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 use std::ops::Deref;
+use std::sync::Arc;
 
 use validit::Valid;
 use validit::Validate;
@@ -469,13 +470,13 @@ where C: RaftTypeConfig
     /// vote.
     /// A Leader established with election using the state in `Engine.candidate`.
     pub(crate) fn new_leader(&mut self) -> Leader<C, LeaderQuorumSet<C>> {
-        let em = &self.membership_state.effective().membership();
+        let em = self.membership_state.effective().membership();
 
         let last_leader_log_ids = self.log_ids.by_last_leader();
 
         Leader::new(
             self.vote_ref().to_committed(),
-            em.to_quorum_set(),
+            Arc::new((*em).clone()),
             em.learner_ids(),
             last_leader_log_ids,
             self.progress_id_gen.clone(),


### PR DESCRIPTION

## Changelog

##### refactor: make Membership implement QuorumSet directly
# Summary

The leader and progress layer previously derived its quorum set by converting
the effective `Membership` into a `Joint` via `to_quorum_set()`. `Membership`
now implements `QuorumSet` itself, as the joint of its voter configs, and the
leader holds the membership directly. Quorum decisions are unchanged.

# Details

- `Membership` implements `QuorumSet` in a dedicated module: `is_quorum`
  requires a majority in every config and `ids` returns the voter union, which
  reproduces the previous `Joint`-based behavior exactly.
- `LeaderQuorumSet` becomes `Arc<Membership<NodeId, Node>>` instead of
  `Joint<NodeId, ...>`. The leader, candidate, and progress-rebuild paths now
  wrap the effective membership in an `Arc` rather than calling
  `to_quorum_set()`. Using `Arc` keeps the progress clone on a membership
  change a refcount bump instead of copying node metadata.
- Removes the now-unused `Membership::to_quorum_set()`.
- Consequence: the previously id-only leader/progress quorum type now carries
  the node type `N`, since `Arc<Membership>` includes the node map that quorum
  logic itself does not read.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1774)
<!-- Reviewable:end -->
