### PR TITLE
fix: reset purged membership on snapshot install

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.10.0-alpha.25"
+version = "0.10.0-alpha.26"
 edition = "2024"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Currently, openraft is the consensus engine of meta-service cluster in [databend
 
 - 💡 **Example Applications**:
 
-    - [Examples with OpenRaft 0.10](https://github.com/databendlabs/openraft/tree/release-0.10/examples) require OpenRaft `0.10.0-alpha.25` (alpha) on [crates.io/openraft](https://crates.io/crates/openraft);
+    - [Examples with OpenRaft 0.10](https://github.com/databendlabs/openraft/tree/release-0.10/examples) require OpenRaft `0.10.0-alpha.26` (alpha) on [crates.io/openraft](https://crates.io/crates/openraft);
     - [Examples with OpenRaft 0.9](https://github.com/databendlabs/openraft/tree/release-0.9/examples) require OpenRaft 0.9 on [crates.io/openraft](https://crates.io/crates/openraft).
 
 - 🙌 **Questions**?
@@ -69,7 +69,7 @@ Whatever your style, we're here to support you. 🚀 Let's make something awesom
 
 - **Branch main** has been under active development.
     The main branch is for the [release-0.10](https://github.com/databendlabs/openraft/tree/release-0.10).
-    Latest alpha on crates.io: [v0.10.0-alpha.25](https://crates.io/crates/openraft/0.10.0-alpha.25).
+    Latest alpha on crates.io: [v0.10.0-alpha.26](https://crates.io/crates/openraft/0.10.0-alpha.26).
     The `0.10` line is in **alpha** — the API may still change before the final `0.10.0` release.
 
 - **Branch [release-0.9](https://github.com/databendlabs/openraft/tree/release-0.9)**:

--- a/benchmarks/minimal/Cargo.toml
+++ b/benchmarks/minimal/Cargo.toml
@@ -17,8 +17,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft            = { path = "../../openraft", version = "0.10.0-alpha.25", features = ["serde", "type-alias", "runtime-stats"] }
-openraft-legacy = { path = "../../legacy", version = "0.10.0-alpha.25" }
+openraft            = { path = "../../openraft", version = "0.10.0-alpha.26", features = ["serde", "type-alias", "runtime-stats"] }
+openraft-legacy = { path = "../../legacy", version = "0.10.0-alpha.26" }
 
 anyhow     = { version = "1.0.63" }
 clap       = { version = "4.2", features = ["derive"] }

--- a/examples/rocksstore/Cargo.toml
+++ b/examples/rocksstore/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/databendlabs/openraft"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-openraft = { path = "../../openraft", version = "0.10.0-alpha.25", features = ["serde", "type-alias"] }
+openraft = { path = "../../openraft", version = "0.10.0-alpha.26", features = ["serde", "type-alias"] }
 types-kv = { path = "../types-kv" }
 
 byteorder  = { version = "1.4.3" }

--- a/legacy/Cargo.toml
+++ b/legacy/Cargo.toml
@@ -14,8 +14,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-openraft = { path = "../openraft", version = "0.10.0-alpha.25", default-features = false }
-openraft-macros = { path = "../macros", version = "0.10.0-alpha.25" }
+openraft = { path = "../openraft", version = "0.10.0-alpha.26", default-features = false }
+openraft-macros = { path = "../macros", version = "0.10.0-alpha.26" }
 
 futures = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "sync"] }

--- a/metrics-otel/Cargo.toml
+++ b/metrics-otel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openraft-metrics-otel"
-version = "0.10.0-alpha.25"
+version = "0.10.0-alpha.26"
 edition = "2024"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",
@@ -13,5 +13,5 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft = { path = "../openraft", version = "0.10.0-alpha.25" }
+openraft = { path = "../openraft", version = "0.10.0-alpha.26" }
 opentelemetry = "0.30.0"

--- a/multiraft/Cargo.toml
+++ b/multiraft/Cargo.toml
@@ -3,7 +3,7 @@ name = "openraft-multi"
 description = "Multi-Raft adapters for connection sharing across Raft groups"
 documentation = "https://docs.rs/openraft-multiraft"
 readme = "README.md"
-version = "0.10.0-alpha.25"
+version = "0.10.0-alpha.26"
 edition = "2024"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 categories = ["network-programming", "asynchronous", "data-structures"]
@@ -13,6 +13,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft  = { path = "../openraft", version = "0.10.0-alpha.25", default-features = false }
+openraft  = { path = "../openraft", version = "0.10.0-alpha.26", default-features = false }
 anyerror  = { version = "0.1" }
 

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -15,9 +15,9 @@ repository    = { workspace = true }
 
 
 [dependencies]
-openraft-rt = { path = "../rt", version = "0.10.0-alpha.25" }
-openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.25", optional = true }
-openraft-macros = { path = "../macros", version = "0.10.0-alpha.25" }
+openraft-rt = { path = "../rt", version = "0.10.0-alpha.26" }
+openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.26", optional = true }
+openraft-macros = { path = "../macros", version = "0.10.0-alpha.26" }
 
 anyerror        = { workspace = true }
 anyhow          = { workspace = true, optional = true }
@@ -44,7 +44,7 @@ peel-off        = { workspace = true }
 
 [dev-dependencies]
 anyhow            = { workspace = true }
-openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.25" }
+openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.26" }
 pretty_assertions = { workspace = true }
 serde_json        = { workspace = true }
 

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -6,6 +6,7 @@ use maplit::btreeset;
 use pretty_assertions::assert_eq;
 
 use crate::Membership;
+use crate::MembershipState;
 use crate::Vote;
 use crate::core::sm;
 use crate::engine::Command;
@@ -169,6 +170,104 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
                 LogIOId::new(Vote::new(2, 1).into_committed(), Some(log_id(4, 1, 6))),
             )),
             Command::PurgeLog { upto: log_id(4, 1, 6) },
+        ],
+        eng.output.take_commands()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_install_snapshot_resets_purged_effective_membership() -> anyhow::Result<()> {
+    // Snapshot last_membership has a lower index than the stale effective membership, but the
+    // snapshot covers and purges the stale effective membership log.
+    let mut eng = eng();
+    let snapshot_membership = StoredMembershipOf::<UTConfig>::new(Some(log_id(5, 1, 4)), m12());
+
+    eng.state.membership_state = MembershipState::new(
+        Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12())),
+        Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(4, 1, 8)), m1234())),
+    );
+    eng.state.server_state = eng.calc_server_state();
+
+    let cond = eng.following_handler().install_full_snapshot(SnapshotOf::<UTConfig> {
+        meta: SnapshotMetaOf::<UTConfig> {
+            last_log_id: Some(log_id(5, 1, 9)),
+            last_membership: snapshot_membership.clone(),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        snapshot: Cursor::new(vec![0u8]),
+    });
+
+    assert_eq!(
+        Some(Condition::Snapshot::<UTConfig> {
+            log_id: log_id(5, 1, 9)
+        }),
+        cond
+    );
+
+    let expected_membership = Arc::new(snapshot_membership);
+    assert_eq!(
+        MembershipState::new(expected_membership.clone(), expected_membership),
+        eng.state.membership_state
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_install_snapshot_resets_purged_effective_without_truncating() -> anyhow::Result<()> {
+    let mut eng = eng();
+    let snapshot_membership = StoredMembershipOf::<UTConfig>::new(Some(log_id(5, 1, 4)), m12());
+
+    eng.state.log_ids = LogIdList::new(None, vec![
+        //
+        log_id(2, 1, 4),
+        log_id(3, 1, 5),
+        log_id(4, 1, 8),
+        log_id(5, 1, 9),
+    ]);
+    eng.state.membership_state = MembershipState::new(
+        Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12())),
+        Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(4, 1, 8)), m1234())),
+    );
+    eng.state.server_state = eng.calc_server_state();
+
+    let cond = eng.following_handler().install_full_snapshot(SnapshotOf::<UTConfig> {
+        meta: SnapshotMetaOf::<UTConfig> {
+            last_log_id: Some(log_id(5, 1, 9)),
+            last_membership: snapshot_membership.clone(),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        snapshot: Cursor::new(vec![0u8]),
+    });
+
+    assert_eq!(
+        Some(Condition::Snapshot::<UTConfig> {
+            log_id: log_id(5, 1, 9)
+        }),
+        cond
+    );
+
+    let expected_membership = Arc::new(snapshot_membership);
+    assert_eq!(
+        MembershipState::new(expected_membership.clone(), expected_membership),
+        eng.state.membership_state
+    );
+    assert_eq!(
+        vec![
+            Command::from(sm::Command::install_full_snapshot(
+                SnapshotOf::<UTConfig> {
+                    meta: SnapshotMetaOf::<UTConfig> {
+                        last_log_id: Some(log_id(5, 1, 9)),
+                        last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(5, 1, 4)), m12()),
+                        snapshot_id: "1-2-3-4".to_string(),
+                    },
+                    snapshot: Cursor::new(vec![0u8]),
+                },
+                LogIOId::new(Vote::new(2, 1).into_committed(), Some(log_id(5, 1, 9)))
+            )),
+            Command::PurgeLog { upto: log_id(5, 1, 9) },
         ],
         eng.output.take_commands()
     );

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -207,12 +207,12 @@ where C: RaftTypeConfig
 
     /// Install into the membership state the membership config carried by a snapshot.
     #[tracing::instrument(level = "debug", skip_all)]
-    fn membership_install_snapshot(&mut self, membership: StoredMembershipOf<C>) {
+    fn membership_install_snapshot(&mut self, membership: StoredMembershipOf<C>, snapshot_last_log_index: u64) {
         tracing::debug!("install membership from snapshot: {}", membership);
 
         let m = Arc::new(membership);
 
-        self.state.membership_state.install_membership_snapshot(m);
+        self.state.membership_state.install_membership_snapshot(m, snapshot_last_log_index);
 
         self.server_state_handler().update_server_state_if_changed();
     }
@@ -278,7 +278,7 @@ where C: RaftTypeConfig
         self.state.apply_progress_mut().accept(snap_last_log_id.clone());
         self.state.snapshot_progress_mut().accept(snap_last_log_id.clone());
 
-        self.membership_install_snapshot(meta.last_membership.clone());
+        self.membership_install_snapshot(meta.last_membership.clone(), snap_last_log_id.index());
 
         self.output.push_command(Command::from(sm::Command::install_full_snapshot(snapshot, log_io_id)));
 

--- a/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
+++ b/openraft/src/engine/handler/following_handler/update_committed_membership_test.rs
@@ -49,7 +49,7 @@ fn test_update_committed_membership_at_index_4() -> anyhow::Result<()> {
     let mut eng = eng();
 
     eng.following_handler()
-        .membership_install_snapshot(StoredMembershipOf::<UTConfig>::new(Some(log_id(3, 1, 4)), m34()));
+        .membership_install_snapshot(StoredMembershipOf::<UTConfig>::new(Some(log_id(3, 1, 4)), m34()), 4);
 
     assert_eq!(
         MembershipState::new(

--- a/openraft/src/raft_state/membership_state/membership_state_test.rs
+++ b/openraft/src/raft_state/membership_state/membership_state_test.rs
@@ -49,14 +49,12 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
             Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(3, 1, 4)), m123_345())),
         )
     };
+    let stored = |log_id, membership| Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id), membership));
 
     // Smaller new committed won't take effect.
     {
         let mut x = new();
-        x.install_membership_snapshot(Arc::new(StoredMembershipOf::<UTConfig>::new(
-            Some(log_id(1, 1, 1)),
-            m12(),
-        )));
+        x.install_membership_snapshot(stored(log_id(1, 1, 1), m12()), 1);
         assert_eq!(&Some(log_id(2, 1, 2)), x.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), x.effective().log_id());
     }
@@ -64,10 +62,7 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
     // Update committed, not effective.
     {
         let mut x = new();
-        x.install_membership_snapshot(Arc::new(StoredMembershipOf::<UTConfig>::new(
-            Some(log_id(2, 1, 3)),
-            m12(),
-        )));
+        x.install_membership_snapshot(stored(log_id(2, 1, 3), m12()), 3);
         assert_eq!(&Some(log_id(2, 1, 3)), x.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), x.effective().log_id());
     }
@@ -75,10 +70,7 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
     // Update both
     {
         let mut x = new();
-        x.install_membership_snapshot(Arc::new(StoredMembershipOf::<UTConfig>::new(
-            Some(log_id(3, 1, 4)),
-            m12(),
-        )));
+        x.install_membership_snapshot(stored(log_id(3, 1, 4), m12()), 4);
         assert_eq!(&Some(log_id(3, 1, 4)), x.committed().log_id());
         assert_eq!(&Some(log_id(3, 1, 4)), x.effective().log_id());
         assert_eq!(&m12(), x.effective().membership());
@@ -88,14 +80,57 @@ fn test_membership_state_update_committed() -> anyhow::Result<()> {
     // Because leader may have a smaller log_id that is committed.
     {
         let mut x = new();
-        x.install_membership_snapshot(Arc::new(StoredMembershipOf::<UTConfig>::new(
-            Some(log_id(2, 1, 5)),
-            m12(),
-        )));
+        x.install_membership_snapshot(stored(log_id(2, 1, 5), m12()), 5);
         assert_eq!(&Some(log_id(2, 1, 5)), x.committed().log_id());
         assert_eq!(&Some(log_id(2, 1, 5)), x.effective().log_id());
         assert_eq!(&m12(), x.effective().membership());
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_install_membership_snapshot_resets_purged_effective() -> anyhow::Result<()> {
+    let snapshot_membership = effmem(5, 4, m12());
+    let mut ms = MembershipStateOf::<UTConfig>::new(effmem(2, 2, m1()), effmem(4, 8, m123_345()));
+
+    ms.install_membership_snapshot(snapshot_membership.clone(), 9);
+
+    assert_eq!(
+        MembershipStateOf::<UTConfig>::new(snapshot_membership.clone(), snapshot_membership),
+        ms
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_install_membership_snapshot_resets_effective_at_purge_boundary() -> anyhow::Result<()> {
+    let snapshot_membership = effmem(5, 4, m12());
+    let mut ms = MembershipStateOf::<UTConfig>::new(effmem(2, 2, m1()), effmem(4, 8, m123_345()));
+
+    ms.install_membership_snapshot(snapshot_membership.clone(), 8);
+
+    assert_eq!(
+        MembershipStateOf::<UTConfig>::new(snapshot_membership.clone(), snapshot_membership),
+        ms
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_install_membership_snapshot_keeps_uncovered_effective() -> anyhow::Result<()> {
+    let snapshot_membership = effmem(2, 4, m12());
+    let local_effective = effmem(4, 8, m123_345());
+    let mut ms = MembershipStateOf::<UTConfig>::new(snapshot_membership.clone(), local_effective.clone());
+
+    ms.install_membership_snapshot(snapshot_membership.clone(), 7);
+
+    assert_eq!(
+        MembershipStateOf::<UTConfig>::new(snapshot_membership, local_effective),
+        ms
+    );
 
     Ok(())
 }

--- a/openraft/src/raft_state/membership_state/mod.rs
+++ b/openraft/src/raft_state/membership_state/mod.rs
@@ -140,13 +140,21 @@ where
     /// committed. It updates `self.committed`(the membership state machine), and may also update
     /// `self.effective`(the last membership log), each only when the snapshot is newer than the
     /// corresponding local membership.
-    pub(crate) fn install_membership_snapshot(&mut self, membership_snapshot: Arc<StoredMembership<CLID, NID, N>>) {
-        // The local effective membership may conflict with the leader.
-        // Thus, it has to compare by log-index, e.g.:
-        //   membership.log_id       = (10, 5);
-        //   local_effective.log_id = (2, 10);
+    pub(crate) fn install_membership_snapshot(
+        &mut self,
+        membership_snapshot: Arc<StoredMembership<CLID, NID, N>>,
+        snapshot_last_log_index: u64,
+    ) {
+        // Snapshot install purges every log entry up to snapshot_last_log_index.
+        let effective_is_purged = self.effective.log_id().index() <= Some(snapshot_last_log_index);
+
+        if effective_is_purged {
+            self.committed = membership_snapshot.clone();
+            self.effective = membership_snapshot;
+            return;
+        }
+
         if membership_snapshot.log_id().index() >= self.effective.log_id().index() {
-            // The effective may override by a new leader with a different one.
             self.effective = membership_snapshot.clone()
         }
 

--- a/rt-compio/Cargo.toml
+++ b/rt-compio/Cargo.toml
@@ -3,7 +3,7 @@ name = "openraft-rt-compio"
 description = "compio AsyncRuntime support for Openraft"
 documentation = "https://docs.rs/openraft-rt-compio"
 readme = "README.md"
-version = "0.10.0-alpha.25"
+version = "0.10.0-alpha.26"
 edition = "2024"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 categories = ["algorithms", "asynchronous", "data-structures"]
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft-rt = { path = "../rt", version = "0.10.0-alpha.25", features = ["single-threaded"] }
+openraft-rt = { path = "../rt", version = "0.10.0-alpha.26", features = ["single-threaded"] }
 
 compio           = { version = ">=0.14.0", features = ["runtime", "time"] }
 flume            = { version = "0.11.1", default-features = false, features = ["async"] }

--- a/rt-monoio/Cargo.toml
+++ b/rt-monoio/Cargo.toml
@@ -3,7 +3,7 @@ name = "openraft-rt-monoio"
 description = "monoio AsyncRuntime support for Openraft"
 documentation = "https://docs.rs/openraft-rt-monoio"
 readme = "README.md"
-version = "0.10.0-alpha.25"
+version = "0.10.0-alpha.26"
 edition = "2024"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft-rt = { path = "../rt", version = "0.10.0-alpha.25", features = ["single-threaded"] }
+openraft-rt = { path = "../rt", version = "0.10.0-alpha.26", features = ["single-threaded"] }
 
 futures-util = { version = "0.3" }
 local-sync   = { version = "0.1.1" }

--- a/rt-tokio/Cargo.toml
+++ b/rt-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.25"
+version = "0.10.0-alpha.26"
 edition = "2024"
 authors = [
     "drdrxp <drdr.xp@gmail.com>",
@@ -13,7 +13,7 @@ readme = "README.md"
 description = "Tokio runtime implementation for Openraft"
 
 [dependencies]
-openraft-rt  = { path = "../rt", version = "0.10.0-alpha.25" }
+openraft-rt  = { path = "../rt", version = "0.10.0-alpha.26" }
 tokio        = { version = "1.39", default-features = false, features = ["rt", "rt-multi-thread", "sync", "time"] }
 futures-util = { version = "0.3" }
 rand         = { version = "0.10", default-features = false, features = ["std", "std_rng", "thread_rng"] }

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -20,6 +20,6 @@ single-threaded = ["openraft-macros/single-threaded"]
 [dependencies]
 futures-channel = { workspace = true }
 futures-util    = { workspace = true }
-openraft-macros    = { version = "0.10.0-alpha.25", path = "../macros" }
+openraft-macros    = { version = "0.10.0-alpha.26", path = "../macros" }
 pin-project-lite   = { version = "0.2" }
 rand               = { workspace = true }

--- a/stores/memstore-custom-node-id/Cargo.toml
+++ b/stores/memstore-custom-node-id/Cargo.toml
@@ -12,7 +12,7 @@ license       = { workspace = true }
 repository    = { workspace = true }
 
 [dependencies]
-openraft  = { path = "../../openraft", version = "0.10.0-alpha.25", features = ["serde", "type-alias"] }
+openraft  = { path = "../../openraft", version = "0.10.0-alpha.26", features = ["serde", "type-alias"] }
 
 futures    = { workspace = true }
 serde      = { workspace = true }

--- a/stores/memstore/Cargo.toml
+++ b/stores/memstore/Cargo.toml
@@ -14,7 +14,7 @@ license       = { workspace = true }
 repository    = { workspace = true }
 
 [dependencies]
-openraft = { path = "../../openraft", version = "0.10.0-alpha.25", features = ["serde", "type-alias"] }
+openraft = { path = "../../openraft", version = "0.10.0-alpha.26", features = ["serde", "type-alias"] }
 
 derive_more = { workspace = true }
 futures     = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -18,7 +18,7 @@ repository    = { workspace = true }
 [dependencies]
 
 [dev-dependencies]
-openraft           = { path = "../openraft", version = "0.10.0-alpha.25", features = ["type-alias"] }
+openraft           = { path = "../openraft", version = "0.10.0-alpha.26", features = ["type-alias"] }
 openraft-memstore  = { path = "../stores/memstore" }
 openraft-legacy = { path = "../legacy" }
 


### PR DESCRIPTION

## Changelog

##### fix: reset purged membership on snapshot install
# Summary

Snapshot install now treats the snapshot last index as the purge
boundary for membership state, preventing a local effective membership
from surviving after its backing log entry is covered by the snapshot.

# Details

The snapshot membership install path now receives only the snapshot last
log index and resets cached membership state when the effective
membership is within that covered range. This keeps the local membership
cache aligned with the installed snapshot while preserving the existing
log-id comparison for normal committed membership updates.

A regression test covers the case where the snapshot's last membership
has a lower index than the stale local effective membership, but the
snapshot last index still covers that local membership log.

- Fix: #1808

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1809)
<!-- Reviewable:end -->
