### PR TITLE
docs: clarify try_get_log_entries boundary-tolerance contract

### DIFF
--- a/openraft/src/storage/v2/raft_log_reader.rs
+++ b/openraft/src/storage/v2/raft_log_reader.rs
@@ -196,16 +196,32 @@ where C: RaftTypeConfig
     ///
     /// ### Correctness requirements
     ///
-    /// - All log entries in the range must be returned. Unlike
+    /// - Every entry in the range that the log **contains** must be returned. Unlike
     ///   [`limited_get_log_entries()`](Self::limited_get_log_entries), which may return only the
-    ///   first several log entries.
+    ///   first several log entries, this method must not stop early.
     ///
-    /// - If the log doesn't contain all the requested entries, return the existing entries. The
-    ///   absence of an entry is tolerated only at the beginning or end of the range. Missing
-    ///   entries within the range (i.e., holes) are not permitted and should result in an error.
+    /// - The absence of an entry is tolerated **only at the beginning or end of the range, and only
+    ///   for entries the log genuinely does not contain**:
+    ///   - at the beginning: entries already removed by [`RaftLogStorage::purge`];
+    ///   - at the end: entries not yet stored by [`RaftLogStorage::append`].
+    ///
+    ///   This tolerance does **not** permit omitting an entry that has already been appended but is
+    ///   not yet visible to this reader handle (for example, a read-after-write or
+    ///   read-after-flush visibility lag in the storage implementation).
+    ///   [`RaftLogStorage::append`] requires appended entries to be readable the moment it returns
+    ///   — even before its flush callback fires — so once the log "contains" an entry, every reader
+    ///   handle must return it. Omitting such an entry is a storage contract violation, not a
+    ///   tolerated boundary short read, and openraft may treat it as a fatal error (committed
+    ///   entries are read back through this method on the apply path).
+    ///
+    ///   Missing entries *within* the range (i.e., holes) are never permitted and must result in an
+    ///   error.
     ///
     /// - The read operation must be atomic. That is, it should not reflect any state changes that
     ///   occur after the read operation has started.
+    ///
+    /// [`RaftLogStorage::append`]: crate::storage::RaftLogStorage::append
+    /// [`RaftLogStorage::purge`]: crate::storage::RaftLogStorage::purge
     async fn try_get_log_entries<RB: RangeBounds<u64> + Clone + Debug + OptionalSend>(
         &mut self,
         range: RB,


### PR DESCRIPTION
## What

Clarifies the documented correctness contract of `RaftLogReader::try_get_log_entries` so the boundary-tolerance wording can no longer be read as permitting a short read on already-appended entries.

This is the documentation direction (direction 3) discussed in #1780.

## Why

The current wording —

> If the log doesn't contain all the requested entries, return the existing entries. The absence of an entry is tolerated only at the beginning or end of the range.

reads as if a reader handle may legally omit an entry at the end of the range whenever it has not yet observed a recently appended entry (a read-after-write / read-after-flush visibility lag). That is not the intent, and as discussed in #1780 it leads to a confusing apply-path panic when a storage implementation exploits the apparent latitude.

The tolerance is only meant to cover entries the log **genuinely does not contain**:
- at the beginning: entries already removed by `RaftLogStorage::purge`;
- at the end: entries not yet stored by `RaftLogStorage::append`.

`RaftLogStorage::append` already requires appended entries to be readable the moment it returns — even before the flush callback fires — so once the log "contains" an entry, every reader handle must return it.

## What changed

- Reworded the "Correctness requirements" section of `try_get_log_entries`.
- Spelled out that omitting an already-appended-but-not-yet-visible entry is a storage contract violation, not a tolerated boundary short read.
- Added a cross-reference to the `RaftLogStorage::append` readability requirement.
- Noted that openraft may treat such a short read as fatal, since committed entries are read back through this method on the apply path.

Docs-only change; no API or behavior change.

Refs #1780

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1782)
<!-- Reviewable:end -->
