### PR TITLE
fix: adopt higher term from Pre-Vote rejection to prevent permanent election deadlock during membership changes

### DIFF
--- a/openraft/src/docs/protocol/pre_vote.md
+++ b/openraft/src/docs/protocol/pre_vote.md
@@ -41,12 +41,13 @@ A peer answers with the same rules it uses for a real vote request:
 
 The crucial difference from a real vote: handling a Pre-Vote request **persists
 nothing and changes nothing** — no term bump, no saved vote, no lease update. It
-is a pure query. Likewise, the requester does not change its own state while
-pre-voting: it stays a Follower with its term unchanged until a quorum responds.
+is a pure query.
 
 If a quorum would grant, the node runs the real election
 ([`elect`](`crate::Raft`)), incrementing its term and persisting its vote as
-usual. If not, nothing changed, and it retries on a later tick.
+usual. If a peer rejects with a higher vote, the requester adopts that vote in
+non-committed form so it can catch up to the cluster's term. Otherwise, nothing
+changed, and it retries on a later tick.
 
 A single-voter cluster always wins its own Pre-Vote, so it skips the round and
 elects directly.

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -511,7 +511,14 @@ where C: RaftTypeConfig
     /// Handle a Pre-Vote response.
     ///
     /// Advance the Pre-Vote tally. When a quorum would grant, start the real election via
-    /// [`elect`](Self::elect). Receiving a Pre-Vote response never changes any persistent state.
+    /// [`elect`](Self::elect).
+    ///
+    /// On rejection, if the responder reports a strictly higher vote, the local vote is
+    /// updated and persisted to catch up to a term that already exists in the cluster.
+    /// This does not grant a vote to anyone — it only propagates term information
+    /// (mirroring `handle_vote_resp` and etcd's term-propagation on message receipt).
+    /// Without it, a lower-term cohort can never discover a higher term via Pre-Vote,
+    /// causing a permanent election deadlock during membership changes (issue #1796).
     #[tracing::instrument(level = "debug", skip(self, resp))]
     pub(crate) fn handle_pre_vote_resp(&mut self, target: C::NodeId, resp: VoteResponse<C>) {
         tracing::info!(
@@ -550,7 +557,15 @@ where C: RaftTypeConfig
             self.set_greater_log();
         }
 
-        // A Pre-Vote response never updates the local vote: the round is side-effect-free.
+        // Adopt the responder's higher term, same as handle_vote_resp does on reject.
+        // Only adopt a strictly higher vote; an equal vote must not disturb the ongoing
+        // Pre-Vote round (update_vote would clear pre_candidate via become_following).
+        // Without this term propagation, a lower-term cohort can never discover a higher
+        // term via Pre-Vote and stays permanently deadlocked (issue #1796).
+        if resp.vote.as_ref_vote() > self.state.vote_ref().as_ref_vote() {
+            let vote = resp.vote.to_non_committed().into_vote();
+            self.vote_handler().update_vote(&vote).ok();
+        }
     }
 
     /// Append entries to follower/learner.

--- a/openraft/src/engine/tests/handle_pre_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_pre_vote_resp_test.rs
@@ -90,3 +90,59 @@ fn test_handle_pre_vote_resp_reject_keeps_waiting() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_handle_pre_vote_resp_reject_adopts_higher_vote() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    // Local vote at a lower term: term=5, node=3.
+    eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(0), Vote::new(5, 3));
+
+    // Pre-vote round in flight at hypothetical term 6, self-granted by node 1.
+    eng.new_pre_candidate(Vote::new(6, 1));
+    eng.pre_candidate_mut().unwrap().grant_by(&1);
+    eng.output.take_commands();
+
+    // Peer 2 rejects with a strictly higher vote: term=10, node=2.
+    eng.handle_pre_vote_resp(2, VoteResponse::new(Vote::new(10, 2), Some(log_id(1, 1, 1)), false));
+
+    // Local vote adopted the responder's higher term (non-committed).
+    assert_eq!(&Vote::new(10, 2), eng.state.vote_ref());
+
+    assert_eq!(
+        vec![
+            Command::SaveVote { vote: Vote::new(10, 2) },
+            Command::CloseReplicationStreams,
+        ],
+        eng.output.take_commands()
+    );
+
+    // Adopting the higher term transitions to following state, clearing pre-candidate.
+    assert!(
+        eng.pre_candidate_ref().is_none(),
+        "pre-candidate cleared by term adoption"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_handle_pre_vote_resp_reject_equal_vote_unchanged() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    // Local vote: term=5, node=1.
+    eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(0), Vote::new(5, 1));
+
+    eng.new_pre_candidate(Vote::new(6, 1));
+    eng.pre_candidate_mut().unwrap().grant_by(&1);
+    eng.output.take_commands();
+
+    // Peer 2 rejects with an equal vote — must not disturb the ongoing pre-vote round.
+    eng.handle_pre_vote_resp(2, VoteResponse::new(Vote::new(5, 1), Some(log_id(1, 1, 1)), false));
+
+    assert!(eng.pre_candidate_ref().is_some(), "pre-vote round still in flight");
+    assert_eq!(&Vote::new(5, 1), eng.state.vote_ref(), "vote unchanged");
+    assert_eq!(0, eng.output.take_commands().len(), "no side effects");
+
+    Ok(())
+}

--- a/tests/tests/elect/t12_pre_vote.rs
+++ b/tests/tests/elect/t12_pre_vote.rs
@@ -5,11 +5,14 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::ServerState;
+use openraft::Vote;
 use openraft::async_runtime::WatchReceiver;
+use openraft::raft::VoteRequest;
 use openraft::type_config::TypeConfigExt;
 use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
+use crate::fixtures::log_id;
 use crate::fixtures::ut_harness;
 
 /// With Pre-Vote enabled, an isolated follower does not inflate its term.
@@ -267,6 +270,61 @@ async fn pre_vote_unreachable_peer_is_not_a_grant() -> Result<()> {
         n1.metrics().borrow_watched().current_term,
         "an Unreachable Pre-Vote response must not count toward the quorum"
     );
+
+    Ok(())
+}
+
+/// A rejected Pre-Vote response with a higher vote must catch the requester up to that vote.
+///
+/// This is the minimal public reproduction for databendlabs/openraft#1796: node 1 cannot reach a
+/// quorum because node 0 is isolated, and node 2 rejects node 1's Pre-Vote with a higher vote. If
+/// node 1 ignores that higher vote, it keeps retrying from the stale term forever.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn pre_vote_rejection_with_higher_vote_catches_up_requester() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            enable_pre_vote: Some(true),
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n1 = router.get_raft_handle(&1)?;
+    let n2 = router.get_raft_handle(&2)?;
+
+    tracing::info!("--- isolate node 0 so node 1 cannot assemble a Pre-Vote quorum");
+    router.set_network_error(0, true);
+    // Drain delayed AppendEntries heartbeats from node 0; one arriving during node 1's Pre-Vote
+    // would reset `pre_candidate` and make node 1 ignore node 2's response.
+    TypeConfig::sleep(Duration::from_millis(config.election_timeout_max * 2)).await;
+
+    tracing::info!("--- move node 2 to a higher vote");
+    let resp = n2
+        .vote(VoteRequest {
+            vote: Vote::new(10, 2),
+            last_log_id: Some(log_id(1, 0, log_index)),
+            leadership_transfer: true,
+        })
+        .await?;
+    assert!(resp.vote_granted);
+    router.wait(&2, timeout()).vote(Vote::new(10, 2), "node 2 has a higher vote").await?;
+
+    tracing::info!("--- node 1 sees node 2's higher vote through a rejected Pre-Vote response");
+    n1.trigger().elect(true).await?;
+    router
+        .wait(&1, Some(Duration::from_millis(1_000)))
+        .vote(Vote::new(10, 2), "node 1 catches up from a higher Pre-Vote rejection")
+        .await?;
+
+    tracing::info!("--- node 1 retries and wins with node 2's vote");
+    n1.trigger().elect(true).await?;
+    n1.wait(timeout()).state(ServerState::Leader, "node 1 becomes leader").await?;
 
     Ok(())
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

close #1796 


**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1800)
<!-- Reviewable:end -->
