### PR TITLE
refactor: add fencing to RefreshServerState command

### DIFF
--- a/examples/raft-kv-memstore-grpc/proto/raft.proto
+++ b/examples/raft-kv-memstore-grpc/proto/raft.proto
@@ -61,6 +61,10 @@ message LogId {
 message VoteRequest {
   Vote vote = 1;
   LogId last_log_id = 2;
+
+  // True if the election is part of a leadership transfer authorized by the current Leader.
+  // A voter grants such a request even if the leader lease has not expired.
+  bool leadership_transfer = 3;
 }
 
 // VoteResponse represents the response to a vote request

--- a/examples/raft-kv-memstore-grpc/src/pb_impl/impl_vote_request.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/impl_vote_request.rs
@@ -6,6 +6,7 @@ impl From<VoteRequest> for pb::VoteRequest {
         pb::VoteRequest {
             vote: Some(vote_req.vote),
             last_log_id: vote_req.last_log_id.map(|log_id| log_id.into()),
+            leadership_transfer: vote_req.leadership_transfer,
         }
     }
 }
@@ -14,6 +15,10 @@ impl From<pb::VoteRequest> for VoteRequest {
     fn from(proto_vote_req: pb::VoteRequest) -> Self {
         let vote = proto_vote_req.vote.unwrap();
         let last_log_id = proto_vote_req.last_log_id.map(|log_id| log_id.into());
-        VoteRequest::new(vote, last_log_id)
+        VoteRequest {
+            vote,
+            last_log_id,
+            leadership_transfer: proto_vote_req.leadership_transfer,
+        }
     }
 }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1605,7 +1605,7 @@ where
 
                     self.engine.state.vote.disable_lease();
                     if self.id == to {
-                        self.engine.elect();
+                        self.engine.elect_by_leadership_transfer();
                     }
                 }
             }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1657,8 +1657,32 @@ where
                         tracing::info!("setting metrics recorder");
                         self.metrics_recorder = recorder;
                     }
-                    ExternalCommand::RefreshServerState => {
-                        self.engine.refresh_server_state();
+                    ExternalCommand::RefreshServerState {
+                        vote,
+                        membership_log_id,
+                    } => {
+                        // The condition to refresh, e.g., the membership config that removes the
+                        // Leader being committed, is checked by the sender. Refresh only if the
+                        // vote and the effective membership config log id still match what the
+                        // sender observed, so that a delayed command can not cause an unexpected
+                        // server state refresh. A `None` skips the corresponding check.
+                        let st = &self.engine.state;
+                        let vote_unchanged = vote.as_ref().is_none_or(|v| st.vote_ref() == v);
+                        let membership_unchanged = membership_log_id
+                            .as_ref()
+                            .is_none_or(|log_id| st.membership_state.effective().log_id().as_ref() == Some(log_id));
+
+                        if vote_unchanged && membership_unchanged {
+                            self.engine.refresh_server_state();
+                        } else {
+                            tracing::info!(
+                                "RefreshServerState is dropped: expected vote: {}, membership log id: {}; current vote: {}, membership log id: {}",
+                                vote.display(),
+                                membership_log_id.display(),
+                                self.engine.state.vote_ref(),
+                                self.engine.state.membership_state.effective().log_id().display(),
+                            );
+                        }
                     }
                 }
             }

--- a/openraft/src/core/raft_msg/external_command.rs
+++ b/openraft/src/core/raft_msg/external_command.rs
@@ -3,13 +3,17 @@
 use std::fmt;
 use std::sync::Arc;
 
+use display_more::DisplayOptionExt;
+
 use crate::RaftTypeConfig;
 use crate::core::raft_msg::ExternalCommandName;
 use crate::core::raft_msg::ResultSender;
 use crate::errors::AllowNextRevertError;
 use crate::metrics::MetricsRecorder;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::OneshotSenderOf;
 use crate::type_config::alias::SnapshotOf;
+use crate::type_config::alias::VoteOf;
 
 /// Application-triggered Raft actions for testing and administration.
 ///
@@ -60,7 +64,21 @@ pub(crate) enum ExternalCommand<C: RaftTypeConfig> {
     ///
     /// Most of the time the internal server state is recalculated automatically; the only
     /// exception is the step down of a Leader that is removed from the membership config.
-    RefreshServerState,
+    ///
+    /// The command may carry the vote and the effective membership config log id observed by
+    /// the sender; it is dropped if either differs from the current state when it is handled,
+    /// so that a delayed command can not cause an unexpected refresh. The condition to refresh,
+    /// e.g., the membership config that removes the Leader being committed, is checked by the
+    /// sender, such as [`StepDownWatcher`].
+    ///
+    /// A `None` skips the corresponding check: with both `None` the server state is refreshed
+    /// unconditionally.
+    ///
+    /// [`StepDownWatcher`]: crate::core::StepDownWatcher
+    RefreshServerState {
+        vote: Option<VoteOf<C>>,
+        membership_log_id: Option<LogIdOf<C>>,
+    },
 }
 
 impl<C: RaftTypeConfig> ExternalCommand<C> {
@@ -75,7 +93,7 @@ impl<C: RaftTypeConfig> ExternalCommand<C> {
             ExternalCommand::TriggerTransferLeader { .. } => ExternalCommandName::TriggerTransferLeader,
             ExternalCommand::AllowNextRevert { .. } => ExternalCommandName::AllowNextRevert,
             ExternalCommand::SetMetricsRecorder { .. } => ExternalCommandName::SetMetricsRecorder,
-            ExternalCommand::RefreshServerState => ExternalCommandName::RefreshServerState,
+            ExternalCommand::RefreshServerState { .. } => ExternalCommandName::RefreshServerState,
         }
     }
 }
@@ -122,8 +140,16 @@ where C: RaftTypeConfig
             ExternalCommand::SetMetricsRecorder { .. } => {
                 write!(f, "SetMetricsRecorder")
             }
-            ExternalCommand::RefreshServerState => {
-                write!(f, "RefreshServerState")
+            ExternalCommand::RefreshServerState {
+                vote,
+                membership_log_id,
+            } => {
+                write!(
+                    f,
+                    "RefreshServerState: expected vote: {}, expected membership_log_id: {}",
+                    vote.display(),
+                    membership_log_id.display()
+                )
             }
         }
     }

--- a/openraft/src/core/step_down_watcher.rs
+++ b/openraft/src/core/step_down_watcher.rs
@@ -108,8 +108,9 @@ where C: RaftTypeConfig
     ///   newer membership config that contains this node is committed.
     /// - Transfer leadership to the most up-to-date voter.
     /// - Wait for `transfer_wait`, then revert this node to a learner. This is the guaranteed
-    ///   fallback in case the transfer takes no effect; it is a no-op if a new Leader is already
-    ///   established.
+    ///   fallback in case the transfer takes no effect; the command is fenced by the vote and the
+    ///   membership config log id observed above, thus it is dropped if a new Leader is already
+    ///   established or the membership config has changed.
     async fn try_step_down(&self) {
         // Clone the metrics out of the watch channel: the borrowed reference is not `Send`,
         // and holding it across an `await` would block the metrics updater.
@@ -135,7 +136,19 @@ where C: RaftTypeConfig
 
         C::sleep(self.transfer_wait).await;
 
-        self.send(ExternalCommand::RefreshServerState).await;
+        // In the fence a `None` membership log id means skipping the membership check, thus it
+        // must be `Some` here. It always holds: this node is a Leader, hence the cluster is
+        // initialized, hence the membership config comes from a log entry that has a log id.
+        debug_assert!(
+            server_metrics.membership_config.log_id().is_some(),
+            "the membership config of a Leader must have a log id"
+        );
+
+        let cmd = ExternalCommand::RefreshServerState {
+            vote: Some(server_metrics.vote.clone()),
+            membership_log_id: server_metrics.membership_config.log_id().clone(),
+        };
+        self.send(cmd).await;
     }
 
     /// Send an external command to `RaftCore`.

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -447,10 +447,10 @@ where C: RaftTypeConfig
     /// is removed from the membership config keeps leading until the membership config that
     /// removes it is committed, and it is this method that then reverts it to a learner.
     ///
-    /// It is safe to call this method at any time on any node; it is a no-op if the effective
-    /// membership config is not yet committed: the Leader, even when removed, must keep leading
-    /// to replicate the membership log entry that removes it; otherwise this entry could never
-    /// be committed.
+    /// This method updates the internal server state unconditionally. The caller must not call
+    /// it on a Leader whose effective membership config is not yet committed: the Leader, even
+    /// when removed, must keep leading to replicate the membership log entry that removes it;
+    /// otherwise this entry could never be committed.
     ///
     /// A Leader demoted to a learner that is still in the membership config is not affected:
     /// openraft allows a learner to act as Leader. See: [Determine Server
@@ -459,7 +459,6 @@ where C: RaftTypeConfig
     pub(crate) fn refresh_server_state(&mut self) {
         tracing::debug!("{}: node_id: {}", func_name!(), self.config.id);
 
-        // A removed Leader keeps leading until the membership config without it is committed.
         let em = &self.state.membership_state.effective();
 
         tracing::debug!(
@@ -469,10 +468,7 @@ where C: RaftTypeConfig
             self.state.is_leading(&self.config.id),
         );
 
-        #[allow(clippy::collapsible_if)]
-        if em.log_id().as_ref() <= self.state.committed() {
-            self.vote_handler().update_internal_server_state();
-        }
+        self.vote_handler().update_internal_server_state();
     }
 
     /// Update Engine state when snapshot building completes or is deferred.

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -199,6 +199,19 @@ where C: RaftTypeConfig
     /// Start to elect this node as leader
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) fn elect(&mut self) {
+        self.do_elect(false);
+    }
+
+    /// Start an election as part of a leadership transfer.
+    ///
+    /// The emitted vote request is marked so that voters grant it even when the leader lease
+    /// has not expired. See: Raft dissertation, section 4.2.3.
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(crate) fn elect_by_leadership_transfer(&mut self) {
+        self.do_elect(true);
+    }
+
+    fn do_elect(&mut self, leadership_transfer: bool) {
         let new_term = self.state.vote.term().next();
         let leader_id = LeaderIdOf::<C>::new(new_term, self.config.id.clone());
         let new_vote = VoteOf::<C>::from_leader_id(leader_id, false);
@@ -214,7 +227,11 @@ where C: RaftTypeConfig
         self.vote_handler().update_vote(&new_vote).unwrap();
 
         self.output.push_command(Command::SendVote {
-            vote_req: VoteRequest::new(new_vote, last_log_id),
+            vote_req: VoteRequest {
+                vote: new_vote,
+                last_log_id,
+                leadership_transfer,
+            },
         });
 
         self.server_state_handler().update_server_state_if_changed();
@@ -249,7 +266,10 @@ where C: RaftTypeConfig
             local_leased_vote.display_lease_info(now)
         );
 
-        if local_leased_vote.is_committed() {
+        // A leadership-transfer election is authorized by the current Leader, thus it proceeds
+        // even when the leader lease has not expired.
+        // See: Raft dissertation, section 4.2.3.
+        if local_leased_vote.is_committed() && !req.leadership_transfer {
             // Current leader lease has not yet expired, reject voting request
             if !local_leased_vote.is_expired(now, Duration::from_millis(0)) {
                 tracing::info!(

--- a/openraft/src/engine/tests/elect_test.rs
+++ b/openraft/src/engine/tests/elect_test.rs
@@ -60,12 +60,48 @@ fn test_elect_single_node() -> anyhow::Result<()> {
                     vote_req: VoteRequest {
                         vote: Vote::new(1, 1),
                         last_log_id: Some(log_id(0, 0, 0)),
+                        leadership_transfer: false,
                     },
                 },
             ],
             eng.output.take_commands()
         );
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_elect_by_leadership_transfer_sets_flag() -> anyhow::Result<()> {
+    // An election started by a leadership transfer marks the vote request, so that voters
+    // grant it even when the leader lease has not expired.
+    let mut eng = eng();
+    eng.config.id = 1;
+    eng.state.membership_state.set_effective(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        Some(log_id(0, 1, 1)),
+        m12(),
+    )));
+
+    eng.elect_by_leadership_transfer();
+
+    assert_eq!(Vote::new(1, 1), *eng.state.vote_ref());
+    assert!(eng.candidate_ref().is_some(), "candidate state is pending");
+    assert_eq!(ServerState::Candidate, eng.state.server_state);
+
+    assert_eq!(
+        vec![
+            //
+            Command::SaveVote { vote: Vote::new(1, 1) },
+            Command::SendVote {
+                vote_req: VoteRequest {
+                    vote: Vote::new(1, 1),
+                    last_log_id: Some(log_id(0, 0, 0)),
+                    leadership_transfer: true,
+                },
+            },
+        ],
+        eng.output.take_commands()
+    );
 
     Ok(())
 }
@@ -107,6 +143,7 @@ fn test_elect_single_node_elect_again() -> anyhow::Result<()> {
                     vote_req: VoteRequest {
                         vote: Vote::new(2, 1),
                         last_log_id: Some(log_id(0, 0, 0)),
+                        leadership_transfer: false,
                     },
                 },
             ],

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -52,6 +52,7 @@ fn test_handle_vote_req_rejected_by_leader_lease() -> anyhow::Result<()> {
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(3, 2),
         last_log_id: Some(log_id(2, 1, 3)),
+        leadership_transfer: false,
     });
 
     assert_eq!(VoteResponse::new(Vote::new_committed(2, 1), None, false), resp);
@@ -67,12 +68,49 @@ fn test_handle_vote_req_rejected_by_leader_lease() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_handle_vote_req_leadership_transfer_overrides_leader_lease() -> anyhow::Result<()> {
+    // An election authorized by the current Leader (leadership transfer) is granted
+    // even when the leader lease has not expired.
+    // See: Raft dissertation, section 4.2.3.
+    let mut eng = eng();
+    eng.state.vote.update(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
+
+    let resp = eng.handle_vote_req(VoteRequest {
+        vote: Vote::new(3, 2),
+        last_log_id: Some(log_id(2, 1, 3)),
+        leadership_transfer: true,
+    });
+
+    assert_eq!(VoteResponse::new(Vote::new(3, 2), None, true), resp);
+
+    assert_eq!(Vote::new(3, 2), *eng.state.vote_ref());
+    assert!(eng.leader.is_none());
+    assert!(eng.candidate_ref().is_none(), "candidate yields to the new candidate");
+
+    assert_eq!(ServerState::Follower, eng.state.server_state);
+    assert_eq!(
+        vec![
+            Command::SaveVote { vote: Vote::new(3, 2) },
+            Command::CloseReplicationStreams,
+        ],
+        eng.output.take_commands()
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
     let mut eng = eng();
 
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(1, 2),
         last_log_id: None,
+        leadership_transfer: false,
     });
 
     assert_eq!(VoteResponse::new(Vote::new(2, 1), None, false), resp);
@@ -95,6 +133,7 @@ fn test_handle_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(3, 2),
         last_log_id: Some(log_id(1, 1, 3)),
+        leadership_transfer: false,
     });
 
     assert_eq!(VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 3)), false), resp);
@@ -122,6 +161,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(2, 1),
         last_log_id: Some(log_id(2, 1, 3)),
+        leadership_transfer: false,
     });
 
     assert_eq!(VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 3)), true), resp);
@@ -148,6 +188,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
     let resp = eng.handle_vote_req(VoteRequest {
         vote: Vote::new(3, 1),
         last_log_id: Some(log_id(2, 1, 3)),
+        leadership_transfer: false,
     });
 
     // respond the updated vote.
@@ -184,6 +225,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
         eng.handle_vote_req(VoteRequest {
             vote: Vote::new(3, 1),
             last_log_id: Some(log_id(2, 1, 3)),
+            leadership_transfer: false,
         });
 
         assert_eq!(st, eng.state.server_state);
@@ -208,6 +250,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
         eng.handle_vote_req(VoteRequest {
             vote: Vote::new(3, 1),
             last_log_id: Some(log_id(2, 1, 3)),
+            leadership_transfer: false,
         });
 
         assert_eq!(st, eng.state.server_state);

--- a/openraft/src/engine/tests/refresh_server_state_test.rs
+++ b/openraft/src/engine/tests/refresh_server_state_test.rs
@@ -97,14 +97,17 @@ fn test_refresh_server_state_learner_leader() -> anyhow::Result<()> {
 
 #[test]
 fn test_refresh_server_state_removed_leader_uncommitted_membership() -> anyhow::Result<()> {
-    // The membership config removing the Leader is not yet committed:
-    // the Leader must keep leading to replicate this membership log entry.
+    // This method updates the server state unconditionally: the Leader is reverted even when
+    // the membership config removing it is not yet committed. The sender of
+    // `ExternalCommand::RefreshServerState`, e.g., the `StepDownWatcher`, is responsible for
+    // checking the commit condition.
     let mut eng = eng_leader(m23(), log_id(2, 1, 2));
 
     eng.refresh_server_state();
 
-    assert!(eng.leader.is_some());
-    assert!(eng.output.take_commands().is_empty());
+    assert!(eng.leader.is_none());
+    assert_eq!(ServerState::Learner, eng.state.server_state);
+    assert_eq!(vec![Command::CloseReplicationStreams], eng.output.take_commands());
 
     Ok(())
 }

--- a/openraft/src/raft/message/vote.rs
+++ b/openraft/src/raft/message/vote.rs
@@ -2,12 +2,14 @@ use std::borrow::Borrow;
 use std::fmt;
 
 use display_more::DisplayOptionExt;
+use openraft_macros::since;
 
 use crate::RaftTypeConfig;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
 
 /// An RPC sent by candidates to gather votes (§5.2).
+#[since]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 pub struct VoteRequest<C: RaftTypeConfig> {
@@ -15,13 +17,29 @@ pub struct VoteRequest<C: RaftTypeConfig> {
     pub vote: VoteOf<C>,
     /// The candidate's last log id.
     pub last_log_id: Option<LogIdOf<C>>,
+
+    /// True if the election is part of a leadership transfer authorized by the current Leader.
+    ///
+    /// A voter processes such a request even if the leader lease has not expired: the disruption
+    /// the lease protects against is legitimate when the Leader itself initiates the election
+    /// ("I have permission to disrupt the leader--it told me to!").
+    /// See: Raft dissertation, section 4.2.3.
+    #[since(version = "0.10.0")]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub leadership_transfer: bool,
 }
 
 impl<C> fmt::Display for VoteRequest<C>
 where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{{vote:{}, last_log:{}}}", self.vote, self.last_log_id.display(),)
+        write!(
+            f,
+            "{{vote:{}, last_log:{}, leadership_transfer:{}}}",
+            self.vote,
+            self.last_log_id.display(),
+            self.leadership_transfer,
+        )
     }
 }
 
@@ -30,7 +48,11 @@ where C: RaftTypeConfig
 {
     /// Create a new vote request.
     pub fn new(vote: VoteOf<C>, last_log_id: Option<LogIdOf<C>>) -> Self {
-        Self { vote, last_log_id }
+        Self {
+            vote,
+            last_log_id,
+            leadership_transfer: false,
+        }
     }
 }
 

--- a/openraft/src/raft/trigger.rs
+++ b/openraft/src/raft/trigger.rs
@@ -8,6 +8,8 @@ use crate::errors::AllowNextRevertError;
 use crate::errors::Fatal;
 use crate::raft::RaftInner;
 use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::VoteOf;
 
 /// Trigger is an interface to trigger an action to RaftCore by external caller.
 ///
@@ -157,13 +159,27 @@ where C: RaftTypeConfig
     /// with the automated step down disabled, the application or the administrator decides when
     /// to revert it to a learner by calling this method.
     ///
-    /// It is safe to call this method at any time on any node: it is a no-op until the membership
-    /// config that removes this node is committed. A Leader keeps leading while that membership
-    /// config is not yet committed, because it is the one responsible for replicating it.
+    /// `vote` and `membership_log_id` are the expected current vote and the expected log id of
+    /// the effective membership config: the refresh is dropped if either differs from the
+    /// current state when the command is handled, so that a delayed command can not cause an
+    /// unexpected refresh. A `None` skips the corresponding check: with both `None` the server
+    /// state is refreshed unconditionally.
+    ///
+    /// To step down a removed Leader, call this method after the membership config that removes
+    /// it is committed: a Leader keeps leading while that membership config is not yet
+    /// committed, because it is the one responsible for replicating it.
     ///
     /// Returns error when RaftCore has [`Fatal`] error, e.g., shut down or having storage error.
     #[since(version = "0.10.0")]
-    pub async fn refresh_server_state(&self) -> Result<(), Fatal<C>> {
-        self.raft_inner.send_external_command(ExternalCommand::RefreshServerState).await
+    pub async fn refresh_server_state(
+        &self,
+        vote: Option<VoteOf<C>>,
+        membership_log_id: Option<LogIdOf<C>>,
+    ) -> Result<(), Fatal<C>> {
+        let cmd = ExternalCommand::RefreshServerState {
+            vote,
+            membership_log_id,
+        };
+        self.raft_inner.send_external_command(cmd).await
     }
 }

--- a/tests/tests/append_entries/t10_see_higher_vote.rs
+++ b/tests/tests/append_entries/t10_see_higher_vote.rs
@@ -44,6 +44,7 @@ async fn append_sees_higher_vote() -> Result<()> {
             .vote(VoteRequest {
                 vote: Vote::new(10, 1),
                 last_log_id: Some(log_id(10, 1, 5)),
+                leadership_transfer: false,
             })
             .await?;
 

--- a/tests/tests/append_entries/t10_stream_append.rs
+++ b/tests/tests/append_entries/t10_stream_append.rs
@@ -149,6 +149,7 @@ async fn stream_append_higher_vote() -> Result<()> {
         .vote(VoteRequest {
             vote: Vote::new(10, 2),
             last_log_id: Some(log_id(10, 2, 100)),
+            leadership_transfer: false,
         })
         .await?;
     assert!(resp.is_granted_to(&Vote::new(10, 2)));

--- a/tests/tests/client_api/t14_transfer_leader.rs
+++ b/tests/tests/client_api/t14_transfer_leader.rs
@@ -280,6 +280,54 @@ async fn transfer_leader_blocks_lease_read() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// A leadership-transfer election succeeds while the other voters still hold a fresh leader
+/// lease.
+///
+/// The `TransferLeaderRequest` is delivered only to the target: the other voters never receive
+/// it, so their leases are never disabled. They grant the vote anyway, because the vote request
+/// of a leadership-transfer election overrides the lease (Raft dissertation, section 4.2.3).
+/// This is the deterministic form of a race where the target's vote request overtakes the
+/// `TransferLeaderRequest` broadcast on its way to another voter.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn transfer_leader_overrides_lease() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            // A lease far longer than the test: the voters' leases stay fresh throughout,
+            // so a granted vote can only result from the leadership-transfer override.
+            election_timeout_min: 10_000,
+            election_timeout_max: 10_001,
+            enable_heartbeat: false,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    let n2 = router.get_raft_handle(&2)?;
+
+    let metrics = n0.metrics().borrow_watched().clone();
+    let leader_vote = metrics.vote;
+    let last_log_id = metrics.last_applied;
+
+    tracing::info!("--- transfer Leader from 0 to 2, deliver the request only to the target");
+    {
+        let req = TransferLeaderRequest::new(leader_vote, 2, last_log_id);
+        n2.handle_transfer_leader(req).await?;
+
+        n2.wait(timeout()).state(ServerState::Leader, "node-2 becomes leader within the lease").await?;
+        n0.wait(timeout()).state(ServerState::Follower, "node-0 steps down").await?;
+    }
+
+    Ok(())
+}
+
 fn timeout() -> Option<Duration> {
     Some(Duration::from_millis(500))
 }

--- a/tests/tests/membership/t31_remove_leader.rs
+++ b/tests/tests/membership/t31_remove_leader.rs
@@ -6,6 +6,7 @@ use maplit::btreeset;
 use openraft::Config;
 use openraft::ServerState;
 use openraft::StepDownPolicy;
+use openraft::Vote;
 use openraft::errors::ClientWriteError;
 use openraft::type_config::TypeConfigExt;
 use openraft_memstore::ClientRequest;
@@ -277,7 +278,93 @@ async fn remove_leader_manual_step_down() -> Result<()> {
     tracing::info!(log_index, "--- manually revert the removed leader to a learner");
     {
         let node = router.get_raft_handle(&0)?;
-        node.trigger().refresh_server_state().await?;
+        node.trigger().refresh_server_state(None, None).await?;
+
+        router.wait(&0, timeout()).state(ServerState::Learner, "removed leader reverts to learner").await?;
+    }
+
+    Ok(())
+}
+
+/// Change membership from {0,1,2} to {1,2} with the automated step down disabled, then step down
+/// the removed leader with a fenced `Trigger::refresh_server_state()`.
+///
+/// The refresh is dropped if the expected vote or the expected membership log id does not match
+/// the current state; it proceeds when both match.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn remove_leader_fenced_step_down() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            removed_leader_step_down: StepDownPolicy::Never,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- change membership 012 to 12");
+    {
+        let node = router.get_raft_handle(&0)?;
+        node.change_membership([1, 2], false).await?;
+        log_index += 2;
+    }
+
+    let node = router.get_raft_handle(&0)?;
+    let metrics = router
+        .wait(&0, timeout())
+        .applied_index(Some(log_index), "the removed leader applies the membership logs")
+        .await?;
+    let vote = metrics.vote;
+    let membership_log_id =
+        (*metrics.membership_config.log_id()).expect("an initialized cluster has a membership log id");
+
+    tracing::info!(log_index, "--- mismatching expected vote: the refresh is dropped");
+    {
+        let mismatching = Vote::new(100, 100);
+        node.trigger().refresh_server_state(Some(mismatching), None).await?;
+
+        let res = router
+            .wait(&0, Some(Duration::from_millis(1_000)))
+            .metrics(
+                |x| x.state != ServerState::Leader,
+                "the removed leader leaves the Leader state",
+            )
+            .await;
+        assert!(res.is_err(), "the expected vote does not match, the refresh is dropped");
+    }
+
+    tracing::info!(
+        log_index,
+        "--- mismatching expected membership log id: the refresh is dropped"
+    );
+    {
+        let mismatching = log_id(1, 0, 1);
+        node.trigger().refresh_server_state(None, Some(mismatching)).await?;
+
+        let res = router
+            .wait(&0, Some(Duration::from_millis(1_000)))
+            .metrics(
+                |x| x.state != ServerState::Leader,
+                "the removed leader leaves the Leader state",
+            )
+            .await;
+        assert!(
+            res.is_err(),
+            "the expected membership log id does not match, the refresh is dropped"
+        );
+    }
+
+    tracing::info!(
+        log_index,
+        "--- matching vote and membership log id: the refresh proceeds"
+    );
+    {
+        node.trigger().refresh_server_state(Some(vote), Some(membership_log_id)).await?;
 
         router.wait(&0, timeout()).state(ServerState::Learner, "removed leader reverts to learner").await?;
     }


### PR DESCRIPTION

## Changelog

##### refactor: add fencing to RefreshServerState command
# Summary

Add optional `vote` and `membership_log_id` fields to
`ExternalCommand::RefreshServerState`. When present, the handler drops the
command if the current vote or effective membership log id has changed since
the command was sent, preventing a delayed command from inadvertently demoting
a new leader.

# Details

- `ExternalCommand::RefreshServerState` becomes a struct variant with two
  optional fields. A `None` in either skips that check; both `None` refreshes
  unconditionally (the behavior of the previous unit variant).
- The `raft_core` dispatch handler performs the fence check before calling
  `Engine::refresh_server_state()`, which itself is now documented as
  unconditional — the caller owns the guard.
- `StepDownWatcher` now populates both fields from the vote and membership
  config log id it observed before sleeping `transfer_wait`. A
  `debug_assert!` documents that a Leader's membership log id is always
  `Some`.
- `Trigger::refresh_server_state()` gains the two optional parameters to let
  callers express their own fence conditions. Passing `(None, None)` preserves
  the previous unconditional behavior.
- The engine-level unit test for the "uncommitted membership" case is updated
  to reflect that `refresh_server_state` is now unconditional at the engine
  layer; the fence lives in `raft_core`.
- New integration test `remove_leader_fenced_step_down` verifies that a
  mismatching vote or membership log id drops the command, while a matching
  pair lets it proceed.

Upgrade tip:

Replace `trigger.refresh_server_state()` with:

    trigger.refresh_server_state(None, None).await

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1784)
<!-- Reviewable:end -->
