### PR TITLE
Fix: clear snapshot_transmit_handle after snapshot transmission completes

### DIFF
--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -87,6 +87,24 @@ where C: RaftTypeConfig
     /// Result of executing a command sent from a state machine worker.
     StateMachine { command_result: sm::CommandResult<C> },
 
+    /// A snapshot transmission task has finished.
+    ///
+    /// Sent by [`SnapshotTransmitter`](`crate::replication::snapshot_transmitter::SnapshotTransmitter`)
+    /// before it returns, regardless of success, failure, or cancellation.
+    /// RaftCore uses this to clear the stored
+    /// [`SnapshotTransmitterHandle`](`crate::replication::snapshot_transmitter_handle::SnapshotTransmitterHandle`)
+    /// so that completed tasks do not accumulate.
+    SnapshotTransmitted {
+        /// The target node to which the snapshot was sent.
+        target: C::NodeId,
+
+        /// The inflight id of the snapshot transmission.
+        ///
+        /// Used to distinguish stale notifications from a newer snapshot transmission
+        /// to the same target.
+        inflight_id: InflightId,
+    },
+
     /// A tick event to wake up RaftCore to check timeout etc.
     Tick {
         /// ith tick
@@ -112,6 +130,7 @@ where C: RaftTypeConfig
             Self::ReplicationProgress { .. } => NotificationName::ReplicationProgress,
             Self::HeartbeatProgress { .. } => NotificationName::HeartbeatProgress,
             Self::StateMachine { .. } => NotificationName::StateMachine,
+            Self::SnapshotTransmitted { .. } => NotificationName::SnapshotTransmitted,
             Self::Tick { .. } => NotificationName::Tick,
         }
     }
@@ -175,6 +194,9 @@ where C: RaftTypeConfig
             }
             Self::StateMachine { command_result } => {
                 write!(f, "{}", command_result)
+            }
+            Self::SnapshotTransmitted { target, inflight_id } => {
+                write!(f, "SnapshotTransmitted: target={}, inflight_id={}", target, inflight_id)
             }
             Self::Tick { i } => {
                 write!(f, "Tick {}", i)

--- a/openraft/src/core/notification_name.rs
+++ b/openraft/src/core/notification_name.rs
@@ -13,13 +13,14 @@ pub enum NotificationName {
     ReplicationProgress,
     HeartbeatProgress,
     StateMachine,
+    SnapshotTransmitted,
     Tick,
 }
 
 impl NotificationName {
     /// Total number of variants.
     #[allow(dead_code)]
-    pub const COUNT: usize = 9;
+    pub const COUNT: usize = 10;
 
     /// All variants in canonical order.
     #[allow(dead_code)]
@@ -32,6 +33,7 @@ impl NotificationName {
         NotificationName::ReplicationProgress,
         NotificationName::HeartbeatProgress,
         NotificationName::StateMachine,
+        NotificationName::SnapshotTransmitted,
         NotificationName::Tick,
     ];
 
@@ -47,7 +49,8 @@ impl NotificationName {
             NotificationName::ReplicationProgress => 5,
             NotificationName::HeartbeatProgress => 6,
             NotificationName::StateMachine => 7,
-            NotificationName::Tick => 8,
+            NotificationName::SnapshotTransmitted => 8,
+            NotificationName::Tick => 9,
         }
     }
 
@@ -62,6 +65,7 @@ impl NotificationName {
             NotificationName::ReplicationProgress => "Notify::ReplicationProgress",
             NotificationName::HeartbeatProgress => "Notify::HeartbeatProgress",
             NotificationName::StateMachine => "Notify::StateMachine",
+            NotificationName::SnapshotTransmitted => "Notify::SnapshotTransmitted",
             NotificationName::Tick => "Notify::Tick",
         }
     }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1916,6 +1916,20 @@ where
                 }
             }
 
+            Notification::SnapshotTransmitted { target, inflight_id } => {
+                tracing::debug!(
+                    "recv Notification::SnapshotTransmitted: target: {}, inflight_id: {}",
+                    target,
+                    inflight_id
+                );
+
+                if let Some(node) = self.replications.get_mut(&target)
+                    && node.clear_snapshot_transmit_if_match(inflight_id)
+                {
+                    tracing::info!("snapshot transmission done for target {}", target);
+                }
+            }
+
             Notification::StateMachine { command_result } => {
                 tracing::debug!("sm::StateMachine command result: {:?}", command_result);
 
@@ -2393,7 +2407,9 @@ where
                 );
 
                 let node = self.replications.get_mut(&target).expect("replication to target node exists");
-                // TODO: it is not cleaned when snapshot transmission is done.
+                // Replace any existing handle. The old handle is dropped, which signals its
+                // snapshot task to cancel. Completed tasks clear the handle via
+                // `Notification::SnapshotTransmitted`.
                 node.snapshot_transmit_handle = Some(handle);
             }
             Command::BroadcastTransferLeader { req } => self.broadcast_transfer_leader(req).await,

--- a/openraft/src/core/sm/handle.rs
+++ b/openraft/src/core/sm/handle.rs
@@ -61,6 +61,11 @@ where C: RaftTypeConfig
 impl<C, SM> SnapshotReader<C, SM>
 where C: RaftTypeConfig
 {
+    #[cfg(test)]
+    pub(crate) fn new_test(cmd_tx: MpscWeakSenderOf<C, sm::Command<C, SM>>) -> Self {
+        Self { cmd_tx }
+    }
+
     /// Get a snapshot from the state machine.
     ///
     /// If the state machine worker has shutdown, it will return an error.

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -14,6 +14,8 @@ mod replication_session_id;
 pub(crate) mod response;
 pub(crate) mod snapshot_transmitter;
 pub(crate) mod snapshot_transmitter_handle;
+#[cfg(test)]
+mod snapshot_transmitter_test;
 pub(crate) mod stream_context;
 pub(crate) mod stream_state;
 

--- a/openraft/src/replication/replication_handle.rs
+++ b/openraft/src/replication/replication_handle.rs
@@ -1,5 +1,6 @@
 use crate::RaftTypeConfig;
 use crate::errors::ReplicationClosed;
+use crate::progress::inflight_id::InflightId;
 use crate::progress::stream_id::StreamId;
 use crate::replication::replicate::Replicate;
 use crate::replication::snapshot_transmitter_handle::SnapshotTransmitterHandle;
@@ -41,5 +42,89 @@ where C: RaftTypeConfig
             snapshot_transmit_handle: None,
             cancel_tx,
         }
+    }
+
+    /// Clear the snapshot transmit handle if `inflight_id` matches the stored one.
+    ///
+    /// Returns `true` if cleared, `false` if the id did not match (stale notification
+    /// from a superseded task) or no handle is stored.
+    pub(crate) fn clear_snapshot_transmit_if_match(&mut self, inflight_id: InflightId) -> bool {
+        if self.snapshot_transmit_handle.as_ref().map(|h| h.inflight_id) == Some(inflight_id) {
+            self.snapshot_transmit_handle = None;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::engine::testing::UTConfig;
+    use crate::progress::inflight_id::InflightId;
+    use crate::progress::stream_id::StreamId;
+    use crate::replication::replicate::Replicate;
+    use crate::replication::replication_handle::ReplicationHandle;
+    use crate::replication::snapshot_transmitter_handle::SnapshotTransmitterHandle;
+    use crate::type_config::TypeConfigExt;
+
+    type C = UTConfig;
+
+    fn make_snapshot_handle(inflight_id: u64) -> SnapshotTransmitterHandle<C> {
+        let (cancel_tx, _cancel_rx) = C::watch_channel(());
+        let join_handle = C::spawn(async {});
+
+        SnapshotTransmitterHandle {
+            _join_handle: join_handle,
+            _tx_cancel: cancel_tx,
+            inflight_id: InflightId::new(inflight_id),
+        }
+    }
+
+    fn make_handle(snapshot_handle: Option<SnapshotTransmitterHandle<C>>) -> ReplicationHandle<C> {
+        let (replicate_tx, _rx) = C::watch_channel(Replicate::<C>::default());
+        let (cancel_tx, _cancel_rx) = C::watch_channel(());
+
+        ReplicationHandle {
+            stream_id: StreamId::new(1),
+            replicate_tx,
+            cancel_tx,
+            join_handle: None,
+            snapshot_transmit_handle: snapshot_handle,
+        }
+    }
+
+    #[test]
+    fn test_clear_snapshot_transmit_when_id_matches() {
+        C::run(async {
+            let mut handle = make_handle(Some(make_snapshot_handle(5)));
+
+            assert!(handle.clear_snapshot_transmit_if_match(InflightId::new(5)));
+            assert!(handle.snapshot_transmit_handle.is_none());
+        });
+    }
+
+    #[test]
+    fn test_keep_snapshot_transmit_when_id_mismatches() {
+        C::run(async {
+            let mut handle = make_handle(Some(make_snapshot_handle(5)));
+
+            assert!(!handle.clear_snapshot_transmit_if_match(InflightId::new(3)));
+            assert!(handle.snapshot_transmit_handle.is_some());
+            assert_eq!(
+                handle.snapshot_transmit_handle.as_ref().unwrap().inflight_id,
+                InflightId::new(5)
+            );
+        });
+    }
+
+    #[test]
+    fn test_clear_snapshot_transmit_when_already_none() {
+        C::run(async {
+            let mut handle = make_handle(None);
+
+            assert!(!handle.clear_snapshot_transmit_if_match(InflightId::new(5)));
+            assert!(handle.snapshot_transmit_handle.is_none());
+        });
     }
 }

--- a/openraft/src/replication/snapshot_transmitter.rs
+++ b/openraft/src/replication/snapshot_transmitter.rs
@@ -84,6 +84,7 @@ where
         SnapshotTransmitterHandle {
             _join_handle: join_handle,
             _tx_cancel: cancel_tx,
+            inflight_id,
         }
     }
 
@@ -100,6 +101,7 @@ where
             let error = match res {
                 Err(error) => error,
                 Ok(_) => {
+                    self.notify_snapshot_transmitted().await;
                     return;
                 }
             };
@@ -109,6 +111,7 @@ where
             match error {
                 ReplicationError::Closed(closed) => {
                     tracing::info!("snapshot transmission canceled: {}", closed);
+                    self.notify_snapshot_transmitted().await;
                     return;
                 }
                 ReplicationError::HigherVote(h) => {
@@ -116,13 +119,14 @@ where
                     self.replication_context
                         .tx_notify
                         .send(Notification::HigherVote {
-                            target: self.replication_context.target,
+                            target: self.replication_context.target.clone(),
                             higher: h.higher,
                             leader_vote: self.replication_context.leader_vote.clone(),
                         })
                         .await
                         .ok();
 
+                    self.notify_snapshot_transmitted().await;
                     return;
                 }
                 ReplicationError::StorageError(error) => {
@@ -132,6 +136,7 @@ where
                         error
                     );
                     self.replication_context.tx_notify.send(Notification::StorageError { error }).await.ok();
+                    self.notify_snapshot_transmitted().await;
                     return;
                 }
                 ReplicationError::RPCError(err) => {
@@ -168,6 +173,7 @@ where
                             }
                             _ = recv.fuse() => {
                                 tracing::info!("snapshot transmission canceled by RaftCore");
+                                self.notify_snapshot_transmitted().await;
                                 return;
                             }
                         }
@@ -241,6 +247,19 @@ where
                     stream_id: self.replication_context.stream_id,
                     target: self.replication_context.target.clone(),
                     sending_time,
+                }
+            })
+            .await
+            .ok();
+    }
+
+    async fn notify_snapshot_transmitted(&mut self) {
+        self.replication_context
+            .tx_notify
+            .send({
+                Notification::SnapshotTransmitted {
+                    target: self.replication_context.target.clone(),
+                    inflight_id: self.inflight_id,
                 }
             })
             .await

--- a/openraft/src/replication/snapshot_transmitter_handle.rs
+++ b/openraft/src/replication/snapshot_transmitter_handle.rs
@@ -1,4 +1,5 @@
 use crate::RaftTypeConfig;
+use crate::progress::inflight_id::InflightId;
 use crate::type_config::alias::JoinHandleOf;
 use crate::type_config::alias::WatchSenderOf;
 
@@ -13,4 +14,9 @@ where C: RaftTypeConfig
 
     /// Dropping this sender signals the task to cancel.
     pub(crate) _tx_cancel: WatchSenderOf<C, ()>,
+
+    /// The inflight id of this snapshot transmission.
+    ///
+    /// Used by RaftCore to match completion notifications against the currently stored handle.
+    pub(crate) inflight_id: InflightId,
 }

--- a/openraft/src/replication/snapshot_transmitter_test.rs
+++ b/openraft/src/replication/snapshot_transmitter_test.rs
@@ -1,0 +1,429 @@
+use std::future::Future;
+use std::io::Cursor;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::Stream;
+
+use crate::Config;
+use crate::OptionalSend;
+use crate::StorageError;
+use crate::async_runtime::MpscReceiver;
+use crate::async_runtime::MpscSender;
+use crate::async_runtime::OneshotSender;
+use crate::base::BoxFuture;
+use crate::base::BoxStream;
+use crate::core::SharedReplicateBatch;
+use crate::core::notification::Notification;
+use crate::core::sm;
+use crate::core::sm::handle::SnapshotReader;
+use crate::engine::testing::UTConfig;
+use crate::errors::RPCError;
+use crate::errors::ReplicationClosed;
+use crate::errors::StreamingError;
+use crate::errors::Unreachable;
+use crate::network::Backoff;
+use crate::network::NetAppend;
+use crate::network::NetBackoff;
+use crate::network::NetSnapshot;
+use crate::network::NetStreamAppend;
+use crate::network::NetTransferLeader;
+use crate::network::NetVote;
+use crate::network::RPCOption;
+use crate::network::RaftNetworkFactory;
+use crate::progress::inflight_id::InflightId;
+use crate::progress::stream_id::StreamId;
+use crate::raft::AppendEntriesRequest;
+use crate::raft::AppendEntriesResponse;
+use crate::raft::SnapshotResponse;
+use crate::raft::StreamAppendResult;
+use crate::raft::TransferLeaderRequest;
+use crate::raft::VoteRequest;
+use crate::raft::VoteResponse;
+use crate::replication::replication_context::ReplicationContext;
+use crate::replication::snapshot_transmitter::SnapshotTransmitter;
+use crate::storage::Snapshot;
+use crate::storage::SnapshotMeta;
+use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::JoinHandleOf;
+use crate::type_config::alias::MpscSenderOf;
+use crate::type_config::alias::SnapshotOf;
+use crate::type_config::alias::VoteOf;
+use crate::type_config::alias::WatchReceiverOf;
+use crate::vote::committed::CommittedVote;
+
+type C = UTConfig;
+
+struct MockNetworkFactory;
+
+impl RaftNetworkFactory<C> for MockNetworkFactory {
+    type Network = MockNetwork;
+
+    async fn new_client(&mut self, _target: u64, _node: &<C as crate::RaftTypeConfig>::Node) -> MockNetwork {
+        MockNetwork::default()
+    }
+}
+
+/// Controls what [`MockNetwork::full_snapshot`] returns, so tests can drive
+/// `SnapshotTransmitter` through each exit path of `stream_snapshot`.
+#[derive(Debug, Clone)]
+enum SnapshotResp {
+    /// Success — returns the caller's vote unchanged.
+    Ok,
+    /// Success — but returns a vote higher than the sender's, triggering the `HigherVote` path.
+    HigherVote(VoteOf<C>),
+    /// Returns a `StorageError`, triggering the `StorageError` exit path.
+    StorageError,
+    /// Returns `Unreachable`, triggering the backoff loop.
+    Unreachable,
+}
+
+#[derive(Debug, Clone)]
+struct MockNetwork {
+    snapshot_resp: SnapshotResp,
+}
+
+impl Default for MockNetwork {
+    fn default() -> Self {
+        Self {
+            snapshot_resp: SnapshotResp::Ok,
+        }
+    }
+}
+
+impl NetBackoff<C> for MockNetwork {
+    fn backoff(&self) -> Option<Backoff> {
+        None
+    }
+}
+
+impl NetAppend<C> for MockNetwork {
+    async fn append_entries(
+        &mut self,
+        _rpc: AppendEntriesRequest<C>,
+        _option: RPCOption,
+    ) -> Result<AppendEntriesResponse<C>, RPCError<C>> {
+        unimplemented!()
+    }
+}
+
+impl NetStreamAppend<C> for MockNetwork {
+    fn stream_append<'s, S>(
+        &'s mut self,
+        _input: S,
+        _option: RPCOption,
+    ) -> BoxFuture<'s, Result<BoxStream<'s, Result<StreamAppendResult<C>, RPCError<C>>>, RPCError<C>>>
+    where
+        S: Stream<Item = AppendEntriesRequest<C>> + OptionalSend + Unpin + 'static,
+    {
+        unimplemented!()
+    }
+}
+
+impl NetVote<C> for MockNetwork {
+    async fn vote(&mut self, _rpc: VoteRequest<C>, _option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>> {
+        unimplemented!()
+    }
+}
+
+impl NetSnapshot<C> for MockNetwork {
+    async fn full_snapshot(
+        &mut self,
+        vote: VoteOf<C>,
+        _snapshot: SnapshotOf<C>,
+        _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
+        _option: RPCOption,
+    ) -> Result<SnapshotResponse<C>, StreamingError<C>> {
+        match &self.snapshot_resp {
+            SnapshotResp::Ok => Ok(SnapshotResponse::new(vote)),
+            SnapshotResp::HigherVote(higher) => Ok(SnapshotResponse::new(*higher)),
+            SnapshotResp::StorageError => Err(StreamingError::StorageError(StorageError::read_snapshot(
+                None,
+                C::err_from_string("test storage error"),
+            ))),
+            SnapshotResp::Unreachable => Err(StreamingError::Unreachable(Unreachable::from_string(
+                "test unreachable",
+            ))),
+        }
+    }
+}
+
+impl NetTransferLeader<C> for MockNetwork {
+    async fn transfer_leader(&mut self, _req: TransferLeaderRequest<C>, _option: RPCOption) -> Result<(), RPCError<C>> {
+        unimplemented!()
+    }
+}
+
+fn build_context(
+    tx_notify: MpscSenderOf<C, Notification<C>>,
+    cancel_rx: WatchReceiverOf<C, ()>,
+) -> ReplicationContext<C> {
+    build_context_with(tx_notify, cancel_rx, Config::default().validate().unwrap())
+}
+
+fn build_context_with(
+    tx_notify: MpscSenderOf<C, Notification<C>>,
+    cancel_rx: WatchReceiverOf<C, ()>,
+    config: Config,
+) -> ReplicationContext<C> {
+    ReplicationContext {
+        id: 1,
+        target: 2,
+        leader_vote: CommittedVote::default(),
+        stream_id: StreamId::new(1),
+        config: Arc::new(config),
+        tx_notify,
+        cancel_rx,
+        replicate_batch: SharedReplicateBatch::default(),
+    }
+}
+
+fn empty_snapshot() -> SnapshotOf<C> {
+    Snapshot::new(SnapshotMeta::default(), Cursor::new(vec![]))
+}
+
+fn spawn_snapshot_worker() -> (MpscSenderOf<C, sm::Command<C>>, JoinHandleOf<C, ()>) {
+    let (tx, mut rx) = C::mpsc::<sm::Command<C>>(1);
+
+    let handle = C::spawn(async move {
+        while let Some(cmd) = rx.recv().await {
+            if let sm::Command::GetSnapshot { tx } = cmd {
+                tx.send(Some(empty_snapshot())).ok();
+            }
+        }
+    });
+
+    (tx, handle)
+}
+
+#[test]
+fn test_snapshot_transmitted_on_success() {
+    C::run(async {
+        let (tx_notify, mut rx_notify) = C::mpsc::<Notification<C>>(10);
+        let (cancel_tx, cancel_rx) = C::watch_channel(());
+        let replication_context = build_context(tx_notify, cancel_rx);
+
+        let (sm_tx, _sm_handle) = spawn_snapshot_worker();
+        let snapshot_reader = SnapshotReader::new_test(sm_tx.downgrade());
+
+        let handle = SnapshotTransmitter::<C, MockNetworkFactory, ()>::spawn(
+            replication_context,
+            MockNetwork::default(),
+            snapshot_reader,
+            InflightId::new(7),
+            cancel_tx,
+        );
+
+        // The successful path first reports heartbeat and replication progress,
+        // then reports that the snapshot transmission is complete.
+        let notification = rx_notify.recv().await.expect("heartbeat progress notification");
+        assert!(
+            matches!(notification, Notification::HeartbeatProgress { target: 2, .. }),
+            "expected HeartbeatProgress notification"
+        );
+
+        let notification = rx_notify.recv().await.expect("replication progress notification");
+        assert!(
+            matches!(
+                notification,
+                Notification::ReplicationProgress {
+                    progress,
+                    inflight_id: Some(id),
+                } if progress.target == 2 && *id == 7
+            ),
+            "expected ReplicationProgress notification"
+        );
+
+        let notification = rx_notify.recv().await.expect("snapshot transmitted notification");
+        assert!(
+            matches!(
+                notification,
+                Notification::SnapshotTransmitted {
+                    target: 2,
+                    inflight_id,
+                } if *inflight_id == 7
+            ),
+            "expected SnapshotTransmitted notification"
+        );
+
+        // Ensure the transmitter task finishes cleanly.
+        handle._join_handle.await.ok();
+    });
+}
+
+#[test]
+fn test_snapshot_transmitted_when_reader_closed() {
+    C::run(async {
+        let (tx_notify, mut rx_notify) = C::mpsc::<Notification<C>>(10);
+        let (cancel_tx, cancel_rx) = C::watch_channel(());
+        let replication_context = build_context(tx_notify, cancel_rx);
+
+        // Create a weak sender with no live strong sender so `SnapshotReader::get_snapshot` fails
+        // immediately and the transmitter exits through the `ReplicationError::Closed` path.
+        let (sm_tx, _sm_rx) = C::mpsc::<sm::Command<C>>(1);
+        let snapshot_reader = SnapshotReader::new_test(sm_tx.downgrade());
+        drop(sm_tx);
+
+        let handle = SnapshotTransmitter::<C, MockNetworkFactory, ()>::spawn(
+            replication_context,
+            MockNetwork::default(),
+            snapshot_reader,
+            InflightId::new(8),
+            cancel_tx,
+        );
+
+        let notification = rx_notify.recv().await.expect("notification received");
+        assert!(
+            matches!(
+                notification,
+                Notification::SnapshotTransmitted {
+                    target: 2,
+                    inflight_id,
+                } if *inflight_id == 8
+            ),
+            "expected SnapshotTransmitted notification"
+        );
+
+        handle._join_handle.await.ok();
+    });
+}
+
+#[test]
+fn test_snapshot_transmitted_on_higher_vote() {
+    C::run(async {
+        let (tx_notify, mut rx_notify) = C::mpsc::<Notification<C>>(10);
+        let (cancel_tx, cancel_rx) = C::watch_channel(());
+        let replication_context = build_context(tx_notify, cancel_rx);
+
+        let (sm_tx, _sm_handle) = spawn_snapshot_worker();
+        let snapshot_reader = SnapshotReader::new_test(sm_tx.downgrade());
+
+        // The sender's vote defaults to (term=0, node=0). A response with a higher
+        // vote triggers the `HigherVote` exit path in `send_snapshot`.
+        let higher_vote = VoteOf::<C>::new(1, 1);
+        let network = MockNetwork {
+            snapshot_resp: SnapshotResp::HigherVote(higher_vote),
+        };
+
+        let handle = SnapshotTransmitter::<C, MockNetworkFactory, ()>::spawn(
+            replication_context,
+            network,
+            snapshot_reader,
+            InflightId::new(9),
+            cancel_tx,
+        );
+
+        // HigherVote path: a HigherVote notification followed by SnapshotTransmitted.
+        let notification = rx_notify.recv().await.expect("higher vote notification");
+        assert!(
+            matches!(notification, Notification::HigherVote { target: 2, .. }),
+            "expected HigherVote notification"
+        );
+
+        let notification = rx_notify.recv().await.expect("snapshot transmitted notification");
+        assert!(
+            matches!(
+                notification,
+                Notification::SnapshotTransmitted {
+                    target: 2,
+                    inflight_id,
+                } if *inflight_id == 9
+            ),
+            "expected SnapshotTransmitted notification after HigherVote"
+        );
+
+        handle._join_handle.await.ok();
+    });
+}
+
+#[test]
+fn test_snapshot_transmitted_on_storage_error() {
+    C::run(async {
+        let (tx_notify, mut rx_notify) = C::mpsc::<Notification<C>>(10);
+        let (cancel_tx, cancel_rx) = C::watch_channel(());
+        let replication_context = build_context(tx_notify, cancel_rx);
+
+        let (sm_tx, _sm_handle) = spawn_snapshot_worker();
+        let snapshot_reader = SnapshotReader::new_test(sm_tx.downgrade());
+
+        let network = MockNetwork {
+            snapshot_resp: SnapshotResp::StorageError,
+        };
+
+        let handle = SnapshotTransmitter::<C, MockNetworkFactory, ()>::spawn(
+            replication_context,
+            network,
+            snapshot_reader,
+            InflightId::new(10),
+            cancel_tx,
+        );
+
+        // StorageError path: a StorageError notification followed by SnapshotTransmitted.
+        let notification = rx_notify.recv().await.expect("storage error notification");
+        assert!(
+            matches!(notification, Notification::StorageError { .. }),
+            "expected StorageError notification"
+        );
+
+        let notification = rx_notify.recv().await.expect("snapshot transmitted notification");
+        assert!(
+            matches!(
+                notification,
+                Notification::SnapshotTransmitted {
+                    target: 2,
+                    inflight_id,
+                } if *inflight_id == 10
+            ),
+            "expected SnapshotTransmitted notification after StorageError"
+        );
+
+        handle._join_handle.await.ok();
+    });
+}
+
+#[test]
+fn test_snapshot_transmitted_on_backoff_cancel() {
+    C::run(async {
+        let (tx_notify, mut rx_notify) = C::mpsc::<Notification<C>>(10);
+        let (cancel_tx, cancel_rx) = C::watch_channel(());
+
+        // Use a long backoff so the task stays in the backoff sleep until we cancel it.
+        let mut config = Config::default().validate().unwrap();
+        config.backoff = "10s".to_string();
+        let replication_context = build_context_with(tx_notify, cancel_rx, config);
+
+        let (sm_tx, _sm_handle) = spawn_snapshot_worker();
+        let snapshot_reader = SnapshotReader::new_test(sm_tx.downgrade());
+
+        let network = MockNetwork {
+            snapshot_resp: SnapshotResp::Unreachable,
+        };
+
+        let handle = SnapshotTransmitter::<C, MockNetworkFactory, ()>::spawn(
+            replication_context,
+            network,
+            snapshot_reader,
+            InflightId::new(11),
+            cancel_tx,
+        );
+
+        // Give the task time to hit Unreachable and enter the backoff sleep.
+        C::sleep(Duration::from_millis(200)).await;
+
+        // Dropping the handle drops `_tx_cancel`, which makes `cancel_rx.changed()` return
+        // immediately and the task exits through the backoff-cancel path.
+        drop(handle);
+
+        let notification = rx_notify.recv().await.expect("snapshot transmitted notification");
+        assert!(
+            matches!(
+                notification,
+                Notification::SnapshotTransmitted {
+                    target: 2,
+                    inflight_id,
+                } if *inflight_id == 11
+            ),
+            "expected SnapshotTransmitted notification after backoff cancel"
+        );
+    });
+}


### PR DESCRIPTION
Previously, `SnapshotTransmitterHandle` stored in
`ReplicationHandle.snapshot_transmit_handle` was never cleared after the transmission task finished (a `TODO` noted this in the code). Completed handles accumulated — each holding a `JoinHandle` and a cancel `WatchSender` — and were only released when a newer handle overwrote them. In clusters that frequently trigger snapshot replication (e.g. a flapping follower) this leaked resources indefinitely.

Add `Notification::SnapshotTransmitted { target, inflight_id }`, sent by `SnapshotTransmitter` on every exit path of `stream_snapshot()` — success, cancellation, higher-vote, storage error, and backoff-cancel. On receipt, `RaftCore` clears the stored handle only when `inflight_id` matches the currently stored one, so a stale notification from a superseded task cannot prematurely clear a newer handle.

`SnapshotTransmitterHandle` gains an `inflight_id` field for this matching.

This change is entirely `pub(crate)`; no public API is affected.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1797)
<!-- Reviewable:end -->
