### PR TITLE
refactor: quorum: make QuorumSet id an associated type

### DIFF
--- a/openraft/src/membership/effective_membership.rs
+++ b/openraft/src/membership/effective_membership.rs
@@ -203,12 +203,13 @@ where
 }
 
 /// Implement node-id joint quorum set.
-impl<CLID, NID, N> QuorumSet<NID> for EffectiveMembership<CLID, NID, N>
+impl<CLID, NID, N> QuorumSet for EffectiveMembership<CLID, NID, N>
 where
     CLID: RaftCommittedLeaderId,
     NID: NodeId,
     N: Node,
 {
+    type Id = NID;
     type Iter = std::collections::btree_set::IntoIter<NID>;
 
     fn is_quorum<'a, I: Iterator<Item = &'a NID> + Clone>(&self, ids: I) -> bool {

--- a/openraft/src/membership/membership_impl_quorum_set.rs
+++ b/openraft/src/membership/membership_impl_quorum_set.rs
@@ -5,11 +5,12 @@ use crate::node::Node;
 use crate::node::NodeId;
 use crate::quorum::QuorumSet;
 
-impl<NID, N> QuorumSet<NID> for Membership<NID, N>
+impl<NID, N> QuorumSet for Membership<NID, N>
 where
     NID: NodeId,
     N: Node,
 {
+    type Id = NID;
     type Iter = std::collections::btree_set::IntoIter<NID>;
 
     fn is_quorum<'a, I>(&self, ids: I) -> bool

--- a/openraft/src/progress/display_vec_progress.rs
+++ b/openraft/src/progress/display_vec_progress.rs
@@ -9,7 +9,7 @@ use crate::quorum::QuorumSet;
 pub(crate) struct DisplayVecProgress<'a, ID, Ent, Prog, QS, Fmt>
 where
     ID: 'static,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
     Fmt: Fn(&mut Formatter<'_>, &ID, &Ent) -> std::fmt::Result,
 {
     pub(crate) inner: &'a VecProgress<ID, Ent, Prog, QS>,
@@ -21,7 +21,7 @@ where
     ID: PartialEq + 'static,
     Ent: Borrow<Prog>,
     Prog: PartialOrd + Copy,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
     Fmt: Fn(&mut Formatter<'_>, &ID, &Ent) -> std::fmt::Result,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -40,7 +40,7 @@ where
     ID: PartialEq + 'static,
     Ent: Borrow<Prog>,
     Prog: PartialOrd + Clone,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
 {
     /// Update one of the scalar values and re-calculate the quorum-accepted value with the provided
     /// function.

--- a/openraft/src/progress/vec_progress.rs
+++ b/openraft/src/progress/vec_progress.rs
@@ -18,7 +18,7 @@ use crate::quorum::QuorumSet;
 pub(crate) struct VecProgress<ID, Ent, Prog, QS>
 where
     ID: 'static,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
 {
     /// Quorum set to determine if a set of `id` constitutes a quorum.
     quorum_set: QS,
@@ -50,7 +50,7 @@ where
     Ent: Clone + 'static,
     Ent: Borrow<Prog>,
     Prog: PartialOrd + Ord + Clone + 'static,
-    QS: QuorumSet<ID> + 'static,
+    QS: QuorumSet<Id = ID> + 'static,
     ID: Display,
     Ent: Display,
 {
@@ -72,7 +72,7 @@ impl<ID, Ent, Prog, QS> VecProgress<ID, Ent, Prog, QS>
 where
     ID: 'static,
     Ent: Borrow<Prog>,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
     Prog: Clone,
 {
     pub(crate) fn new(quorum_set: QS, learner_ids: impl IntoIterator<Item = ID>, default_v: impl Fn() -> Ent) -> Self {
@@ -139,7 +139,7 @@ where
     ID: PartialEq + 'static,
     Ent: Borrow<Prog>,
     Prog: PartialOrd + Clone,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
 {
     /// Update one of the scalar values and re-calculate the quorum-accepted value.
     ///

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -21,7 +21,7 @@ use crate::vote::raft_vote::RaftVoteExt;
 pub(crate) struct Candidate<C, QS>
 where
     C: RaftTypeConfig,
-    QS: QuorumSet<C::NodeId>,
+    QS: QuorumSet<Id = C::NodeId>,
 {
     /// When the voting is started.
     starting_time: InstantOf<C>,
@@ -44,7 +44,7 @@ where
 impl<C, QS> fmt::Display for Candidate<C, QS>
 where
     C: RaftTypeConfig,
-    QS: QuorumSet<C::NodeId> + fmt::Debug + 'static,
+    QS: QuorumSet<Id = C::NodeId> + fmt::Debug + 'static,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -61,7 +61,7 @@ where
 impl<C, QS> Candidate<C, QS>
 where
     C: RaftTypeConfig,
-    QS: QuorumSet<C::NodeId> + fmt::Debug + Clone + 'static,
+    QS: QuorumSet<Id = C::NodeId> + fmt::Debug + Clone + 'static,
 {
     pub(crate) fn new(
         starting_time: InstantOf<C>,

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -32,7 +32,7 @@ use crate::vote::raft_vote::RaftVoteExt;
 /// a higher `leader_id`(roughly the `term` in original raft) is seen.
 /// But instead it will be able to upgrade its `leader_id` without losing leadership.
 #[derive(Clone, Debug)]
-pub(crate) struct Leader<C, QS: QuorumSet<C::NodeId>>
+pub(crate) struct Leader<C, QS: QuorumSet<Id = C::NodeId>>
 where C: RaftTypeConfig
 {
     /// Whether this Leader is marked as transferring to another node.
@@ -82,7 +82,7 @@ where C: RaftTypeConfig
 impl<C, QS> Leader<C, QS>
 where
     C: RaftTypeConfig,
-    QS: QuorumSet<C::NodeId> + Clone + fmt::Debug + 'static,
+    QS: QuorumSet<Id = C::NodeId> + Clone + fmt::Debug + 'static,
 {
     /// Create a new Leader.
     ///

--- a/openraft/src/quorum/coherent.rs
+++ b/openraft/src/quorum/coherent.rs
@@ -8,8 +8,8 @@ use crate::quorum::QuorumSet;
 pub(crate) trait Coherent<ID, Other>
 where
     ID: PartialOrd + Ord + 'static,
-    Self: QuorumSet<ID>,
-    Other: QuorumSet<ID>,
+    Self: QuorumSet<Id = ID>,
+    Other: QuorumSet<Id = ID>,
 {
     /// Returns `true` if this QuorumSet is coherent with the other quorum set.
     fn is_coherent_with(&self, other: &Other) -> bool;
@@ -18,8 +18,8 @@ where
 pub(crate) trait FindCoherent<ID, Other>
 where
     ID: PartialOrd + Ord + 'static,
-    Self: QuorumSet<ID>,
-    Other: QuorumSet<ID>,
+    Self: QuorumSet<Id = ID>,
+    Other: QuorumSet<Id = ID>,
 {
     /// Build a QuorumSet `X` so that `self` is coherent with `X` and `X` is coherent with `other`,
     /// i.e., `self ~ X ~ other`.

--- a/openraft/src/quorum/coherent_impl.rs
+++ b/openraft/src/quorum/coherent_impl.rs
@@ -6,7 +6,7 @@ use crate::quorum::coherent::FindCoherent;
 impl<ID, QS> Coherent<ID, Joint<ID, QS, Vec<QS>>> for Joint<ID, QS, Vec<QS>>
 where
     ID: PartialOrd + Ord + 'static,
-    QS: QuorumSet<ID> + PartialEq,
+    QS: QuorumSet<Id = ID> + PartialEq,
 {
     /// Check if two `joint` are coherent.
     ///
@@ -28,7 +28,7 @@ where
 impl<ID, QS> Coherent<ID, Joint<ID, QS, &[QS]>> for Joint<ID, QS, &[QS]>
 where
     ID: PartialOrd + Ord + 'static,
-    QS: QuorumSet<ID> + PartialEq,
+    QS: QuorumSet<Id = ID> + PartialEq,
 {
     fn is_coherent_with(&self, other: &Joint<ID, QS, &[QS]>) -> bool {
         for a in self.children().iter() {
@@ -46,7 +46,7 @@ where
 impl<ID, QS> Coherent<ID, QS> for Joint<ID, QS, Vec<QS>>
 where
     ID: PartialOrd + Ord + 'static,
-    QS: QuorumSet<ID> + PartialEq,
+    QS: QuorumSet<Id = ID> + PartialEq,
 {
     fn is_coherent_with(&self, other: &QS) -> bool {
         for a in self.children().iter() {
@@ -63,7 +63,7 @@ where
 impl<ID, QS> FindCoherent<ID, QS> for Joint<ID, QS, Vec<QS>>
 where
     ID: PartialOrd + Ord + 'static,
-    QS: QuorumSet<ID> + PartialEq + Clone,
+    QS: QuorumSet<Id = ID> + PartialEq + Clone,
 {
     fn find_coherent(&self, other: QS) -> Self {
         if self.is_coherent_with(&other) {

--- a/openraft/src/quorum/joint.rs
+++ b/openraft/src/quorum/joint.rs
@@ -11,7 +11,7 @@ use crate::quorum::QuorumSet;
 pub(crate) trait AsJoint<'d, ID, QS, D>
 where
     ID: 'static,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
 {
     fn as_joint(&'d self) -> Joint<ID, QS, D>
     where D: 'd;
@@ -26,7 +26,7 @@ where
 pub(crate) struct Joint<ID, QS, D>
 where
     ID: 'static,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
 {
     data: D,
     _p: PhantomData<(ID, QS)>,
@@ -35,7 +35,7 @@ where
 impl<ID, QS, D> Default for Joint<ID, QS, D>
 where
     ID: 'static,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
     D: Default,
 {
     fn default() -> Self {
@@ -49,7 +49,7 @@ where
 impl<ID, QS, D> Joint<ID, QS, D>
 where
     ID: 'static,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
 {
     pub(crate) fn new(data: D) -> Self {
         Self { data, _p: PhantomData }
@@ -61,11 +61,12 @@ where
 }
 
 /// Implement QuorumSet for `Joint<.., &[QS]>`
-impl<ID, QS> QuorumSet<ID> for Joint<ID, QS, &[QS]>
+impl<ID, QS> QuorumSet for Joint<ID, QS, &[QS]>
 where
     ID: PartialOrd + Ord + 'static,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
 {
+    type Id = ID;
     type Iter = std::collections::btree_set::IntoIter<ID>;
 
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
@@ -87,11 +88,12 @@ where
 }
 
 /// Implement QuorumSet for `Joint<.., Vec<QS>>`
-impl<ID, QS> QuorumSet<ID> for Joint<ID, QS, Vec<QS>>
+impl<ID, QS> QuorumSet for Joint<ID, QS, Vec<QS>>
 where
     ID: PartialOrd + Ord + 'static,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
 {
+    type Id = ID;
     type Iter = std::collections::btree_set::IntoIter<ID>;
 
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {

--- a/openraft/src/quorum/joint_impl.rs
+++ b/openraft/src/quorum/joint_impl.rs
@@ -6,7 +6,7 @@ use crate::quorum::QuorumSet;
 impl<'d, ID, QS> AsJoint<'d, ID, QS, &'d [QS]> for Vec<QS>
 where
     ID: 'static,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
 {
     fn as_joint(&'d self) -> Joint<ID, QS, &'d [QS]>
     where &'d [QS]: 'd {
@@ -17,7 +17,7 @@ where
 impl<ID, QS> From<Vec<QS>> for Joint<ID, QS, Vec<QS>>
 where
     ID: 'static,
-    QS: QuorumSet<ID>,
+    QS: QuorumSet<Id = ID>,
 {
     fn from(v: Vec<QS>) -> Self {
         Joint::new(v)

--- a/openraft/src/quorum/quorum_set.rs
+++ b/openraft/src/quorum/quorum_set.rs
@@ -4,20 +4,24 @@ use std::sync::Arc;
 ///
 /// A quorum is a collection of nodes that a read or write operation in a distributed system has to
 /// contact. See: <http://web.mit.edu/6.033/2005/wwwdocs/quorum_note.html>
-pub(crate) trait QuorumSet<ID: 'static> {
-    type Iter: Iterator<Item = ID>;
+pub(crate) trait QuorumSet {
+    type Id: 'static;
+
+    type Iter: Iterator<Item = Self::Id>;
 
     /// Check if a series of ID constitute a quorum that is defined by this quorum set.
-    fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool;
+    fn is_quorum<'a, I: Iterator<Item = &'a Self::Id> + Clone>(&self, ids: I) -> bool;
 
     /// Returns all ids in this QuorumSet
     fn ids(&self) -> Self::Iter;
 }
 
-impl<ID: 'static, T: QuorumSet<ID>> QuorumSet<ID> for Arc<T> {
+impl<T: QuorumSet> QuorumSet for Arc<T> {
+    type Id = T::Id;
+
     type Iter = T::Iter;
 
-    fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
+    fn is_quorum<'a, I: Iterator<Item = &'a Self::Id> + Clone>(&self, ids: I) -> bool {
         self.as_ref().is_quorum(ids)
     }
 

--- a/openraft/src/quorum/quorum_set_impl.rs
+++ b/openraft/src/quorum/quorum_set_impl.rs
@@ -3,9 +3,10 @@ use std::collections::BTreeSet;
 use crate::quorum::quorum_set::QuorumSet;
 
 /// Impl a simple majority quorum set
-impl<ID> QuorumSet<ID> for BTreeSet<ID>
+impl<ID> QuorumSet for BTreeSet<ID>
 where ID: PartialOrd + Ord + Clone + 'static
 {
+    type Id = ID;
     type Iter = std::collections::btree_set::IntoIter<ID>;
 
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
@@ -28,9 +29,10 @@ where ID: PartialOrd + Ord + Clone + 'static
 }
 
 /// Impl a simple majority quorum set
-impl<ID> QuorumSet<ID> for Vec<ID>
+impl<ID> QuorumSet for Vec<ID>
 where ID: PartialOrd + Ord + Clone + 'static
 {
+    type Id = ID;
     type Iter = std::collections::btree_set::IntoIter<ID>;
 
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {
@@ -53,9 +55,10 @@ where ID: PartialOrd + Ord + Clone + 'static
 }
 
 /// Impl a simple majority quorum set
-impl<ID> QuorumSet<ID> for &[ID]
+impl<ID> QuorumSet for &[ID]
 where ID: PartialOrd + Ord + Copy + 'static
 {
+    type Id = ID;
     type Iter = std::collections::btree_set::IntoIter<ID>;
 
     fn is_quorum<'a, I: Iterator<Item = &'a ID> + Clone>(&self, ids: I) -> bool {


### PR DESCRIPTION

## Changelog

##### refactor: quorum: make QuorumSet id an associated type
# Summary

The `QuorumSet` trait carried an `ID` type parameter that every implementor
bound to a single concrete id type. This converts `ID` into an associated type
`Id`, so the "one quorum set, one id type" relationship lives in the trait
itself and the redundant parameter drops out of every bound that referenced it.
The trait is `pub(crate)`, so there is no public API or behavior change.

# Details

- The trait gains `type Id` and its methods reference `Self::Id`; bounds across
  the progress, proposer, and quorum layers change from `QuorumSet<ID>` to
  `QuorumSet<Id = ID>`. The standalone `ID` parameter was never instantiated
  differently from each type's own id, so an associated type models it without
  losing expressiveness.
- Every implementor pins `Id` to the concrete type it already used, so the
  resolved method signatures are unchanged. This is a purely type-level
  refactor with no logic touched.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1775)
<!-- Reviewable:end -->
