### PR TITLE
fix: avoid commit channels for complete-only responders

### DIFF
--- a/openraft/src/raft/api/app.rs
+++ b/openraft/src/raft/api/app.rs
@@ -60,7 +60,7 @@ where C: RaftTypeConfig
         payload: EntryPayloadOf<C>,
         // TODO: ClientWriteError can only be ForwardToLeader Error
     ) -> Result<Result<ClientWriteResponse<C>, ClientWriteError<C>>, Fatal<C>> {
-        let (responder, _commit_rx, complete_rx) = ProgressResponder::new();
+        let (responder, complete_rx) = ProgressResponder::complete_only();
 
         self.do_client_write_ff(
             Batch::of([payload]),
@@ -126,7 +126,7 @@ where C: RaftTypeConfig
         let mut receivers = Vec::with_capacity(payloads.len());
 
         for _ in 0..payloads.len() {
-            let (responder, _commit_rx, complete_rx) = ProgressResponder::<C, ClientWriteResult<C>>::new();
+            let (responder, complete_rx) = ProgressResponder::<C, ClientWriteResult<C>>::complete_only();
             responders.push(Some(CoreResponder::Progress(responder)));
             receivers.push(complete_rx);
         }

--- a/openraft/src/raft/api/management.rs
+++ b/openraft/src/raft/api/management.rs
@@ -240,7 +240,7 @@ where
     C: RaftTypeConfig,
     T: OptionalSend,
 {
-    let (tx, _commit_rx, complete_rx) = ProgressResponder::new();
+    let (tx, complete_rx) = ProgressResponder::complete_only();
 
     (tx, complete_rx)
 }

--- a/openraft/src/raft/message/write_request.rs
+++ b/openraft/src/raft/message/write_request.rs
@@ -33,7 +33,7 @@ use crate::type_config::alias::WriteResponderOf;
 /// raft.write(my_data).await?;
 ///
 /// // With responder to receive result
-/// let (responder, _commit_rx, complete_rx) = ProgressResponder::new();
+/// let (responder, complete_rx) = ProgressResponder::complete_only();
 /// raft.write(my_data).responder(responder).await?;
 /// let result = complete_rx.await??;
 /// ```
@@ -63,7 +63,7 @@ where C: RaftTypeConfig
     /// ```ignore
     /// use openraft::impls::ProgressResponder;
     ///
-    /// let (responder, _commit_rx, complete_rx) = ProgressResponder::new();
+    /// let (responder, complete_rx) = ProgressResponder::complete_only();
     /// raft.write(my_data).responder(responder).await?;
     /// let result = complete_rx.await??;
     /// ```

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -1232,7 +1232,7 @@ where C: RaftTypeConfig
     /// raft.write(my_data).await?;
     ///
     /// // With responder
-    /// let (responder, _, rx) = ProgressResponder::new();
+    /// let (responder, rx) = ProgressResponder::complete_only();
     /// raft.write(my_data).responder(responder).await?;
     /// let result = rx.await??;
     ///

--- a/openraft/src/raft/responder/impls/progress_responder.rs
+++ b/openraft/src/raft/responder/impls/progress_responder.rs
@@ -1,3 +1,5 @@
+use openraft_macros::since;
+
 use crate::OptionalSend;
 use crate::RaftTypeConfig;
 use crate::async_runtime::OneshotSender;
@@ -7,15 +9,17 @@ use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::OneshotReceiverOf;
 use crate::type_config::alias::OneshotSenderOf;
 
-/// A [`Responder`] implementation that sends notifications via two oneshot channels.
+/// A [`Responder`] implementation that sends notifications via oneshot channels.
 ///
-/// This responder provides both commit and completion notifications:
+/// This responder can provide both commit and completion notifications:
 /// - **Commit channel**: Notifies when the log entry is committed (replicated to a quorum)
 /// - **Complete channel**: Sends the final result when the request completes
 ///
-/// Use this when the caller wants to be notified at both stages:
+/// Use [`ProgressResponder::new()`] when the caller wants to be notified at both stages:
 /// 1. When the entry is committed and safe to read
 /// 2. When the entry is applied and the result is available
+///
+/// Use [`ProgressResponder::complete_only()`] when the caller only needs the final result.
 ///
 /// # Example
 ///
@@ -69,6 +73,22 @@ where
 
         (responder, commit_rx, complete_rx)
     }
+
+    /// Create a new responder with only a complete receiver.
+    ///
+    /// Commit notifications are ignored. Use this when callers only wait for
+    /// the final result and intentionally do not need commit progress.
+    #[since(version = "0.10.0", change = "added complete_only constructor")]
+    pub fn complete_only() -> (Self, OneshotReceiverOf<C, T>) {
+        let (complete_tx, complete_rx) = C::oneshot();
+
+        let responder = Self {
+            commit_tx: None,
+            complete_tx,
+        };
+
+        (responder, complete_rx)
+    }
 }
 
 impl<C, T> Responder<C, T> for ProgressResponder<C, T>
@@ -118,6 +138,35 @@ mod tests {
             // Receivers should be created but not yet have values
             assert!(commit_rx.try_recv().is_err());
             assert!(complete_rx.try_recv().is_err());
+        });
+    }
+
+    #[test]
+    fn test_twoshot_responder_complete_only_new() {
+        UTConfig::<()>::run(async {
+            let (_responder, mut complete_rx): (ProgressResponder<UTConfig, String>, _) =
+                ProgressResponder::complete_only();
+
+            // Receiver should be created but not yet have a value.
+            assert!(complete_rx.try_recv().is_err());
+        });
+    }
+
+    #[test]
+    fn test_twoshot_responder_complete_only_ignores_commit() {
+        UTConfig::<()>::run(async {
+            let (mut responder, complete_rx): (ProgressResponder<UTConfig, String>, _) =
+                ProgressResponder::complete_only();
+
+            let test_log_id = log_id(1, 2, 3);
+            let test_result = "test_result".to_string();
+
+            // The complete-only responder intentionally has no commit receiver.
+            responder.on_commit(test_log_id);
+            responder.on_complete(test_result.clone());
+
+            let received_result = complete_rx.await.unwrap();
+            assert_eq!(test_result, received_result);
         });
     }
 

--- a/tests/tests/client_api/t10_client_writes.rs
+++ b/tests/tests/client_api/t10_client_writes.rs
@@ -104,7 +104,7 @@ async fn client_write_ff() -> Result<()> {
 
     let n0 = router.get_raft_handle(&0)?;
 
-    let (responder, _commit_rx, complete_rx) = ProgressResponder::new();
+    let (responder, complete_rx) = ProgressResponder::complete_only();
     n0.client_write_ff(ClientRequest::make_request("foo", 2), Some(responder)).await?;
     let got: ClientWriteResponse<TypeConfig> = complete_rx.await??;
     assert_eq!(None, got.response().0.as_deref());
@@ -112,7 +112,7 @@ async fn client_write_ff() -> Result<()> {
     // Deliberately set the responder to None and do not wait for the result.
     n0.client_write_ff(ClientRequest::make_request("foo", 3), None).await?;
 
-    let (responder, _commit_rx, complete_rx) = ProgressResponder::new();
+    let (responder, complete_rx) = ProgressResponder::complete_only();
     n0.client_write_ff(ClientRequest::make_request("foo", 4), Some(responder)).await?;
     let got: ClientWriteResponse<TypeConfig> = complete_rx.await??;
     assert_eq!(Some("request-3"), got.response().0.as_deref());
@@ -143,7 +143,7 @@ async fn write_builder() -> Result<()> {
     let n0 = router.get_raft_handle(&0)?;
 
     // Test write with responder
-    let (responder, _commit_rx, complete_rx) = ProgressResponder::new();
+    let (responder, complete_rx) = ProgressResponder::complete_only();
     n0.write(ClientRequest::make_request("foo", 2)).responder(responder).await?;
     let got: ClientWriteResponse<TypeConfig> = complete_rx.await??;
     assert_eq!(None, got.response().0.as_deref());
@@ -152,7 +152,7 @@ async fn write_builder() -> Result<()> {
     n0.write(ClientRequest::make_request("foo", 3)).await?;
 
     // Test write with responder again to verify previous write completed
-    let (responder, _commit_rx, complete_rx) = ProgressResponder::new();
+    let (responder, complete_rx) = ProgressResponder::complete_only();
     n0.write(ClientRequest::make_request("foo", 4)).responder(responder).await?;
     let got: ClientWriteResponse<TypeConfig> = complete_rx.await??;
     assert_eq!(Some("request-3"), got.response().0.as_deref());
@@ -187,7 +187,7 @@ async fn write_with_leader() -> Result<()> {
     let leader_id = n0.as_leader().unwrap().to_committed_leader_id();
 
     // Test 1: Write with correct leader should succeed
-    let (responder, _commit_rx, complete_rx) = ProgressResponder::new();
+    let (responder, complete_rx) = ProgressResponder::complete_only();
     n0.write(ClientRequest::make_request("foo", 2)).with_leader(leader_id).responder(responder).await?;
 
     log_index += 1;
@@ -201,7 +201,7 @@ async fn write_with_leader() -> Result<()> {
     // Create a fake leader ID that doesn't match
     let fake_leader = LeaderIdOf::<TypeConfig>::new(100, 99).to_committed();
 
-    let (responder, _commit_rx, complete_rx) = ProgressResponder::new();
+    let (responder, complete_rx) = ProgressResponder::complete_only();
     n0.write(ClientRequest::make_request("foo", 3))
         .with_leader(fake_leader)
         .responder(responder)
@@ -215,7 +215,7 @@ async fn write_with_leader() -> Result<()> {
     assert_eq!(Some(0), forward.leader_id);
 
     // Test 3: Write without leader check should succeed
-    let (responder, _commit_rx, complete_rx) = ProgressResponder::new();
+    let (responder, complete_rx) = ProgressResponder::complete_only();
     n0.write(ClientRequest::make_request("foo", 4)).responder(responder).await?;
 
     log_index += 1;


### PR DESCRIPTION
Add ProgressResponder::complete_only() for callers that only need the final result, and use it in completion-only write paths.

ProgressResponder::new() always creates both commit and completion channels. Callers such as client_write or client_write_many only use the completion receiver.  client_write happens to keep the commit receiver in scope until it is signaled, but client_write_man, in each loop iteration drops the commit receiver immediately after constructing the responder.

When Raft later commits those entries, ProgressResponder::on_commit() attempts to send through each abandoned commit channel and logs a warning for every dropped receiver. This is benign because these call sites deliberately only wait for completion, but batch writes can produce a large amount of misleading log noise.

I considered a few alternatives here. One option was to retain all commit receivers in client_write_many until completion, mirroring how client_write avoids the issue, but that would allocate and hold extra receivers and a vec only to suppress warnings for progress the caller does not observe. Another option was to introduce a separate responder type or CoreResponder variant, but that seemed heavier than the problem needs. The complete_only constructor keeps the existing responder type and core wiring, while making the caller intent explicit and avoiding the unused oneshot entirely. I am open to feedback though if you believe a different direction would be preferable here.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1799)
<!-- Reviewable:end -->
