### PR TITLE
refactor: quorum: remove AsJoint trait

### DIFF
--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -12,10 +12,8 @@ use crate::errors::Operation;
 use crate::membership::IntoNodes;
 use crate::node::Node;
 use crate::node::NodeId;
-use crate::quorum::AsJoint;
 use crate::quorum::FindCoherent;
 use crate::quorum::Joint;
-use crate::quorum::QuorumSet;
 
 /// The membership configuration of the cluster.
 ///
@@ -159,7 +157,7 @@ where
         T: IntoIterator<Item = NID>,
         N: Default,
     {
-        let voter_nodes = config.as_joint().ids().map(|x| (x, N::default())).collect::<BTreeMap<_, _>>();
+        let voter_nodes = config.iter().flatten().cloned().map(|x| (x, N::default())).collect::<BTreeMap<_, _>>();
 
         let nodes = Self::extend_nodes(nodes.into_iter().map(|x| (x, N::default())).collect(), &voter_nodes);
 
@@ -189,7 +187,7 @@ where
 
     /// Returns an Iterator of all voter node ids. Learners are not included.
     pub fn voter_ids(&self) -> impl Iterator<Item = NID> {
-        self.configs.as_joint().ids()
+        self.configs.iter().flatten().cloned().collect::<BTreeSet<_>>().into_iter()
     }
 
     /// Returns an Iterator of all learner node ids. Voters are not included.
@@ -307,8 +305,8 @@ where
         let mut nodes = self.nodes.clone();
 
         if !retain {
-            let old_voter_ids = self.configs.as_joint().ids().collect::<BTreeSet<_>>();
-            let new_voter_ids = config.as_joint().ids().collect::<BTreeSet<_>>();
+            let old_voter_ids = self.configs.iter().flatten().cloned().collect::<BTreeSet<_>>();
+            let new_voter_ids = config.iter().flatten().cloned().collect::<BTreeSet<_>>();
 
             for node_id in old_voter_ids.difference(&new_voter_ids) {
                 nodes.remove(node_id);

--- a/openraft/src/quorum/bench/is_quorum.rs
+++ b/openraft/src/quorum/bench/is_quorum.rs
@@ -4,7 +4,7 @@ use maplit::btreeset;
 use test::Bencher;
 use test::black_box;
 
-use crate::quorum::AsJoint;
+use crate::quorum::Joint;
 use crate::quorum::QuorumSet;
 
 #[bench]
@@ -30,21 +30,21 @@ fn quorum_set_btreeset_ids_slice(b: &mut Bencher) {
 
 #[bench]
 fn quorum_set_vec_of_vec_ids_slice(b: &mut Bencher) {
-    let m12345_678 = vec![vec![1, 2, 3, 4, 5], vec![6, 7, 8]];
+    let m12345_678 = [vec![1, 2, 3, 4, 5], vec![6, 7, 8]];
     let x = [1, 2, 3, 6, 7];
-    b.iter(|| m12345_678.as_joint().is_quorum(black_box(x.iter())))
+    b.iter(|| Joint::new(&m12345_678[..]).is_quorum(black_box(x.iter())))
 }
 
 #[bench]
 fn quorum_set_vec_of_btreeset_ids_slice(b: &mut Bencher) {
-    let m12345_678 = vec![btreeset! {1,2,3,4,5}, btreeset! {6,7,8}];
+    let m12345_678 = [btreeset! {1,2,3,4,5}, btreeset! {6,7,8}];
     let x = [1, 2, 3, 6, 7];
-    b.iter(|| m12345_678.as_joint().is_quorum(black_box(x.iter())))
+    b.iter(|| Joint::new(&m12345_678[..]).is_quorum(black_box(x.iter())))
 }
 
 #[bench]
 fn quorum_set_vec_of_btreeset_ids_btreeset(b: &mut Bencher) {
-    let m12345_678 = vec![btreeset! {1,2,3,4,5}, btreeset! {6,7,8}];
+    let m12345_678 = [btreeset! {1,2,3,4,5}, btreeset! {6,7,8}];
     let x = btreeset! {1,2,3,6,7};
-    b.iter(|| m12345_678.as_joint().is_quorum(black_box(x.iter())))
+    b.iter(|| Joint::new(&m12345_678[..]).is_quorum(black_box(x.iter())))
 }

--- a/openraft/src/quorum/coherent_test.rs
+++ b/openraft/src/quorum/coherent_test.rs
@@ -3,7 +3,6 @@ use maplit::btreeset;
 use crate::quorum::Joint;
 use crate::quorum::coherent::Coherent;
 use crate::quorum::coherent::FindCoherent;
-use crate::quorum::joint::AsJoint;
 
 #[test]
 fn test_is_coherent_vec() -> anyhow::Result<()> {
@@ -45,15 +44,15 @@ fn test_is_coherent_slice() -> anyhow::Result<()> {
     let s345 = || btreeset! {3,4,5};
     let s789 = || btreeset! {7,8,9};
 
-    let v123 = vec![s123()];
-    let v345 = vec![s345()];
-    let v123_345 = vec![s123(), s345()];
-    let v345_789 = vec![s345(), s789()];
+    let v123 = [s123()];
+    let v345 = [s345()];
+    let v123_345 = [s123(), s345()];
+    let v345_789 = [s345(), s789()];
 
-    let j123 = v123.as_joint();
-    let j345 = v345.as_joint();
-    let j123_345 = v123_345.as_joint();
-    let j345_789 = v345_789.as_joint();
+    let j123 = Joint::new(&v123[..]);
+    let j345 = Joint::new(&v345[..]);
+    let j123_345 = Joint::new(&v123_345[..]);
+    let j345_789 = Joint::new(&v345_789[..]);
 
     assert!(j123.is_coherent_with(&j123));
     assert!(!j123.is_coherent_with(&j345));

--- a/openraft/src/quorum/joint.rs
+++ b/openraft/src/quorum/joint.rs
@@ -5,18 +5,6 @@ use maplit::btreeset;
 
 use crate::quorum::QuorumSet;
 
-/// Use another data as a joint quorum set.
-///
-/// The ids have to be a quorum in every sub-config to constitute a joint-quorum.
-pub(crate) trait AsJoint<'d, ID, QS, D>
-where
-    ID: 'static,
-    QS: QuorumSet<Id = ID>,
-{
-    fn as_joint(&'d self) -> Joint<ID, QS, D>
-    where D: 'd;
-}
-
 /// A wrapper that uses other data to define a joint quorum set.
 ///
 /// The input ids have to be a quorum in every sub-config to constitute a joint-quorum.

--- a/openraft/src/quorum/joint_impl.rs
+++ b/openraft/src/quorum/joint_impl.rs
@@ -1,18 +1,5 @@
-use crate::quorum::AsJoint;
 use crate::quorum::Joint;
 use crate::quorum::QuorumSet;
-
-/// Use a vec of some implementation of `QuorumSet` as a joint quorum set.
-impl<'d, ID, QS> AsJoint<'d, ID, QS, &'d [QS]> for Vec<QS>
-where
-    ID: 'static,
-    QS: QuorumSet<Id = ID>,
-{
-    fn as_joint(&'d self) -> Joint<ID, QS, &'d [QS]>
-    where &'d [QS]: 'd {
-        Joint::new(self)
-    }
-}
 
 impl<ID, QS> From<Vec<QS>> for Joint<ID, QS, Vec<QS>>
 where

--- a/openraft/src/quorum/mod.rs
+++ b/openraft/src/quorum/mod.rs
@@ -21,6 +21,5 @@ mod quorum_set_test;
 
 pub(crate) use coherent::Coherent;
 pub(crate) use coherent::FindCoherent;
-pub(crate) use joint::AsJoint;
 pub(crate) use joint::Joint;
 pub(crate) use quorum_set::QuorumSet;

--- a/openraft/src/quorum/quorum_set_test.rs
+++ b/openraft/src/quorum/quorum_set_test.rs
@@ -1,6 +1,5 @@
 use maplit::btreeset;
 
-use crate::quorum::AsJoint;
 use crate::quorum::Joint;
 use crate::quorum::QuorumSet;
 
@@ -37,8 +36,8 @@ fn test_simple_quorum_set_impl() -> anyhow::Result<()> {
 fn test_joint_quorum_set_impl() -> anyhow::Result<()> {
     // Vec<BTreeSet> as majority quorum set
     {
-        let m12345 = vec![btreeset! {1,2,3,4,5}];
-        let qs = m12345.as_joint();
+        let m12345 = [btreeset! {1,2,3,4,5}];
+        let qs = Joint::new(&m12345[..]);
 
         assert!(!qs.is_quorum([0].iter()));
         assert!(!qs.is_quorum([0, 1, 2].iter()));
@@ -50,8 +49,8 @@ fn test_joint_quorum_set_impl() -> anyhow::Result<()> {
 
     // Vec<BTreeSet, BTreeSet> as joint-of-majority quorum set
     {
-        let m12345_678 = vec![btreeset! {1,2,3,4,5}, btreeset! {6,7,8}];
-        let qs = m12345_678.as_joint();
+        let m12345_678 = [btreeset! {1,2,3,4,5}, btreeset! {6,7,8}];
+        let qs = Joint::new(&m12345_678[..]);
 
         assert!(!qs.is_quorum([0].iter()));
         assert!(!qs.is_quorum([0, 1, 2].iter()));
@@ -64,7 +63,7 @@ fn test_joint_quorum_set_impl() -> anyhow::Result<()> {
     // Vec<&[], &[]> as joint-of-majority quorum set
     {
         let m12345_678: Vec<&[usize]> = vec![&[1, 2, 3, 4, 5], &[6, 7, 8]];
-        let qs = m12345_678.as_joint();
+        let qs = Joint::new(&m12345_678[..]);
 
         assert!(!qs.is_quorum([0].iter()));
         assert!(!qs.is_quorum([0, 1, 2].iter()));
@@ -76,8 +75,8 @@ fn test_joint_quorum_set_impl() -> anyhow::Result<()> {
 
     // Vec<Vec, Vec> as joint-of-majority quorum set
     {
-        let m12345_678 = vec![vec![1, 2, 3, 4, 5], vec![6, 7, 8]];
-        let qs = m12345_678.as_joint();
+        let m12345_678 = [vec![1, 2, 3, 4, 5], vec![6, 7, 8]];
+        let qs = Joint::new(&m12345_678[..]);
 
         assert!(!qs.is_quorum([0].iter()));
         assert!(!qs.is_quorum([0, 1, 2].iter()));
@@ -120,8 +119,8 @@ fn test_ids() -> anyhow::Result<()> {
     }
 
     {
-        let m12345_678 = vec![btreeset! {1,2,3,4,5}, btreeset! {4,5,6,7,8}];
-        let qs = m12345_678.as_joint();
+        let m12345_678 = [btreeset! {1,2,3,4,5}, btreeset! {4,5,6,7,8}];
+        let qs = Joint::new(&m12345_678[..]);
 
         assert_eq!(btreeset! {1,2,3,4,5,6,7,8}, qs.ids().collect());
     }


### PR DESCRIPTION

## Changelog

##### refactor: quorum: remove AsJoint trait
# Summary

`AsJoint` was pure sugar for viewing a `Vec<QS>` as a borrowed joint quorum
set: `vec.as_joint()` desugared to `Joint::new(&vec[..])`. It is removed. The
production callers that used it only to enumerate a joint config's voter ids
now compute that id-union directly, and the remaining callers build `Joint`
directly. The trait is `pub(crate)`, so there is no public API or behavior
change.

# Details

- In `Membership`, the `as_joint().ids()` calls backing voter-id enumeration
  now collect the deduplicated id-union straight from the configs. This drops
  a throwaway `Joint` allocation per call and leaves the `QuorumSet` import
  there unused, so it is removed alongside `AsJoint`.
- `Joint` and its quorum-set behavior are untouched; the trait only added a
  `Vec`-receiver shortcut, so the test and bench call sites now construct the
  same `Joint` via `Joint::new`.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1776)
<!-- Reviewable:end -->
