### PR TITLE
fix: stop replication after storage read error

### DIFF
--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -168,9 +168,19 @@ where
     async fn next_append_request(
         stream_context: StreamContext<C, LS>,
     ) -> Option<(AppendEntriesRequest<C>, StreamContext<C, LS>)> {
-        let req = {
+        let res = {
             let mut state = stream_context.stream_state.as_ref().lock().await;
-            state.next_request().await?
+            state.next_request().await
+        };
+
+        let req = match res {
+            Ok(Some(req)) => req,
+            Ok(None) => return None,
+            Err(err) => {
+                let mut fatal_error = stream_context.fatal_error.lock().await;
+                *fatal_error = Some(err);
+                return None;
+            }
         };
 
         stream_context.inflight_append_queue.push(req.last_log_id());
@@ -245,10 +255,12 @@ where
             }
 
             let inflight_queue = InflightAppendQueue::new();
+            let fatal_error = Arc::new(MutexOf::<C, _>::new(None));
 
             let stream_context = StreamContext {
                 stream_state: self.stream_state.clone(),
                 inflight_append_queue: inflight_queue.clone(),
+                fatal_error: fatal_error.clone(),
             };
 
             let req_strm = Self::new_request_stream(stream_context);
@@ -257,6 +269,13 @@ where
             let option = RPCOption::new(rpc_timeout);
 
             let resp_strm_res = network.stream_append(req_strm, option).await;
+            // A custom streaming transport may poll the request stream while establishing
+            // `stream_append()` and then still return an RPC error. Check the fatal marker here too,
+            // because in that case there is no response stream for `handle_response_stream()` to
+            // consume.
+            if let Some(err) = Self::take_stream_fatal_error(&fatal_error).await {
+                return Err(err);
+            }
 
             let resp_strm = match resp_strm_res {
                 Ok(resp_strm) => resp_strm,
@@ -269,6 +288,9 @@ where
             };
 
             let res = self.handle_response_stream(resp_strm, inflight_queue).await;
+            if let Some(err) = Self::take_stream_fatal_error(&fatal_error).await {
+                return Err(err);
+            }
 
             // Response stream is successfully exhausted.
             if res.is_ok() {
@@ -282,6 +304,13 @@ where
                 }
             }
         }
+    }
+
+    async fn take_stream_fatal_error(
+        fatal_error: &Arc<MutexOf<C, Option<ReplicationClosed>>>,
+    ) -> Option<ReplicationClosed> {
+        let mut fatal_error = fatal_error.lock().await;
+        fatal_error.take()
     }
 
     async fn handle_response_stream<'s>(

--- a/openraft/src/replication/stream_context.rs
+++ b/openraft/src/replication/stream_context.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::RaftTypeConfig;
+use crate::errors::ReplicationClosed;
 use crate::replication::inflight_append_queue::InflightAppendQueue;
 use crate::replication::stream_state::StreamState;
 use crate::storage::RaftLogStorage;
@@ -21,4 +22,7 @@ where
 
     /// Tracks in-flight requests for RTT measurement.
     pub(crate) inflight_append_queue: InflightAppendQueue<C>,
+
+    /// Fatal error found while generating the request stream.
+    pub(crate) fatal_error: Arc<MutexOf<C, Option<ReplicationClosed>>>,
 }

--- a/openraft/src/replication/stream_state.rs
+++ b/openraft/src/replication/stream_state.rs
@@ -12,6 +12,7 @@ use crate::async_runtime::watch::WatchReceiver;
 use crate::core::notification::Notification;
 use crate::entry::RaftEntry;
 use crate::entry::raft_entry_ext::RaftEntryExt;
+use crate::errors::ReplicationClosed;
 use crate::errors::StorageIOResult;
 use crate::log_id_range::LogIdRange;
 use crate::progress::inflight_id::InflightId;
@@ -68,11 +69,13 @@ where
 {
     /// Generates the next AppendEntries request from the current log range.
     ///
-    /// Returns `None` when there are no more entries to send or on storage error.
+    /// Returns `Ok(None)` when there are no more entries to send.
     /// After each call, `log_id_range` is updated to exclude the sent entries.
-    pub(crate) async fn next_request(&mut self) -> Option<AppendEntriesRequest<C>> {
+    pub(crate) async fn next_request(&mut self) -> Result<Option<AppendEntriesRequest<C>>, ReplicationClosed> {
         // An empty range still sends one RPC and is then cleared by `update_log_id_range()`.
-        let log_id_range = self.get_log_id_range().await?;
+        let Some(log_id_range) = self.get_log_id_range().await else {
+            return Ok(None);
+        };
 
         tracing::debug!("{}: log_id_range: {}", func_name!(), log_id_range);
 
@@ -83,7 +86,7 @@ where
                 tracing::error!("{} replication to target={}", sto_err, self.replication_context.target);
 
                 self.replication_context.tx_notify.send(Notification::StorageError { error: sto_err }).await.ok();
-                return None;
+                return Err(ReplicationClosed::new("storage error"));
             }
         };
 
@@ -96,17 +99,27 @@ where
                 belonging_leader,
                 current_leader
             );
-            return None;
+            return Ok(None);
         }
 
         self.update_log_id_range(sending_range.last);
 
-        let payload = AppendEntriesRequest {
+        let payload: AppendEntriesRequest<C> = AppendEntriesRequest {
             vote: self.replication_context.leader_vote.clone().into_vote(),
             prev_log_id: sending_range.prev.clone(),
             leader_commit: self.event_watcher.committed_rx.borrow_watched().clone(),
             entries,
         };
+
+        if let Some(first) = payload.entries.first() {
+            debug_assert_eq!(
+                payload.prev_log_id.next_index(),
+                first.index(),
+                "expect AppendEntries prev_log_id({}) to be immediately before the first entry at index {}",
+                payload.prev_log_id.display(),
+                first.index()
+            );
+        }
 
         let entry_count = payload.entries.len() as u64;
         self.replication_context.replicate_batch.record(entry_count);
@@ -115,7 +128,7 @@ where
 
         self.backoff_if_enabled().await;
 
-        Some(payload)
+        Ok(Some(payload))
     }
 
     /// Return None if no more data to send.

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -176,6 +176,9 @@ pub struct MemLogStore {
     /// When set to true, `limited_get_log_entries` will return empty result.
     /// This is for testing graceful handling of faulty storage implementations.
     pub return_empty_limited_get: AtomicBool,
+
+    /// When set to true, the next `limited_get_log_entries` call will return an IO error.
+    pub fail_next_limited_get: AtomicBool,
 }
 
 impl MemLogStore {
@@ -190,6 +193,7 @@ impl MemLogStore {
             block,
             vote: RwLock::new(None),
             return_empty_limited_get: AtomicBool::new(false),
+            fail_next_limited_get: AtomicBool::new(false),
         }
     }
 
@@ -197,6 +201,11 @@ impl MemLogStore {
     /// This is for testing graceful handling of faulty storage implementations.
     pub fn set_return_empty_limited_get(&self, value: bool) {
         self.return_empty_limited_get.store(value, Ordering::Relaxed);
+    }
+
+    /// Make the next `limited_get_log_entries` call fail with an IO error.
+    pub fn set_fail_next_limited_get(&self, value: bool) {
+        self.fail_next_limited_get.store(value, Ordering::Relaxed);
     }
 }
 
@@ -294,6 +303,15 @@ impl RaftLogReader<TypeConfig> for Arc<MemLogStore> {
     }
 
     async fn limited_get_log_entries(&mut self, start: u64, end: u64) -> Result<Vec<EntryOf<TypeConfig>>, io::Error> {
+        if self.fail_next_limited_get.swap(false, Ordering::Relaxed) {
+            tracing::info!(
+                "limited_get_log_entries({}, {}): returning io::Error for testing",
+                start,
+                end
+            );
+            return Err(io::Error::other("injected limited_get_log_entries error"));
+        }
+
         if self.return_empty_limited_get.load(Ordering::Relaxed) {
             tracing::info!(
                 "limited_get_log_entries({}, {}): returning empty for testing",

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -668,6 +668,13 @@ impl TypedRaftRouter {
         Ok(())
     }
 
+    /// Set whether the next `limited_get_log_entries` call should fail for a node.
+    pub fn set_fail_next_limited_get(&self, node_id: &MemNodeId, value: bool) -> anyhow::Result<()> {
+        let (log_store, _) = self.get_storage_handle(node_id)?;
+        log_store.set_fail_next_limited_get(value);
+        Ok(())
+    }
+
     pub fn wait(&self, node_id: &MemNodeId, timeout: Option<Duration>) -> Wait<MemConfig> {
         let node = {
             let rt = self.nodes.lock().unwrap();

--- a/tests/tests/replication/main.rs
+++ b/tests/tests/replication/main.rs
@@ -13,3 +13,4 @@ mod t60_feature_loosen_follower_log_revert;
 mod t61_allow_follower_log_revert;
 mod t62_follower_clear_restart_recover;
 mod t99_issue_1500_heartbeat_cause_reversion_panic;
+mod t99_issue_1795_storage_error_stops_replication;

--- a/tests/tests/replication/t99_issue_1795_storage_error_stops_replication.rs
+++ b/tests/tests/replication/t99_issue_1795_storage_error_stops_replication.rs
@@ -1,0 +1,102 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::RPCTypes;
+use openraft::SnapshotPolicy;
+use openraft::errors::RPCError;
+use openraft::errors::Unreachable;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::log_id;
+use crate::fixtures::rpc_request::RpcRequest;
+use crate::fixtures::ut_harness;
+
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn storage_error_stops_replication() -> Result<()> {
+    let snapshot_threshold = 20;
+    let live_log_index = snapshot_threshold + 11;
+
+    let config = Arc::new(
+        Config {
+            snapshot_policy: SnapshotPolicy::LogsSinceLast(snapshot_threshold),
+            max_in_snapshot_log_to_keep: 0,
+            purge_batch_size: 1,
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- build a leader with a purged prefix and a live log suffix");
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
+    router.client_request_many(0, "snapshot", (snapshot_threshold - 1 - log_index) as usize).await?;
+    log_index = snapshot_threshold - 1;
+
+    router.wait(&0, timeout()).applied_index(Some(log_index), "snapshot trigger entries").await?;
+    router.wait(&0, timeout()).snapshot(log_id(1, 0, log_index), "leader has built snapshot").await?;
+    router
+        .wait(&0, timeout())
+        .purged(Some(log_id(1, 0, log_index)), "leader has purged snapshot logs")
+        .await?;
+
+    router.client_request_many(0, "suffix", (live_log_index - log_index) as usize).await?;
+    log_index = live_log_index;
+    router.wait(&0, timeout()).applied_index(Some(log_index), "leader has live suffix").await?;
+
+    let sent_malformed = Arc::new(AtomicBool::new(false));
+    {
+        let sent_malformed = sent_malformed.clone();
+        router
+            .set_rpc_pre_hook(RPCTypes::AppendEntries, move |_router, req, _id, target| {
+                let malformed = match req {
+                    RpcRequest::AppendEntries(append) if target == 1 => {
+                        append.prev_log_id.is_none()
+                            && append.entries.first().is_some_and(|entry| entry.log_id.index() > 0)
+                    }
+                    _ => false,
+                };
+
+                let res = if malformed {
+                    sent_malformed.store(true, Ordering::SeqCst);
+                    Err(RPCError::Unreachable(Unreachable::<TypeConfig>::from_string(
+                        "malformed append-entries",
+                    )))
+                } else {
+                    Ok(())
+                };
+
+                Box::pin(futures::future::ready(res))
+            })
+            .await;
+    }
+
+    tracing::info!("--- inject one storage read error and add a fresh learner");
+    router.new_raft_node(1).await;
+    router.set_fail_next_limited_get(&0, true)?;
+
+    let leader = router.get_raft_handle(&0)?;
+    leader.add_learner(1, (), false).await?;
+
+    TypeConfig::sleep(Duration::from_millis(800)).await;
+
+    assert!(
+        !sent_malformed.load(Ordering::SeqCst),
+        "replication retried after a storage error and sent prev_log_id=None with entries after a purged prefix"
+    );
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(2_000))
+}


### PR DESCRIPTION

## Changelog

##### fix: stop replication after storage read error
# Summary

Replication now treats a storage read error while generating
AppendEntries as fatal to the replication task, instead of letting
stream exhaustion look like a successful send and retrying the payload.

# Details

Add an integration regression test for issue #1795 that injects a
one-shot memstore read error while a leader replicates a live suffix
after a purged prefix. The test records whether the leader emits the
malformed retry with `prev_log_id=None` and non-empty entries.

Record a fatal marker in the stream state after reporting the storage
error to RaftCore. The owning replication loop checks this marker both
after stream setup and after response consumption so eager custom
streaming transports and the default lazy stream path both stop
immediately.

Add a debug assertion on the generated AppendEntries request to verify
that a non-empty entries vector starts exactly after its `prev_log_id`.

- Fixes #1795

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1798)
<!-- Reviewable:end -->
