### PR TITLE
feat: add Pre-Vote to avoid disruptive term inflation

### DIFF
--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -52,6 +52,7 @@ pub(crate) struct Defaults {
     pub enable_heartbeat: bool,
     pub enable_elect: bool,
     pub removed_leader_step_down: StepDownPolicy,
+    pub enable_pre_vote: Option<bool>,
 }
 
 pub(crate) const DEFAULTS: Defaults = Defaults {
@@ -78,6 +79,7 @@ pub(crate) const DEFAULTS: Defaults = Defaults {
     enable_heartbeat: true,
     enable_elect: true,
     removed_leader_step_down: StepDownPolicy::After(150),
+    enable_pre_vote: None,
 };
 
 /// The serde default for [`Config::removed_leader_step_down`]: it is used when the field is
@@ -392,6 +394,38 @@ pub struct Config {
     #[cfg_attr(feature = "serde", serde(default = "default_removed_leader_step_down"))]
     pub removed_leader_step_down: StepDownPolicy,
 
+    /// Whether a follower runs a Pre-Vote round before incrementing its term and starting a real
+    /// election.
+    ///
+    /// When enabled (`Some(true)`), a follower whose election timer fires first asks peers whether
+    /// they *would* grant it a vote at `term + 1`, without persisting any vote or bumping its term.
+    /// Only after a quorum would grant does it run the real election. This prevents a node that
+    /// cannot currently win — e.g. one that was partitioned, restarted, or has a stale log — from
+    /// inflating its term and disrupting a healthy leader once it reconnects.
+    ///
+    /// When disabled (`Some(false)`), a follower increments its term and votes for itself
+    /// immediately on election timeout, the historical Openraft behavior. The leader-lease already
+    /// rejects such a candidate's vote requests, so Pre-Vote is an optional refinement rather than
+    /// a correctness requirement.
+    ///
+    /// `None` (the default) leaves the choice to Openraft, which currently treats it as disabled.
+    /// Leaving it unset lets a future release change this default without breaking configs that
+    /// never opted in.
+    ///
+    /// Pre-Vote uses a separate network RPC
+    /// ([`RaftNetworkV2::pre_vote`](crate::network::v2::RaftNetworkV2::pre_vote)). A peer whose
+    /// network does not implement it is counted as granting the Pre-Vote, so a cluster mid-upgrade
+    /// stays live.
+    #[since(version = "0.10.0")]
+    // clap 4 requires `num_args = 0..=1`, or it complains about missing arg error
+    // https://github.com/clap-rs/clap/discussions/4374
+    #[cfg_attr(feature = "clap", clap(long,
+           action = clap::ArgAction::Set,
+           num_args = 0..=1,
+           default_missing_value = "true"
+    ))]
+    pub enable_pre_vote: Option<bool>,
+
     /// Default backoff policy used when
     /// [`RaftNetworkV2::backoff`](crate::network::RaftNetworkV2::backoff) returns `None`.
     ///
@@ -532,6 +566,7 @@ impl Default for Config {
             enable_heartbeat: DEFAULTS.enable_heartbeat,
             enable_elect: DEFAULTS.enable_elect,
             removed_leader_step_down: DEFAULTS.removed_leader_step_down.clone(),
+            enable_pre_vote: DEFAULTS.enable_pre_vote,
             backoff: DEFAULTS.backoff.to_string(),
             allow_log_reversion: None,
             enable_leader_restore: None,
@@ -580,6 +615,14 @@ impl Config {
     #[since(version = "0.10.0")]
     pub(crate) fn enable_leader_restore(&self) -> bool {
         self.enable_leader_restore.unwrap_or(true)
+    }
+
+    /// Whether a follower runs a Pre-Vote round before starting a real election.
+    ///
+    /// Evaluates the [`enable_pre_vote`](Self::enable_pre_vote) option: `None` is treated as
+    /// disabled (`false`), the current default.
+    pub(crate) fn get_enable_pre_vote(&self) -> bool {
+        self.enable_pre_vote.unwrap_or(false)
     }
 
     /// Get the API channel size for bounded MPSC channel.

--- a/openraft/src/config/config_clap_test.rs
+++ b/openraft/src/config/config_clap_test.rs
@@ -155,6 +155,28 @@ fn test_config_enable_elect() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_config_enable_pre_vote() -> anyhow::Result<()> {
+    let config = Config::build(&["foo", "--enable-pre-vote=false"])?;
+    assert_eq!(Some(false), config.enable_pre_vote);
+    assert_eq!(false, config.get_enable_pre_vote());
+
+    let config = Config::build(&["foo", "--enable-pre-vote=true"])?;
+    assert_eq!(Some(true), config.enable_pre_vote);
+    assert_eq!(true, config.get_enable_pre_vote());
+
+    let config = Config::build(&["foo", "--enable-pre-vote"])?;
+    assert_eq!(Some(true), config.enable_pre_vote);
+    assert_eq!(true, config.get_enable_pre_vote());
+
+    // Omitted: the field defaults to `None`, which evaluates to disabled (`false`).
+    let config = Config::build(&["foo"])?;
+    assert_eq!(None, config.enable_pre_vote);
+    assert_eq!(false, config.get_enable_pre_vote());
+
+    Ok(())
+}
+
+#[test]
 fn test_config_allow_log_reversion() -> anyhow::Result<()> {
     let config = Config::build(&["foo", "--allow-log-reversion=false"])?;
     assert_eq!(Some(false), config.allow_log_reversion);

--- a/openraft/src/config/runtime_config.rs
+++ b/openraft/src/config/runtime_config.rs
@@ -8,6 +8,7 @@ use crate::Config;
 pub(crate) struct RuntimeConfig {
     pub(crate) enable_heartbeat: AtomicBool,
     pub(crate) enable_elect: AtomicBool,
+    pub(crate) enable_pre_vote: AtomicBool,
 }
 
 impl RuntimeConfig {
@@ -15,6 +16,7 @@ impl RuntimeConfig {
         Self {
             enable_heartbeat: AtomicBool::from(config.enable_heartbeat),
             enable_elect: AtomicBool::from(config.enable_elect),
+            enable_pre_vote: AtomicBool::from(config.get_enable_pre_vote()),
         }
     }
 }

--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -31,6 +31,18 @@ where C: RaftTypeConfig
         candidate_vote: UncommittedVoteOf<C>,
     },
 
+    /// Response to a Pre-Vote request sent by a pre-candidate.
+    ///
+    /// Unlike [`VoteResponse`](Self::VoteResponse), receiving this does not change any persistent
+    /// state; it only advances the pre-vote tally that decides whether to start a real election.
+    PreVoteResponse {
+        target: C::NodeId,
+        resp: VoteResponse<C>,
+
+        /// The pre-candidate vote (the hypothetical next-term vote) this response answers.
+        candidate_vote: UncommittedVoteOf<C>,
+    },
+
     /// A Leader sees a higher `vote` when replicating.
     HigherVote {
         /// The ID of the target node from which the new term was observed.
@@ -93,6 +105,7 @@ where C: RaftTypeConfig
     pub(crate) fn name(&self) -> NotificationName {
         match self {
             Self::VoteResponse { .. } => NotificationName::VoteResponse,
+            Self::PreVoteResponse { .. } => NotificationName::PreVoteResponse,
             Self::HigherVote { .. } => NotificationName::HigherVote,
             Self::StorageError { .. } => NotificationName::StorageError,
             Self::LocalIO { .. } => NotificationName::LocalIO,
@@ -117,6 +130,17 @@ where C: RaftTypeConfig
                 write!(
                     f,
                     "VoteResponse: from target={}, to candidate_vote: {}, {}",
+                    target, candidate_vote, resp
+                )
+            }
+            Self::PreVoteResponse {
+                target,
+                resp,
+                candidate_vote,
+            } => {
+                write!(
+                    f,
+                    "PreVoteResponse: from target={}, to pre_candidate_vote: {}, {}",
                     target, candidate_vote, resp
                 )
             }

--- a/openraft/src/core/notification_name.rs
+++ b/openraft/src/core/notification_name.rs
@@ -6,6 +6,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NotificationName {
     VoteResponse,
+    PreVoteResponse,
     HigherVote,
     StorageError,
     LocalIO,
@@ -18,12 +19,13 @@ pub enum NotificationName {
 impl NotificationName {
     /// Total number of variants.
     #[allow(dead_code)]
-    pub const COUNT: usize = 8;
+    pub const COUNT: usize = 9;
 
     /// All variants in canonical order.
     #[allow(dead_code)]
     pub const ALL: &'static [NotificationName] = &[
         NotificationName::VoteResponse,
+        NotificationName::PreVoteResponse,
         NotificationName::HigherVote,
         NotificationName::StorageError,
         NotificationName::LocalIO,
@@ -38,13 +40,14 @@ impl NotificationName {
     pub const fn index(&self) -> usize {
         match self {
             NotificationName::VoteResponse => 0,
-            NotificationName::HigherVote => 1,
-            NotificationName::StorageError => 2,
-            NotificationName::LocalIO => 3,
-            NotificationName::ReplicationProgress => 4,
-            NotificationName::HeartbeatProgress => 5,
-            NotificationName::StateMachine => 6,
-            NotificationName::Tick => 7,
+            NotificationName::PreVoteResponse => 1,
+            NotificationName::HigherVote => 2,
+            NotificationName::StorageError => 3,
+            NotificationName::LocalIO => 4,
+            NotificationName::ReplicationProgress => 5,
+            NotificationName::HeartbeatProgress => 6,
+            NotificationName::StateMachine => 7,
+            NotificationName::Tick => 8,
         }
     }
 
@@ -52,6 +55,7 @@ impl NotificationName {
     pub const fn as_str(&self) -> &'static str {
         match self {
             NotificationName::VoteResponse => "Notify::VoteResponse",
+            NotificationName::PreVoteResponse => "Notify::PreVoteResponse",
             NotificationName::HigherVote => "Notify::HigherVote",
             NotificationName::StorageError => "Notify::StorageError",
             NotificationName::LocalIO => "Notify::LocalIO",

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -258,6 +258,23 @@ where
     pub(crate) span: Span,
 }
 
+/// Selects whether [`RaftCore::spawn_parallel_vote_requests`] sends real Vote or Pre-Vote RPCs.
+#[derive(Clone, Copy)]
+enum VoteRequestKind {
+    Vote,
+    PreVote,
+}
+
+impl VoteRequestKind {
+    /// Lowercase label used in log messages: `"vote"` or `"pre-vote"`.
+    fn as_str(self) -> &'static str {
+        match self {
+            VoteRequestKind::Vote => "vote",
+            VoteRequestKind::PreVote => "pre-vote",
+        }
+    }
+}
+
 impl<C, NF, LS, SM> RaftCore<C, NF, LS, SM>
 where
     C: RaftTypeConfig,
@@ -1357,9 +1374,15 @@ where
         Ok(processed)
     }
 
-    /// Spawn parallel vote requests to all cluster members.
+    /// Spawn parallel Vote or Pre-Vote requests to all other cluster members, selected by `kind`.
+    ///
+    /// For a Pre-Vote, only an affirmative `Ok(granted)` response counts toward the quorum: a
+    /// transport error — including [`Unreachable`](crate::error::Unreachable) from a genuinely
+    /// partitioned peer — is **not** a grant, otherwise a fully isolated node would synthesize a
+    /// quorum and inflate its term. A network that has not implemented `pre_vote` returns
+    /// `Ok(granted)` from the default impl, keeping Pre-Vote a no-op during a rolling upgrade.
     #[tracing::instrument(level = "trace", skip_all)]
-    async fn spawn_parallel_vote_requests(&mut self, vote_req: &VoteRequest<C>) {
+    async fn spawn_parallel_vote_requests(&mut self, vote_req: &VoteRequest<C>, kind: VoteRequestKind) {
         let members = self.engine.state.membership_state.effective().voter_ids();
 
         let vote = vote_req.vote.clone();
@@ -1383,13 +1406,25 @@ where
 
             let vote = vote.clone();
 
+            let span = match kind {
+                VoteRequestKind::Vote => {
+                    tracing::debug_span!(parent: &Span::current(), "send_vote_req", target = display(&target))
+                }
+                VoteRequestKind::PreVote => {
+                    tracing::debug_span!(parent: &Span::current(), "send_pre_vote_req", target = display(&target))
+                }
+            };
+
             // False positive lint warning(`non-binding `let` on a future`): https://github.com/rust-lang/rust-clippy/issues/9932
             #[allow(clippy::let_underscore_future)]
             let _ = C::spawn(
                 {
                     let target = target.clone();
                     async move {
-                        let tm_res = C::timeout(ttl, client.vote(req, option)).await;
+                        let tm_res = match kind {
+                            VoteRequestKind::Vote => C::timeout(ttl, client.vote(req, option)).await,
+                            VoteRequestKind::PreVote => C::timeout(ttl, client.pre_vote(req, option)).await,
+                        };
                         let res = match tm_res {
                             Ok(res) => res,
 
@@ -1400,30 +1435,44 @@ where
                                     target: target.clone(),
                                     timeout: ttl,
                                 };
-                                tracing::error!("timeout: {}", timeout_err);
+                                tracing::error!("timeout while requesting {}: {}", kind.as_str(), timeout_err);
                                 return;
                             }
                         };
 
                         match res {
                             Ok(resp) => {
-                                tx.send(Notification::VoteResponse {
-                                    target,
-                                    resp,
-                                    candidate_vote: vote.into_non_committed(),
-                                })
-                                .await
-                                .ok();
+                                let candidate_vote = vote.into_non_committed();
+                                let notification = match kind {
+                                    VoteRequestKind::Vote => Notification::VoteResponse {
+                                        target,
+                                        resp,
+                                        candidate_vote,
+                                    },
+                                    VoteRequestKind::PreVote => Notification::PreVoteResponse {
+                                        target,
+                                        resp,
+                                        candidate_vote,
+                                    },
+                                };
+                                tx.send(notification).await.ok();
                             }
-                            Err(err) => tracing::error!("while requesting vote, error: {}, target: {}", err, target),
+                            // A transport failure is not a grant: a partitioned peer must not count
+                            // toward the (Pre-)Vote quorum. A network that has not implemented
+                            // `pre_vote` returns `Ok(granted)` from the default impl, so Pre-Vote
+                            // degrades to a no-op rather than relying on this.
+                            Err(err) => {
+                                tracing::error!(
+                                    "while requesting {}, error: {}, target: {}",
+                                    kind.as_str(),
+                                    err,
+                                    target
+                                )
+                            }
                         }
                     }
                 }
-                .instrument(tracing::debug_span!(
-                    parent: &Span::current(),
-                    "send_vote_req",
-                    target = display(&target)
-                )),
+                .instrument(span),
             );
         }
     }
@@ -1500,6 +1549,19 @@ where
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
+    pub(super) fn handle_pre_vote_request(&mut self, req: VoteRequest<C>, tx: VoteTx<C>) {
+        tracing::info!("{}: req: {}", func_name!(), req);
+
+        let resp = self.engine.handle_pre_vote_req(req);
+
+        // A Pre-Vote persists nothing, so there is no vote IO to wait for: respond at once.
+        self.engine.output.push_command(Command::Respond {
+            when: None,
+            resp: Respond::new(resp, tx),
+        });
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(super) fn handle_append_entries_request(&mut self, req: AppendEntriesRequest<C>, tx: AppendEntriesTx<C>) {
         tracing::debug!("{}: req: {}", func_name!(), req);
 
@@ -1537,6 +1599,11 @@ where
                 );
 
                 self.handle_vote_request(rpc, tx);
+            }
+            RaftMsg::RequestPreVote { rpc, tx } => {
+                tracing::info!("received RaftMsg::RequestPreVote: vote_request: {}", rpc);
+
+                self.handle_pre_vote_request(rpc, tx);
             }
             RaftMsg::GetSnapshotReceiver { tx } => {
                 self.engine.handle_begin_receiving_snapshot(tx);
@@ -1613,11 +1680,15 @@ where
                 tracing::info!("{}: received RaftMsg::ExternalCommand, cmd: {:?}", func_name!(), cmd);
 
                 match cmd {
-                    ExternalCommand::Elect => {
+                    ExternalCommand::Elect { pre_vote } => {
                         if self.engine.state.membership_state.effective().is_voter(&self.id) {
                             // TODO: reject if it is already a leader?
-                            self.engine.elect();
-                            tracing::debug!("ExternalCommand: triggered election");
+                            if pre_vote {
+                                self.engine.pre_elect();
+                            } else {
+                                self.engine.elect();
+                            }
+                            tracing::debug!("ExternalCommand: triggered election, pre_vote: {}", pre_vote);
                         } else {
                             // Node is switched to learner.
                         }
@@ -1725,6 +1796,25 @@ where
                 if self.engine.candidate.is_some() {
                     if self.does_candidate_vote_match(&candidate_vote, "VoteResponse") {
                         self.engine.handle_vote_resp(target, resp);
+                    }
+                }
+            }
+
+            Notification::PreVoteResponse {
+                target,
+                resp,
+                candidate_vote,
+            } => {
+                tracing::info!(
+                    "received Notification::PreVoteResponse: target: {}, resp: {}",
+                    target,
+                    resp
+                );
+
+                #[allow(clippy::collapsible_if)]
+                if self.engine.pre_candidate.is_some() {
+                    if self.does_pre_candidate_vote_match(&candidate_vote, "PreVoteResponse") {
+                        self.engine.handle_pre_vote_resp(target, resp);
                     }
                 }
             }
@@ -1888,7 +1978,14 @@ where
             return;
         }
 
-        if self.engine.state.membership_state.effective().voter_ids().count() == 1 {
+        let mut election_timeout = self.engine.config.timer_config.election_timeout;
+        if self.engine.is_there_greater_log() {
+            election_timeout += self.engine.config.timer_config.smaller_log_timeout;
+        }
+
+        let voter_count = self.engine.state.membership_state.effective().voter_ids().count();
+
+        if voter_count == 1 {
             // When a node restart, it may stay in any state but the in progress election(engine.candidate) is
             // empty.
             if self.engine.candidate_ref().is_some() {
@@ -1900,14 +1997,6 @@ where
             tracing::debug!("multiple voters, check election timeout");
 
             let local_vote = &self.engine.state.vote;
-            let timer_config = &self.engine.config.timer_config;
-
-            let mut election_timeout = timer_config.election_timeout;
-
-            if self.engine.is_there_greater_log() {
-                election_timeout += timer_config.smaller_log_timeout;
-            }
-
             tracing::debug!("local vote: {}, election_timeout: {:?}", local_vote, election_timeout,);
 
             if local_vote.is_expired(now, election_timeout) {
@@ -1918,11 +2007,32 @@ where
             }
         }
 
+        // Pre-Vote (multi-voter only): probe a quorum before incrementing the term.
+        // A single voter always wins its own Pre-Vote, so it elects directly.
+        let pre_vote = self.runtime_config.enable_pre_vote.load(Ordering::Relaxed) && voter_count > 1;
+
+        if pre_vote {
+            // A Pre-Vote does not advance `vote.last_update_time`, so without this guard a node
+            // would re-issue a Pre-Vote on every tick. Skip while a fresh round is still in flight;
+            // restart once it has been pending longer than `election_timeout`.
+            if let Some(started) = self.engine.pre_candidate_ref().map(|pc| pc.starting_time())
+                && now < started + election_timeout
+            {
+                tracing::debug!("skip pre-vote, a pre-vote round is already in flight");
+                return;
+            }
+        }
+
         // Every time elect, reset this flag.
         self.engine.reset_greater_log();
 
-        tracing::info!("trigger election");
-        self.engine.elect();
+        if pre_vote {
+            tracing::info!("trigger pre-vote");
+            self.engine.pre_elect();
+        } else {
+            tracing::info!("trigger election");
+            self.engine.elect();
+        }
     }
 
     /// If a message is sent by a previous Candidate but is received by current Candidate,
@@ -1943,6 +2053,32 @@ where
             tracing::warn!(
                 "A message will be ignored because vote changed: \
                 msg sent by vote: {}; current my vote: {}; when ({})",
+                candidate_vote,
+                my_vote,
+                msg
+            );
+            false
+        } else {
+            true
+        }
+    }
+
+    /// If a Pre-Vote response is for a previous Pre-Vote round, it is stale and should be ignored.
+    fn does_pre_candidate_vote_match(&self, candidate_vote: &UncommittedVoteOf<C>, msg: impl fmt::Display) -> bool {
+        let Some(my_vote) = self.engine.pre_candidate_ref().map(|x| x.vote_ref().clone()) else {
+            tracing::warn!(
+                "A message will be ignored because this node is no longer a pre-candidate: \
+                 msg sent by vote: {}; when ({})",
+                candidate_vote,
+                msg
+            );
+            return false;
+        };
+
+        if candidate_vote.leader_id() != my_vote.leader_id() {
+            tracing::warn!(
+                "A message will be ignored because pre-candidate vote changed: \
+                msg sent by vote: {}; current my pre-vote: {}; when ({})",
                 candidate_vote,
                 my_vote,
                 msg
@@ -2201,7 +2337,10 @@ where
                 }
             }
             Command::SendVote { vote_req } => {
-                self.spawn_parallel_vote_requests(&vote_req).await;
+                self.spawn_parallel_vote_requests(&vote_req, VoteRequestKind::Vote).await;
+            }
+            Command::SendPreVote { vote_req } => {
+                self.spawn_parallel_vote_requests(&vote_req, VoteRequestKind::PreVote).await;
             }
             Command::ReplicateCommitted { committed } => {
                 self.committed_tx.send_if_greater(committed);

--- a/openraft/src/core/raft_msg/external_command.rs
+++ b/openraft/src/core/raft_msg/external_command.rs
@@ -22,8 +22,19 @@ use crate::type_config::alias::VoteOf;
 /// An application can also disable these policy-based triggering and use these commands manually,
 /// for testing or administrative purposes.
 pub(crate) enum ExternalCommand<C: RaftTypeConfig> {
-    /// Initiate an election at once.
-    Elect,
+    /// Initiate an election immediately.
+    ///
+    /// With `pre_vote = false`, a real election starts at once: the term is incremented and the
+    /// node votes for itself, bypassing both `enable_elect` and Pre-Vote. The term climbs even
+    /// when the node cannot win, which can step down a healthy leader of a lower term once it
+    /// observes the higher term.
+    ///
+    /// With `pre_vote = true`, a Pre-Vote round runs first: it probes whether a quorum *would*
+    /// grant a vote at `term + 1` without changing any state, and runs the real election only
+    /// if a quorum would. A node that cannot currently win — e.g. while a healthy leader still
+    /// holds its lease — leaves the term untouched, so an incautious trigger does not disrupt a
+    /// live leader.
+    Elect { pre_vote: bool },
 
     /// Send a heartbeat message, only if the node is leader, or it will be ignored.
     Heartbeat,
@@ -85,7 +96,7 @@ impl<C: RaftTypeConfig> ExternalCommand<C> {
     /// Returns the name of this command variant.
     pub fn name(&self) -> ExternalCommandName {
         match self {
-            ExternalCommand::Elect => ExternalCommandName::Elect,
+            ExternalCommand::Elect { .. } => ExternalCommandName::Elect,
             ExternalCommand::Heartbeat => ExternalCommandName::Heartbeat,
             ExternalCommand::Snapshot => ExternalCommandName::Snapshot,
             ExternalCommand::GetSnapshot { .. } => ExternalCommandName::GetSnapshot,
@@ -111,8 +122,8 @@ where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ExternalCommand::Elect => {
-                write!(f, "Elect")
+            ExternalCommand::Elect { pre_vote } => {
+                write!(f, "Elect{{pre_vote={pre_vote}}}")
             }
             ExternalCommand::Heartbeat => {
                 write!(f, "Heartbeat")

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -66,6 +66,12 @@ where C: RaftTypeConfig
         tx: VoteTx<C>,
     },
 
+    /// A Pre-Vote request: probe whether a quorum would grant a vote without changing any state.
+    RequestPreVote {
+        rpc: VoteRequest<C>,
+        tx: VoteTx<C>,
+    },
+
     InstallSnapshot {
         vote: VoteOf<C>,
         snapshot: SnapshotOf<C>,
@@ -144,6 +150,7 @@ impl<C: RaftTypeConfig> RaftMsg<C> {
         match self {
             RaftMsg::AppendEntries { .. } => RaftMsgName::AppendEntries,
             RaftMsg::RequestVote { .. } => RaftMsgName::RequestVote,
+            RaftMsg::RequestPreVote { .. } => RaftMsgName::RequestPreVote,
             RaftMsg::InstallSnapshot { .. } => RaftMsgName::InstallSnapshot,
             RaftMsg::GetSnapshotReceiver { .. } => RaftMsgName::GetSnapshotReceiver,
             RaftMsg::ClientWrite { .. } => RaftMsgName::ClientWrite,
@@ -169,6 +176,9 @@ where C: RaftTypeConfig
             }
             RaftMsg::RequestVote { rpc, .. } => {
                 write!(f, "RequestVote: {}", rpc)
+            }
+            RaftMsg::RequestPreVote { rpc, .. } => {
+                write!(f, "RequestPreVote: {}", rpc)
             }
             RaftMsg::GetSnapshotReceiver { .. } => {
                 write!(f, "GetSnapshotReceiver")

--- a/openraft/src/core/raft_msg/raft_msg_name.rs
+++ b/openraft/src/core/raft_msg/raft_msg_name.rs
@@ -79,6 +79,7 @@ impl std::fmt::Display for ExternalCommandName {
 pub enum RaftMsgName {
     AppendEntries,
     RequestVote,
+    RequestPreVote,
     InstallSnapshot,
     GetSnapshotReceiver,
     ClientWrite,
@@ -93,7 +94,7 @@ pub enum RaftMsgName {
 
 impl RaftMsgName {
     /// Total number of variants (including expanded ExternalCommand variants).
-    pub const COUNT: usize = 20;
+    pub const COUNT: usize = 21;
 
     /// All variants in canonical order.
     ///
@@ -102,6 +103,7 @@ impl RaftMsgName {
     pub const ALL: &'static [RaftMsgName] = &[
         RaftMsgName::AppendEntries,
         RaftMsgName::RequestVote,
+        RaftMsgName::RequestPreVote,
         RaftMsgName::InstallSnapshot,
         RaftMsgName::GetSnapshotReceiver,
         RaftMsgName::ClientWrite,
@@ -127,16 +129,17 @@ impl RaftMsgName {
         match self {
             RaftMsgName::AppendEntries => 0,
             RaftMsgName::RequestVote => 1,
-            RaftMsgName::InstallSnapshot => 2,
-            RaftMsgName::GetSnapshotReceiver => 3,
-            RaftMsgName::ClientWrite => 4,
-            RaftMsgName::GetLinearizer => 5,
-            RaftMsgName::Initialize => 6,
-            RaftMsgName::ChangeMembership => 7,
-            RaftMsgName::HandleTransferLeader => 8,
-            RaftMsgName::WithRaftState => 9,
-            RaftMsgName::ExternalCommand(ext) => 10 + ext.index(),
-            RaftMsgName::GetRuntimeStats => 10 + ExternalCommandName::COUNT,
+            RaftMsgName::RequestPreVote => 2,
+            RaftMsgName::InstallSnapshot => 3,
+            RaftMsgName::GetSnapshotReceiver => 4,
+            RaftMsgName::ClientWrite => 5,
+            RaftMsgName::GetLinearizer => 6,
+            RaftMsgName::Initialize => 7,
+            RaftMsgName::ChangeMembership => 8,
+            RaftMsgName::HandleTransferLeader => 9,
+            RaftMsgName::WithRaftState => 10,
+            RaftMsgName::ExternalCommand(ext) => 11 + ext.index(),
+            RaftMsgName::GetRuntimeStats => 11 + ExternalCommandName::COUNT,
         }
     }
 
@@ -146,6 +149,7 @@ impl RaftMsgName {
         match self {
             RaftMsgName::AppendEntries => "AppendEntries",
             RaftMsgName::RequestVote => "RequestVote",
+            RaftMsgName::RequestPreVote => "RequestPreVote",
             RaftMsgName::InstallSnapshot => "InstallSnapshot",
             RaftMsgName::GetSnapshotReceiver => "GetSnapshotReceiver",
             RaftMsgName::ClientWrite => "ClientWrite",

--- a/openraft/src/docs/protocol/mod.rs
+++ b/openraft/src/docs/protocol/mod.rs
@@ -12,6 +12,10 @@ pub mod read {
     #![doc = include_str!("read.md")]
 }
 
+pub mod pre_vote {
+    #![doc = include_str!("pre_vote.md")]
+}
+
 pub mod replication {
     #![doc = include_str!("replication.md")]
 

--- a/openraft/src/docs/protocol/pre_vote.md
+++ b/openraft/src/docs/protocol/pre_vote.md
@@ -1,0 +1,63 @@
+# Pre-Vote
+
+Pre-Vote is an optional round that a follower runs **before** it increments its
+term and starts a real election. It probes whether a quorum *would* grant it a
+vote, without changing any state. Only if a quorum would grant does the node run
+the real election.
+
+It is disabled by default and enabled with
+[`Config::enable_pre_vote`](`crate::Config::enable_pre_vote`).
+
+
+## The problem it solves
+
+A node that cannot currently win an election — one that was partitioned,
+restarted, or whose log fell behind — still increments its term every time its
+election timer fires. When it later reconnects, that inflated term forces the
+healthy leader to step down (the leader observes the higher term while
+replicating to the returned node), triggering an unnecessary election even
+though the cluster was healthy.
+
+The [leader lease](`crate::docs::protocol::replication::leader_lease`) already
+prevents such a node from *winning* votes: peers reject its vote requests while
+their lease from the current leader is still valid. Pre-Vote addresses the
+complementary problem — it stops the term from ever climbing, so there is no
+higher term to disrupt the leader with on reconnect.
+
+
+## How it works
+
+When the election timer fires and Pre-Vote is enabled, a multi-voter node sends
+a Pre-Vote request to its peers asking: *"would you grant me a vote at
+`term + 1`?"* The request carries a hypothetical next-term vote and the
+candidate's last log id.
+
+A peer answers with the same rules it uses for a real vote request:
+
+- If it has a committed vote whose [leader lease](`crate::docs::protocol::replication::leader_lease`)
+  has not expired, it would not grant — there is a live leader.
+- If the candidate's last log id is behind its own, it would not grant.
+- Otherwise it would grant.
+
+The crucial difference from a real vote: handling a Pre-Vote request **persists
+nothing and changes nothing** — no term bump, no saved vote, no lease update. It
+is a pure query. Likewise, the requester does not change its own state while
+pre-voting: it stays a Follower with its term unchanged until a quorum responds.
+
+If a quorum would grant, the node runs the real election
+([`elect`](`crate::Raft`)), incrementing its term and persisting its vote as
+usual. If not, nothing changed, and it retries on a later tick.
+
+A single-voter cluster always wins its own Pre-Vote, so it skips the round and
+elects directly.
+
+
+## Backward compatibility
+
+Pre-Vote uses a dedicated RPC,
+[`RaftNetworkV2::pre_vote`](`crate::network::v2::RaftNetworkV2::pre_vote`), which
+has a default implementation that returns
+[`Unreachable`](`crate::error::Unreachable`). A node treats an `Unreachable`
+Pre-Vote response as a grant, so a cluster whose peers have not implemented
+`pre_vote` — for example during a rolling upgrade — still makes progress by
+falling back to the normal election path.

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -135,6 +135,12 @@ where C: RaftTypeConfig
     /// Send vote to all other members
     SendVote { vote_req: VoteRequest<C> },
 
+    /// Send a Pre-Vote request to all other members.
+    ///
+    /// Unlike [`SendVote`](Command::SendVote), this does not persist a vote or bump the term; it
+    /// only probes whether a quorum would grant a vote at the hypothetical next term.
+    SendPreVote { vote_req: VoteRequest<C> },
+
     /// Purge log from the beginning to `upto`, inclusive.
     PurgeLog { upto: LogIdOf<C> },
 
@@ -223,6 +229,7 @@ where C: RaftTypeConfig
             }
             Command::SaveVote { vote } => write!(f, "SaveVote: {}", vote),
             Command::SendVote { vote_req } => write!(f, "SendVote: {}", vote_req),
+            Command::SendPreVote { vote_req } => write!(f, "SendPreVote: {}", vote_req),
             Command::PurgeLog { upto } => write!(f, "PurgeLog: upto: {}", upto),
             Command::TruncateLog { after } => write!(f, "TruncateLog: since: {}", after.display()),
             Command::StateMachine { command } => write!(f, "StateMachine: command: {}", command),
@@ -259,6 +266,7 @@ where
             (Command::RebuildReplicationStreams { leader_vote, targets, close_old_streams },   Command::RebuildReplicationStreams { leader_vote: lb, targets: b, close_old_streams: cb }, ) => leader_vote == lb && targets == b && close_old_streams == cb,
             (Command::SaveVote { vote },                       Command::SaveVote { vote: b })                                        => vote == b,
             (Command::SendVote { vote_req },                   Command::SendVote { vote_req: b }, )                                  => vote_req == b,
+            (Command::SendPreVote { vote_req },                Command::SendPreVote { vote_req: b }, )                               => vote_req == b,
             (Command::PurgeLog { upto },                       Command::PurgeLog { upto: b })                                        => upto == b,
             (Command::TruncateLog { after },                   Command::TruncateLog { after: b }, )                                  => after == b,
             (Command::Respond { when, resp: send },            Command::Respond { when: b_when, resp: b })                           => send == b && when == b_when,
@@ -289,6 +297,7 @@ where C: RaftTypeConfig
             Command::RebuildReplicationStreams { .. } => CommandName::RebuildReplicationStreams,
             Command::SaveVote { .. }                  => CommandName::SaveVote,
             Command::SendVote { .. }                  => CommandName::SendVote,
+            Command::SendPreVote { .. }               => CommandName::SendPreVote,
             Command::PurgeLog { .. }                  => CommandName::PurgeLog,
             Command::TruncateLog { .. }               => CommandName::TruncateLog,
             Command::StateMachine { command }          => CommandName::StateMachine(command.name()),
@@ -319,6 +328,7 @@ where C: RaftTypeConfig
             Command::ReplicateSnapshot { .. }         => CommandKind::Network,
             Command::BroadcastTransferLeader { .. }   => CommandKind::Network,
             Command::SendVote { .. }                  => CommandKind::Network,
+            Command::SendPreVote { .. }               => CommandKind::Network,
 
             Command::SaveCommittedAndApply { .. }     => CommandKind::StateMachine,
             Command::StateMachine { .. }              => CommandKind::StateMachine,
@@ -346,6 +356,7 @@ where C: RaftTypeConfig
             Command::ReplicateSnapshot { .. }         => None,
             Command::BroadcastTransferLeader { .. }   => None,
             Command::SendVote { .. }                  => None,
+            Command::SendPreVote { .. }               => None,
 
             Command::SaveCommittedAndApply { .. }                     => None,
             Command::StateMachine { .. }              => None,

--- a/openraft/src/engine/command_name.rs
+++ b/openraft/src/engine/command_name.rs
@@ -71,6 +71,7 @@ pub enum CommandName {
     RebuildReplicationStreams,
     SaveVote,
     SendVote,
+    SendPreVote,
     PurgeLog,
     TruncateLog,
     StateMachine(SMCommandName),
@@ -79,7 +80,7 @@ pub enum CommandName {
 
 impl CommandName {
     /// Total number of variants (including expanded StateMachine variants).
-    pub const COUNT: usize = 21;
+    pub const COUNT: usize = 22;
 
     /// All variants in canonical order.
     ///
@@ -98,6 +99,7 @@ impl CommandName {
         CommandName::RebuildReplicationStreams,
         CommandName::SaveVote,
         CommandName::SendVote,
+        CommandName::SendPreVote,
         CommandName::PurgeLog,
         CommandName::TruncateLog,
         CommandName::StateMachine(SMCommandName::BuildSnapshot),
@@ -124,10 +126,11 @@ impl CommandName {
             CommandName::RebuildReplicationStreams => 9,
             CommandName::SaveVote => 10,
             CommandName::SendVote => 11,
-            CommandName::PurgeLog => 12,
-            CommandName::TruncateLog => 13,
-            CommandName::StateMachine(sm) => 14 + sm.index(),
-            CommandName::Respond => 14 + SMCommandName::COUNT,
+            CommandName::SendPreVote => 12,
+            CommandName::PurgeLog => 13,
+            CommandName::TruncateLog => 14,
+            CommandName::StateMachine(sm) => 15 + sm.index(),
+            CommandName::Respond => 15 + SMCommandName::COUNT,
         }
     }
 
@@ -147,6 +150,7 @@ impl CommandName {
             CommandName::RebuildReplicationStreams => "RebuildReplicationStreams",
             CommandName::SaveVote => "SaveVote",
             CommandName::SendVote => "SendVote",
+            CommandName::SendPreVote => "SendPreVote",
             CommandName::PurgeLog => "PurgeLog",
             CommandName::TruncateLog => "TruncateLog",
             CommandName::StateMachine(sm) => sm.as_str(),

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -92,6 +92,14 @@ where C: RaftTypeConfig
     /// without losing leadership status.
     pub(crate) candidate: CandidateState<C>,
 
+    /// Represents the Pre-Vote state.
+    ///
+    /// A pre-candidate runs a Pre-Vote round — probing whether a quorum would grant a vote — before
+    /// committing to a real election. Unlike [`candidate`](Self::candidate), entering this state
+    /// does not change `vote`: no term bump, no persisted vote. It is only populated when
+    /// [`Config::enable_pre_vote`](crate::Config::enable_pre_vote) is set.
+    pub(crate) pre_candidate: CandidateState<C>,
+
     /// Output entry for the runtime.
     pub(crate) output: EngineOutput<C, SM>,
 }
@@ -106,6 +114,7 @@ where C: RaftTypeConfig
             seen_greater_log: false,
             leader: None,
             candidate: None,
+            pre_candidate: None,
             output: EngineOutput::new(4096),
         }
     }
@@ -130,6 +139,29 @@ where C: RaftTypeConfig
         ));
 
         self.candidate.as_mut().unwrap()
+    }
+
+    /// Create a new pre-candidate state and return the mutable reference to it.
+    ///
+    /// Like [`new_candidate`](Self::new_candidate), but for the Pre-Vote round: the resulting
+    /// quorum tracker lives in [`pre_candidate`](Self::pre_candidate) and `vote` is only a
+    /// hypothetical next-term vote that is never persisted.
+    pub(crate) fn new_pre_candidate(&mut self, vote: VoteOf<C>) -> &mut Candidate<C, LeaderQuorumSet<C>> {
+        let now = C::now();
+        let last_log_id = self.state.last_log_id().cloned();
+
+        let membership = self.state.membership_state.effective().membership();
+
+        self.pre_candidate = Some(Candidate::new(
+            now,
+            vote,
+            last_log_id,
+            Arc::new((*membership).clone()),
+            membership.learner_ids(),
+            self.state.progress_id_gen.clone(),
+        ));
+
+        self.pre_candidate.as_mut().unwrap()
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
@@ -228,6 +260,9 @@ where C: RaftTypeConfig
     }
 
     fn do_elect(&mut self, leadership_transfer: bool) {
+        // A real election supersedes any in-flight Pre-Vote round.
+        self.pre_candidate = None;
+
         let new_term = self.state.vote.term().next();
         let leader_id = LeaderIdOf::<C>::new(new_term, self.config.id.clone());
         let new_vote = VoteOf::<C>::from_leader_id(leader_id, false);
@@ -253,6 +288,39 @@ where C: RaftTypeConfig
         self.server_state_handler().update_server_state_if_changed();
     }
 
+    /// Start a Pre-Vote round.
+    ///
+    /// Probe whether a quorum *would* grant a vote at `term + 1` without changing any local state:
+    /// no term bump, no persisted vote, no server-state change. If a quorum grants (tallied by
+    /// [`handle_pre_vote_resp`](Self::handle_pre_vote_resp)), a real [`elect`](Self::elect)
+    /// follows.
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(crate) fn pre_elect(&mut self) {
+        let new_term = self.state.vote.term().next();
+        let leader_id = LeaderIdOf::<C>::new(new_term, self.config.id.clone());
+        let pre_vote = VoteOf::<C>::from_leader_id(leader_id, false);
+
+        let pre_candidate = self.new_pre_candidate(pre_vote.clone());
+        tracing::info!("{}: new pre-candidate: {}", func_name!(), pre_candidate);
+
+        let last_log_id = pre_candidate.last_log_id().cloned();
+
+        // Grant the Pre-Vote to itself. A single-voter cluster reaches a quorum at once and proceeds
+        // directly to a real election, without an unnecessary network round-trip.
+        let id = self.config.id.clone();
+        let quorum_granted = self.pre_candidate.as_mut().unwrap().grant_by(&id);
+        if quorum_granted {
+            self.elect();
+            return;
+        }
+
+        // Unlike `elect`, this neither updates `vote` (no term bump, no SaveVote) nor changes the
+        // server state: the node stays a Follower until a quorum would grant the vote.
+        self.output.push_command(Command::SendPreVote {
+            vote_req: VoteRequest::new(pre_vote, last_log_id),
+        });
+    }
+
     pub(crate) fn leader_ref(&self) -> Option<&Leader<C, LeaderQuorumSet<C>>> {
         self.leader.as_deref()
     }
@@ -267,6 +335,15 @@ where C: RaftTypeConfig
 
     pub(crate) fn candidate_mut(&mut self) -> Option<&mut Candidate<C, LeaderQuorumSet<C>>> {
         self.candidate.as_mut()
+    }
+
+    pub(crate) fn pre_candidate_ref(&self) -> Option<&Candidate<C, LeaderQuorumSet<C>>> {
+        self.pre_candidate.as_ref()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pre_candidate_mut(&mut self) -> Option<&mut Candidate<C, LeaderQuorumSet<C>>> {
+        self.pre_candidate.as_mut()
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
@@ -324,6 +401,49 @@ where C: RaftTypeConfig
         // Return the updated vote, this way the candidate knows which vote is granted, in case
         // the candidate's vote is changed after sending the vote request.
         VoteResponse::new(self.state.vote_ref(), self.state.last_log_id().cloned(), res.is_ok())
+    }
+
+    /// Handle a Pre-Vote request.
+    ///
+    /// Report whether this node *would* grant a vote for `req.vote`, judged by the leader-lease
+    /// and last-log-id rules, but **without persisting any vote or changing the term**: the local
+    /// state is left untouched and no command is emitted. Unlike
+    /// [`handle_vote_req`](Self::handle_vote_req), a Pre-Vote is never a leadership transfer, so
+    /// the leader lease is always honored.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) fn handle_pre_vote_req(&mut self, req: VoteRequest<C>) -> VoteResponse<C> {
+        let now = C::now();
+        let local_leased_vote = &self.state.vote;
+
+        tracing::info!(
+            "handle pre-vote request: req: {}, my_vote: {}, my_last_log_id: {}, lease: {}",
+            req,
+            **local_leased_vote,
+            self.state.last_log_id().display(),
+            local_leased_vote.display_lease_info(now)
+        );
+
+        // Respect the leader lease: while an established Leader's lease has not expired, this node
+        // would not grant a vote, so it would not grant a Pre-Vote either.
+        if local_leased_vote.is_committed() && !local_leased_vote.is_expired(now, Duration::from_millis(0)) {
+            tracing::info!("reject pre-vote-request: leader lease has not yet expired");
+            return VoteResponse::new(self.state.vote_ref(), self.state.last_log_id().cloned(), false);
+        }
+
+        // Reject if the candidate's log is behind.
+        if req.last_log_id.as_ref() < self.state.last_log_id() {
+            tracing::info!(
+                "reject pre-vote-request: by last_log_id: req.last_log_id({}) < my_last_log_id({})",
+                req.last_log_id.display(),
+                self.state.last_log_id().display(),
+            );
+            return VoteResponse::new(self.state.vote_ref(), self.state.last_log_id().cloned(), false);
+        }
+
+        // Whether this node *would* grant the vote, compared the same way as a real vote — but
+        // without persisting anything. The local vote and term are left untouched.
+        let granted = req.vote.as_ref_vote() >= self.state.vote_ref().as_ref_vote();
+        VoteResponse::new(self.state.vote_ref(), self.state.last_log_id().cloned(), granted)
     }
 
     #[tracing::instrument(level = "debug", skip(self, resp))]
@@ -386,6 +506,51 @@ where C: RaftTypeConfig
 
         // Update if resp.vote is greater.
         self.vote_handler().update_vote(&vote).ok();
+    }
+
+    /// Handle a Pre-Vote response.
+    ///
+    /// Advance the Pre-Vote tally. When a quorum would grant, start the real election via
+    /// [`elect`](Self::elect). Receiving a Pre-Vote response never changes any persistent state.
+    #[tracing::instrument(level = "debug", skip(self, resp))]
+    pub(crate) fn handle_pre_vote_resp(&mut self, target: C::NodeId, resp: VoteResponse<C>) {
+        tracing::info!(
+            "{}: target: {}, resp: {}, my_vote: {}, my_last_log_id: {}",
+            func_name!(),
+            target,
+            resp,
+            self.state.vote_ref(),
+            self.state.last_log_id().display()
+        );
+
+        if self.pre_candidate.is_none() {
+            // The Pre-Vote round has finished or been canceled; ignore the delayed response.
+            return;
+        }
+
+        // A Pre-Vote response reports whether the target *would* grant the vote. Unlike a real vote
+        // response, the responder does not adopt the candidate's vote, so the grant is read from
+        // `vote_granted` rather than by comparing votes.
+        if resp.vote_granted {
+            let quorum_granted = self.pre_candidate.as_mut().unwrap().grant_by(&target);
+            if quorum_granted {
+                tracing::info!("a quorum would grant the vote; starting a real election");
+                self.elect();
+            }
+            return;
+        }
+
+        // Rejected. If the responder has a longer log, delay the next election attempt.
+        if resp.last_log_id.as_ref() > self.state.last_log_id() {
+            tracing::info!(
+                "{}: seen a greater log id during pre-vote: {}",
+                func_name!(),
+                resp.last_log_id.display()
+            );
+            self.set_greater_log();
+        }
+
+        // A Pre-Vote response never updates the local vote: the round is side-effect-free.
     }
 
     /// Append entries to follower/learner.
@@ -781,6 +946,7 @@ where C: RaftTypeConfig
             output: &mut self.output,
             leader: &mut self.leader,
             candidate: &mut self.candidate,
+            pre_candidate: &mut self.pre_candidate,
         }
     }
 

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -48,6 +48,7 @@ where C: RaftTypeConfig
     pub(crate) output: &'st mut EngineOutput<C, SM>,
     pub(crate) leader: &'st mut LeaderState<C>,
     pub(crate) candidate: &'st mut CandidateState<C>,
+    pub(crate) pre_candidate: &'st mut CandidateState<C>,
 }
 
 impl<C, SM> VoteHandler<'_, C, SM>
@@ -240,6 +241,7 @@ where C: RaftTypeConfig
 
         *self.leader = None;
         *self.candidate = None;
+        *self.pre_candidate = None;
 
         self.output.push_command(Command::CloseReplicationStreams);
 

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -48,10 +48,13 @@ pub(crate) mod time_state;
 mod tests {
     mod append_entries_test;
     mod elect_test;
+    mod handle_pre_vote_req_test;
+    mod handle_pre_vote_resp_test;
     mod handle_vote_req_test;
     mod handle_vote_resp_test;
     mod initialize_test;
     mod install_full_snapshot_test;
+    mod pre_elect_test;
     mod refresh_server_state_test;
     mod startup_test;
     mod trigger_purge_log_test;

--- a/openraft/src/engine/tests/handle_pre_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_pre_vote_req_test.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use pretty_assertions::assert_eq;
+
+use crate::Membership;
+use crate::Vote;
+use crate::core::ServerState;
+use crate::engine::Engine;
+use crate::engine::LogIdList;
+use crate::engine::testing::UTConfig;
+use crate::engine::testing::log_id;
+use crate::raft::VoteRequest;
+use crate::raft::VoteResponse;
+use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::StoredMembershipOf;
+use crate::utime::Leased;
+
+fn m01() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new_with_defaults(vec![btreeset! {0,1}], [])
+}
+
+fn eng() -> Engine<UTConfig> {
+    let mut eng = Engine::testing_default(0);
+    eng.state.enable_validation(false); // Disable validation for incomplete state
+
+    eng.config.id = 1;
+    // By default expire the leader lease so that a pre-vote can be granted in these tests.
+    eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(0), Vote::new(2, 1));
+    eng.state.server_state = ServerState::Follower;
+    eng.state.log_ids = LogIdList::new(None, [log_id(1, 1, 1)]);
+    eng.state.membership_state.set_effective(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        Some(log_id(1, 1, 1)),
+        m01(),
+    )));
+    eng.output.take_commands();
+
+    eng
+}
+
+#[test]
+fn test_handle_pre_vote_req_rejected_by_leader_lease() -> anyhow::Result<()> {
+    let mut eng = eng();
+    // An established Leader whose lease has not expired.
+    eng.state.vote.update(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
+    let vote_before = *eng.state.vote_ref();
+
+    let resp = eng.handle_pre_vote_req(VoteRequest {
+        vote: Vote::new(3, 2),
+        last_log_id: Some(log_id(2, 1, 3)),
+        leadership_transfer: false,
+    });
+
+    assert_eq!(
+        VoteResponse::new(Vote::new_committed(2, 1), Some(log_id(1, 1, 1)), false),
+        resp
+    );
+    // A pre-vote must not mutate any state.
+    assert_eq!(vote_before, *eng.state.vote_ref());
+    assert_eq!(ServerState::Follower, eng.state.server_state);
+    assert_eq!(0, eng.output.take_commands().len());
+
+    Ok(())
+}
+
+#[test]
+fn test_handle_pre_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
+    let mut eng = eng();
+    let vote_before = *eng.state.vote_ref();
+
+    // Local last_log_id is (1,1,1); the candidate has none → reject.
+    let resp = eng.handle_pre_vote_req(VoteRequest {
+        vote: Vote::new(3, 0),
+        last_log_id: None,
+        leadership_transfer: false,
+    });
+
+    assert_eq!(VoteResponse::new(Vote::new(2, 1), Some(log_id(1, 1, 1)), false), resp);
+    assert_eq!(vote_before, *eng.state.vote_ref());
+    assert_eq!(0, eng.output.take_commands().len());
+
+    Ok(())
+}
+
+#[test]
+fn test_handle_pre_vote_req_granted_without_mutation() -> anyhow::Result<()> {
+    let mut eng = eng();
+    let vote_before = *eng.state.vote_ref();
+
+    // Lease expired (default), the candidate's vote >= local vote and its log is up to date → grant.
+    let resp = eng.handle_pre_vote_req(VoteRequest {
+        vote: Vote::new(3, 0),
+        last_log_id: Some(log_id(1, 1, 1)),
+        leadership_transfer: false,
+    });
+
+    assert_eq!(VoteResponse::new(Vote::new(2, 1), Some(log_id(1, 1, 1)), true), resp);
+    // The defining invariant: granting a pre-vote changes nothing locally.
+    assert_eq!(vote_before, *eng.state.vote_ref());
+    assert_eq!(ServerState::Follower, eng.state.server_state);
+    assert_eq!(0, eng.output.take_commands().len());
+
+    Ok(())
+}

--- a/openraft/src/engine/tests/handle_pre_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_pre_vote_resp_test.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use pretty_assertions::assert_eq;
+
+use crate::Membership;
+use crate::Vote;
+use crate::core::ServerState;
+use crate::engine::Command;
+use crate::engine::Engine;
+use crate::engine::LogIdList;
+use crate::engine::testing::UTConfig;
+use crate::engine::testing::log_id;
+use crate::raft::VoteRequest;
+use crate::raft::VoteResponse;
+use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::StoredMembershipOf;
+use crate::utime::Leased;
+
+fn m12() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2}], [])
+}
+
+fn eng() -> Engine<UTConfig> {
+    let mut eng = Engine::testing_default(0);
+    eng.state.enable_validation(false); // Disable validation for incomplete state
+    eng.config.id = 1;
+    eng.state.log_ids = LogIdList::new(None, [log_id(1, 1, 1)]);
+    eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(0), Vote::new(0, 0));
+    eng.state.server_state = ServerState::Follower;
+    eng.state.membership_state.set_effective(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        Some(log_id(1, 1, 1)),
+        m12(),
+    )));
+    eng
+}
+
+#[test]
+fn test_handle_pre_vote_resp_quorum_starts_real_election() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    // A pre-vote round in flight at the hypothetical next term, self-granted.
+    eng.new_pre_candidate(Vote::new(1, 1));
+    eng.pre_candidate_mut().unwrap().grant_by(&1);
+    eng.output.take_commands();
+
+    // Peer 2 would grant → quorum {1,2} reached → start a real election.
+    eng.handle_pre_vote_resp(2, VoteResponse::new(Vote::new(0, 0), Some(log_id(1, 1, 1)), true));
+
+    assert!(
+        eng.pre_candidate_ref().is_none(),
+        "pre-vote consumed by the real election"
+    );
+    assert_eq!(
+        Vote::new(1, 1),
+        *eng.state.vote_ref(),
+        "the real election bumped the vote"
+    );
+    assert!(eng.candidate_ref().is_some());
+    assert_eq!(ServerState::Candidate, eng.state.server_state);
+
+    assert_eq!(
+        vec![Command::SaveVote { vote: Vote::new(1, 1) }, Command::SendVote {
+            vote_req: VoteRequest::new(Vote::new(1, 1), Some(log_id(1, 1, 1))),
+        },],
+        eng.output.take_commands()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_handle_pre_vote_resp_reject_keeps_waiting() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    eng.new_pre_candidate(Vote::new(1, 1));
+    eng.pre_candidate_mut().unwrap().grant_by(&1);
+    eng.output.take_commands();
+
+    let vote_before = *eng.state.vote_ref();
+
+    // Peer 2 rejects → no quorum, no real election, and no state mutation.
+    eng.handle_pre_vote_resp(2, VoteResponse::new(Vote::new(0, 0), Some(log_id(1, 1, 1)), false));
+
+    assert!(eng.pre_candidate_ref().is_some(), "still pre-voting");
+    assert!(eng.candidate_ref().is_none(), "no real election started");
+    assert_eq!(vote_before, *eng.state.vote_ref());
+    assert_eq!(0, eng.output.take_commands().len());
+
+    Ok(())
+}

--- a/openraft/src/engine/tests/pre_elect_test.rs
+++ b/openraft/src/engine/tests/pre_elect_test.rs
@@ -1,0 +1,99 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use maplit::btreeset;
+use pretty_assertions::assert_eq;
+
+use crate::Membership;
+use crate::Vote;
+use crate::core::ServerState;
+use crate::engine::Command;
+use crate::engine::Engine;
+use crate::engine::LogIdList;
+use crate::engine::testing::UTConfig;
+use crate::engine::testing::log_id;
+use crate::raft::VoteRequest;
+use crate::type_config::alias::StoredMembershipOf;
+
+fn m1() -> Membership<u64, ()> {
+    Membership::new_with_defaults(vec![btreeset! {1}], [])
+}
+
+fn m12() -> Membership<u64, ()> {
+    Membership::new_with_defaults(vec![btreeset! {1,2}], [])
+}
+
+fn eng() -> Engine<UTConfig> {
+    let mut eng = Engine::testing_default(0);
+    eng.state.log_ids = LogIdList::new(None, [log_id(0, 0, 0)]);
+    eng.state.enable_validation(false); // Disable validation for incomplete state
+    eng
+}
+
+#[test]
+fn test_pre_elect_multi_node_no_mutation() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.config.id = 1;
+    eng.state.membership_state.set_effective(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        Some(log_id(0, 1, 1)),
+        m12(),
+    )));
+    eng.state.log_ids = LogIdList::new(None, vec![log_id(1, 1, 1)]);
+
+    let vote_before = *eng.state.vote_ref();
+    let server_state_before = eng.state.server_state;
+
+    eng.pre_elect();
+
+    // A pre-vote must NOT bump the term, persist a vote, or change server state.
+    assert_eq!(vote_before, *eng.state.vote_ref());
+    assert_eq!(server_state_before, eng.state.server_state);
+    assert!(eng.candidate_ref().is_none(), "no real candidate during pre-vote");
+
+    // A pre-candidate at the hypothetical next term, having granted itself.
+    assert_eq!(Vote::new(1, 1), *eng.pre_candidate_ref().unwrap().vote_ref());
+    assert_eq!(
+        btreeset! {1},
+        eng.pre_candidate_ref().unwrap().granters().collect::<BTreeSet<_>>()
+    );
+
+    // Only SendPreVote is emitted — crucially, NO SaveVote and NO SendVote.
+    assert_eq!(
+        vec![Command::SendPreVote {
+            vote_req: VoteRequest::new(Vote::new(1, 1), Some(log_id(1, 1, 1)))
+        }],
+        eng.output.take_commands()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_pre_elect_single_node_starts_real_election() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.config.id = 1;
+    eng.state.membership_state.set_effective(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        Some(log_id(0, 1, 1)),
+        m1(),
+    )));
+
+    eng.pre_elect();
+
+    // A single voter wins its own pre-vote and proceeds straight to a real election.
+    assert_eq!(Vote::new(1, 1), *eng.state.vote_ref());
+    assert!(eng.candidate_ref().is_some());
+    assert!(
+        eng.pre_candidate_ref().is_none(),
+        "pre-vote consumed by the real election"
+    );
+    assert_eq!(ServerState::Candidate, eng.state.server_state);
+
+    assert_eq!(
+        vec![Command::SaveVote { vote: Vote::new(1, 1) }, Command::SendVote {
+            vote_req: VoteRequest::new(Vote::new(1, 1), Some(log_id(0, 0, 0))),
+        },],
+        eng.output.take_commands()
+    );
+
+    Ok(())
+}

--- a/openraft/src/network/v2/network.rs
+++ b/openraft/src/network/v2/network.rs
@@ -138,6 +138,28 @@ where C: RaftTypeConfig
     /// Send a RequestVote RPC to the target.
     async fn vote(&mut self, rpc: VoteRequest<C>, option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>>;
 
+    /// Send a Pre-Vote RPC to the target.
+    ///
+    /// The node receiving this message should pass it to [`Raft::pre_vote()`]. Pre-Vote asks the
+    /// target whether it *would* grant a vote for `rpc.vote` (a hypothetical `term + 1`) without
+    /// persisting any vote or changing its term. It is only sent when
+    /// [`Config::enable_pre_vote`](crate::Config::enable_pre_vote) is set.
+    ///
+    /// The default implementation synthesizes a **granting** response, so a network that has not
+    /// implemented `pre_vote` makes Pre-Vote a no-op and elections proceed exactly as before (e.g.
+    /// during a rolling upgrade). This is deliberately distinct from a transport failure: an
+    /// implementor that cannot reach the target must return `Err` (typically
+    /// [`Unreachable`]), which the caller does **not** count as a grant — otherwise a fully
+    /// isolated node would synthesize a quorum of grants and inflate its term, defeating
+    /// Pre-Vote.
+    ///
+    /// [`Raft::pre_vote()`]: crate::raft::Raft::pre_vote
+    #[since(version = "0.10.0", change = "added pre_vote RPC for the Pre-Vote feature")]
+    async fn pre_vote(&mut self, rpc: VoteRequest<C>, _option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>> {
+        // Not implemented: grant unconditionally so Pre-Vote degrades to the normal election path.
+        Ok(VoteResponse::new(rpc.vote, None, true))
+    }
+
     /// Send a complete Snapshot to the target.
     ///
     /// This method is responsible for fragmenting the snapshot and sending it to the target node.
@@ -247,6 +269,10 @@ where
 {
     async fn vote(&mut self, rpc: VoteRequest<C>, option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>> {
         RaftNetworkV2::vote(self, rpc, option).await
+    }
+
+    async fn pre_vote(&mut self, rpc: VoteRequest<C>, option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>> {
+        RaftNetworkV2::pre_vote(self, rpc, option).await
     }
 }
 

--- a/openraft/src/network/vote_trait.rs
+++ b/openraft/src/network/vote_trait.rs
@@ -24,4 +24,14 @@ where C: RaftTypeConfig
 {
     /// Send a RequestVote RPC to the target.
     async fn vote(&mut self, rpc: VoteRequest<C>, option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>>;
+
+    /// Send a Pre-Vote RPC to the target.
+    ///
+    /// The default implementation synthesizes a **granting** response, so a network that has not
+    /// implemented `pre_vote` makes Pre-Vote a no-op and elections proceed as before. A transport
+    /// failure must instead be returned as `Err` (it is not counted as a grant). See
+    /// [`RaftNetworkV2::pre_vote`](crate::network::v2::RaftNetworkV2::pre_vote).
+    async fn pre_vote(&mut self, rpc: VoteRequest<C>, _option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>> {
+        Ok(VoteResponse::new(rpc.vote, None, true))
+    }
 }

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -90,6 +90,14 @@ where
         self.last_log_id.as_ref()
     }
 
+    /// The time at which this voting round started.
+    ///
+    /// Used to rate-limit Pre-Vote retries: a fresh round already in flight should not be restarted
+    /// on every tick.
+    pub(crate) fn starting_time(&self) -> InstantOf<C> {
+        self.starting_time
+    }
+
     pub(crate) fn progress(&self) -> &VecProgress<C::NodeId, bool, bool, QS> {
         &self.progress
     }

--- a/openraft/src/raft/api/protocol.rs
+++ b/openraft/src/raft/api/protocol.rs
@@ -84,6 +84,14 @@ where C: RaftTypeConfig
         self.inner.call_core(RaftMsg::RequestVote { rpc, tx }, rx).await
     }
 
+    #[tracing::instrument(level = "debug", skip(self, rpc))]
+    pub(crate) async fn pre_vote(&self, rpc: VoteRequest<C>) -> Result<VoteResponse<C>, Fatal<C>> {
+        tracing::info!("Raft::pre_vote(): rpc: {}", rpc);
+
+        let (tx, rx) = C::oneshot();
+        self.inner.call_core(RaftMsg::RequestPreVote { rpc, tx }, rx).await
+    }
+
     #[since(version = "0.10.0")]
     #[tracing::instrument(level = "debug", skip(self, rpc))]
     pub(crate) async fn append_entries(

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -804,7 +804,7 @@ where C: RaftTypeConfig
     /// Example:
     /// ```ignore
     /// let raft = Raft::new(...).await?;
-    /// raft.trigger().elect().await?;
+    /// raft.trigger().elect(false).await?;
     /// ```
     pub fn trigger(&self) -> Trigger<'_, C> {
         Trigger::new(self.inner.as_ref())
@@ -931,6 +931,20 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn vote(&self, rpc: VoteRequest<C>) -> Result<VoteResponse<C>, RaftError<C>> {
         self.protocol_api().vote(rpc).await.into_raft_result()
+    }
+
+    /// Submit a Pre-Vote RPC to this Raft node.
+    ///
+    /// A pre-candidate sends this before incrementing its term to ask whether peers *would* grant
+    /// it a vote at `rpc.vote` (a hypothetical next term). Handling this RPC never persists a
+    /// vote or changes this node's term; it only reports whether the vote would be granted,
+    /// judged by the same leader-lease and last-log-id rules as [`Raft::vote()`]. Pre-Vote is
+    /// only used when [`Config::enable_pre_vote`](crate::Config::enable_pre_vote) is enabled on
+    /// the sender.
+    #[since(version = "0.10.0", change = "added for the Pre-Vote feature")]
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn pre_vote(&self, rpc: VoteRequest<C>) -> Result<VoteResponse<C>, RaftError<C>> {
+        self.protocol_api().pre_vote(rpc).await.into_raft_result()
     }
 
     /// Get the latest snapshot from the state machine.

--- a/openraft/src/raft/runtime_config_handle.rs
+++ b/openraft/src/raft/runtime_config_handle.rs
@@ -42,4 +42,13 @@ where C: RaftTypeConfig
     pub fn elect(&self, enabled: bool) {
         self.raft_inner.runtime_config.enable_elect.store(enabled, Ordering::Relaxed);
     }
+
+    /// Enable or disable the Pre-Vote round that precedes a real election.
+    ///
+    /// When enabled, a follower asks peers whether they would grant it a vote before incrementing
+    /// its term, avoiding term inflation by a node that cannot currently win. See
+    /// [`Config::enable_pre_vote`](crate::Config::enable_pre_vote).
+    pub fn pre_vote(&self, enabled: bool) {
+        self.raft_inner.runtime_config.enable_pre_vote.store(enabled, Ordering::Relaxed);
+    }
 }

--- a/openraft/src/raft/trigger.rs
+++ b/openraft/src/raft/trigger.rs
@@ -17,7 +17,7 @@ use crate::type_config::alias::VoteOf;
 ///
 /// For example, to trigger an election at once, you can use the following code
 /// ```ignore
-/// raft.trigger().elect().await?;
+/// raft.trigger().elect(false).await?;
 /// ```
 ///
 /// Or to fire a heartbeat, building a snapshot, or purging logs:
@@ -44,10 +44,22 @@ where C: RaftTypeConfig
 
     /// Trigger election at once and return at once.
     ///
+    /// With `pre_vote = false`, a real election starts immediately: the term is incremented and the
+    /// node votes for itself. This bypasses both `enable_elect` and Pre-Vote, so the term climbs
+    /// even when the node cannot win — which may step down a healthy leader of a lower term.
+    ///
+    /// With `pre_vote = true`, a Pre-Vote round runs first and the real election proceeds only if a
+    /// quorum would grant a vote. A live leader holding its lease causes the Pre-Vote to be
+    /// declined, leaving the term untouched — use this to avoid disrupting a healthy leader
+    /// with a manual trigger. It does not require [`Config::enable_pre_vote`]; the caller opts
+    /// in per call.
+    ///
     /// Returns error when RaftCore has [`Fatal`] error, e.g., shut down or having storage error.
     /// It is not affected by `Raft::enable_elect(false)`.
-    pub async fn elect(&self) -> Result<(), Fatal<C>> {
-        self.raft_inner.send_external_command(ExternalCommand::Elect).await
+    ///
+    /// [`Config::enable_pre_vote`]: crate::Config::enable_pre_vote
+    pub async fn elect(&self, pre_vote: bool) -> Result<(), Fatal<C>> {
+        self.raft_inner.send_external_command(ExternalCommand::Elect { pre_vote }).await
     }
 
     /// Trigger a heartbeat at once and return at once.

--- a/tests/tests/client_api/t11_client_reads.rs
+++ b/tests/tests/client_api/t11_client_reads.rs
@@ -136,7 +136,7 @@ async fn get_read_log_id() -> Result<()> {
 
     tracing::info!("--- let node 1 to become leader, append a blank log");
     let n1 = router.get_raft_handle(&1).unwrap();
-    n1.trigger().elect().await?;
+    n1.trigger().elect(false).await?;
 
     n1.wait(timeout()).state(ServerState::Leader, "node 1 becomes leader").await?;
 

--- a/tests/tests/client_api/t90_issue_1761_purge_stranded_responder.rs
+++ b/tests/tests/client_api/t90_issue_1761_purge_stranded_responder.rs
@@ -79,7 +79,7 @@ async fn write_then_superseded_by_snapshot_install() -> Result<()> {
     );
     {
         let n1 = router.get_raft_handle(&1)?;
-        n1.trigger().elect().await?;
+        n1.trigger().elect(false).await?;
         // node 1 becomes leader at term 2 and commits its blank log at index log_index+1.
         router.wait(&1, timeout()).applied_index(Some(log_index + 1), "node 1 leader blank").await?;
     }

--- a/tests/tests/elect/main.rs
+++ b/tests/tests/elect/main.rs
@@ -9,3 +9,4 @@ mod fixtures;
 
 mod t10_elect_compare_last_log;
 mod t11_elect_seize_leadership;
+mod t12_pre_vote;

--- a/tests/tests/elect/t11_elect_seize_leadership.rs
+++ b/tests/tests/elect/t11_elect_seize_leadership.rs
@@ -38,7 +38,7 @@ async fn elect_seize_leadership() -> Result<()> {
     tracing::info!(log_index, "--- trigger election on node 1");
     {
         let n1 = router.get_raft_handle(&1)?;
-        n1.trigger().elect().await?;
+        n1.trigger().elect(false).await?;
 
         n1.wait(timeout()).state(ServerState::Leader, "node 1 becomes leader").await?;
     }

--- a/tests/tests/elect/t12_pre_vote.rs
+++ b/tests/tests/elect/t12_pre_vote.rs
@@ -1,0 +1,276 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::ServerState;
+use openraft::async_runtime::WatchReceiver;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::ut_harness;
+
+/// With Pre-Vote enabled, an isolated follower does not inflate its term.
+///
+/// This is the scenario from databendlabs/openraft#1770: a follower that loses contact with the
+/// leader keeps timing out. Without Pre-Vote it bumps its term every timeout (1 → 2 → 3 → ...),
+/// and that inflated term disrupts the healthy leader once the follower reconnects. With Pre-Vote
+/// the follower cannot reach a quorum to grant its Pre-Vote, so it never increments its term.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn pre_vote_prevents_term_inflation() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_pre_vote: Some(true),
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- create cluster of 0,1,2; node 0 becomes leader at term 1");
+    router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    let n1 = router.get_raft_handle(&1)?;
+    n0.wait(timeout()).state(ServerState::Leader, "node 0 is leader").await?;
+    n1.wait(timeout()).state(ServerState::Follower, "node 1 is follower").await?;
+
+    let follower_term_before = n1.metrics().borrow_watched().current_term;
+    let leader_term_before = n0.metrics().borrow_watched().current_term;
+
+    tracing::info!("--- isolate node 1 and let many election timeouts pass");
+    router.set_network_error(1, true);
+    TypeConfig::sleep(Duration::from_secs(2)).await;
+
+    tracing::info!("--- node 1's term must NOT have inflated");
+    let follower_term_after = n1.metrics().borrow_watched().current_term;
+    assert_eq!(
+        follower_term_before, follower_term_after,
+        "Pre-Vote must keep the isolated follower from bumping its term, was {}, now {}",
+        follower_term_before, follower_term_after
+    );
+
+    tracing::info!("--- the leader kept leadership at the same term");
+    n0.wait(timeout()).state(ServerState::Leader, "node 0 still leader").await?;
+    assert_eq!(leader_term_before, n0.metrics().borrow_watched().current_term);
+
+    tracing::info!("--- reconnect node 1; it rejoins as a follower without disruption");
+    router.set_network_error(1, false);
+    n1.wait(timeout()).state(ServerState::Follower, "node 1 rejoins as follower").await?;
+
+    Ok(())
+}
+
+/// Baseline contrast: with Pre-Vote disabled (the default), the same isolated follower *does*
+/// inflate its term. This proves the previous test actually exercises Pre-Vote rather than some
+/// other quiescence.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn without_pre_vote_term_inflates() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_pre_vote: Some(false),
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- create cluster of 0,1,2");
+    router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    let n1 = router.get_raft_handle(&1)?;
+    n0.wait(timeout()).state(ServerState::Leader, "node 0 is leader").await?;
+    n1.wait(timeout()).state(ServerState::Follower, "node 1 is follower").await?;
+
+    let follower_term_before = n1.metrics().borrow_watched().current_term;
+
+    tracing::info!("--- isolate node 1 and let many election timeouts pass");
+    router.set_network_error(1, true);
+    TypeConfig::sleep(Duration::from_secs(2)).await;
+
+    let follower_term_after = n1.metrics().borrow_watched().current_term;
+    assert!(
+        follower_term_after > follower_term_before,
+        "without Pre-Vote the isolated follower inflates its term, was {}, now {}",
+        follower_term_before,
+        follower_term_after
+    );
+
+    Ok(())
+}
+
+/// A manual `trigger().elect(true)` runs a Pre-Vote round first: against a healthy leader it is
+/// declined, so the follower's term is left untouched and the leader is not disrupted.
+///
+/// This is the administrative-safety scenario: an operator triggering an election on a node that
+/// cannot currently win must not inflate the cluster term. Pre-Vote is requested per call here — it
+/// does not depend on `Config::enable_pre_vote`, which is left at its default.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn manual_elect_with_pre_vote_does_not_disrupt_leader() -> Result<()> {
+    let config = Arc::new(Config::default().validate()?);
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- create cluster of 0,1,2; node 0 becomes leader");
+    router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    let n1 = router.get_raft_handle(&1)?;
+    n0.wait(timeout()).state(ServerState::Leader, "node 0 is leader").await?;
+    n1.wait(timeout()).state(ServerState::Follower, "node 1 is follower").await?;
+
+    let follower_term_before = n1.metrics().borrow_watched().current_term;
+    let leader_term_before = n0.metrics().borrow_watched().current_term;
+
+    tracing::info!("--- node 1 manually triggers a cautious (pre-vote) election");
+    n1.trigger().elect(true).await?;
+
+    tracing::info!("--- give the Pre-Vote round time to be declined by the healthy peers");
+    TypeConfig::sleep(Duration::from_millis(500)).await;
+
+    tracing::info!("--- node 1's term is untouched and it stays a follower");
+    assert_eq!(
+        follower_term_before,
+        n1.metrics().borrow_watched().current_term,
+        "a declined Pre-Vote must not inflate the follower's term"
+    );
+    n1.wait(timeout()).state(ServerState::Follower, "node 1 stays follower").await?;
+
+    tracing::info!("--- the leader kept leadership at the same term");
+    n0.wait(timeout()).state(ServerState::Leader, "node 0 still leader").await?;
+    assert_eq!(leader_term_before, n0.metrics().borrow_watched().current_term);
+
+    Ok(())
+}
+
+/// Baseline contrast: a manual `trigger().elect(false)` starts a real election immediately and
+/// inflates the follower's term, even against a healthy leader. This proves the previous test
+/// exercises the Pre-Vote round rather than some other quiescence.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn manual_elect_without_pre_vote_inflates_term() -> Result<()> {
+    let config = Arc::new(Config::default().validate()?);
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- create cluster of 0,1,2; node 0 becomes leader");
+    router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    let n1 = router.get_raft_handle(&1)?;
+    n0.wait(timeout()).state(ServerState::Leader, "node 0 is leader").await?;
+    n1.wait(timeout()).state(ServerState::Follower, "node 1 is follower").await?;
+
+    let follower_term_before = n1.metrics().borrow_watched().current_term;
+
+    tracing::info!("--- node 1 manually triggers a direct (no pre-vote) election");
+    n1.trigger().elect(false).await?;
+
+    tracing::info!("--- node 1's term inflates immediately");
+    n1.wait(timeout())
+        .metrics(
+            |m| m.current_term > follower_term_before,
+            "a direct manual election inflates the term",
+        )
+        .await?;
+
+    Ok(())
+}
+
+/// With Pre-Vote enabled, a cluster must still elect a new leader after the current leader fails.
+///
+/// Pre-Vote makes elections *cautious*, not *impossible*: this is the core liveness requirement.
+/// When the leader is isolated its lease expires on the remaining voters; they run a Pre-Vote
+/// round, grant each other (no live leader holds a lease), and one wins and starts a real election.
+/// If a node's in-flight Pre-Vote state were dropped before its peers' responses arrived, no voter
+/// could ever assemble a Pre-Vote quorum and the cluster would stay leaderless forever.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn pre_vote_elects_new_leader_after_leader_isolated() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_pre_vote: Some(true),
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- create cluster of 0,1,2; node 0 becomes leader");
+    router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    n0.wait(timeout()).state(ServerState::Leader, "node 0 is leader").await?;
+
+    tracing::info!("--- isolate the leader; nodes 1 and 2 still reach each other");
+    router.set_network_error(0, true);
+
+    tracing::info!("--- a new leader must emerge among 1,2 via the Pre-Vote path");
+    for id in [1, 2] {
+        router
+            .wait(&id, Some(Duration::from_secs(5)))
+            .metrics(
+                |m| m.current_leader == Some(1) || m.current_leader == Some(2),
+                "a new leader is elected via Pre-Vote after the old leader is isolated",
+            )
+            .await?;
+    }
+
+    Ok(())
+}
+
+/// A fully isolated voter whose peers are **unreachable** must not inflate its term, even when the
+/// network implements `pre_vote`.
+///
+/// This guards the regression where an `Unreachable` Pre-Vote response was counted as a grant: an
+/// isolated node would then synthesize a quorum of grants and run a real election anyway, defeating
+/// Pre-Vote. The sibling [`pre_vote_prevents_term_inflation`] isolates with a `NetworkError`; this
+/// one isolates with `Unreachable` specifically — the exact response a real network returns for a
+/// partitioned peer, and the one previously (and wrongly) treated as a grant.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn pre_vote_unreachable_peer_is_not_a_grant() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_pre_vote: Some(true),
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- create cluster of 0,1,2; node 0 becomes leader at term 1");
+    router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n1 = router.get_raft_handle(&1)?;
+    n1.wait(timeout()).state(ServerState::Follower, "node 1 is follower").await?;
+
+    let follower_term_before = n1.metrics().borrow_watched().current_term;
+
+    tracing::info!("--- isolate node 1 with Unreachable and let many election timeouts pass");
+    router.set_unreachable(1, true);
+    TypeConfig::sleep(Duration::from_secs(2)).await;
+
+    tracing::info!("--- node 1's term must NOT inflate: an Unreachable peer is not a grant");
+    assert_eq!(
+        follower_term_before,
+        n1.metrics().borrow_watched().current_term,
+        "an Unreachable Pre-Vote response must not count toward the quorum"
+    );
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(2000))
+}

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -970,6 +970,33 @@ impl RaftNetworkV2<MemConfig> for RaftRouterNetwork {
         Ok(resp)
     }
 
+    async fn pre_vote(
+        &mut self,
+        rpc: VoteRequest<MemConfig>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<MemConfig>, RPCError<MemConfig>> {
+        let from_id = rpc.vote.leader_id().to_node_id();
+
+        self.owner.count_rpc(RPCTypes::Vote);
+        self.owner.call_rpc_pre_hook(rpc.clone(), from_id, self.target).await?;
+        self.owner.emit_rpc_error(from_id, self.target)?;
+        self.owner.rand_send_delay().await;
+
+        let node = self.owner.get_raft_handle(&self.target)?;
+
+        let resp = node.pre_vote(rpc.clone()).await;
+        let resp = resp.map_err(|e| {
+            RPCError::Unreachable(Unreachable::<MemConfig>::from_string(format!(
+                "error: {} target={}",
+                e, self.target
+            )))
+        })?;
+
+        self.owner.call_rpc_post_hook(rpc, resp.clone(), from_id, self.target).await?;
+
+        Ok(resp)
+    }
+
     async fn transfer_leader(
         &mut self,
         rpc: TransferLeaderRequest<MemConfig>,

--- a/tests/tests/life_cycle/t50_leader_restart_clears_state.rs
+++ b/tests/tests/life_cycle/t50_leader_restart_clears_state.rs
@@ -69,7 +69,7 @@ async fn leader_restart_clears_state() -> anyhow::Result<()> {
         n0.initialize(btreemap! {0 => (), 1=>(), 2=>()}).await?;
 
         tracing::info!(log_index, "--- trigger election for node-0 after restart");
-        n0.trigger().elect().await?;
+        n0.trigger().elect(false).await?;
 
         let res = n0.wait(timeout()).state(ServerState::Leader, "should not become leader upon restart").await;
         assert!(res.is_err());

--- a/tests/tests/membership/t30_elect_with_new_config.rs
+++ b/tests/tests/membership/t30_elect_with_new_config.rs
@@ -47,7 +47,7 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
 
     // Let node-1 become leader.
     let node_1 = router.get_raft_handle(&1)?;
-    node_1.trigger().elect().await?;
+    node_1.trigger().elect(false).await?;
     log_index += 1; // leader initial blank log
 
     router.wait(&1, timeout()).metrics(|x| x.current_leader == Some(1), "wait for new leader").await?;

--- a/tests/tests/metrics/t10_metrics_recorder.rs
+++ b/tests/tests/metrics/t10_metrics_recorder.rs
@@ -250,7 +250,7 @@ async fn test_metrics_recorder_on_follower() -> Result<()> {
     // Node 2 will send vote requests to node 1 (which has our recorder)
     tracing::info!("--- trigger election on node 2 to test vote_count");
     let node2 = router.get_raft_handle(&2)?;
-    node2.trigger().elect().await?;
+    node2.trigger().elect(false).await?;
 
     // Wait a bit for vote to be processed
     TypeConfig::sleep(Duration::from_millis(200)).await;

--- a/tests/tests/metrics/t30_leader_metrics.rs
+++ b/tests/tests/metrics/t30_leader_metrics.rs
@@ -153,7 +153,7 @@ async fn leader_metrics() -> Result<()> {
         // Let the leader lease expire
         TypeConfig::sleep(Duration::from_millis(700)).await;
 
-        n1.trigger().elect().await?;
+        n1.trigger().elect(false).await?;
         n1.wait(timeout()).state(ServerState::Leader, "node-1 becomes leader").await?;
         n1.wait(timeout()).metrics(|x| x.replication.is_some(), "node-1 starts replication").await?;
 

--- a/tests/tests/metrics/t50_log_progress_api.rs
+++ b/tests/tests/metrics/t50_log_progress_api.rs
@@ -143,7 +143,7 @@ async fn log_progress_with_leader_change() -> Result<()> {
 
     tracing::info!(log_index, "--- trigger election on node 1");
     let n1 = router.get_raft_handle(&1)?;
-    n1.trigger().elect().await?;
+    n1.trigger().elect(false).await?;
 
     tracing::info!(log_index, "--- send client requests to new leader");
     router
@@ -221,7 +221,7 @@ async fn vote_progress_api() -> Result<()> {
 
     tracing::info!("--- trigger election on node 1 to seize leadership");
     let n1 = router.get_raft_handle(&1)?;
-    n1.trigger().elect().await?;
+    n1.trigger().elect(false).await?;
 
     tracing::info!("--- verify wait_until_ge returns with term 2 vote");
     let got_wait = handle.await??;

--- a/tests/tests/metrics/t50_watch_leader_api.rs
+++ b/tests/tests/metrics/t50_watch_leader_api.rs
@@ -75,7 +75,7 @@ async fn on_cluster_leader_change_api() -> Result<()> {
 
     tracing::info!("--- trigger election on node 2");
     let n2 = router.get_raft_handle(&2)?;
-    n2.trigger().elect().await?;
+    n2.trigger().elect(false).await?;
 
     tracing::info!("--- wait for node 2 to become leader");
     n2.wait(Some(Duration::from_millis(2000)))
@@ -108,7 +108,7 @@ async fn on_cluster_leader_change_api() -> Result<()> {
     TypeConfig::sleep(Duration::from_millis(700)).await;
 
     tracing::info!("--- trigger election on node 1 after handle closed (node 2 still running for quorum)");
-    n1.trigger().elect().await?;
+    n1.trigger().elect(false).await?;
 
     n1.wait(Some(Duration::from_millis(2000)))
         .state(ServerState::Leader, "wait for node 1 to become leader")
@@ -193,7 +193,7 @@ async fn on_leader_change_api() -> Result<()> {
 
     tracing::info!("--- trigger election on node 2");
     let n2 = router.get_raft_handle(&2)?;
-    n2.trigger().elect().await?;
+    n2.trigger().elect(false).await?;
 
     tracing::info!("--- wait for node 2 to become leader");
     n2.wait(Some(Duration::from_millis(2000)))
@@ -294,7 +294,7 @@ async fn on_leader_change_future_is_awaited() -> Result<()> {
 
     tracing::info!("--- trigger election on node 2 to cause leadership change");
     let n2 = router.get_raft_handle(&2)?;
-    n2.trigger().elect().await?;
+    n2.trigger().elect(false).await?;
 
     n2.wait(Some(Duration::from_millis(2000)))
         .state(ServerState::Leader, "wait for node 2 to become leader")
@@ -369,7 +369,7 @@ async fn on_cluster_leader_change_future_is_awaited() -> Result<()> {
 
     tracing::info!("--- trigger election on node 2");
     let n2 = router.get_raft_handle(&2)?;
-    n2.trigger().elect().await?;
+    n2.trigger().elect(false).await?;
 
     n2.wait(Some(Duration::from_millis(2000)))
         .state(ServerState::Leader, "wait for node 2 to become leader")

--- a/tests/tests/replication/t50_append_entries_backoff_rejoin.rs
+++ b/tests/tests/replication/t50_append_entries_backoff_rejoin.rs
@@ -48,7 +48,7 @@ async fn append_entries_backoff_rejoin() -> Result<()> {
         // Timeout leader lease otherwise vote-request will be rejected by node-2
         TypeConfig::sleep(Duration::from_millis(1_000)).await;
 
-        n1.trigger().elect().await?;
+        n1.trigger().elect(false).await?;
         n1.wait(timeout()).state(ServerState::Leader, "node-1 elect").await?;
     }
 


### PR DESCRIPTION

## Changelog

##### feat: add Pre-Vote to avoid disruptive term inflation
# Summary

A follower probes whether a quorum would grant its vote at the next term
before persisting a vote or bumping its term, so a node that cannot
currently win -- partitioned, restarted, or with a stale log -- does not
inflate the cluster term and disrupt a healthy leader on reconnect.

# Details

- Config::enable_pre_vote: Option<bool> gates the automatic round on election
  timeout. None, the default, is treated as disabled, leaving room to change
  the default later without breaking existing configs.

- Trigger::elect now takes pre_vote: bool, so an operator can run a cautious
  manual election independent of the config; existing callers pass false.

- New RaftNetworkV2::pre_vote RPC. The default impl grants unconditionally so
  a cluster mid-upgrade stays live, and a transport error is never counted as
  a grant, so an isolated node cannot synthesize a quorum.

- Engine pre_elect / handle_pre_vote_req / handle_pre_vote_resp run the round
  without persisting a vote or changing server state; a would-grant quorum
  starts the real election, and a real election or a higher accepted vote
  supersedes an in-flight round.

- Fix: #1770

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1785)
<!-- Reviewable:end -->
