### PR TITLE
Make sure get_log_id_range never turns reversed range

### DIFF
--- a/openraft/src/replication/stream_state.rs
+++ b/openraft/src/replication/stream_state.rs
@@ -146,7 +146,8 @@ where
 
             if last_log_id > prev || committed > self.leader_committed {
                 self.leader_committed = committed;
-                return Some(LogIdRange::new(prev, last_log_id));
+                let last = std::cmp::max(last_log_id, prev.clone());
+                return Some(LogIdRange::new(prev, last));
             } else {
                 let data_change = self.event_watcher.replicate_rx.changed();
                 let io_change = self.event_watcher.io_submitted_rx.changed();
@@ -171,7 +172,8 @@ where
                         // in which scenario, it is for replication committed log id,
                         // thus we just emit an RPC once committed receiver is notified.
                         self.leader_committed = self.event_watcher.committed_rx.borrow_watched().clone();
-                        return Some(LogIdRange::new(prev, last_log_id));
+                        let last = std::cmp::max(last_log_id, prev.clone());
+                        return Some(LogIdRange::new(prev, last));
                     }
                     cancel_res = cancel.fuse() => {
                         tracing::info!("Replication Stream is canceled, res: {:?}, when:(get_log_id_range:wait-for-changed)", cancel_res);
@@ -239,8 +241,17 @@ where
             (start, end)
         };
 
-        if start == end {
-            // Heartbeat RPC, no logs to send, last log id is the same as prev_log_id
+        if start >= end {
+            // Heartbeat RPC: no logs to send. Callers guarantee prev <= last,
+            // so this should only be reached with start == end. The >= guard
+            // is defense-in-depth.
+            debug_assert!(
+                start == end,
+                "read_log_entries received reversed range: start({}) > end({}), log_id_range: {}",
+                start,
+                end,
+                log_id_range
+            );
             let r = LogIdRange::new(rng.prev.clone(), rng.prev.clone());
             Ok((vec![], r))
         } else {


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1792)
<!-- Reviewable:end -->
