### PR TITLE
refactor: add return value to MembershipState::commit()

### DIFF
--- a/openraft/src/raft_state/membership_state/membership_state_test.rs
+++ b/openraft/src/raft_state/membership_state/membership_state_test.rs
@@ -121,7 +121,8 @@ fn test_membership_state_commit() -> anyhow::Result<()> {
     // Less than committed
     {
         let mut ms = new();
-        ms.commit(&Some(log_id(1, 1, 1)));
+        let got = ms.commit(&Some(log_id(1, 1, 1)));
+        assert_eq!(None, got);
         assert_eq!(&Some(log_id(2, 1, 2)), ms.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), ms.effective().log_id());
     }
@@ -129,7 +130,8 @@ fn test_membership_state_commit() -> anyhow::Result<()> {
     // Equal committed
     {
         let mut ms = new();
-        ms.commit(&Some(log_id(2, 1, 2)));
+        let got = ms.commit(&Some(log_id(2, 1, 2)));
+        assert_eq!(None, got);
         assert_eq!(&Some(log_id(2, 1, 2)), ms.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), ms.effective().log_id());
     }
@@ -137,7 +139,8 @@ fn test_membership_state_commit() -> anyhow::Result<()> {
     // Greater than committed, smaller than effective
     {
         let mut ms = new();
-        ms.commit(&Some(log_id(2, 1, 3)));
+        let got = ms.commit(&Some(log_id(2, 1, 3)));
+        assert_eq!(None, got);
         assert_eq!(&Some(log_id(2, 1, 2)), ms.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), ms.effective().log_id());
     }
@@ -145,9 +148,38 @@ fn test_membership_state_commit() -> anyhow::Result<()> {
     // Greater than committed, equal effective
     {
         let mut ms = new();
-        ms.commit(&Some(log_id(3, 1, 4)));
+        let got = ms.commit(&Some(log_id(3, 1, 4)));
+        assert_eq!(Some((Some(log_id(2, 1, 2)), log_id(3, 1, 4))), got);
         assert_eq!(&Some(log_id(3, 1, 4)), ms.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), ms.effective().log_id());
+    }
+
+    // Greater than effective
+    {
+        let mut ms = new();
+        let got = ms.commit(&Some(log_id(3, 1, 5)));
+        assert_eq!(Some((Some(log_id(2, 1, 2)), log_id(3, 1, 4))), got);
+        assert_eq!(&Some(log_id(3, 1, 4)), ms.committed().log_id());
+        assert_eq!(&Some(log_id(3, 1, 4)), ms.effective().log_id());
+    }
+
+    // Commit again: the effective membership is already committed; no change to report.
+    {
+        let mut ms = new();
+        ms.commit(&Some(log_id(3, 1, 4)));
+        let got = ms.commit(&Some(log_id(3, 1, 5)));
+        assert_eq!(None, got);
+        assert_eq!(&Some(log_id(3, 1, 4)), ms.committed().log_id());
+        assert_eq!(&Some(log_id(3, 1, 4)), ms.effective().log_id());
+    }
+
+    // Initial state: both log ids are None; no change to report.
+    {
+        let mut ms = MembershipStateOf::<UTConfig>::default();
+        let got = ms.commit(&Some(log_id(1, 1, 1)));
+        assert_eq!(None, got);
+        assert_eq!(&None, ms.committed().log_id());
+        assert_eq!(&None, ms.effective().log_id());
     }
 
     Ok(())

--- a/openraft/src/raft_state/membership_state/mod.rs
+++ b/openraft/src/raft_state/membership_state/mod.rs
@@ -118,13 +118,32 @@ where
         self.effective.membership().is_voter(id)
     }
 
-    /// Update the membership state if the specified committed_log_id is greater than
-    /// `self.effective`
-    pub(crate) fn commit(&mut self, committed_log_id: &Option<LogId<CLID>>) {
-        if committed_log_id >= self.effective().log_id() {
-            debug_assert!(committed_log_id.index() >= self.effective().log_id().index());
+    /// Commit the effective membership config if `committed_log_id` is greater than or equal to
+    /// its log id.
+    ///
+    /// Committing replaces `self.committed`(the membership state machine) with
+    /// `self.effective`(the last membership log).
+    ///
+    /// If the committed membership config changes, it returns the committed log ids before and
+    /// after the update; otherwise it returns `None`, e.g., when the effective membership is
+    /// already committed.
+    pub(crate) fn commit(
+        &mut self,
+        committed_log_id: &Option<LogId<CLID>>,
+    ) -> Option<(Option<LogId<CLID>>, LogId<CLID>)> {
+        let current = self.committed.log_id().clone();
+        let last = self.effective().log_id().clone();
+
+        // `current == last` means the effective membership is already committed.
+        if committed_log_id >= &last && current < last {
+            debug_assert!(committed_log_id.index() >= last.index());
             self.committed = self.effective.clone();
+
+            // `current < last` implies `last` is not `None`.
+            return Some((current, last.unwrap()));
         }
+
+        None
     }
 
     /// Install the membership config carried by a snapshot.


### PR DESCRIPTION

## Changelog

##### refactor: add return value to MembershipState::commit()
# Summary

`MembershipState::commit()` now reports the transition of the committed
membership config: it returns the committed log ids before and after the
update, or `None` if nothing changes, so a caller can detect exactly when
a membership config becomes committed.

# Details

- The update happens only on an actual transition: if the effective
  membership is already committed, `commit()` is a no-op and returns
  `None`. Previously it re-assigned `self.committed` whenever
  `committed_log_id >= effective.log_id()`, including the equal case
  where the assignment had no effect.

- The doc comment is rewritten in terms of the `MembershipState` storage
  model: committing replaces `self.committed`(the membership state
  machine) with `self.effective`(the last membership log).

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1781)
<!-- Reviewable:end -->
