### PR TITLE
feat: add Raft::wait_for_recovery to recover state machine after restart

### DIFF
--- a/openraft/src/core/heartbeat/event.rs
+++ b/openraft/src/core/heartbeat/event.rs
@@ -29,7 +29,7 @@ where C: RaftTypeConfig
     ///
     /// When there are no new logs to replicate, the Leader sends a heartbeat to replicate committed
     /// log id to followers to update their committed log id.
-    pub(crate) committed: Option<LogIdOf<C>>,
+    pub(crate) cluster_committed: Option<LogIdOf<C>>,
 }
 
 impl<C> fmt::Display for HeartbeatEvent<C>
@@ -38,10 +38,10 @@ where C: RaftTypeConfig
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "(time={}, matching: {}, committed: {})",
+            "(time={}, matching: {}, cluster_committed: {})",
             self.time.display(),
             self.matching.display(),
-            self.committed.display()
+            self.cluster_committed.display()
         )
     }
 }

--- a/openraft/src/core/heartbeat/worker.rs
+++ b/openraft/src/core/heartbeat/worker.rs
@@ -107,9 +107,9 @@ where
                 // prev_log_id == None does not conflict.
                 //
                 // Fail test `t99_issue_1500_heartbeat_cause_reversion_panic` by changing the
-                // following line to `prev_log_id = heartbeat.committed.clone()`.
+                // following line to `prev_log_id = heartbeat.cluster_committed.clone()`.
                 prev_log_id: heartbeat.matching.clone(),
-                leader_commit: heartbeat.committed.clone(),
+                leader_commit: heartbeat.cluster_committed.clone(),
                 entries: vec![],
             };
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -411,7 +411,7 @@ where
                 vote: my_vote.clone(),
                 prev_log_id: progress.matching().cloned(),
                 entries: vec![],
-                leader_commit: self.engine.state.committed().cloned(),
+                leader_commit: self.engine.state.cluster_committed().cloned(),
             };
 
             // Safe unwrap(): target is in membership
@@ -753,7 +753,9 @@ where
             current_term: st.vote_ref().term(),
             vote: vote.clone(),
             last_log_index: st.last_log_id().index(),
-            committed: st.committed().cloned(),
+            local_committed: st.local_committed().cloned(),
+            committed: st.local_committed().cloned(),
+            cluster_committed: st.cluster_committed().cloned(),
             last_applied: st.io_applied().cloned(),
             snapshot: st.io_snapshot_last_log_id().cloned(),
             purged: st.io_purged().cloned(),
@@ -777,7 +779,9 @@ where
         #[allow(deprecated)]
         let data_metrics = RaftDataMetrics {
             last_log: st.last_log_id().cloned(),
-            committed: st.committed().cloned(),
+            local_committed: st.local_committed().cloned(),
+            committed: st.local_committed().cloned(),
+            cluster_committed: st.cluster_committed().cloned(),
             last_applied: st.io_applied().cloned(),
             snapshot: st.io_snapshot_last_log_id().cloned(),
             purged: st.io_purged().cloned(),
@@ -1040,7 +1044,7 @@ where
         let (mut replication_handle, replication_context) = self.new_replication(leader_vote, prog, replicate_tx);
 
         let progress = replication_progress::ReplicationProgress {
-            local_committed: self.engine.state.committed().cloned(),
+            local_committed: self.engine.state.local_committed().cloned(),
             remote_matched: prog.progress.matching.clone(),
         };
 
@@ -2137,7 +2141,7 @@ where
             return;
         }
 
-        let committed = lh.state.committed().cloned();
+        let cluster_committed = lh.state.cluster_committed().cloned();
         let now = C::now();
         let events =
             lh.leader
@@ -2148,7 +2152,7 @@ where
                     (progress_entry.id.clone(), HeartbeatEvent {
                         time: now,
                         matching: progress_entry.val.matching.clone(),
-                        committed: committed.clone(),
+                        cluster_committed: cluster_committed.clone(),
                     })
                 });
 

--- a/openraft/src/docs/data/log_pointers.md
+++ b/openraft/src/docs/data/log_pointers.md
@@ -90,6 +90,33 @@ If the state machine does not flush state to disk before returning from `apply()
 - If the `committed` log id is not saved, Openraft will just recover the state machine to
   the state of the last snapshot taken.
 
+### Reverted reads when `committed` is not saved
+
+If `committed` is not saved, the state machine is recovered only to the last snapshot on
+restart. It catches back up once this node perceives the cluster commit re-established by the
+current leader and re-applies up to it; until then a read may observe a state older than one
+observed before the restart.
+
+The recovery signal is the cluster commit, established only by the current leader replicating to
+a quorum — it is never recovered from local storage. After a restart this node perceives it only
+once the current leader has re-established the commit by committing its own-term (blank) entry to
+a quorum. That re-established commit is at least every previously committed — hence previously
+applied — log id, so once the state machine applies up to it, no read can be reverted. This is
+the same `read_log_id` condition that linearizable reads rely on; see [`docs::protocol::read`]
+and [`docs::protocol::commit`].
+
+To avoid serving a reverted read, either:
+
+- Persist `committed` (recommended): on restart the recovered `committed` is the true
+  pre-restart value, and the state machine is re-applied up to it on startup.
+- Wait for recovery before serving reads: [`Raft::wait_for_recovery`] blocks until the
+  re-established cluster commit has been applied.
+
+```ignore
+let raft = Raft::new(id, config, network, log_store, sm).await?;
+raft.wait_for_recovery(Some(Duration::from_secs(5))).await?;
+```
+
 ### Why
 
 The reason of adding a persisted `committed` is to just make things clear.
@@ -108,3 +135,6 @@ Meanwhile, I do not quite worry about the penalty, unless there is a measurable 
 
 [`RaftLogStorage`]: `crate::storage::RaftLogStorage`
 [`RaftLogStorage::save_committed`]: `crate::storage::RaftLogStorage::save_committed`
+[`docs::protocol::read`]: `crate::docs::protocol::read`
+[`docs::protocol::commit`]: `crate::docs::protocol::commit`
+[`Raft::wait_for_recovery`]: `crate::Raft::wait_for_recovery`

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -665,7 +665,7 @@ where C: RaftTypeConfig
         tracing::debug!(
             "membership: {}, committed: {}, is_leading: {}",
             em,
-            self.state.committed().display(),
+            self.state.local_committed().display(),
             self.state.is_leading(&self.config.id),
         );
 

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -149,7 +149,7 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
     );
     assert_eq!(Some(&log_id(4, 1, 6)), eng.state.log_ids.purged());
     assert_eq!(&[log_id(4, 1, 8)], eng.state.log_ids.key_log_ids());
-    assert_eq!(Some(&log_id(4, 1, 6)), eng.state.committed());
+    assert_eq!(Some(&log_id(4, 1, 6)), eng.state.local_committed());
     assert_eq!(
         &Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234())),
         eng.state.membership_state.committed()
@@ -235,7 +235,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
     // All logs purged by snapshot, only purged field contains the snapshot's last_log_id
     assert!(eng.state.log_ids.key_log_ids().is_empty());
     assert_eq!(Some(&log_id(5, 1, 6)), eng.state.log_ids.purged());
-    assert_eq!(Some(&log_id(5, 1, 6)), eng.state.committed());
+    assert_eq!(Some(&log_id(5, 1, 6)), eng.state.local_committed());
     assert_eq!(
         &Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234())),
         eng.state.membership_state.committed()
@@ -297,7 +297,7 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
     // All logs purged by snapshot, only purged field contains the snapshot's last_log_id
     assert!(eng.state.log_ids.key_log_ids().is_empty());
     assert_eq!(Some(&log_id(100, 1, 100)), eng.state.log_ids.purged());
-    assert_eq!(Some(&log_id(100, 1, 100)), eng.state.committed());
+    assert_eq!(Some(&log_id(100, 1, 100)), eng.state.local_committed());
     assert_eq!(
         &Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234())),
         eng.state.membership_state.committed()

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -242,11 +242,11 @@ where C: RaftTypeConfig
 
         let snap_last_log_id = meta.last_log_id.clone();
 
-        if snap_last_log_id.as_ref() <= self.state.committed() {
+        if snap_last_log_id.as_ref() <= self.state.local_committed() {
             tracing::info!(
                 "No need to install snapshot; snapshot last_log_id({}) <= committed({})",
                 snap_last_log_id.display(),
-                self.state.committed().display()
+                self.state.local_committed().display()
             );
             return None;
         }
@@ -269,7 +269,7 @@ where C: RaftTypeConfig
             && local != snap_last_log_id
         {
             // Conflict, delete all non-committed logs.
-            self.truncate_logs(self.state.committed().next_index());
+            self.truncate_logs(self.state.local_committed().next_index());
         }
 
         let log_io_id = LogIOId::new(self.leader_vote.to_committed(), Some(snap_last_log_id.clone()));

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -224,7 +224,7 @@ fn test_leader_append_entries_single_node_leader() -> anyhow::Result<()> {
         ),
         eng.state.membership_state
     );
-    assert_eq!(Some(&log_id(0, 1, 0)), eng.state.committed());
+    assert_eq!(Some(&log_id(0, 1, 0)), eng.state.local_committed());
 
     assert_eq!(
         vec![Command::AppendEntries {
@@ -287,7 +287,7 @@ fn test_leader_append_entries_with_membership_log() -> anyhow::Result<()> {
         ),
         eng.state.membership_state
     );
-    assert_eq!(Some(&log_id(0, 1, 0)), eng.state.committed());
+    assert_eq!(Some(&log_id(0, 1, 0)), eng.state.local_committed());
 
     assert_eq!(
         vec![

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -115,7 +115,7 @@ where C: RaftTypeConfig
     ///
     /// See: [Read Operation](crate::docs::protocol::read)
     pub(crate) fn get_read_log_id(&self) -> LogIdOf<C> {
-        let committed = self.state.committed().cloned();
+        let committed = self.state.local_committed().cloned();
         let Some(committed) = committed else {
             return self.leader.noop_log_id.clone();
         };

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -212,12 +212,20 @@ where C: RaftTypeConfig
             return;
         }
 
-        let committed = LogIOId::new(self.state.vote_ref().to_committed(), granted.clone());
-        self.state.io_state_mut().cluster_committed.try_update(committed.clone()).ok();
+        let prev_cluster_committed = self.state.cluster_committed().cloned();
 
-        if let Some(_membership_transition) = self.state.update_local_committed(&granted) {
+        let committed = LogIOId::new(self.state.vote_ref().to_committed(), granted.clone());
+        self.state.io_state_mut().cluster_committed.try_update(committed).ok();
+
+        // Advance the local apply ceiling regardless; it is a no-op when nothing changed.
+        self.state.update_local_committed(&granted);
+
+        // Notify replication only when the cluster-committed log id advanced. The vote component of
+        // `cluster_committed` can bump on its own at leadership start with no new committed log id,
+        // which must not trigger a broadcast.
+        if self.state.cluster_committed() > prev_cluster_committed.as_ref() {
             self.output.push_command(Command::ReplicateCommitted {
-                committed: self.state.committed().cloned(),
+                committed: self.state.cluster_committed().cloned(),
             });
         }
     }

--- a/openraft/src/engine/handler/replication_handler/update_matching_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_matching_test.rs
@@ -81,7 +81,7 @@ fn test_update_matching() -> anyhow::Result<()> {
     // progress: None, None, (1,2)
     {
         rh.update_matching(3, Some(log_id(1, 1, 2)), None);
-        assert_eq!(None, rh.state.committed());
+        assert_eq!(None, rh.state.local_committed());
         assert_eq!(0, rh.output.take_commands().len());
     }
 
@@ -89,7 +89,7 @@ fn test_update_matching() -> anyhow::Result<()> {
     {
         rh.output.clear_commands();
         rh.update_matching(2, Some(log_id(2, 1, 1)), None);
-        assert_eq!(None, rh.state.committed());
+        assert_eq!(None, rh.state.local_committed());
         assert_eq!(0, rh.output.take_commands().len());
     }
 
@@ -97,7 +97,7 @@ fn test_update_matching() -> anyhow::Result<()> {
     {
         rh.output.clear_commands();
         rh.update_matching(3, Some(log_id(2, 1, 3)), None);
-        assert_eq!(Some(&log_id(2, 1, 1)), rh.state.committed());
+        assert_eq!(Some(&log_id(2, 1, 1)), rh.state.local_committed());
         assert_eq!(
             vec![Command::ReplicateCommitted {
                 committed: Some(log_id(2, 1, 1))
@@ -112,7 +112,7 @@ fn test_update_matching() -> anyhow::Result<()> {
     {
         rh.output.clear_commands();
         rh.update_matching(1, Some(log_id(2, 1, 4)), None);
-        assert_eq!(Some(&log_id(2, 1, 3)), rh.state.committed());
+        assert_eq!(Some(&log_id(2, 1, 3)), rh.state.local_committed());
         assert_eq!(
             vec![Command::ReplicateCommitted {
                 committed: Some(log_id(2, 1, 3))

--- a/openraft/src/metrics/metric.rs
+++ b/openraft/src/metrics/metric.rs
@@ -67,7 +67,7 @@ where C: RaftTypeConfig
             Metric::Term(v) => self.current_term == *v,
             Metric::Vote(v) => &self.vote == v,
             Metric::LastLogIndex(v) => self.last_log_index == *v,
-            Metric::Committed(v) => &self.committed == v,
+            Metric::Committed(v) => &self.local_committed == v,
             Metric::Applied(v) => &self.last_applied == v,
             Metric::AppliedIndex(v) => self.last_applied.index() == *v,
             Metric::Snapshot(v) => &self.snapshot == v,
@@ -85,7 +85,7 @@ where C: RaftTypeConfig
             Metric::Term(v) => Some(self.current_term.cmp(v)),
             Metric::Vote(v) => self.vote.as_ref_vote().partial_cmp(&v.as_ref_vote()),
             Metric::LastLogIndex(v) => Some(self.last_log_index.cmp(v)),
-            Metric::Committed(v) => Some(self.committed.cmp(v)),
+            Metric::Committed(v) => Some(self.local_committed.cmp(v)),
             Metric::Applied(v) => Some(self.last_applied.cmp(v)),
             Metric::AppliedIndex(v) => Some(self.last_applied.index().cmp(v)),
             Metric::Snapshot(v) => Some(self.snapshot.cmp(v)),
@@ -105,7 +105,7 @@ mod tests {
 
     fn init_metrics() -> RaftMetrics<UTConfig> {
         let mut m = RaftMetrics::new_initial(0);
-        m.committed = Some(log_id(1, 0, 5));
+        m.local_committed = Some(log_id(1, 0, 5));
         m
     }
 

--- a/openraft/src/metrics/raft_metrics.rs
+++ b/openraft/src/metrics/raft_metrics.rs
@@ -96,12 +96,31 @@ pub struct RaftMetrics<C: RaftTypeConfig> {
     /// The last log ID known to this node as committed, i.e., safe to apply to the local state
     /// machine.
     ///
-    /// This is the **local committed** value, which may lag behind the **cluster-committed** value
-    /// (the actual quorum-acknowledged frontier) due to network delays or out-of-order RPC
-    /// delivery. See [`commit`] for the full explanation of the distinction.
+    /// This is the **local committed** value, which may lag behind the
+    /// [**cluster-committed**](Self::cluster_committed) value (the actual quorum-acknowledged
+    /// frontier) due to network delays or out-of-order RPC delivery. See [`commit`] for the full
+    /// explanation of the distinction.
     ///
     /// [`commit`]: crate::docs::protocol::commit
     #[since(version = "0.10.0")]
+    pub local_committed: Option<LogIdOf<C>>,
+
+    /// The last log ID known to be committed by a quorum of the cluster, as last reported by the
+    /// leader.
+    ///
+    /// This is the **cluster-committed** value. It may lead
+    /// [`local_committed`](Self::local_committed) on a node that has not yet received the
+    /// corresponding log entries. See [`commit`] for the full explanation of the distinction.
+    ///
+    /// [`commit`]: crate::docs::protocol::commit
+    #[since(version = "0.10.0")]
+    pub cluster_committed: Option<LogIdOf<C>>,
+
+    /// The last log ID known to this node as committed.
+    #[deprecated(
+        since = "0.10.0",
+        note = "use `local_committed` instead, or `cluster_committed` for the quorum-granted commit"
+    )]
     pub committed: Option<LogIdOf<C>>,
 
     /// The last log index has been applied to this Raft node's state machine.
@@ -206,13 +225,14 @@ where C: RaftTypeConfig
 
         write!(
             f,
-            "id:{}, {:?}, term:{}, vote:{}, last_log:{}, committed:{}, last_applied:{}, leader:{}",
+            "id:{}, {:?}, term:{}, vote:{}, last_log:{}, local_committed:{}, cluster_committed:{}, last_applied:{}, leader:{}",
             self.id,
             self.state,
             self.current_term,
             self.vote,
             self.last_log_index.display(),
-            self.committed.display(),
+            self.local_committed.display(),
+            self.cluster_committed.display(),
             self.last_applied.display(),
             self.current_leader.display(),
         )?;
@@ -259,7 +279,9 @@ where C: RaftTypeConfig
             current_term: Default::default(),
             vote,
             last_log_index: None,
+            local_committed: None,
             committed: None,
+            cluster_committed: None,
             last_applied: None,
             snapshot: None,
             purged: None,
@@ -286,13 +308,32 @@ where C: RaftTypeConfig
 pub struct RaftDataMetrics<C: RaftTypeConfig> {
     /// The last log id.
     pub last_log: Option<LogIdOf<C>>,
-    /// The last log ID known to this node as committed.
+    /// The last log ID known to this node as committed, i.e., safe to apply to the local state
+    /// machine.
     ///
-    /// This is the **local committed** value. See [`commit`] for the distinction from
-    /// cluster-committed.
+    /// This is the **local committed** value, which may lag behind the
+    /// [**cluster-committed**](Self::cluster_committed) value (the actual quorum-acknowledged
+    /// frontier) due to network delays or out-of-order RPC delivery. See [`commit`] for the full
+    /// explanation of the distinction.
     ///
     /// [`commit`]: crate::docs::protocol::commit
     #[since(version = "0.10.0")]
+    pub local_committed: Option<LogIdOf<C>>,
+    /// The last log ID known to be committed by a quorum of the cluster, as last reported by the
+    /// leader.
+    ///
+    /// This is the **cluster-committed** value. It may lead
+    /// [`local_committed`](Self::local_committed) on a node that has not yet received the
+    /// corresponding log entries. See [`commit`] for the full explanation of the distinction.
+    ///
+    /// [`commit`]: crate::docs::protocol::commit
+    #[since(version = "0.10.0")]
+    pub cluster_committed: Option<LogIdOf<C>>,
+    /// The last log ID known to this node as committed.
+    #[deprecated(
+        since = "0.10.0",
+        note = "use `local_committed` instead, or `cluster_committed` for the quorum-granted commit"
+    )]
     pub committed: Option<LogIdOf<C>>,
     /// The last applied log id.
     pub last_applied: Option<LogIdOf<C>>,
@@ -363,9 +404,10 @@ where C: RaftTypeConfig
 
         write!(
             f,
-            "last_log:{}, committed:{}, last_applied:{}, snapshot:{}, purged:{}",
+            "last_log:{}, local_committed:{}, cluster_committed:{}, last_applied:{}, snapshot:{}, purged:{}",
             self.last_log.display(),
-            self.committed.display(),
+            self.local_committed.display(),
+            self.cluster_committed.display(),
             self.last_applied.display(),
             self.snapshot.display(),
             self.purged.display(),

--- a/openraft/src/metrics/recorder.rs
+++ b/openraft/src/metrics/recorder.rs
@@ -118,7 +118,7 @@ pub fn forward_metrics<C: RaftTypeConfig>(metrics: &RaftMetrics<C>, recorder: &d
         recorder.set_last_log_index(index);
     }
 
-    if let Some(ref committed) = metrics.committed {
+    if let Some(ref committed) = metrics.local_committed {
         recorder.set_committed_index(committed.index());
     }
 

--- a/openraft/src/metrics/wait.rs
+++ b/openraft/src/metrics/wait.rs
@@ -228,7 +228,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
     pub async fn committed_index(&self, index: Option<u64>, msg: impl ToString) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
-            |m| m.committed.index() == index,
+            |m| m.local_committed.index() == index,
             &format!("{} .committed_index == {:?}", msg.to_string(), index),
         )
         .await
@@ -242,7 +242,7 @@ where C: RaftTypeConfig
         msg: impl ToString,
     ) -> Result<RaftMetrics<C>, WaitError> {
         self.metrics(
-            |m| m.committed.index() >= index,
+            |m| m.local_committed.index() >= index,
             &format!("{} .committed_index >= {:?}", msg.to_string(), index),
         )
         .await

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -262,7 +262,7 @@ fn test_wait_committed_index() {
         let h = UTConfig::<()>::spawn(async move {
             UTConfig::<()>::sleep(Duration::from_millis(10)).await;
             let mut update = init.clone();
-            update.committed = Some(log_id(1, 0, 3));
+            update.local_committed = Some(log_id(1, 0, 3));
             let rst = tx.send(update);
             assert!(rst.is_ok());
         });
@@ -273,9 +273,9 @@ fn test_wait_committed_index() {
         let got_least4 = w.committed_index_at_least(Some(4), "committed").await;
         h.await?;
 
-        assert_eq!(Some(3), got.committed.index());
-        assert_eq!(Some(3), got_least2.committed.index());
-        assert_eq!(Some(3), got_least3.committed.index());
+        assert_eq!(Some(3), got.local_committed.index());
+        assert_eq!(Some(3), got_least2.local_committed.index());
+        assert_eq!(Some(3), got_least3.local_committed.index());
 
         assert!(got_least4.is_err());
 
@@ -298,7 +298,9 @@ where C: RaftTypeConfig<NodeId = u64> {
         current_term: Default::default(),
         vote: VoteOf::<C>::new_with_default_term(0),
         last_log_index: None,
+        local_committed: None,
         committed: None,
+        cluster_committed: None,
         last_applied: None,
         purged: None,
 

--- a/openraft/src/raft/message/append_entries_request.rs
+++ b/openraft/src/raft/message/append_entries_request.rs
@@ -31,7 +31,10 @@ pub struct AppendEntriesRequest<C: RaftTypeConfig> {
     /// are batched for efficiency.
     pub entries: Vec<C::Entry>,
 
-    /// The leader's committed log id.
+    /// The leader's cluster-committed log id: the quorum-granted commit frontier.
+    ///
+    /// The receiver records this as its own cluster-committed value and applies up to it (gated by
+    /// the locally persisted logs).
     pub leader_commit: Option<LogIdOf<C>>,
 }
 

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -113,6 +113,7 @@ use crate::metrics::RaftDataMetrics;
 use crate::metrics::RaftMetrics;
 use crate::metrics::RaftServerMetrics;
 use crate::metrics::Wait;
+use crate::metrics::WaitError;
 use crate::raft::raft_inner::RaftInner;
 pub use crate::raft::runtime_config_handle::RuntimeConfigHandle;
 use crate::raft::trigger::Trigger;
@@ -1754,6 +1755,50 @@ where C: RaftTypeConfig
     /// ```
     pub fn wait(&self, timeout: Option<Duration>) -> Wait<C> {
         self.inner.wait(timeout)
+    }
+
+    /// Wait for this node's state machine to recover to at least the state it had before restart.
+    ///
+    /// On restart, [`cluster_committed`](RaftMetrics::cluster_committed) is reset to `None` and is
+    /// re-established only by replicating to a quorum — it is never restored from storage. A
+    /// non-null `cluster_committed` is therefore always a genuine, freshly quorum-granted commit,
+    /// so it is greater than or equal to any commit this node perceived before restart, and hence
+    /// to everything its state machine had already applied.
+    ///
+    /// The method waits in two phases, together bounded by `timeout`:
+    /// 1. until `cluster_committed` is perceived as non-null (the cluster commit is
+    ///    re-established),
+    /// 2. until the state machine has applied up to that cluster commit.
+    ///
+    /// The target is pinned to the *first* non-null `cluster_committed`, so the node catches up to
+    /// the commit perceived at recovery time. If the cluster advanced while this node was down,
+    /// that target may exceed the node's own pre-restart applied index — which still satisfies "at
+    /// least the same state".
+    ///
+    /// It requires a reachable, functioning cluster: if no cluster commit is re-established (no
+    /// leader, lost quorum, or this node is isolated), the method returns [`WaitError::Timeout`].
+    /// If `timeout` is `None` it waits forever (see [`wait`](Self::wait)).
+    #[since(version = "0.10.0")]
+    pub async fn wait_for_recovery(&self, timeout: Option<Duration>) -> Result<RaftMetrics<C>, WaitError> {
+        let start = C::now();
+
+        // Phase 1: wait until the cluster commit is re-established (perceived as non-null).
+        let metrics = self
+            .wait(timeout)
+            .metrics(
+                |m| m.cluster_committed.is_some(),
+                "wait_for_recovery: cluster commit re-established",
+            )
+            .await?;
+
+        let target = metrics.cluster_committed.as_ref().map(|x| x.index());
+
+        // Phase 2: wait until the state machine has applied up to that cluster commit, within the
+        // time remaining from the original budget.
+        let remaining = timeout.map(|t| t.saturating_sub(C::now() - start));
+        self.wait(remaining)
+            .applied_index_at_least(target, "wait_for_recovery: state machine applied cluster commit")
+            .await
     }
 
     /// Shutdown this Raft node.

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -426,6 +426,19 @@ where
     /// ### `storage`
     /// An implementation of the [`RaftLogStorage`] and [`RaftStateMachine`] trait which will be
     /// used by Raft for data storage.
+    ///
+    /// ### Recovering committed state on startup
+    /// `new()` returns as soon as the node task is spawned, but the state machine may still lag the
+    /// state it had before a restart — see [`RaftLogStorage::save_committed`]. An
+    /// application that serves reads immediately (especially when `committed` is not persisted) may
+    /// then observe a reverted state. To prevent that, await
+    /// [`wait_for_recovery`](Self::wait_for_recovery) before serving reads:
+    ///
+    /// ```ignore
+    /// let raft = Raft::new(id, config, network, log_store, sm).await?;
+    /// raft.wait_for_recovery(Some(Duration::from_secs(5))).await?;
+    /// // The state machine has recovered at least its pre-restart committed state.
+    /// ```
     #[tracing::instrument(level="debug", skip_all, fields(cluster=%config.cluster_name))]
     pub async fn new<LS, N>(
         id: C::NodeId,
@@ -1759,11 +1772,11 @@ where C: RaftTypeConfig
 
     /// Wait for this node's state machine to recover to at least the state it had before restart.
     ///
-    /// On restart, [`cluster_committed`](RaftMetrics::cluster_committed) is reset to `None` and is
-    /// re-established only by replicating to a quorum — it is never restored from storage. A
-    /// non-null `cluster_committed` is therefore always a genuine, freshly quorum-granted commit,
-    /// so it is greater than or equal to any commit this node perceived before restart, and hence
-    /// to everything its state machine had already applied.
+    /// Call this **once**, right after the node is created, before it starts serving requests. It
+    /// is a one-time step for recovering across a restart, **not** a per-read primitive: it does
+    /// not make later reads linearizable — use [`ensure_linearizable`](Self::ensure_linearizable)
+    /// for each linearizable read instead. (Once recovered, the node stays recovered, so calling it
+    /// again is a no-op that returns as soon as the current cluster commit has been applied.)
     ///
     /// The method waits in two phases, together bounded by `timeout`:
     /// 1. until `cluster_committed` is perceived as non-null (the cluster commit is
@@ -1778,6 +1791,26 @@ where C: RaftTypeConfig
     /// It requires a reachable, functioning cluster: if no cluster commit is re-established (no
     /// leader, lost quorum, or this node is isolated), the method returns [`WaitError::Timeout`].
     /// If `timeout` is `None` it waits forever (see [`wait`](Self::wait)).
+    ///
+    /// # Why this works
+    ///
+    /// Perceiving a non-null `cluster_committed` means the current leader has re-established the
+    /// commit by committing its own-term (blank) entry to a quorum, so that commit is at least the
+    /// leader's blank log id — and therefore at least any previously committed, hence previously
+    /// applied, log id. Applying up to it restores everything the state machine held before the
+    /// restart. This is the same `read_log_id` argument that makes linearizable reads safe: see
+    /// [the read protocol](crate::docs::protocol::read) for the read-safety argument and
+    /// [the commit protocol](crate::docs::protocol::commit) for why `cluster_committed` is never a
+    /// value restored from storage. A node that did not persist `committed` can use this in place
+    /// of, or together with, saving it (see [log pointers](crate::docs::data::log_pointers)).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // On startup, block until the state machine has recovered the committed state before
+    /// // serving reads:
+    /// raft.wait_for_recovery(Some(Duration::from_secs(5))).await?;
+    /// ```
     #[since(version = "0.10.0")]
     pub async fn wait_for_recovery(&self, timeout: Option<Duration>) -> Result<RaftMetrics<C>, WaitError> {
         let start = C::now();

--- a/openraft/src/raft_state/membership_state/membership_state_test.rs
+++ b/openraft/src/raft_state/membership_state/membership_state_test.rs
@@ -121,8 +121,7 @@ fn test_membership_state_commit() -> anyhow::Result<()> {
     // Less than committed
     {
         let mut ms = new();
-        let got = ms.commit(&Some(log_id(1, 1, 1)));
-        assert_eq!(None, got);
+        ms.commit(&Some(log_id(1, 1, 1)));
         assert_eq!(&Some(log_id(2, 1, 2)), ms.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), ms.effective().log_id());
     }
@@ -130,8 +129,7 @@ fn test_membership_state_commit() -> anyhow::Result<()> {
     // Equal committed
     {
         let mut ms = new();
-        let got = ms.commit(&Some(log_id(2, 1, 2)));
-        assert_eq!(None, got);
+        ms.commit(&Some(log_id(2, 1, 2)));
         assert_eq!(&Some(log_id(2, 1, 2)), ms.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), ms.effective().log_id());
     }
@@ -139,8 +137,7 @@ fn test_membership_state_commit() -> anyhow::Result<()> {
     // Greater than committed, smaller than effective
     {
         let mut ms = new();
-        let got = ms.commit(&Some(log_id(2, 1, 3)));
-        assert_eq!(None, got);
+        ms.commit(&Some(log_id(2, 1, 3)));
         assert_eq!(&Some(log_id(2, 1, 2)), ms.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), ms.effective().log_id());
     }
@@ -148,8 +145,7 @@ fn test_membership_state_commit() -> anyhow::Result<()> {
     // Greater than committed, equal effective
     {
         let mut ms = new();
-        let got = ms.commit(&Some(log_id(3, 1, 4)));
-        assert_eq!(Some((Some(log_id(2, 1, 2)), log_id(3, 1, 4))), got);
+        ms.commit(&Some(log_id(3, 1, 4)));
         assert_eq!(&Some(log_id(3, 1, 4)), ms.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), ms.effective().log_id());
     }
@@ -157,27 +153,24 @@ fn test_membership_state_commit() -> anyhow::Result<()> {
     // Greater than effective
     {
         let mut ms = new();
-        let got = ms.commit(&Some(log_id(3, 1, 5)));
-        assert_eq!(Some((Some(log_id(2, 1, 2)), log_id(3, 1, 4))), got);
+        ms.commit(&Some(log_id(3, 1, 5)));
         assert_eq!(&Some(log_id(3, 1, 4)), ms.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), ms.effective().log_id());
     }
 
-    // Commit again: the effective membership is already committed; no change to report.
+    // Commit again: the effective membership is already committed; committed stays unchanged.
     {
         let mut ms = new();
         ms.commit(&Some(log_id(3, 1, 4)));
-        let got = ms.commit(&Some(log_id(3, 1, 5)));
-        assert_eq!(None, got);
+        ms.commit(&Some(log_id(3, 1, 5)));
         assert_eq!(&Some(log_id(3, 1, 4)), ms.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), ms.effective().log_id());
     }
 
-    // Initial state: both log ids are None; no change to report.
+    // Initial state: both log ids are None; committed stays None.
     {
         let mut ms = MembershipStateOf::<UTConfig>::default();
-        let got = ms.commit(&Some(log_id(1, 1, 1)));
-        assert_eq!(None, got);
+        ms.commit(&Some(log_id(1, 1, 1)));
         assert_eq!(&None, ms.committed().log_id());
         assert_eq!(&None, ms.effective().log_id());
     }

--- a/openraft/src/raft_state/membership_state/mod.rs
+++ b/openraft/src/raft_state/membership_state/mod.rs
@@ -123,14 +123,7 @@ where
     ///
     /// Committing replaces `self.committed`(the membership state machine) with
     /// `self.effective`(the last membership log).
-    ///
-    /// If the committed membership config changes, it returns the committed log ids before and
-    /// after the update; otherwise it returns `None`, e.g., when the effective membership is
-    /// already committed.
-    pub(crate) fn commit(
-        &mut self,
-        committed_log_id: &Option<LogId<CLID>>,
-    ) -> Option<(Option<LogId<CLID>>, LogId<CLID>)> {
+    pub(crate) fn commit(&mut self, committed_log_id: &Option<LogId<CLID>>) {
         let current = self.committed.log_id().clone();
         let last = self.effective().log_id().clone();
 
@@ -138,12 +131,7 @@ where
         if committed_log_id >= &last && current < last {
             debug_assert!(committed_log_id.index() >= last.index());
             self.committed = self.effective.clone();
-
-            // `current < last` implies `last` is not `None`.
-            return Some((current, last.unwrap()));
         }
-
-        None
     }
 
     /// Install the membership config carried by a snapshot.

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use std::ops::Deref;
 use std::sync::Arc;
 
+use openraft_macros::since;
 use validit::Valid;
 use validit::Validate;
 
@@ -177,12 +178,12 @@ where C: RaftTypeConfig
             // There is no snapshot, it is possible the application does not store snapshot, and
             // just restarted. it is just ok.
             // In such a case, we assert the monotonic relation without  snapshot-last-log-id
-            validit::less_equal!(self.purge_upto(), self.committed());
+            validit::less_equal!(self.purge_upto(), self.local_committed());
         } else {
             validit::less_equal!(self.purge_upto(), self.snapshot_last_log_id());
         }
-        validit::less_equal!(self.snapshot_last_log_id(), self.committed());
-        validit::less_equal!(self.committed(), self.last_log_id());
+        validit::less_equal!(self.snapshot_last_log_id(), self.local_committed());
+        validit::less_equal!(self.local_committed(), self.last_log_id());
 
         self.membership_state.validate()?;
         self.io_state.validate()?;
@@ -221,9 +222,33 @@ where C: RaftTypeConfig
         self.vote.last_update()
     }
 
-    /// Get the last committed log ID.
-    pub fn committed(&self) -> Option<&LogIdOf<C>> {
+    /// Get the local committed log ID: the log id up to which entries are safe to apply to the
+    /// local state machine.
+    ///
+    /// On a node that has not yet received and accepted all committed entries (e.g. a follower
+    /// catching up, or just after restart), this may lag [`Self::cluster_committed`].
+    #[since(version = "0.10.0")]
+    pub fn local_committed(&self) -> Option<&LogIdOf<C>> {
         self.apply_progress().accepted()
+    }
+
+    /// Get the cluster committed log ID: the log id granted by a quorum, as last reported by the
+    /// leader.
+    ///
+    /// This is the cluster-wide commit, visible to all future leaders. It may be ahead of
+    /// [`Self::local_committed`] on a node that has not yet received the corresponding entries.
+    #[since(version = "0.10.0")]
+    pub fn cluster_committed(&self) -> Option<&LogIdOf<C>> {
+        self.io_state().cluster_committed.value().and_then(|io_id| io_id.last_log_id())
+    }
+
+    /// Get the last committed log ID.
+    #[deprecated(
+        since = "0.10.0",
+        note = "use `local_committed()` instead, or `cluster_committed()` for the quorum-granted commit"
+    )]
+    pub fn committed(&self) -> Option<&LogIdOf<C>> {
+        self.local_committed()
     }
 
     pub(crate) fn is_initialized(&self) -> bool {
@@ -308,7 +333,7 @@ where C: RaftTypeConfig
             func_name!(),
             cluster_committed,
             self.accepted_log_io().display(),
-            self.committed().display()
+            self.local_committed().display()
         );
 
         self.io_state_mut().cluster_committed.try_update(cluster_committed.clone()).ok();
@@ -326,22 +351,11 @@ where C: RaftTypeConfig
     ///
     /// This method updates the committed log id only if the input is greater than the current
     /// value.
-    ///
-    /// If updated, it returns `Some(membership_transition)`, where `membership_transition` is
-    /// the committed membership config change reported by `MembershipState::commit()`;
-    /// otherwise it returns `None`.
-    pub(crate) fn update_local_committed(
-        &mut self,
-        committed: &Option<LogIdOf<C>>,
-    ) -> Option<Option<(Option<LogIdOf<C>>, LogIdOf<C>)>> {
-        if committed.as_ref() > self.committed() {
+    pub(crate) fn update_local_committed(&mut self, committed: &Option<LogIdOf<C>>) {
+        if committed.as_ref() > self.local_committed() {
             // Safe unwrap(): committed > self.committed(), implies it cannot be None
             self.apply_progress_mut().accept(committed.clone().unwrap());
-            let membership_transition = self.membership_state.commit(committed);
-
-            Some(membership_transition)
-        } else {
-            None
+            self.membership_state.commit(committed);
         }
     }
 

--- a/openraft/src/raft_state/tests/update_committed_test.rs
+++ b/openraft/src/raft_state/tests/update_committed_test.rs
@@ -48,7 +48,7 @@ fn test_update_committed_none() -> anyhow::Result<()> {
 
     state.update_committed(LogIOId::new(committed_vote, None));
 
-    assert_eq!(Some(&log_id(1, 1, 1)), state.committed());
+    assert_eq!(Some(&log_id(1, 1, 1)), state.local_committed());
     assert_eq!(
         MembershipState::new(
             Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m01())),
@@ -72,7 +72,7 @@ fn test_update_committed_ge_accepted() -> anyhow::Result<()> {
 
     // Local committed is min(accepted, cluster_committed) = min(log_id(1,1,2), log_id(2,1,3)) =
     // log_id(1,1,2)
-    assert_eq!(Some(&log_id(1, 1, 2)), state.committed());
+    assert_eq!(Some(&log_id(1, 1, 2)), state.local_committed());
     assert_eq!(
         MembershipState::new(
             Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m01())),
@@ -96,7 +96,7 @@ fn test_update_committed_le_accepted() -> anyhow::Result<()> {
 
     // Local committed is min(accepted, cluster_committed) = min(log_id(3,1,4), log_id(2,1,3)) =
     // log_id(2,1,3)
-    assert_eq!(Some(&log_id(2, 1, 3)), state.committed());
+    assert_eq!(Some(&log_id(2, 1, 3)), state.local_committed());
     assert_eq!(
         MembershipState::new(
             Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(2, 1, 3)), m23())),
@@ -122,7 +122,7 @@ fn test_update_committed_local_vote_lags_cluster_vote() -> anyhow::Result<()> {
     state.update_committed(cluster_committed.clone());
 
     // Local committed must not advance until an IO accepted under the new leader vote arrives.
-    assert_eq!(Some(&log_id(1, 1, 1)), state.committed());
+    assert_eq!(Some(&log_id(1, 1, 1)), state.local_committed());
     assert_eq!(
         Some(cluster_committed),
         state.io_state.cluster_committed.value().cloned()
@@ -144,7 +144,7 @@ fn test_update_committed_advances_after_local_vote_catches_up() -> anyhow::Resul
 
     // Commit notification arrives before logs from the new leader; no local advancement yet.
     state.update_committed(cluster_committed.clone());
-    assert_eq!(Some(&log_id(1, 1, 1)), state.committed());
+    assert_eq!(Some(&log_id(1, 1, 1)), state.local_committed());
 
     // Later the follower accepts the log written by the new leader.
     state.log_progress_mut().accept(IOId::new_log_io(higher_vote.clone(), Some(log_id(3, 2, 4))));
@@ -152,9 +152,63 @@ fn test_update_committed_advances_after_local_vote_catches_up() -> anyhow::Resul
     // Re-evaluating committed now that votes match should advance local committed.
     state.update_committed(cluster_committed.clone());
 
-    assert_eq!(Some(&log_id(3, 2, 4)), state.committed());
+    assert_eq!(Some(&log_id(3, 2, 4)), state.local_committed());
     assert_eq!(Some(&log_id(3, 2, 4)), state.io_state.apply_progress.accepted());
     assert_eq!(None, state.io_state.apply_progress.submitted());
+
+    Ok(())
+}
+
+#[test]
+fn test_committed_accessors() -> anyhow::Result<()> {
+    // Fresh state: neither commit is known yet.
+    {
+        let state = RaftState::<UTConfig>::default();
+        assert_eq!(None, state.local_committed());
+        assert_eq!(None, state.cluster_committed());
+    }
+
+    // Restored node: `local_committed` is restored from storage (the apply ceiling), but
+    // `cluster_committed` is never restored — it stays None until a quorum re-grants a commit. This
+    // guards the invariant that a non-null `cluster_committed` is always a genuine, freshly granted
+    // cluster commit, never a value read back from `RaftStorage`.
+    {
+        let state = new_state();
+        assert_eq!(Some(&log_id(1, 1, 1)), state.local_committed());
+        assert_eq!(None, state.cluster_committed());
+    }
+
+    // Caught-up node: the accepted log id reaches the quorum-granted commit, so the two agree.
+    {
+        let mut state = new_state();
+        let committed_vote = state.vote_ref().into_committed();
+        state.log_progress_mut().accept(IOId::new_log_io(committed_vote.clone(), Some(log_id(2, 1, 3))));
+
+        state.update_committed(LogIOId::new(committed_vote, Some(log_id(2, 1, 3))));
+
+        assert_eq!(Some(&log_id(2, 1, 3)), state.cluster_committed());
+        assert_eq!(Some(&log_id(2, 1, 3)), state.local_committed());
+    }
+
+    // Lagging follower: a commit granted under a newer leader vote arrives before its logs, so
+    // cluster-committed leads local-committed.
+    {
+        let mut state = new_state();
+        let committed_vote = state.vote_ref().into_committed();
+        state.log_progress_mut().accept(IOId::new_log_io(committed_vote, Some(log_id(2, 1, 3))));
+
+        let higher_vote = Vote::new_committed(3, 2).into_committed();
+        state.update_committed(LogIOId::new(higher_vote, Some(log_id(3, 2, 4))));
+
+        assert_eq!(Some(&log_id(3, 2, 4)), state.cluster_committed());
+        assert_eq!(Some(&log_id(1, 1, 1)), state.local_committed());
+
+        // The deprecated `committed()` mirrors `local_committed()`, not `cluster_committed()`.
+        #[allow(deprecated)]
+        {
+            assert_eq!(state.local_committed(), state.committed());
+        }
+    }
 
     Ok(())
 }

--- a/openraft/src/storage/v2/raft_log_storage.rs
+++ b/openraft/src/storage/v2/raft_log_storage.rs
@@ -68,13 +68,35 @@ where C: RaftTypeConfig
     ///
     /// If the state machine flushes state to disk before
     /// returning from `apply()`, then the application does not need to implement this method.
-    /// Otherwise, this method is also optional(but not recommended), but your application has to
-    /// deal with state reversion of state machine carefully upon restart. E.g., do not serve
-    /// read operation a new `commit` message is received.
+    /// Otherwise, this method is optional (but not recommended): without it the state machine
+    /// may revert to an older state on restart, and the application must handle that carefully.
     ///
-    /// See: [`docs::data::log_pointers`].
+    /// When `committed` is not saved, on restart the state machine is recovered only to the last
+    /// snapshot. It catches back up once this node perceives the cluster commit re-established by
+    /// the current leader and re-applies up to it; until then a read — linearizable or not — may
+    /// observe a state older than one already observed before the restart.
+    ///
+    /// To avoid serving such a reverted read, either:
+    ///
+    /// - save `committed` here (recommended): the recovered `committed` is then the true
+    ///   pre-restart value, and the state machine is re-applied up to it on startup; or
+    /// - wait for recovery before serving reads: [`Raft::wait_for_recovery`] blocks until the
+    ///   re-established cluster commit has been applied. This is sound for the same reason
+    ///   linearizable reads are — the re-established commit is at least the current leader's first
+    ///   (blank) log entry, hence at least any previously applied log id (the `read_log_id`
+    ///   condition).
+    ///
+    /// ```ignore
+    /// let raft = Raft::new(id, config, network, log_store, sm).await?;
+    /// raft.wait_for_recovery(Some(Duration::from_secs(5))).await?;
+    /// ```
+    ///
+    /// See: [`docs::data::log_pointers`], [`docs::protocol::read`] and [`docs::protocol::commit`].
     ///
     /// [`docs::data::log_pointers`]: `crate::docs::data::log_pointers#optionally-persisted-committed`
+    /// [`docs::protocol::read`]: `crate::docs::protocol::read`
+    /// [`docs::protocol::commit`]: `crate::docs::protocol::commit`
+    /// [`Raft::wait_for_recovery`]: `crate::Raft::wait_for_recovery`
     async fn save_committed(&mut self, _committed: Option<LogIdOf<C>>) -> Result<(), io::Error> {
         // By default `committed` log id is not saved
         Ok(())

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -508,7 +508,7 @@ where
             "state machine has higher log"
         );
         assert_eq!(
-            initial.committed(),
+            initial.local_committed(),
             Some(&log_id_0::<C>(3, 1)),
             "unexpected value for last applied log"
         );

--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -812,7 +812,7 @@ fn run_single_iteration(
             let metrics = cluster_state.lock().unwrap().get_all_metrics();
             let leaders: Vec<_> = metrics.iter().filter(|(_, m)| m.state.is_leader()).map(|(id, _)| *id).collect();
             let max_term = metrics.iter().map(|(_, m)| m.vote.leader_id().term).max().unwrap_or(0);
-            let max_committed = metrics.iter().filter_map(|(_, m)| m.committed).max_by_key(|id| id.index());
+            let max_committed = metrics.iter().filter_map(|(_, m)| m.local_committed).max_by_key(|id| id.index());
             println!(
                 "[Step {steps}] leaders={leaders:?}, term={max_term}, \
                  voters={active_voters:?}, checks={invariant_checks}, \
@@ -831,7 +831,7 @@ fn run_single_iteration(
     let metrics = cluster_state.lock().unwrap().get_all_metrics();
     let leaders: Vec<_> = metrics.iter().filter(|(_, m)| m.state.is_leader()).map(|(id, _)| *id).collect();
     let max_term = metrics.iter().map(|(_, m)| m.vote.leader_id().term).max().unwrap_or(0);
-    let max_committed = metrics.iter().filter_map(|(_, m)| m.committed).max_by_key(|id| id.index());
+    let max_committed = metrics.iter().filter_map(|(_, m)| m.local_committed).max_by_key(|id| id.index());
     println!(
         "Final summary: leaders={leaders:?}, term={max_term}, voters={active_voters:?}, \
          workload_attempts={}, max_committed={max_committed:?}",

--- a/tests-turmoil/src/invariants/committed_immutable.rs
+++ b/tests-turmoil/src/invariants/committed_immutable.rs
@@ -38,7 +38,9 @@ impl Witness {
         violations: &mut Vec<InvariantViolation>,
     ) {
         for (node_id, s) in snapshots {
-            let Some(committed) = s.raft.committed else { continue };
+            let Some(committed) = s.raft.local_committed else {
+                continue;
+            };
 
             // Include the purged entry (boundary) — see module docs.
             let first = s.raft.log_id_list.purged().map(|id| id.index()).unwrap_or(0);

--- a/tests-turmoil/src/invariants/committed_on_quorum.rs
+++ b/tests-turmoil/src/invariants/committed_on_quorum.rs
@@ -35,7 +35,7 @@ pub fn check(
         if !s.raft.state.is_leader() {
             continue;
         }
-        let Some(committed) = &s.raft.committed else {
+        let Some(committed) = &s.raft.local_committed else {
             continue;
         };
 

--- a/tests-turmoil/src/invariants/leader_completeness.rs
+++ b/tests-turmoil/src/invariants/leader_completeness.rs
@@ -71,7 +71,7 @@ pub fn check(snapshots: &[(NodeId, FullNodeSnapshot)], violations: &mut Vec<Inva
 fn collect_committed_entries(snapshots: &[(NodeId, FullNodeSnapshot)]) -> HashMap<u64, LogId> {
     let mut committed: HashMap<u64, LogId> = HashMap::new();
     for (_, s) in snapshots {
-        let Some(c) = s.raft.committed else { continue };
+        let Some(c) = s.raft.local_committed else { continue };
 
         // Include the purged entry (`LogIdList::get(purged.index)` returns it).
         let first = s.raft.log_id_list.purged().map(|id| id.index()).unwrap_or(0);

--- a/tests-turmoil/src/invariants/log_matching.rs
+++ b/tests-turmoil/src/invariants/log_matching.rs
@@ -27,8 +27,8 @@ pub fn check(a: &(NodeId, FullNodeSnapshot), b: &(NodeId, FullNodeSnapshot), vio
     let (id_a, s_a) = a;
     let (id_b, s_b) = b;
 
-    let last_a = s_a.raft.committed.map(|id: LogId| id.index()).unwrap_or(0);
-    let last_b = s_b.raft.committed.map(|id: LogId| id.index()).unwrap_or(0);
+    let last_a = s_a.raft.local_committed.map(|id: LogId| id.index()).unwrap_or(0);
+    let last_b = s_b.raft.local_committed.map(|id: LogId| id.index()).unwrap_or(0);
 
     // Include the purged entry itself — `LogIdList::get(purged.index)` returns
     // the purged log id, so we can still compare at the boundary.

--- a/tests-turmoil/src/invariants/monotonic.rs
+++ b/tests-turmoil/src/invariants/monotonic.rs
@@ -63,7 +63,7 @@ impl MonotonicHistory {
 fn observe(s: &FullNodeSnapshot) -> LastSeen {
     LastSeen {
         term: s.raft.current_term,
-        committed_index: s.raft.committed.as_ref().map(|id| id.index()).unwrap_or(0),
+        committed_index: s.raft.local_committed.as_ref().map(|id| id.index()).unwrap_or(0),
         applied_index: s.raft.last_applied.as_ref().map(|id| id.index()).unwrap_or(0),
         vote: s.raft.vote,
     }

--- a/tests-turmoil/src/invariants/state_ordering.rs
+++ b/tests-turmoil/src/invariants/state_ordering.rs
@@ -19,7 +19,7 @@ pub fn check(node: NodeId, s: &FullNodeSnapshot, violations: &mut Vec<InvariantV
     let purged = s.raft.purged.as_ref().map(|id| id.index());
     let snapshot = s.raft.snapshot.as_ref().map(|id| id.index());
     let applied = s.raft.last_applied.as_ref().map(|id| id.index());
-    let committed = s.raft.committed.as_ref().map(|id| id.index());
+    let committed = s.raft.local_committed.as_ref().map(|id| id.index());
     let last_log = s.raft.last_log_index;
 
     let pairs = [

--- a/tests-turmoil/src/invariants/tests.rs
+++ b/tests-turmoil/src/invariants/tests.rs
@@ -147,7 +147,7 @@ impl SnapshotBuilder {
         raft.vote = vote;
         raft.state = self.state;
         raft.last_log_index = self.last_log_index;
-        raft.committed = self.committed;
+        raft.local_committed = self.committed;
         raft.last_applied = self.last_applied;
         raft.snapshot = self.snapshot;
         raft.purged = self.purged;

--- a/tests/tests/client_api/t16_with_raft_state.rs
+++ b/tests/tests/client_api/t16_with_raft_state.rs
@@ -28,13 +28,17 @@ async fn with_raft_state() -> Result<()> {
 
     let n0 = router.get_raft_handle(&0)?;
 
-    let committed = n0.with_raft_state(|st| st.committed().cloned()).await?;
+    let committed = n0.with_raft_state(|st| st.local_committed().cloned()).await?;
     assert_eq!(committed, Some(log_id(1, 0, log_index)));
+
+    // On the leader, the cluster-committed log id equals the local committed log id.
+    let cluster_committed = n0.with_raft_state(|st| st.cluster_committed().cloned()).await?;
+    assert_eq!(cluster_committed, Some(log_id(1, 0, log_index)));
 
     tracing::info!("--- shutting down node 0");
     n0.shutdown().await?;
 
-    let res = n0.with_raft_state(|st| st.committed().cloned()).await;
+    let res = n0.with_raft_state(|st| st.local_committed().cloned()).await;
     assert_eq!(Err(Fatal::Stopped), res);
 
     Ok(())

--- a/tests/tests/life_cycle/main.rs
+++ b/tests/tests/life_cycle/main.rs
@@ -11,6 +11,7 @@ mod t10_initialization;
 mod t11_shutdown;
 mod t50_follower_restart_does_not_interrupt;
 mod t50_leader_restart_clears_state;
+mod t50_leader_restart_cluster_committed_not_restored;
 mod t50_leader_restart_leader_restore_disabled;
 mod t50_single_follower_restart;
 mod t50_single_leader_restart_re_apply_logs;

--- a/tests/tests/life_cycle/main.rs
+++ b/tests/tests/life_cycle/main.rs
@@ -15,6 +15,7 @@ mod t50_leader_restart_cluster_committed_not_restored;
 mod t50_leader_restart_leader_restore_disabled;
 mod t50_single_follower_restart;
 mod t50_single_leader_restart_re_apply_logs;
+mod t50_wait_for_recovery;
 mod t90_issue_607_single_restart;
 mod t90_issue_881_transient_state_machine;
 mod t90_issue_920_non_voter_leader_restart;

--- a/tests/tests/life_cycle/t50_leader_restart_cluster_committed_not_restored.rs
+++ b/tests/tests/life_cycle/t50_leader_restart_cluster_committed_not_restored.rs
@@ -1,0 +1,159 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::Config;
+use openraft::RPCTypes;
+use openraft::ServerState;
+use openraft::errors::Infallible;
+use openraft::errors::RPCError;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::MemLogStore;
+use crate::fixtures::MemRaft;
+use crate::fixtures::MemStateMachine;
+use crate::fixtures::RaftRouter;
+use crate::fixtures::rpc_request::RpcRequest;
+use crate::fixtures::ut_harness;
+
+/// A leader that restarts and restores leadership without a re-election must not surface a
+/// cluster-committed log id that was read back from storage.
+///
+/// `cluster_committed` is established only by replicating to a quorum; it is never restored from
+/// `RaftStorage`. So a restored leader that has lost its quorum reports `local_committed` (the
+/// apply ceiling, restored from storage) while `cluster_committed` stays `None`. This guarantees a
+/// non-null `cluster_committed` in the metrics is always a genuine, freshly quorum-granted commit
+/// — never a stale value resurrected from storage and broadcast to followers.
+///
+/// Beyond the metric, the test triggers a heartbeat and asserts the broadcast
+/// `AppendEntriesRequest.leader_commit` is null, proving the restored commit never reaches the
+/// wire.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn leader_restart_cluster_committed_not_restored() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- bring up a 3-node cluster; node-0 is the leader");
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- the live leader has an established cluster commit");
+    {
+        let m = router.get_metrics(&0)?;
+        assert_eq!(
+            Some(log_index),
+            m.cluster_committed.as_ref().map(|x| x.index()),
+            "cluster_committed established by quorum replication"
+        );
+        assert_eq!(Some(log_index), m.local_committed.as_ref().map(|x| x.index()));
+    }
+
+    tracing::info!(
+        log_index,
+        "--- take both followers offline so the leader loses its quorum"
+    );
+    for id in [1, 2] {
+        let (node, _ls, _sm): (MemRaft, MemLogStore, MemStateMachine) = router.remove_node(id).unwrap();
+        node.shutdown().await?;
+    }
+
+    tracing::info!(
+        log_index,
+        "--- restart node-0 with its persisted state; it restores leadership"
+    );
+    {
+        let (node, ls, sm): (MemRaft, MemLogStore, MemStateMachine) = router.remove_node(0).unwrap();
+        node.shutdown().await?;
+
+        router.new_raft_node_with_sto(0, ls, sm).await;
+        router.wait(&0, timeout()).state(ServerState::Leader, "restore leadership without election").await?;
+        router.wait(&0, timeout()).applied_index(Some(log_index), "applied restored from storage").await?;
+    }
+
+    tracing::info!(
+        log_index,
+        "--- local_committed is restored from storage, cluster_committed is not"
+    );
+    {
+        let m = router.get_metrics(&0)?;
+
+        // The committed value persisted in `RaftStorage` is restored into the local apply ceiling.
+        assert_eq!(
+            Some(log_index),
+            m.local_committed.as_ref().map(|x| x.index()),
+            "local_committed restored from storage"
+        );
+
+        // Without a quorum the restored leader can never re-establish the cluster commit, so the
+        // restored value is never promoted to `cluster_committed` nor broadcast to followers.
+        assert_eq!(
+            None, m.cluster_committed,
+            "cluster_committed must not be restored from storage"
+        );
+    }
+
+    tracing::info!(
+        log_index,
+        "--- a triggered heartbeat must broadcast a null leader_commit"
+    );
+    {
+        // Intercept node-0's outgoing AppendEntries (heartbeats use the same RPC) and record the
+        // `leader_commit` carried on the wire.
+        let total = Arc::new(AtomicU64::new(0));
+        let non_null = Arc::new(AtomicU64::new(0));
+        {
+            let total = total.clone();
+            let non_null = non_null.clone();
+            router
+                .set_rpc_pre_hook(RPCTypes::AppendEntries, move |_router, req, from_id, _target| {
+                    if from_id == 0
+                        && let RpcRequest::AppendEntries(ae) = &req
+                    {
+                        total.fetch_add(1, Ordering::Relaxed);
+                        if ae.leader_commit.is_some() {
+                            non_null.fetch_add(1, Ordering::Relaxed);
+                        }
+                    }
+                    Box::pin(futures::future::ready(Ok::<(), RPCError<TypeConfig, Infallible>>(())))
+                })
+                .await;
+        }
+
+        router.get_raft_handle(&0)?.trigger().heartbeat().await?;
+
+        // Wait until the heartbeat workers have actually emitted the broadcast.
+        let mut sent = 0;
+        for _ in 0..100 {
+            sent = total.load(Ordering::Relaxed);
+            if sent > 0 {
+                break;
+            }
+            TypeConfig::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(sent > 0, "the restored leader must broadcast at least one heartbeat");
+
+        // The commit restored from storage is never put on the wire.
+        assert_eq!(
+            0,
+            non_null.load(Ordering::Relaxed),
+            "a restored leader's heartbeat must broadcast a null leader_commit"
+        );
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}

--- a/tests/tests/life_cycle/t50_wait_for_recovery.rs
+++ b/tests/tests/life_cycle/t50_wait_for_recovery.rs
@@ -1,0 +1,121 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::Config;
+use openraft::ServerState;
+use openraft::metrics::WaitError;
+
+use crate::fixtures::MemLogStore;
+use crate::fixtures::MemRaft;
+use crate::fixtures::MemStateMachine;
+use crate::fixtures::RaftRouter;
+use crate::fixtures::ut_harness;
+
+/// `wait_for_recovery` returns once the cluster commit is re-established and the state machine has
+/// applied up to it.
+///
+/// A follower restarts with a cleared (transient) state machine and `save_committed` disabled, so
+/// nothing is recovered locally on startup — recovery is driven entirely by the cluster commit the
+/// leader replicates. The surviving `{0,2}` quorum keeps that commit established.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn wait_for_recovery_recovers_state_machine() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: true,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    // Recovery must come from the cluster commit, not a locally restored committed pointer.
+    router.enable_saving_committed = false;
+
+    tracing::info!("--- bring up a 3-node cluster; node-0 is the leader");
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- restart follower node-1 with a cleared state machine");
+    {
+        let (node, ls, sm): (MemRaft, MemLogStore, MemStateMachine) = router.remove_node(1).unwrap();
+        node.shutdown().await?;
+
+        // Transient state machine: in-memory applied state is lost on restart.
+        sm.clear_state_machine().await;
+
+        router.new_raft_node_with_sto(1, ls, sm).await;
+    }
+
+    tracing::info!(
+        log_index,
+        "--- wait_for_recovery returns once the state machine catches up"
+    );
+    {
+        let m = router.get_raft_handle(&1)?.wait_for_recovery(timeout()).await?;
+
+        assert!(m.cluster_committed.is_some(), "the cluster commit is perceived");
+        assert!(
+            m.last_applied.as_ref().map(|x| x.index()) >= Some(log_index),
+            "state machine recovered: last_applied {:?} >= {}",
+            m.last_applied,
+            log_index
+        );
+    }
+
+    Ok(())
+}
+
+/// `wait_for_recovery` times out when no cluster commit can be re-established.
+///
+/// A restarted leader that has lost its quorum never perceives a non-null cluster commit, so the
+/// recovery wait cannot complete and returns [`WaitError::Timeout`].
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn wait_for_recovery_times_out_without_quorum() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- bring up a 3-node cluster; node-0 is the leader");
+    let _log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    tracing::info!("--- take both followers offline so the leader loses its quorum");
+    for id in [1, 2] {
+        let (node, _ls, _sm): (MemRaft, MemLogStore, MemStateMachine) = router.remove_node(id).unwrap();
+        node.shutdown().await?;
+    }
+
+    tracing::info!("--- restart node-0; it restores leadership but cannot re-establish the commit");
+    {
+        let (node, ls, sm): (MemRaft, MemLogStore, MemStateMachine) = router.remove_node(0).unwrap();
+        node.shutdown().await?;
+
+        router.new_raft_node_with_sto(0, ls, sm).await;
+        router.wait(&0, timeout()).state(ServerState::Leader, "restore leadership without election").await?;
+    }
+
+    tracing::info!("--- with no quorum the cluster commit stays null, so recovery times out");
+    {
+        let res = router.get_raft_handle(&0)?.wait_for_recovery(Some(Duration::from_millis(500))).await;
+        assert!(
+            matches!(res, Err(WaitError::Timeout(..))),
+            "expected a timeout, got {:?}",
+            res
+        );
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(2_000))
+}

--- a/tests/tests/metrics/t10_server_metrics_and_data_metrics.rs
+++ b/tests/tests/metrics/t10_server_metrics_and_data_metrics.rs
@@ -234,6 +234,104 @@ async fn committed_membership_config() -> Result<()> {
     Ok(())
 }
 
+/// The `cluster_committed` metric reports the quorum-granted commit. It is exposed via both
+/// `metrics()` and `data_metrics()`, and in steady state equals the local `committed`.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn cluster_committed_metric() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- initializing cluster");
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- write logs to advance the commit");
+    log_index += router.client_request_many(0, "foo", 10).await?;
+
+    for id in [0, 1, 2] {
+        // Once applied reaches the last log, the local committed and the cluster committed have
+        // both converged to it (applied <= local_committed <= cluster_committed).
+        router.wait(&id, timeout()).applied_index(Some(log_index), "applied log index").await?;
+
+        let node = router.get_raft_handle(&id)?;
+        let metrics = node.metrics().borrow_watched().clone();
+        let data_metrics = node.data_metrics().borrow_watched().clone();
+
+        // The cluster-committed frontier reached the last written log.
+        assert_eq!(
+            metrics.cluster_committed.as_ref().map(|x| x.index()),
+            Some(log_index),
+            "node {}: cluster_committed index",
+            id
+        );
+
+        // In steady state the quorum-granted commit equals the local committed.
+        assert_eq!(
+            metrics.cluster_committed, metrics.local_committed,
+            "node {}: cluster_committed should equal local_committed",
+            id
+        );
+
+        // The deprecated `committed` field is still populated, mirroring `local_committed`.
+        #[allow(deprecated)]
+        {
+            assert_eq!(
+                metrics.committed, metrics.local_committed,
+                "node {}: deprecated committed mirrors local_committed",
+                id
+            );
+        }
+
+        // The same values are reported through data_metrics.
+        assert_eq!(
+            data_metrics.local_committed, metrics.local_committed,
+            "node {}: data_metrics.local_committed should match metrics",
+            id
+        );
+        assert_eq!(
+            data_metrics.cluster_committed, metrics.cluster_committed,
+            "node {}: data_metrics.cluster_committed should match metrics",
+            id
+        );
+
+        // The deprecated data_metrics `committed` field is still populated, mirroring
+        // `local_committed`.
+        #[allow(deprecated)]
+        {
+            assert_eq!(
+                data_metrics.committed, data_metrics.local_committed,
+                "node {}: deprecated data_metrics.committed mirrors local_committed",
+                id
+            );
+        }
+
+        // The canonical fields are rendered by the Display impls.
+        let metrics_str = format!("{}", metrics);
+        assert!(
+            metrics_str.contains("local_committed:") && metrics_str.contains("cluster_committed:"),
+            "node {}: RaftMetrics Display should include local_committed and cluster_committed: {}",
+            id,
+            metrics_str
+        );
+        let data_metrics_str = format!("{}", data_metrics);
+        assert!(
+            data_metrics_str.contains("local_committed:") && data_metrics_str.contains("cluster_committed:"),
+            "node {}: RaftDataMetrics Display should include local_committed and cluster_committed: {}",
+            id,
+            data_metrics_str
+        );
+    }
+
+    Ok(())
+}
+
 fn timeout() -> Option<Duration> {
     Some(Duration::from_millis(500))
 }


### PR DESCRIPTION
## Summary

Adds `Raft::wait_for_recovery` — a one-shot readiness signal for a restarted
node. Call it right after `Raft::new`; it blocks until this node's state machine
has recovered to at least its pre-restart state, so the application can serve
reads without observing a reverted state.

```ignore
let raft = Raft::new(id, config, network, log_store, sm).await?;
raft.wait_for_recovery(Some(Duration::from_secs(5))).await?;
```

## Why

When `committed` is not persisted and the state machine does not flush on
`apply()`, a restarted node recovers only to its last snapshot, and a later read
may observe a state older than one already returned before the restart.
Persisting `committed` is one remedy; `wait_for_recovery` is the other and needs
no extra bookkeeping: it waits for the current leader to re-establish the cluster
commit, then for the state machine to apply up to it.

## Supporting change: two commit frontiers

Recovery is sound because Openraft now distinguishes two frontiers:

- `local_committed` — entries safe to apply to this node's state machine.
- `cluster_committed` — the quorum-granted frontier; never restored from
  storage, so a non-null value is always genuine and ≥ everything applied before
  the restart.

Both are exposed on `RaftState` and `RaftMetrics`, and
`AppendEntries.leader_commit` now carries the cluster value — so a leader that
restarts and resumes leadership without re-election broadcasts a null commit
until it re-establishes one. The old `committed` name is deprecated and keeps
returning the local value.

A small refactor is bundled in: `MembershipState::commit()` returns a named
`CommittedMembershipTransition` instead of an anonymous tuple.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1788)
<!-- Reviewable:end -->
