### PR TITLE
feat: removed leader transfers leadership before stepping down

### DIFF
--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -12,11 +12,14 @@ use rand::RngExt;
 use crate::AsyncRuntime;
 use crate::LogId;
 use crate::LogIdOptionExt;
+use crate::config::StepDownPolicy;
 use crate::config::error::ConfigError;
 #[cfg(feature = "clap")]
 use crate::config::parser::parse_bytes_with_unit;
 #[cfg(feature = "clap")]
 use crate::config::parser::parse_snapshot_policy;
+#[cfg(feature = "clap")]
+use crate::config::parser::parse_step_down_policy;
 use crate::network::Backoff;
 use crate::raft_state::LogStateReader;
 use crate::vote::RaftCommittedLeaderId;
@@ -48,6 +51,7 @@ pub(crate) struct Defaults {
     pub enable_tick: bool,
     pub enable_heartbeat: bool,
     pub enable_elect: bool,
+    pub removed_leader_step_down: StepDownPolicy,
 }
 
 pub(crate) const DEFAULTS: Defaults = Defaults {
@@ -73,7 +77,15 @@ pub(crate) const DEFAULTS: Defaults = Defaults {
     enable_tick: true,
     enable_heartbeat: true,
     enable_elect: true,
+    removed_leader_step_down: StepDownPolicy::After(150),
 };
+
+/// The serde default for [`Config::removed_leader_step_down`]: it is used when the field is
+/// absent, so that config files written before this field existed keep the default behavior.
+#[cfg(feature = "serde")]
+fn default_removed_leader_step_down() -> StepDownPolicy {
+    DEFAULTS.removed_leader_step_down.clone()
+}
 
 /// Log compaction and snapshot policy.
 ///
@@ -358,6 +370,28 @@ pub struct Config {
     ))]
     pub enable_elect: bool,
 
+    /// The policy for stepping down a Leader that is removed from a committed membership config.
+    ///
+    /// - [`After(ms)`](StepDownPolicy::After): when the membership config that removes this Leader
+    ///   is committed and `ms` milliseconds have elapsed, the Leader transfers leadership to the
+    ///   most up-to-date voter, then reverts itself to a learner. During the delay it keeps serving
+    ///   as a Leader, so that in-flight requests and the commit notification of the membership log
+    ///   entry can still reach the followers.
+    /// - [`Never`](StepDownPolicy::Never): the removed Leader keeps leading, until the application
+    ///   reverts it manually with [`Trigger::refresh_server_state()`].
+    ///
+    /// In CLI it is either a "never" literal (`never`, `no`, `none`, `off` or `false`,
+    /// case-insensitive) or the number of milliseconds, e.g.,
+    /// `--removed-leader-step-down=never` or `--removed-leader-step-down=150`.
+    ///
+    /// Defaults to `After(150)`.
+    ///
+    /// [`Trigger::refresh_server_state()`]: crate::raft::trigger::Trigger::refresh_server_state
+    #[since(version = "0.10.0")]
+    #[cfg_attr(feature = "clap", clap(long, default_value = "150", value_parser = parse_step_down_policy))]
+    #[cfg_attr(feature = "serde", serde(default = "default_removed_leader_step_down"))]
+    pub removed_leader_step_down: StepDownPolicy,
+
     /// Default backoff policy used when
     /// [`RaftNetworkV2::backoff`](crate::network::RaftNetworkV2::backoff) returns `None`.
     ///
@@ -459,6 +493,7 @@ impl Default for Config {
             enable_tick: DEFAULTS.enable_tick,
             enable_heartbeat: DEFAULTS.enable_heartbeat,
             enable_elect: DEFAULTS.enable_elect,
+            removed_leader_step_down: DEFAULTS.removed_leader_step_down.clone(),
             backoff: DEFAULTS.backoff.to_string(),
             allow_log_reversion: None,
         }

--- a/openraft/src/config/config_clap_test.rs
+++ b/openraft/src/config/config_clap_test.rs
@@ -7,6 +7,7 @@ use core::time::Duration;
 
 use crate::Config;
 use crate::SnapshotPolicy;
+use crate::StepDownPolicy;
 
 #[test]
 fn test_build() -> anyhow::Result<()> {
@@ -73,6 +74,30 @@ fn test_config_snapshot_policy() -> anyhow::Result<()> {
     assert_eq!(SnapshotPolicy::LogsSinceLast(3), config.snapshot_policy);
 
     let res = Config::build(&["foo", "--snapshot-policy=bar:3"]);
+    assert!(res.is_err());
+
+    Ok(())
+}
+
+#[test]
+fn test_config_removed_leader_step_down() -> anyhow::Result<()> {
+    let config = Config::build(&["foo"])?;
+    assert_eq!(StepDownPolicy::After(150), config.removed_leader_step_down);
+
+    for never in ["never", "no", "none", "off", "false", "Never", "NO", "OFF"] {
+        let config = Config::build(&["foo", &format!("--removed-leader-step-down={}", never)])?;
+        assert_eq!(
+            StepDownPolicy::Never,
+            config.removed_leader_step_down,
+            "literal: {}",
+            never
+        );
+    }
+
+    let config = Config::build(&["foo", "--removed-leader-step-down=500"])?;
+    assert_eq!(StepDownPolicy::After(500), config.removed_leader_step_down);
+
+    let res = Config::build(&["foo", "--removed-leader-step-down=bar"]);
     assert!(res.is_err());
 
     Ok(())

--- a/openraft/src/config/config_test.rs
+++ b/openraft/src/config/config_test.rs
@@ -1,5 +1,6 @@
 use crate::Config;
 use crate::SnapshotPolicy;
+use crate::StepDownPolicy;
 use crate::config::error::ConfigError;
 
 #[test]
@@ -17,6 +18,21 @@ fn test_config_defaults() {
     assert_eq!(SnapshotPolicy::LogsSinceLast(5000), cfg.snapshot_policy);
     assert_eq!(Some(65536), cfg.api_channel_size);
     assert_eq!(Some(65536), cfg.notification_channel_size);
+    assert_eq!(StepDownPolicy::After(150), cfg.removed_leader_step_down);
+}
+
+/// A config serialized before `removed_leader_step_down` existed deserializes to the default
+/// policy.
+#[cfg(feature = "serde")]
+#[test]
+fn test_removed_leader_step_down_serde_default() -> anyhow::Result<()> {
+    let mut value = serde_json::to_value(Config::default())?;
+    value.as_object_mut().unwrap().remove("removed_leader_step_down");
+
+    let cfg: Config = serde_json::from_value(value)?;
+    assert_eq!(StepDownPolicy::After(150), cfg.removed_leader_step_down);
+
+    Ok(())
 }
 
 #[test]

--- a/openraft/src/config/mod.rs
+++ b/openraft/src/config/mod.rs
@@ -6,6 +6,7 @@
 //!
 //! - [`Config`] - Main configuration for Raft runtime behavior
 //! - [`SnapshotPolicy`] - Policy for triggering automatic snapshots
+//! - [`StepDownPolicy`] - Policy for stepping down a removed Leader
 //! - [`RuntimeConfig`] - Dynamic configuration that can be changed at runtime
 //! - [`ConfigError`] - Configuration validation errors
 //!
@@ -41,6 +42,7 @@ mod error;
 #[cfg(feature = "clap")]
 mod parser;
 mod runtime_config;
+mod step_down_policy;
 
 #[cfg(test)]
 mod config_test;
@@ -52,3 +54,4 @@ pub use config::Config;
 pub use config::SnapshotPolicy;
 pub use error::ConfigError;
 pub(crate) use runtime_config::RuntimeConfig;
+pub use step_down_policy::StepDownPolicy;

--- a/openraft/src/config/parser.rs
+++ b/openraft/src/config/parser.rs
@@ -10,6 +10,7 @@ use clap::Parser;
 
 use crate::Config;
 use crate::SnapshotPolicy;
+use crate::StepDownPolicy;
 use crate::config::error::ConfigError;
 
 /// Parse number with unit such as 5.3 KB
@@ -47,6 +48,22 @@ pub(super) fn parse_snapshot_policy(src: &str) -> Result<SnapshotPolicy, ConfigE
         reason: e.to_string(),
     })?;
     Ok(SnapshotPolicy::LogsSinceLast(n_logs))
+}
+
+/// Parse a step-down policy: a "never" literal (`never`, `no`, `none`, `off` or `false`,
+/// case-insensitive), or the number of milliseconds to wait.
+pub(super) fn parse_step_down_policy(src: &str) -> Result<StepDownPolicy, ConfigError> {
+    const NEVER_LITERALS: &[&str] = &["never", "no", "none", "off", "false"];
+
+    if NEVER_LITERALS.iter().any(|x| src.eq_ignore_ascii_case(x)) {
+        return Ok(StepDownPolicy::Never);
+    }
+
+    let ms = src.parse::<u64>().map_err(|e| ConfigError::InvalidNumber {
+        invalid: src.to_string(),
+        reason: e.to_string(),
+    })?;
+    Ok(StepDownPolicy::After(ms))
 }
 
 impl Config {

--- a/openraft/src/config/step_down_policy.rs
+++ b/openraft/src/config/step_down_policy.rs
@@ -1,0 +1,28 @@
+//! Policy for stepping down a Leader that is removed from the membership config.
+
+use openraft_macros::since;
+
+/// Policy for stepping down a Leader that is removed from a committed membership config.
+///
+/// It is the value of
+/// [`Config::removed_leader_step_down`](crate::Config::removed_leader_step_down).
+#[since(version = "0.10.0")]
+#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum StepDownPolicy {
+    /// Never step down automatically.
+    ///
+    /// The removed Leader keeps leading, until the application reverts it to a learner with
+    /// [`Trigger::refresh_server_state()`].
+    ///
+    /// [`Trigger::refresh_server_state()`]: crate::raft::trigger::Trigger::refresh_server_state
+    Never,
+
+    /// Step down after the specified number of milliseconds.
+    ///
+    /// The countdown starts when the membership config that removes the Leader is committed.
+    /// When it expires, the Leader transfers leadership to the most up-to-date voter, then
+    /// reverts itself to a learner.
+    After(u64),
+}

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -40,6 +40,7 @@ mod raft_core;
 mod replication_state;
 mod server_state;
 mod shared_replicate_batch;
+mod step_down_watcher;
 mod tick;
 
 pub(crate) use client_responder_queue::ClientResponderQueue;
@@ -49,5 +50,6 @@ pub use raft_core::RaftCore;
 pub(crate) use replication_state::replication_lag;
 pub use server_state::ServerState;
 pub(crate) use shared_replicate_batch::SharedReplicateBatch;
+pub(crate) use step_down_watcher::StepDownWatcher;
 pub(crate) use tick::Tick;
 pub(crate) use tick::TickHandle;

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1762,7 +1762,7 @@ where
                 //       ---
                 //       A better way is to make leader step down a command that waits for the log to be applied.
                 if self.engine.state.io_applied() >= self.engine.state.membership_state.effective().log_id().as_ref() {
-                    self.engine.leader_step_down();
+                    self.engine.refresh_server_state();
                 }
             }
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -716,6 +716,7 @@ where
         let st = &self.engine.state;
 
         let membership_config = st.membership_state.effective().clone();
+        let committed_membership_config = st.membership_state.committed().clone();
         let current_leader = self.current_leader();
 
         // Get the last flushed vote, or use initial vote (term=0, node_id=self.id)
@@ -749,6 +750,7 @@ where
             millis_since_quorum_ack,
             last_quorum_acked: last_quorum_acked.map(SerdeInstant::new),
             membership_config: membership_config.clone(),
+            committed_membership_config: committed_membership_config.clone(),
             heartbeat: heartbeat.clone(),
 
             // --- replication ---
@@ -778,6 +780,7 @@ where
             state: st.server_state,
             current_leader,
             membership_config,
+            committed_membership_config,
         };
 
         // Record to external metrics recorder

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1748,28 +1748,6 @@ where
                         l.next_heartbeat = C::now() + Duration::from_millis(self.config.heartbeat_interval);
                     }
                 }
-
-                // When a membership that removes the leader is committed,
-                // the leader continue to work for a short while before reverting to a learner.
-                // This way, let the leader replicate the `membership-log-is-committed` message to
-                // followers.
-                // Otherwise, if the leader step down at once, the follower might have to
-                // re-commit the membership log again, electing itself.
-                //
-                // ---
-                //
-                // Stepping down only when the response of the second change-membership is sent.
-                // Otherwise, the Sender to the caller will be dropped before sending back the
-                // response.
-
-                // TODO: temp solution: Manually wait until the second membership log being applied to state
-                //       machine. Because the response is sent back to the caller after log is
-                //       applied.
-                //       ---
-                //       A better way is to make leader step down a command that waits for the log to be applied.
-                if self.engine.state.io_applied() >= self.engine.state.membership_state.effective().log_id().as_ref() {
-                    self.engine.refresh_server_state();
-                }
             }
 
             Notification::StorageError { error } => {

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1654,6 +1654,9 @@ where
                         tracing::info!("setting metrics recorder");
                         self.metrics_recorder = recorder;
                     }
+                    ExternalCommand::RefreshServerState => {
+                        self.engine.refresh_server_state();
+                    }
                 }
             }
             #[cfg(feature = "runtime-stats")]

--- a/openraft/src/core/raft_msg/external_command.rs
+++ b/openraft/src/core/raft_msg/external_command.rs
@@ -55,6 +55,12 @@ pub(crate) enum ExternalCommand<C: RaftTypeConfig> {
     /// (e.g., OpenTelemetry, Prometheus, StatsD) at runtime.
     /// Pass `None` to disable metrics recording.
     SetMetricsRecorder { recorder: Option<Arc<dyn MetricsRecorder>> },
+
+    /// Recalculate the internal server state based on the vote and the membership config.
+    ///
+    /// Most of the time the internal server state is recalculated automatically; the only
+    /// exception is the step down of a Leader that is removed from the membership config.
+    RefreshServerState,
 }
 
 impl<C: RaftTypeConfig> ExternalCommand<C> {
@@ -69,6 +75,7 @@ impl<C: RaftTypeConfig> ExternalCommand<C> {
             ExternalCommand::TriggerTransferLeader { .. } => ExternalCommandName::TriggerTransferLeader,
             ExternalCommand::AllowNextRevert { .. } => ExternalCommandName::AllowNextRevert,
             ExternalCommand::SetMetricsRecorder { .. } => ExternalCommandName::SetMetricsRecorder,
+            ExternalCommand::RefreshServerState => ExternalCommandName::RefreshServerState,
         }
     }
 }
@@ -114,6 +121,9 @@ where C: RaftTypeConfig
             }
             ExternalCommand::SetMetricsRecorder { .. } => {
                 write!(f, "SetMetricsRecorder")
+            }
+            ExternalCommand::RefreshServerState => {
+                write!(f, "RefreshServerState")
             }
         }
     }

--- a/openraft/src/core/raft_msg/raft_msg_name.rs
+++ b/openraft/src/core/raft_msg/raft_msg_name.rs
@@ -10,12 +10,13 @@ pub enum ExternalCommandName {
     TriggerTransferLeader,
     AllowNextRevert,
     SetMetricsRecorder,
+    RefreshServerState,
 }
 
 impl ExternalCommandName {
     /// Total number of variants.
     #[allow(dead_code)]
-    pub const COUNT: usize = 8;
+    pub const COUNT: usize = 9;
 
     /// All variants in canonical order.
     #[allow(dead_code)]
@@ -28,6 +29,7 @@ impl ExternalCommandName {
         ExternalCommandName::TriggerTransferLeader,
         ExternalCommandName::AllowNextRevert,
         ExternalCommandName::SetMetricsRecorder,
+        ExternalCommandName::RefreshServerState,
     ];
 
     /// Returns the index of this variant for array-based storage.
@@ -42,6 +44,7 @@ impl ExternalCommandName {
             ExternalCommandName::TriggerTransferLeader => 5,
             ExternalCommandName::AllowNextRevert => 6,
             ExternalCommandName::SetMetricsRecorder => 7,
+            ExternalCommandName::RefreshServerState => 8,
         }
     }
 
@@ -56,6 +59,7 @@ impl ExternalCommandName {
             ExternalCommandName::TriggerTransferLeader => "Ext::TriggerTransferLeader",
             ExternalCommandName::AllowNextRevert => "Ext::AllowNextRevert",
             ExternalCommandName::SetMetricsRecorder => "Ext::SetMetricsRecorder",
+            ExternalCommandName::RefreshServerState => "Ext::RefreshServerState",
         }
     }
 }
@@ -89,7 +93,7 @@ pub enum RaftMsgName {
 
 impl RaftMsgName {
     /// Total number of variants (including expanded ExternalCommand variants).
-    pub const COUNT: usize = 19;
+    pub const COUNT: usize = 20;
 
     /// All variants in canonical order.
     ///
@@ -114,6 +118,7 @@ impl RaftMsgName {
         RaftMsgName::ExternalCommand(ExternalCommandName::TriggerTransferLeader),
         RaftMsgName::ExternalCommand(ExternalCommandName::AllowNextRevert),
         RaftMsgName::ExternalCommand(ExternalCommandName::SetMetricsRecorder),
+        RaftMsgName::ExternalCommand(ExternalCommandName::RefreshServerState),
         RaftMsgName::GetRuntimeStats,
     ];
 

--- a/openraft/src/core/step_down_watcher.rs
+++ b/openraft/src/core/step_down_watcher.rs
@@ -1,0 +1,286 @@
+//! Step-down watcher: a task that steps down a Leader that is removed from a committed
+//! membership config.
+
+use std::time::Duration;
+
+use tracing::Instrument;
+
+use crate::Config;
+use crate::RaftTypeConfig;
+use crate::StepDownPolicy;
+use crate::async_runtime::MpscSender;
+use crate::async_runtime::MpscWeakSender;
+use crate::async_runtime::watch::WatchReceiver;
+use crate::core::ServerState;
+use crate::core::raft_msg::RaftMsg;
+use crate::core::raft_msg::external_command::ExternalCommand;
+use crate::metrics::RaftMetrics;
+use crate::metrics::RaftServerMetrics;
+use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::MpscWeakSenderOf;
+use crate::type_config::alias::WatchReceiverOf;
+
+/// Steps down a Leader that is removed from a committed membership config.
+///
+/// It watches the server metrics, which change only on server state transitions, such as when
+/// the membership config that removes this Leader is committed. When this node is a Leader and
+/// the committed membership config does not contain it, after the delay given by
+/// [`removed_leader_step_down`] it transfers leadership to the most up-to-date voter (chosen
+/// from a snapshot of the full metrics), then after another `heartbeat_interval` it reverts this
+/// node to a learner, in case the transfer does not take effect.
+///
+/// It is an automation plugin outside the consensus kernel: it only sends the commands an
+/// application could send manually, [`TriggerTransferLeader`] and [`RefreshServerState`], both of
+/// which re-validate the state inside `RaftCore`. Therefore acting on stale or coalesced metrics
+/// is harmless: an outdated command is just a no-op.
+///
+/// The task quits when `RaftCore` terminates.
+///
+/// [`removed_leader_step_down`]: crate::Config::removed_leader_step_down
+/// [`TriggerTransferLeader`]: ExternalCommand::TriggerTransferLeader
+/// [`RefreshServerState`]: ExternalCommand::RefreshServerState
+pub(crate) struct StepDownWatcher<C>
+where C: RaftTypeConfig
+{
+    rx_server_metrics: WatchReceiverOf<C, RaftServerMetrics<C>>,
+
+    /// The full metrics, read only when acting, to choose the transfer-leader target.
+    rx_metrics: WatchReceiverOf<C, RaftMetrics<C>>,
+
+    /// Weak sender to the `RaftCore` API channel: the watcher must not keep the channel alive.
+    tx_api: MpscWeakSenderOf<C, RaftMsg<C>>,
+
+    /// The delay between the commit of the removing membership config and the transfer-leader.
+    step_down_delay: Duration,
+
+    /// The delay between the transfer-leader and reverting this node to a learner.
+    transfer_wait: Duration,
+}
+
+impl<C> StepDownWatcher<C>
+where C: RaftTypeConfig
+{
+    /// Spawn the watcher task.
+    ///
+    /// It does nothing if the automated step down is disabled,
+    /// i.e., [`removed_leader_step_down`] is [`StepDownPolicy::Never`].
+    ///
+    /// [`removed_leader_step_down`]: crate::Config::removed_leader_step_down
+    pub(crate) fn spawn(
+        rx_server_metrics: WatchReceiverOf<C, RaftServerMetrics<C>>,
+        rx_metrics: WatchReceiverOf<C, RaftMetrics<C>>,
+        tx_api: MpscWeakSenderOf<C, RaftMsg<C>>,
+        config: &Config,
+    ) {
+        let delay = match config.removed_leader_step_down {
+            StepDownPolicy::Never => return,
+            StepDownPolicy::After(ms) => ms,
+        };
+
+        let this = Self {
+            rx_server_metrics,
+            rx_metrics,
+            tx_api,
+            step_down_delay: Duration::from_millis(delay),
+            transfer_wait: Duration::from_millis(config.heartbeat_interval),
+        };
+
+        let span = tracing::debug_span!("step_down_watcher");
+        let watch_fut = this.watch_loop().instrument(span);
+        let _join_handle = C::spawn(watch_fut);
+    }
+
+    async fn watch_loop(mut self) {
+        loop {
+            self.try_step_down().await;
+
+            let recv_res = self.rx_server_metrics.changed().await;
+            if recv_res.is_err() {
+                tracing::info!("RaftCore terminated, quit step_down_watcher");
+                return;
+            }
+        }
+    }
+
+    /// Step down this node if it is a Leader that is removed from a committed membership config:
+    ///
+    /// - Wait for `step_down_delay`, then re-check the condition: it may no longer hold, e.g., a
+    ///   newer membership config that contains this node is committed.
+    /// - Transfer leadership to the most up-to-date voter.
+    /// - Wait for `transfer_wait`, then revert this node to a learner. This is the guaranteed
+    ///   fallback in case the transfer takes no effect; it is a no-op if a new Leader is already
+    ///   established.
+    async fn try_step_down(&self) {
+        // Clone the metrics out of the watch channel: the borrowed reference is not `Send`,
+        // and holding it across an `await` would block the metrics updater.
+        let server_metrics = self.rx_server_metrics.borrow_watched().clone();
+        if !is_removed_leader(&server_metrics) {
+            return;
+        }
+
+        C::sleep(self.step_down_delay).await;
+
+        let server_metrics = self.rx_server_metrics.borrow_watched().clone();
+        if !is_removed_leader(&server_metrics) {
+            return;
+        }
+
+        let metrics = self.rx_metrics.borrow_watched().clone();
+        let target = transfer_target(&metrics);
+
+        if let Some(to) = target {
+            tracing::info!("removed Leader steps down: transfer leadership to {}", to);
+            self.send(ExternalCommand::TriggerTransferLeader { to }).await;
+        }
+
+        C::sleep(self.transfer_wait).await;
+
+        self.send(ExternalCommand::RefreshServerState).await;
+    }
+
+    /// Send an external command to `RaftCore`.
+    ///
+    /// A failure to upgrade the weak sender or to send means `RaftCore` is terminated. It is
+    /// safe to ignore it here: the watch loop quits at the next `changed()` call in this case.
+    async fn send(&self, cmd: ExternalCommand<C>) {
+        let Some(tx_api) = self.tx_api.upgrade() else {
+            return;
+        };
+
+        let _ = tx_api.send(RaftMsg::ExternalCommand { cmd }).await;
+    }
+}
+
+/// Decide whether this node is a Leader that is removed from a committed membership config.
+///
+/// The decision is level-based: it is derived from a single metrics snapshot, so skipped or
+/// stale snapshots do not affect correctness.
+fn is_removed_leader<C>(metrics: &RaftServerMetrics<C>) -> bool
+where C: RaftTypeConfig {
+    if metrics.state != ServerState::Leader {
+        return false;
+    }
+
+    // A Leader that is still in the membership config, as a voter or a learner, keeps leading.
+    if metrics.membership_config.membership().contains(&metrics.id) {
+        return false;
+    }
+
+    // The Leader keeps leading until the membership config that removes it is committed,
+    // because it is the one responsible for replicating this config.
+    // The committed membership config equals the effective one iff the latter is committed.
+    metrics.committed_membership_config == metrics.membership_config
+}
+
+/// Choose the transfer-leader target: the voter with the greatest matching log id, which needs
+/// the least catching up.
+fn transfer_target<C>(metrics: &RaftMetrics<C>) -> Option<C::NodeId>
+where C: RaftTypeConfig {
+    // Only a Leader publishes replication metrics.
+    let replication = metrics.replication.as_ref()?;
+
+    let membership = metrics.membership_config.membership();
+    let matching = |id: &C::NodeId| replication.get(id).cloned().flatten();
+
+    membership.voter_ids().max_by_key(matching)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use maplit::btreemap;
+    use maplit::btreeset;
+
+    use super::is_removed_leader;
+    use super::transfer_target;
+    use crate::Membership;
+    use crate::core::ServerState;
+    use crate::engine::testing::UTConfig;
+    use crate::engine::testing::log_id;
+    use crate::metrics::RaftMetrics;
+    use crate::metrics::RaftServerMetrics;
+    use crate::type_config::alias::StoredMembershipOf;
+
+    /// Voters 2,3; node 1 is removed.
+    fn m23() -> Membership<u64, ()> {
+        Membership::new_with_defaults(vec![btreeset! {2,3}], [])
+    }
+
+    fn stored(log_index: u64, mem: Membership<u64, ()>) -> Arc<StoredMembershipOf<UTConfig>> {
+        Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(2, 1, log_index)), mem))
+    }
+
+    /// Build server metrics of a Leader node 1, with the same effective and committed
+    /// membership config.
+    fn server_metrics(mem: Membership<u64, ()>) -> RaftServerMetrics<UTConfig> {
+        let mut m = RaftServerMetrics::new_initial(1);
+        m.state = ServerState::Leader;
+        m.membership_config = stored(3, mem.clone());
+        m.committed_membership_config = stored(3, mem);
+        m
+    }
+
+    #[test]
+    fn test_is_removed_leader_not_leader() {
+        let mut m = server_metrics(m23());
+        m.state = ServerState::Follower;
+
+        assert!(!is_removed_leader(&m));
+    }
+
+    #[test]
+    fn test_is_removed_leader_voter_leader() {
+        let m = server_metrics(Membership::new_with_defaults(vec![btreeset! {1,2,3}], []));
+
+        assert!(!is_removed_leader(&m));
+    }
+
+    #[test]
+    fn test_is_removed_leader_learner_leader() {
+        let m = server_metrics(Membership::new_with_defaults(vec![btreeset! {2,3}], btreeset! {1}));
+
+        assert!(!is_removed_leader(&m));
+    }
+
+    #[test]
+    fn test_is_removed_leader_uncommitted_membership() {
+        let mut m = server_metrics(m23());
+        m.committed_membership_config = stored(1, Membership::new_with_defaults(vec![btreeset! {1,2}], []));
+
+        assert!(!is_removed_leader(&m));
+    }
+
+    #[test]
+    fn test_is_removed_leader_committed_membership() {
+        let m = server_metrics(m23());
+
+        assert!(is_removed_leader(&m));
+    }
+
+    #[test]
+    fn test_transfer_target_not_leader() {
+        let m = RaftMetrics::<UTConfig>::new_initial(1);
+
+        assert_eq!(None, transfer_target(&m));
+    }
+
+    #[test]
+    fn test_transfer_target_greatest_matching() {
+        let mut m = RaftMetrics::<UTConfig>::new_initial(1);
+        m.membership_config = stored(3, m23());
+        m.replication = Some(btreemap! {
+            2u64 => Some(log_id(2, 1, 2)),
+            3u64 => Some(log_id(2, 1, 3)),
+        });
+
+        assert_eq!(Some(3), transfer_target(&m));
+
+        m.replication = Some(btreemap! {
+            2u64 => Some(log_id(2, 1, 3)),
+            3u64 => None,
+        });
+
+        assert_eq!(Some(2), transfer_target(&m));
+    }
+}

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -440,15 +440,26 @@ where C: RaftTypeConfig
         self.output.push_command(Command::from(sm::Command::begin_receiving_snapshot(tx)));
     }
 
-    /// Leader steps down(convert to learner) once the membership not containing it is committed.
+    /// Re-derive the internal server state(Leader/Following) from the vote and the membership
+    /// config.
     ///
-    /// This is only called by leader.
+    /// The internal server state is maintained automatically, with one exception: a Leader that
+    /// is removed from the membership config keeps leading until the membership config that
+    /// removes it is committed, and it is this method that then reverts it to a learner.
+    ///
+    /// It is safe to call this method at any time on any node; it is a no-op if the effective
+    /// membership config is not yet committed: the Leader, even when removed, must keep leading
+    /// to replicate the membership log entry that removes it; otherwise this entry could never
+    /// be committed.
+    ///
+    /// A Leader demoted to a learner that is still in the membership config is not affected:
+    /// openraft allows a learner to act as Leader. See: [Determine Server
+    /// State](crate::docs::data::vote#vote-and-membership-define-the-server-state).
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn leader_step_down(&mut self) {
-        tracing::debug!("leader step down, node_id: {}", self.config.id);
+    pub(crate) fn refresh_server_state(&mut self) {
+        tracing::debug!("{}: node_id: {}", func_name!(), self.config.id);
 
-        // Step down:
-        // Keep acting as leader until a membership without this node is committed.
+        // A removed Leader keeps leading until the membership config without it is committed.
         let em = &self.state.membership_state.effective();
 
         tracing::debug!(

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -215,7 +215,7 @@ where C: RaftTypeConfig
         let committed = LogIOId::new(self.state.vote_ref().to_committed(), granted.clone());
         self.state.io_state_mut().cluster_committed.try_update(committed.clone()).ok();
 
-        if let Some(_prev_committed) = self.state.update_local_committed(&granted) {
+        if let Some(_membership_transition) = self.state.update_local_committed(&granted) {
             self.output.push_command(Command::ReplicateCommitted {
                 committed: self.state.committed().cloned(),
             });

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -52,6 +52,7 @@ mod tests {
     mod handle_vote_resp_test;
     mod initialize_test;
     mod install_full_snapshot_test;
+    mod refresh_server_state_test;
     mod startup_test;
     mod trigger_purge_log_test;
 }

--- a/openraft/src/engine/tests/refresh_server_state_test.rs
+++ b/openraft/src/engine/tests/refresh_server_state_test.rs
@@ -1,0 +1,124 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use pretty_assertions::assert_eq;
+
+use crate::Membership;
+use crate::MembershipState;
+use crate::Vote;
+use crate::core::ServerState;
+use crate::engine::Command;
+use crate::engine::Engine;
+use crate::engine::testing::UTConfig;
+use crate::engine::testing::log_id;
+use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::StoredMembershipOf;
+use crate::utime::Leased;
+
+fn m12() -> Membership<u64, ()> {
+    Membership::new_with_defaults(vec![btreeset! {1,2}], [])
+}
+
+/// Voters 2,3; node 1 is demoted to a learner.
+fn m23_l1() -> Membership<u64, ()> {
+    Membership::new_with_defaults(vec![btreeset! {2,3}], btreeset! {1})
+}
+
+/// Voters 2,3; node 1 is removed.
+fn m23() -> Membership<u64, ()> {
+    Membership::new_with_defaults(vec![btreeset! {2,3}], [])
+}
+
+/// Build a Leader engine of node 1: the committed membership config is `m12()` at log-id(1,1,1),
+/// the effective membership config is `effective` at log-id(2,1,3),
+/// and logs up to `committed` are committed.
+fn eng_leader(effective: Membership<u64, ()>, committed: LogIdOf<UTConfig>) -> Engine<UTConfig> {
+    let mut eng = Engine::testing_default(0);
+    eng.state.enable_validation(false); // Disable validation for incomplete state
+
+    eng.config.id = 1;
+    eng.state.apply_progress_mut().accept(committed);
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(3, 1),
+    );
+    eng.state.log_ids.append(log_id(1, 1, 1));
+    eng.state.log_ids.append(log_id(2, 1, 3));
+
+    // Establish the Leader under a membership config that contains node-1, then install the
+    // target membership state, mirroring the production order: a Leader exists first, then a
+    // membership log entry is appended.
+    eng.state.membership_state = MembershipState::new(
+        Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12())),
+        Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12())),
+    );
+    eng.testing_new_leader();
+
+    eng.state.membership_state = MembershipState::new(
+        Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12())),
+        Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(2, 1, 3)), effective)),
+    );
+    eng.state.server_state = eng.calc_server_state();
+    eng.output.clear_commands();
+
+    eng
+}
+
+#[test]
+fn test_refresh_server_state_voter_leader() -> anyhow::Result<()> {
+    // The Leader is a voter in the committed effective membership config: nothing changes.
+    let mut eng = eng_leader(m12(), log_id(2, 1, 3));
+
+    eng.refresh_server_state();
+
+    assert!(eng.leader.is_some());
+    assert_eq!(ServerState::Leader, eng.state.server_state);
+    assert!(eng.output.take_commands().is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_refresh_server_state_learner_leader() -> anyhow::Result<()> {
+    // A Leader demoted to a learner but still in the membership config keeps leading.
+    let mut eng = eng_leader(m23_l1(), log_id(2, 1, 3));
+
+    eng.refresh_server_state();
+
+    assert!(eng.leader.is_some());
+    assert_eq!(ServerState::Leader, eng.state.server_state);
+    assert!(eng.output.take_commands().is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_refresh_server_state_removed_leader_uncommitted_membership() -> anyhow::Result<()> {
+    // The membership config removing the Leader is not yet committed:
+    // the Leader must keep leading to replicate this membership log entry.
+    let mut eng = eng_leader(m23(), log_id(2, 1, 2));
+
+    eng.refresh_server_state();
+
+    assert!(eng.leader.is_some());
+    assert!(eng.output.take_commands().is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_refresh_server_state_removed_leader_committed_membership() -> anyhow::Result<()> {
+    // The membership config removing the Leader is committed: the Leader reverts to a learner.
+    let mut eng = eng_leader(m23(), log_id(2, 1, 3));
+
+    eng.refresh_server_state();
+
+    assert!(eng.leader.is_none());
+    assert_eq!(ServerState::Learner, eng.state.server_state);
+    assert_eq!(vec![Command::CloseReplicationStreams], eng.output.take_commands());
+
+    Ok(())
+}

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -120,6 +120,7 @@ pub use crate::change_members::ChangeMembers;
 pub use crate::config::Config;
 pub use crate::config::ConfigError;
 pub use crate::config::SnapshotPolicy;
+pub use crate::config::StepDownPolicy;
 pub use crate::core::ServerState;
 pub use crate::entry::Entry;
 pub use crate::entry::EntryPayload;

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -172,6 +172,14 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     /// The current membership config of the cluster.
     pub membership_config: Arc<StoredMembershipOf<C>>,
 
+    /// The last committed membership config.
+    ///
+    /// It lags behind [`membership_config`](Self::membership_config) until the effective
+    /// membership config is committed: when the two are equal, the last membership log entry is
+    /// committed, i.e., a membership change is fully completed.
+    #[since(version = "0.10.0")]
+    pub committed_membership_config: Arc<StoredMembershipOf<C>>,
+
     /// Heartbeat metrics. It is Some() only when this node is leader.
     ///
     /// This field records a mapping between a node's ID and the time of the
@@ -223,8 +231,9 @@ where C: RaftTypeConfig
         write!(f, ", ")?;
         write!(
             f,
-            "membership:{}, snapshot:{}, purged:{}, replication:{{{}}}, heartbeat:{{{}}}",
+            "membership:{}, committed_membership:{}, snapshot:{}, purged:{}, replication:{{{}}}, heartbeat:{{{}}}",
             self.membership_config,
+            self.committed_membership_config,
             self.snapshot.display(),
             self.purged.display(),
             self.replication.as_ref().map(DisplayBTreeMapOptValue).display(),
@@ -263,6 +272,7 @@ where C: RaftTypeConfig
             millis_since_quorum_ack: None,
             last_quorum_acked: None,
             membership_config: Arc::new(StoredMembershipOf::<C>::default()),
+            committed_membership_config: Arc::new(StoredMembershipOf::<C>::default()),
             replication: None,
             heartbeat: None,
         }
@@ -385,6 +395,7 @@ where C: RaftTypeConfig
 }
 
 /// Subset of RaftMetrics, only include server-related metrics
+#[since]
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct RaftServerMetrics<C: RaftTypeConfig> {
@@ -399,6 +410,14 @@ pub struct RaftServerMetrics<C: RaftTypeConfig> {
 
     /// The current membership configuration.
     pub membership_config: Arc<StoredMembershipOf<C>>,
+
+    /// The last committed membership config.
+    ///
+    /// It lags behind [`membership_config`](Self::membership_config) until the effective
+    /// membership config is committed: when the two are equal, the last membership log entry is
+    /// committed, i.e., a membership change is fully completed.
+    #[since(version = "0.10.0")]
+    pub committed_membership_config: Arc<StoredMembershipOf<C>>,
 }
 
 impl<C> fmt::Display for RaftServerMetrics<C>
@@ -409,12 +428,13 @@ where C: RaftTypeConfig
 
         write!(
             f,
-            "id:{}, {:?}, vote:{}, leader:{}, membership:{}",
+            "id:{}, {:?}, vote:{}, leader:{}, membership:{}, committed_membership:{}",
             self.id,
             self.state,
             self.vote,
             self.current_leader.display(),
             self.membership_config,
+            self.committed_membership_config,
         )?;
 
         write!(f, "}}")?;
@@ -437,6 +457,7 @@ where C: RaftTypeConfig
             state: Default::default(),
             current_leader: None,
             membership_config: Arc::new(Default::default()),
+            committed_membership_config: Arc::new(Default::default()),
         }
     }
 }

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -309,6 +309,7 @@ where C: RaftTypeConfig<NodeId = u64> {
         millis_since_quorum_ack: None,
         last_quorum_acked: None,
         membership_config: Arc::new(StoredMembershipOf::<C>::new(None, Membership::default())),
+        committed_membership_config: Arc::new(StoredMembershipOf::<C>::new(None, Membership::default())),
         heartbeat: None,
 
         snapshot: None,

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -80,6 +80,7 @@ use crate::config::RuntimeConfig;
 use crate::core::ClientResponderQueue;
 use crate::core::RaftCore;
 use crate::core::SharedReplicateBatch;
+use crate::core::StepDownWatcher;
 use crate::core::Tick;
 use crate::core::heartbeat::handle::HeartbeatWorkersHandle;
 use crate::core::io_flush_tracking::AppliedProgress;
@@ -550,6 +551,13 @@ where
 
         // Spawn forwarder task to bridge Watch channel to notification channel
         let _forwarder_handle = C::spawn(io_completion_forwarder::<C>(rx_io_completed, weak_tx_notify));
+
+        StepDownWatcher::<C>::spawn(
+            rx_server_metrics.clone(),
+            rx_metrics.clone(),
+            tx_api.downgrade(),
+            &config,
+        );
 
         let core_handle = C::spawn(core.main(rx_shutdown).instrument(trace_span!("spawn").or_current()));
 

--- a/openraft/src/raft/trigger.rs
+++ b/openraft/src/raft/trigger.rs
@@ -1,5 +1,7 @@
 //! Trigger an action to RaftCore by an external caller.
 
+use openraft_macros::since;
+
 use crate::RaftTypeConfig;
 use crate::core::raft_msg::external_command::ExternalCommand;
 use crate::errors::AllowNextRevertError;
@@ -142,5 +144,24 @@ where C: RaftTypeConfig
         let res: Result<(), AllowNextRevertError<C>> = self.raft_inner.recv_msg(rx).await?;
 
         Ok(res)
+    }
+
+    /// Recalculate the internal server state(Leader/Follower/Learner) based on the vote and the
+    /// membership config.
+    ///
+    /// Usually this method is not used at all: the internal server state is always recalculated
+    /// automatically. The only exception is the step down of a Leader that is removed from the
+    /// membership config: openraft allows such a removed node to keep acting as a Leader, and the
+    /// application or the administrator decides when to revert it to a learner by calling this
+    /// method.
+    ///
+    /// It is safe to call this method at any time on any node: it is a no-op until the membership
+    /// config that removes this node is committed. A Leader keeps leading while that membership
+    /// config is not yet committed, because it is the one responsible for replicating it.
+    ///
+    /// Returns error when RaftCore has [`Fatal`] error, e.g., shut down or having storage error.
+    #[since(version = "0.10.0")]
+    pub async fn refresh_server_state(&self) -> Result<(), Fatal<C>> {
+        self.raft_inner.send_external_command(ExternalCommand::RefreshServerState).await
     }
 }

--- a/openraft/src/raft/trigger.rs
+++ b/openraft/src/raft/trigger.rs
@@ -151,9 +151,11 @@ where C: RaftTypeConfig
     ///
     /// Usually this method is not used at all: the internal server state is always recalculated
     /// automatically. The only exception is the step down of a Leader that is removed from the
-    /// membership config: openraft allows such a removed node to keep acting as a Leader, and the
-    /// application or the administrator decides when to revert it to a learner by calling this
-    /// method.
+    /// membership config: openraft allows such a removed node to keep acting as a Leader. By
+    /// default it is stepped down automatically (see
+    /// [`Config::removed_leader_step_down`](crate::Config::removed_leader_step_down));
+    /// with the automated step down disabled, the application or the administrator decides when
+    /// to revert it to a learner by calling this method.
     ///
     /// It is safe to call this method at any time on any node: it is a no-op until the membership
     /// config that removes this node is committed. A Leader keeps leading while that membership

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -327,16 +327,19 @@ where C: RaftTypeConfig
     /// This method updates the committed log id only if the input is greater than the current
     /// value.
     ///
-    /// Returns `Some(previous_value)` if updated, or `None` if the input was not greater.
-    pub(crate) fn update_local_committed(&mut self, committed: &Option<LogIdOf<C>>) -> Option<Option<LogIdOf<C>>> {
+    /// If updated, it returns `Some(membership_transition)`, where `membership_transition` is
+    /// the committed membership config change reported by `MembershipState::commit()`;
+    /// otherwise it returns `None`.
+    pub(crate) fn update_local_committed(
+        &mut self,
+        committed: &Option<LogIdOf<C>>,
+    ) -> Option<Option<(Option<LogIdOf<C>>, LogIdOf<C>)>> {
         if committed.as_ref() > self.committed() {
-            let prev = self.committed().cloned();
-
             // Safe unwrap(): committed > self.committed(), implies it cannot be None
             self.apply_progress_mut().accept(committed.clone().unwrap());
-            self.membership_state.commit(committed);
+            let membership_transition = self.membership_state.commit(committed);
 
-            Some(prev)
+            Some(membership_transition)
         } else {
             None
         }

--- a/tests/tests/membership/t31_remove_leader.rs
+++ b/tests/tests/membership/t31_remove_leader.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::ServerState;
+use openraft::StepDownPolicy;
 use openraft::errors::ClientWriteError;
 use openraft::type_config::TypeConfigExt;
 use openraft_memstore::ClientRequest;
@@ -17,7 +18,8 @@ use crate::fixtures::ut_harness;
 
 /// Change membership from {0,1} to {1,2,3}.
 ///
-/// - Then the leader should step down after joint log is committed.
+/// - The leader should transfer leadership and step down after the second membership log is
+///   committed.
 /// - Check logs on other node.
 #[tracing::instrument]
 #[test_harness::test(harness = ut_harness)]
@@ -177,6 +179,112 @@ async fn remove_leader_and_convert_to_learner() -> Result<()> {
     Ok(())
 }
 
+/// Change membership from {0,1,2} to {1,2}: the removed leader transfers leadership and steps
+/// down automatically.
+///
+/// Election is disabled: the new leader can only be established by transfer-leader.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn remove_leader_auto_transfer() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- change membership 012 to 12");
+    {
+        let node = router.get_raft_handle(&0)?;
+        node.change_membership([1, 2], false).await?;
+        log_index += 2;
+    }
+
+    tracing::info!(
+        log_index,
+        "--- a new leader is established by transfer-leader, not by election"
+    );
+    {
+        router
+            .wait(&1, timeout())
+            .metrics(
+                |x| matches!(x.current_leader, Some(1) | Some(2)) && x.current_term >= 2,
+                "a new leader is established by transfer-leader",
+            )
+            .await?;
+    }
+
+    tracing::info!(log_index, "--- the removed leader reverts to learner");
+    {
+        let metrics = router.wait(&0, timeout()).state(ServerState::Learner, "removed leader steps down").await?;
+        assert_eq!(
+            metrics.current_term, 1,
+            "the removed leader is not disturbed by the new election"
+        );
+    }
+
+    Ok(())
+}
+
+/// Change membership from {0,1,2} to {1,2} with the automated step down disabled.
+///
+/// The removed leader keeps leading, until the application reverts it to a learner with
+/// `Trigger::refresh_server_state()`.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn remove_leader_manual_step_down() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            removed_leader_step_down: StepDownPolicy::Never,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- change membership 012 to 12");
+    {
+        let node = router.get_raft_handle(&0)?;
+        node.change_membership([1, 2], false).await?;
+        log_index += 2;
+    }
+
+    tracing::info!(log_index, "--- the removed leader keeps leading");
+    {
+        let res = router
+            .wait(&0, Some(Duration::from_millis(1_000)))
+            .metrics(
+                |x| x.state != ServerState::Leader,
+                "the removed leader leaves the Leader state",
+            )
+            .await;
+
+        assert!(
+            res.is_err(),
+            "the automated step down is disabled, the removed leader keeps leading"
+        );
+    }
+
+    tracing::info!(log_index, "--- manually revert the removed leader to a learner");
+    {
+        let node = router.get_raft_handle(&0)?;
+        node.trigger().refresh_server_state().await?;
+
+        router.wait(&0, timeout()).state(ServerState::Learner, "removed leader reverts to learner").await?;
+    }
+
+    Ok(())
+}
+
 /// Change membership from {0,1,2} to {2}. Access {2} at once.
 ///
 /// It should not respond a ForwardToLeader error that pointing to the removed leader.
@@ -188,6 +296,8 @@ async fn remove_leader_access_new_cluster() -> Result<()> {
         Config {
             enable_heartbeat: false,
             enable_elect: false,
+            // Disable the automated step down, to keep the new cluster leaderless.
+            removed_leader_step_down: StepDownPolicy::Never,
             ..Default::default()
         }
         .validate()?,
@@ -207,12 +317,9 @@ async fn remove_leader_access_new_cluster() -> Result<()> {
 
         router
             .wait(&2, timeout())
-            // The last_applied may not be updated on follower nodes:
-            // because leader node-0 will steps down at once when the second membership log is
-            // committed.
             .metrics(
                 |x| x.last_log_index == Some(log_index),
-                "new leader node-2 commits 2 membership log",
+                "node-2 receives 2 membership logs",
             )
             .await?;
     }

--- a/tests/tests/metrics/t10_server_metrics_and_data_metrics.rs
+++ b/tests/tests/metrics/t10_server_metrics_and_data_metrics.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
+use openraft::Membership;
 use openraft::async_runtime::WatchReceiver;
 use openraft::type_config::TypeConfigExt;
 use openraft_memstore::TypeConfig;
@@ -141,6 +142,93 @@ async fn heartbeat_metrics() -> Result<()> {
 
         assert_eq!(n1_hb_ts2, n1_hb_ts);
         assert_eq!(n2_hb_ts2, n2_hb_ts);
+    }
+
+    Ok(())
+}
+
+/// The `committed_membership_config` lags behind the effective `membership_config` until the
+/// effective one is committed; the two become equal when a membership change is completed.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn committed_membership_config() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let log_index = router.new_cluster(btreeset! {0,1}, btreeset! {}).await?;
+
+    let node = router.get_raft_handle(&0)?;
+
+    let old_membership = Membership::new_with_defaults(vec![btreeset! {0,1}], []);
+    let new_membership = Membership::new_with_defaults(vec![btreeset! {0,1}], [2]);
+
+    tracing::info!(
+        log_index,
+        "--- the initial membership config is committed: the two are equal"
+    );
+    {
+        let metrics = node.metrics().borrow_watched().clone();
+        assert_eq!(metrics.committed_membership_config, metrics.membership_config);
+        assert_eq!(&old_membership, metrics.committed_membership_config.membership());
+    }
+
+    tracing::info!(
+        log_index,
+        "--- block node-1, add a learner: the membership log can not commit"
+    );
+    router.new_raft_node(2).await;
+    router.set_network_error(1, true);
+
+    let n0 = node.clone();
+    let add_learner_handle = TypeConfig::spawn(async move { n0.add_learner(2, (), false).await });
+
+    tracing::info!(
+        log_index,
+        "--- the effective membership config updates, the committed one lags"
+    );
+    {
+        let metrics = router
+            .wait(&0, Some(Duration::from_millis(3_000)))
+            .metrics(
+                |x| x.membership_config.membership() == &new_membership,
+                "the effective membership config contains the new learner",
+            )
+            .await?;
+
+        assert_eq!(&old_membership, metrics.committed_membership_config.membership());
+        assert!(metrics.committed_membership_config.log_id() < metrics.membership_config.log_id());
+    }
+
+    tracing::info!(
+        log_index,
+        "--- restore node-1, the membership log commits: the two are equal"
+    );
+    {
+        router.set_network_error(1, false);
+        add_learner_handle.await??;
+
+        let metrics = router
+            .wait(&0, Some(Duration::from_millis(3_000)))
+            .metrics(
+                |x| x.committed_membership_config == x.membership_config,
+                "the committed membership config catches up with the effective one",
+            )
+            .await?;
+        assert_eq!(&new_membership, metrics.committed_membership_config.membership());
+
+        let server_metrics = node.server_metrics().borrow_watched().clone();
+        assert_eq!(
+            metrics.committed_membership_config,
+            server_metrics.committed_membership_config
+        );
     }
 
     Ok(())


### PR DESCRIPTION

## Changelog

##### feat: removed leader transfers leadership before stepping down
# Summary

A Leader removed from a committed membership config now steps down
gently: after a configurable delay it transfers leadership to the most
up-to-date voter, then reverts itself to a learner as a guaranteed
fallback. The automation runs as a task watching the metrics, outside
the consensus kernel, replacing the tick-driven step down inside
`RaftCore`.

# Details

- Add `Config::removed_leader_step_down: StepDownPolicy`: `After(ms)`
  (default `After(150)`) is the delay counted from the commit of the
  membership config that removes the Leader; `Never` disables the
  automation so the application reverts the Leader manually with
  `Trigger::refresh_server_state()`. In CLI the value is either a
  "never" literal (`never`, `no`, `none`, `off`, `false`,
  case-insensitive) or the number of milliseconds; a config file
  without this field keeps the default via a serde default.

- `StepDownWatcher`, spawned in `Raft::new()`, waits on the server
  metrics channel, which changes only on server state transitions,
  including the commit of a membership config. When this node is a
  Leader not contained in the committed membership config, it sends
  `TriggerTransferLeader` targeting the voter with the greatest
  matching log id, then after another `heartbeat_interval` sends
  `RefreshServerState`. Both commands re-validate the state inside
  `RaftCore`, so acting on stale metrics is a no-op. It holds a weak
  API sender and quits when `RaftCore` terminates.

- Remove the tick-driven step down from `RaftCore`, which polled the
  condition on every tick and reverted the removed Leader without
  transferring leadership, leaving the new cluster to elect a Leader
  only by election timeout.


##### feat: add committed_membership_config to metrics
# Summary

Expose the last committed membership config in `RaftMetrics` and
`RaftServerMetrics`, alongside the effective `membership_config`.

# Details

The new `committed_membership_config` field lags behind the effective
`membership_config` until the effective membership log entry is
committed: the two become equal exactly when a membership change is
fully completed. This gives applications an observable, level-based
signal for the completion of a membership change, and makes
`RaftServerMetrics` change on this transition, so a watcher of the
low-frequency server-metrics channel can wake on it.


##### feat: expose refresh_server_state on Trigger as public API
# Summary

Add `Trigger::refresh_server_state()` so applications and administrators can
explicitly tell a removed Leader to step down once the membership config that
removes it is committed. Until this method is called, the removed Leader
continues leading, which is by design.

# Details

- New `ExternalCommand::RefreshServerState` variant wired through
  `ExternalCommandName`, `RaftMsgName`, and the `raft_core` dispatch loop —
  it calls `Engine::refresh_server_state()`.
- `Trigger::refresh_server_state()` is the public entry point, marked
  `#[since(version = "0.10.0")]`.
- Four unit tests cover the four cases: voter-leader (no-op),
  learner-leader (no-op), removed leader with uncommitted membership (no-op),
  and removed leader with committed membership (demotes and emits
  `CloseReplicationStreams`).

- Fix: #2123


##### refactor: thread membership_transition through update_local_committed
# Summary

Change `update_local_committed` to return the membership transition from
`MembershipState::commit()` instead of the previous committed log id. This
makes the membership change observable to callers.

# Details

- The previous return value (`Some(prev_committed)`) was unused at the only
  call site. The new return value (`Some(membership_transition)`) exposes what
  `MembershipState::commit()` already computed, so callers can react to
  membership config changes without a second lookup.
- The call-site binding is renamed from `_prev_committed` to
  `_membership_transition` to match the new semantics.


##### refactor: rename leader_step_down to refresh_server_state
# Summary

Rename `Engine::leader_step_down` to `refresh_server_state` to reflect that
the method re-derives server state from vote and membership config, not just
demotes a leader.

# Details

The old name implied the method was only for leaders stepping down. The new
name captures the actual semantics: given the current vote and effective
membership, compute what server state (Leader/Follower/Learner) the node
should be in. The behavior is unchanged; only the name and doc comment are
updated.

- The doc now explains the one exceptional case: a removed Leader keeps
  leading until the membership config without it is committed, because only
  then can `refresh_server_state` safely demote it.
- The call site in `raft_core.rs` is updated to match.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1783)
<!-- Reviewable:end -->
