### PR TITLE
refactor: rename methods that install snapshot membership

### DIFF
--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -205,17 +205,14 @@ where C: RaftTypeConfig
         self.server_state_handler().update_server_state_if_changed();
     }
 
-    /// Update membership state with a committed membership config
+    /// Install into the membership state the membership config carried by a snapshot.
     #[tracing::instrument(level = "debug", skip_all)]
-    fn update_committed_membership(&mut self, membership: StoredMembershipOf<C>) {
-        tracing::debug!("update committed membership: {}", membership);
+    fn membership_install_snapshot(&mut self, membership: StoredMembershipOf<C>) {
+        tracing::debug!("install membership from snapshot: {}", membership);
 
         let m = Arc::new(membership);
 
-        // TODO: if effective membership changes, call `update_replication()`, if a follower has replication
-        //       streams. Now we don't have replication streams for follower, so it's ok to not call
-        //       `update_replication()`.
-        let _effective_changed = self.state.membership_state.update_committed(m);
+        self.state.membership_state.install_membership_snapshot(m);
 
         self.server_state_handler().update_server_state_if_changed();
     }
@@ -281,7 +278,7 @@ where C: RaftTypeConfig
         self.state.apply_progress_mut().accept(snap_last_log_id.clone());
         self.state.snapshot_progress_mut().accept(snap_last_log_id.clone());
 
-        self.update_committed_membership(meta.last_membership.clone());
+        self.membership_install_snapshot(meta.last_membership.clone());
 
         self.output.push_command(Command::from(sm::Command::install_full_snapshot(snapshot, log_io_id)));
 

--- a/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
+++ b/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
@@ -49,7 +49,7 @@ fn test_update_committed_membership_at_index_4() -> anyhow::Result<()> {
     let mut eng = eng();
 
     eng.following_handler()
-        .update_committed_membership(StoredMembershipOf::<UTConfig>::new(Some(log_id(3, 1, 4)), m34()));
+        .membership_install_snapshot(StoredMembershipOf::<UTConfig>::new(Some(log_id(3, 1, 4)), m34()));
 
     assert_eq!(
         MembershipState::new(

--- a/openraft/src/raft_state/membership_state/membership_state_test.rs
+++ b/openraft/src/raft_state/membership_state/membership_state_test.rs
@@ -53,11 +53,10 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
     // Smaller new committed won't take effect.
     {
         let mut x = new();
-        let res = x.update_committed(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        x.install_membership_snapshot(Arc::new(StoredMembershipOf::<UTConfig>::new(
             Some(log_id(1, 1, 1)),
             m12(),
         )));
-        assert!(res.is_none());
         assert_eq!(&Some(log_id(2, 1, 2)), x.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), x.effective().log_id());
     }
@@ -65,11 +64,10 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
     // Update committed, not effective.
     {
         let mut x = new();
-        let res = x.update_committed(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        x.install_membership_snapshot(Arc::new(StoredMembershipOf::<UTConfig>::new(
             Some(log_id(2, 1, 3)),
             m12(),
         )));
-        assert!(res.is_none());
         assert_eq!(&Some(log_id(2, 1, 3)), x.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), x.effective().log_id());
     }
@@ -77,11 +75,10 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
     // Update both
     {
         let mut x = new();
-        let res = x.update_committed(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        x.install_membership_snapshot(Arc::new(StoredMembershipOf::<UTConfig>::new(
             Some(log_id(3, 1, 4)),
             m12(),
         )));
-        assert_eq!(Some(x.effective().clone()), res);
         assert_eq!(&Some(log_id(3, 1, 4)), x.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), x.effective().log_id());
         assert_eq!(&m12(), x.effective().membership());
@@ -91,11 +88,10 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
     // Because leader may have a smaller log_id that is committed.
     {
         let mut x = new();
-        let res = x.update_committed(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        x.install_membership_snapshot(Arc::new(StoredMembershipOf::<UTConfig>::new(
             Some(log_id(2, 1, 5)),
             m12(),
         )));
-        assert_eq!(Some(x.effective().clone()), res);
         assert_eq!(&Some(log_id(2, 1, 5)), x.committed().log_id());
         assert_eq!(&Some(log_id(2, 1, 5)), x.effective().log_id());
         assert_eq!(&m12(), x.effective().membership());

--- a/openraft/src/raft_state/membership_state/mod.rs
+++ b/openraft/src/raft_state/membership_state/mod.rs
@@ -23,6 +23,11 @@ use crate::vote::RaftCommittedLeaderId;
 
 /// The state of membership configs a raft node needs to know.
 ///
+/// `MembershipState` is a minimal store of the membership log and the membership state machine:
+/// - `committed` is the membership state machine, i.e., the last committed membership;
+/// - `effective` is the last membership log, and thus plays the role of a log entry: the last seen
+///   membership, committed or not.
+///
 /// A raft node needs to store at most 2 membership config logs:
 /// - The first(committed) one must have been committed, because (1): raft allows proposing new
 ///   membership only when the previous one is committed.
@@ -122,44 +127,38 @@ where
         }
     }
 
-    /// A committed membership log is found, and either of `self.committed` and `self.effective`
-    /// should be updated if it is smaller than the new one.
+    /// Install the membership config carried by a snapshot.
     ///
-    /// If `self.effective` changed, it returns a reference to the new one.
-    /// If not, it returns None.
-    pub(crate) fn update_committed(
-        &mut self,
-        c: Arc<StoredMembership<CLID, NID, N>>,
-    ) -> Option<Arc<StoredMembership<CLID, NID, N>>> {
-        let mut changed = false;
-
+    /// A snapshot stores the last membership applied to its state machine, so this membership is
+    /// committed. It updates `self.committed`(the membership state machine), and may also update
+    /// `self.effective`(the last membership log), each only when the snapshot is newer than the
+    /// corresponding local membership.
+    pub(crate) fn install_membership_snapshot(&mut self, membership_snapshot: Arc<StoredMembership<CLID, NID, N>>) {
         // The local effective membership may conflict with the leader.
         // Thus, it has to compare by log-index, e.g.:
         //   membership.log_id       = (10, 5);
         //   local_effective.log_id = (2, 10);
-        if c.log_id().index() >= self.effective.log_id().index() {
-            changed = c.membership() != self.effective.membership();
-
+        if membership_snapshot.log_id().index() >= self.effective.log_id().index() {
             // The effective may override by a new leader with a different one.
-            self.effective = c.clone()
+            self.effective = membership_snapshot.clone()
         }
 
         #[allow(clippy::collapsible_if)]
         if cfg!(debug_assertions) {
-            if c.log_id() == self.committed.log_id() {
+            if membership_snapshot.log_id() == self.committed.log_id() {
                 debug_assert_eq!(
-                    c.membership(),
+                    membership_snapshot.membership(),
                     self.committed.membership(),
                     "the same log id implies the same membership"
                 );
             }
         }
 
-        if c.log_id() > self.committed.log_id() {
-            self.committed = c
+        // same log id implies the same membership,
+        // so it only needs to compare log id.
+        if membership_snapshot.log_id() > self.committed.log_id() {
+            self.committed = membership_snapshot
         }
-
-        if changed { Some(self.effective().clone()) } else { None }
     }
 
     /// Append a membership config `m`.


### PR DESCRIPTION

## Changelog

##### refactor: rename methods that install snapshot membership
# Summary

Rename the membership-state methods invoked when a snapshot is installed so
their names state the snapshot-install intent, and drop the return value that
no caller used.

# Details

- `MembershipState::update_committed` becomes `install_membership_snapshot`,
  and the following handler's `update_committed_membership` becomes
  `membership_install_snapshot`. The names now describe what they do -- apply
  the membership embedded in an installed snapshot -- instead of the
  lower-level "update committed".
- The method no longer returns the changed effective membership; its only
  caller already discarded the value.
- Docs are refreshed to frame `committed` as the membership state machine and
  `effective` as the last membership log, and to describe the operation as
  installing a snapshot's membership rather than the removed return-value
  contract.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1779)
<!-- Reviewable:end -->
