### PR TITLE
chore: release: bump version to v0.10.0-alpha.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.10.0-alpha.22"
+version = "0.10.0-alpha.23"
 edition = "2024"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",

--- a/benchmarks/minimal/Cargo.toml
+++ b/benchmarks/minimal/Cargo.toml
@@ -17,8 +17,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft            = { path = "../../openraft", version = "0.10.0-alpha.22", features = ["serde", "type-alias", "runtime-stats"] }
-openraft-legacy = { path = "../../legacy", version = "0.10.0-alpha.22" }
+openraft            = { path = "../../openraft", version = "0.10.0-alpha.23", features = ["serde", "type-alias", "runtime-stats"] }
+openraft-legacy = { path = "../../legacy", version = "0.10.0-alpha.23" }
 
 anyhow     = { version = "1.0.63" }
 clap       = { version = "4.2", features = ["derive"] }

--- a/examples/rocksstore/Cargo.toml
+++ b/examples/rocksstore/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/databendlabs/openraft"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-openraft = { path = "../../openraft", version = "0.10.0-alpha.22", features = ["serde", "type-alias"] }
+openraft = { path = "../../openraft", version = "0.10.0-alpha.23", features = ["serde", "type-alias"] }
 types-kv = { path = "../types-kv" }
 
 byteorder  = { version = "1.4.3" }

--- a/legacy/Cargo.toml
+++ b/legacy/Cargo.toml
@@ -14,8 +14,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-openraft = { path = "../openraft", version = "0.10.0-alpha.22", default-features = false }
-openraft-macros = { path = "../macros", version = "0.10.0-alpha.22" }
+openraft = { path = "../openraft", version = "0.10.0-alpha.23", default-features = false }
+openraft-macros = { path = "../macros", version = "0.10.0-alpha.23" }
 
 futures = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "sync"] }

--- a/metrics-otel/Cargo.toml
+++ b/metrics-otel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openraft-metrics-otel"
-version = "0.10.0-alpha.22"
+version = "0.10.0-alpha.23"
 edition = "2024"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",
@@ -13,5 +13,5 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft = { path = "../openraft", version = "0.10.0-alpha.22" }
+openraft = { path = "../openraft", version = "0.10.0-alpha.23" }
 opentelemetry = "0.30.0"

--- a/multiraft/Cargo.toml
+++ b/multiraft/Cargo.toml
@@ -3,7 +3,7 @@ name = "openraft-multi"
 description = "Multi-Raft adapters for connection sharing across Raft groups"
 documentation = "https://docs.rs/openraft-multiraft"
 readme = "README.md"
-version = "0.10.0-alpha.22"
+version = "0.10.0-alpha.23"
 edition = "2024"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 categories = ["network-programming", "asynchronous", "data-structures"]
@@ -13,6 +13,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft  = { path = "../openraft", version = "0.10.0-alpha.22", default-features = false }
+openraft  = { path = "../openraft", version = "0.10.0-alpha.23", default-features = false }
 anyerror  = { version = "0.1" }
 

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -15,9 +15,9 @@ repository    = { workspace = true }
 
 
 [dependencies]
-openraft-rt = { path = "../rt", version = "0.10.0-alpha.22" }
-openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.22", optional = true }
-openraft-macros = { path = "../macros", version = "0.10.0-alpha.22" }
+openraft-rt = { path = "../rt", version = "0.10.0-alpha.23" }
+openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.23", optional = true }
+openraft-macros = { path = "../macros", version = "0.10.0-alpha.23" }
 
 anyerror        = { workspace = true }
 anyhow          = { workspace = true, optional = true }
@@ -44,7 +44,7 @@ peel-off        = { workspace = true }
 
 [dev-dependencies]
 anyhow            = { workspace = true }
-openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.22" }
+openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.23" }
 pretty_assertions = { workspace = true }
 serde_json        = { workspace = true }
 

--- a/rt-compio/Cargo.toml
+++ b/rt-compio/Cargo.toml
@@ -3,7 +3,7 @@ name = "openraft-rt-compio"
 description = "compio AsyncRuntime support for Openraft"
 documentation = "https://docs.rs/openraft-rt-compio"
 readme = "README.md"
-version = "0.10.0-alpha.22"
+version = "0.10.0-alpha.23"
 edition = "2024"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 categories = ["algorithms", "asynchronous", "data-structures"]
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft-rt = { path = "../rt", version = "0.10.0-alpha.22", features = ["single-threaded"] }
+openraft-rt = { path = "../rt", version = "0.10.0-alpha.23", features = ["single-threaded"] }
 
 compio           = { version = ">=0.14.0", features = ["runtime", "time"] }
 flume            = { version = "0.11.1", default-features = false, features = ["async"] }

--- a/rt-monoio/Cargo.toml
+++ b/rt-monoio/Cargo.toml
@@ -3,7 +3,7 @@ name = "openraft-rt-monoio"
 description = "monoio AsyncRuntime support for Openraft"
 documentation = "https://docs.rs/openraft-rt-monoio"
 readme = "README.md"
-version = "0.10.0-alpha.22"
+version = "0.10.0-alpha.23"
 edition = "2024"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft-rt = { path = "../rt", version = "0.10.0-alpha.22", features = ["single-threaded"] }
+openraft-rt = { path = "../rt", version = "0.10.0-alpha.23", features = ["single-threaded"] }
 
 futures-util = { version = "0.3" }
 local-sync   = { version = "0.1.1" }

--- a/rt-tokio/Cargo.toml
+++ b/rt-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.22"
+version = "0.10.0-alpha.23"
 edition = "2024"
 authors = [
     "drdrxp <drdr.xp@gmail.com>",
@@ -13,7 +13,7 @@ readme = "README.md"
 description = "Tokio runtime implementation for Openraft"
 
 [dependencies]
-openraft-rt  = { path = "../rt", version = "0.10.0-alpha.22" }
+openraft-rt  = { path = "../rt", version = "0.10.0-alpha.23" }
 tokio        = { version = "1.39", default-features = false, features = ["rt", "rt-multi-thread", "sync", "time"] }
 futures-util = { version = "0.3" }
 rand         = { version = "0.10", default-features = false, features = ["std", "std_rng", "thread_rng"] }

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -20,6 +20,6 @@ single-threaded = ["openraft-macros/single-threaded"]
 [dependencies]
 futures-channel = { workspace = true }
 futures-util    = { workspace = true }
-openraft-macros    = { version = "0.10.0-alpha.22", path = "../macros" }
+openraft-macros    = { version = "0.10.0-alpha.23", path = "../macros" }
 pin-project-lite   = { version = "0.2" }
 rand               = { workspace = true }

--- a/stores/memstore-custom-node-id/Cargo.toml
+++ b/stores/memstore-custom-node-id/Cargo.toml
@@ -12,7 +12,7 @@ license       = { workspace = true }
 repository    = { workspace = true }
 
 [dependencies]
-openraft  = { path = "../../openraft", version = "0.10.0-alpha.22", features = ["serde", "type-alias"] }
+openraft  = { path = "../../openraft", version = "0.10.0-alpha.23", features = ["serde", "type-alias"] }
 
 futures    = { workspace = true }
 serde      = { workspace = true }

--- a/stores/memstore/Cargo.toml
+++ b/stores/memstore/Cargo.toml
@@ -14,7 +14,7 @@ license       = { workspace = true }
 repository    = { workspace = true }
 
 [dependencies]
-openraft = { path = "../../openraft", version = "0.10.0-alpha.22", features = ["serde", "type-alias"] }
+openraft = { path = "../../openraft", version = "0.10.0-alpha.23", features = ["serde", "type-alias"] }
 
 derive_more = { workspace = true }
 futures     = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,7 +18,7 @@ repository    = { workspace = true }
 [dependencies]
 
 [dev-dependencies]
-openraft           = { path = "../openraft", version = "0.10.0-alpha.22", features = ["type-alias"] }
+openraft           = { path = "../openraft", version = "0.10.0-alpha.23", features = ["type-alias"] }
 openraft-memstore  = { path = "../stores/memstore" }
 openraft-legacy = { path = "../legacy" }
 


### PR DESCRIPTION

## Changelog

##### chore: release: bump version to v0.10.0-alpha.23
# Summary

Advance the workspace and related crate dependency constraints to the next alpha release version.

# Details

This keeps the workspace package version and local path dependency constraints aligned for the v0.10.0-alpha.23 release cycle.

Verified with `cargo check --workspace --all-targets`.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1794)
<!-- Reviewable:end -->
