### PR TITLE
fix: avoid blocking RaftCore on closed replication

### DIFF
--- a/openraft/src/core/heartbeat/worker.rs
+++ b/openraft/src/core/heartbeat/worker.rs
@@ -171,6 +171,7 @@ where
                 let conflict_log_id = heartbeat.matching.clone().unwrap();
 
                 let noti = Notification::ReplicationProgress {
+                    stream_id: self.stream_id,
                     progress: Progress {
                         target: self.target.clone(),
                         result: Ok(ReplicationResult(Err(conflict_log_id))),

--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -64,6 +64,9 @@ where C: RaftTypeConfig
 
     /// Result of executing a command sent from network worker.
     ReplicationProgress {
+        /// Identifies the replication stream that produced this progress.
+        stream_id: StreamId,
+
         progress: replication::Progress<C>,
 
         /// The `InflightId` of the replication request that produced this response.
@@ -157,8 +160,18 @@ where C: RaftTypeConfig
             }
             Self::StorageError { error } => write!(f, "StorageError: {}", error),
             Self::LocalIO { io_id } => write!(f, "IOFlushed: {}", io_id),
-            Self::ReplicationProgress { progress, inflight_id } => {
-                write!(f, "{}, inflight_id: {}", progress, inflight_id.display())
+            Self::ReplicationProgress {
+                stream_id,
+                progress,
+                inflight_id,
+            } => {
+                write!(
+                    f,
+                    "{}, stream_id: {}, inflight_id: {}",
+                    progress,
+                    stream_id,
+                    inflight_id.display()
+                )
             }
             Self::HeartbeatProgress {
                 stream_id: leader_vote,

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1911,11 +1911,15 @@ where
                 }
             }
 
-            Notification::ReplicationProgress { progress, inflight_id } => {
+            Notification::ReplicationProgress {
+                stream_id,
+                progress,
+                inflight_id,
+            } => {
                 tracing::debug!("recv Notification::ReplicationProgress: progress: {}", progress);
 
                 if let Some(mut rh) = self.engine.try_replication_handler() {
-                    rh.update_progress(progress.target, progress.result, inflight_id);
+                    rh.update_progress(progress.target, stream_id, progress.result, inflight_id);
                 }
             }
 
@@ -2196,7 +2200,7 @@ where
         (ctx, cancel_tx)
     }
 
-    async fn close_replication(target: &C::NodeId, mut s: ReplicationHandle<C>) {
+    fn close_replication(target: &C::NodeId, mut s: ReplicationHandle<C>) {
         let Some(handle) = s.join_handle.take() else {
             return;
         };
@@ -2205,9 +2209,13 @@ where
         drop(s.replicate_tx);
         drop(s.cancel_tx);
 
-        tracing::debug!("joining removed replication: {}", target);
-        let _x = handle.await;
-        tracing::info!("done joining removed replication: {}", target);
+        let target = target.clone();
+        #[allow(clippy::let_underscore_future)]
+        let _ = C::spawn(async move {
+            tracing::debug!("joining removed replication: {}", target);
+            let _x = handle.await;
+            tracing::info!("done joining removed replication: {}", target);
+        });
     }
 }
 
@@ -2416,7 +2424,7 @@ where
 
                 let left = std::mem::take(&mut self.replications);
                 for (target, s) in left {
-                    Self::close_replication(&target, s).await;
+                    Self::close_replication(&target, s);
                 }
             }
             Command::RebuildReplicationStreams {
@@ -2441,7 +2449,7 @@ where
 
                     let handle = if let Some(removed) = removed {
                         if close_old_streams {
-                            Self::close_replication(&prog.target, removed).await;
+                            Self::close_replication(&prog.target, removed);
                             None
                         } else {
                             Some(removed)
@@ -2464,7 +2472,7 @@ where
                 let left = std::mem::replace(&mut self.replications, new_replications);
 
                 for (target, s) in left {
-                    Self::close_replication(&target, s).await;
+                    Self::close_replication(&target, s);
                 }
             }
             Command::StateMachine { command } => {

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -286,17 +286,23 @@ where C: RaftTypeConfig
     pub(crate) fn update_progress(
         &mut self,
         target: C::NodeId,
+        stream_id: StreamId,
         repl_res: Result<ReplicationResult<C>, String>,
         inflight_id: Option<InflightId>,
     ) {
         tracing::debug!(
-            "{}: target: {}, result: {}, inflight_id: {}, current progresses: {}",
+            "{}: target: {}, stream_id: {}, result: {}, inflight_id: {}, current progresses: {}",
             func_name!(),
             target,
+            stream_id,
             repl_res.display(),
             inflight_id.display(),
             self.leader.progress
         );
+
+        if !self.leader.is_replication_stream_valid(&target, stream_id) {
+            return;
+        }
 
         match repl_res {
             Ok(p) => match p.0 {

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -319,8 +319,26 @@ where
         inflight_queue: InflightAppendQueue<C>,
     ) -> Result<(), &'static str> {
         let mut resp_strm = std::pin::pin!(resp_strm);
+        let mut cancel_rx = self.replication_context.cancel_rx.clone();
 
-        while let Some(rpc_res) = resp_strm.next().await {
+        loop {
+            let rpc_res = {
+                let next_resp = resp_strm.next();
+                let cancel = cancel_rx.changed();
+
+                futures_util::select! {
+                    rpc_res = next_resp.fuse() => rpc_res,
+                    cancel_res = cancel.fuse() => {
+                        tracing::info!("ReplicationCore: canceled while waiting response: {:?}", cancel_res);
+                        return Err("canceled");
+                    }
+                }
+            };
+
+            let Some(rpc_res) = rpc_res else {
+                return Ok(());
+            };
+
             tracing::debug!("AppendEntries RPC response: {:?}", rpc_res);
 
             self.backoff_state.observe(&rpc_res);
@@ -366,7 +384,6 @@ where
                 }
             }
         }
-        Ok(())
     }
 
     /// Send the error result to RaftCore.
@@ -386,6 +403,7 @@ where
         self.replication_context
             .tx_notify
             .send(Notification::ReplicationProgress {
+                stream_id: self.replication_context.stream_id,
                 progress: Progress {
                     target: self.replication_context.target.clone(),
                     result: Err(err.to_string()),
@@ -447,6 +465,7 @@ where
             .tx_notify
             .send({
                 Notification::ReplicationProgress {
+                    stream_id: self.replication_context.stream_id,
                     progress: Progress {
                         target: self.replication_context.target.clone(),
                         result: Ok(replication_result.clone()),

--- a/openraft/src/replication/snapshot_transmitter.rs
+++ b/openraft/src/replication/snapshot_transmitter.rs
@@ -259,6 +259,7 @@ where
             .tx_notify
             .send({
                 Notification::ReplicationProgress {
+                    stream_id: self.replication_context.stream_id,
                     progress: Progress {
                         target: self.replication_context.target.clone(),
                         result: Ok(replication_result.clone()),

--- a/tests/tests/membership/main.rs
+++ b/tests/tests/membership/main.rs
@@ -19,6 +19,7 @@ mod t30_elect_with_new_config;
 mod t31_add_remove_follower;
 mod t31_remove_leader;
 mod t31_removed_follower;
+mod t51_hung_follower_blocks_loop;
 mod t51_remove_unreachable_follower;
 mod t52_change_membership_on_uninitialized_node;
 mod t99_issue_471_adding_learner_uses_uninit_leader_id;

--- a/tests/tests/membership/t51_hung_follower_blocks_loop.rs
+++ b/tests/tests/membership/t51_hung_follower_blocks_loop.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::RPCTypes;
+use openraft::errors::Infallible;
+use openraft::errors::RPCError;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::TypedRaftRouter;
+use crate::fixtures::ut_harness;
+
+/// How long an AppendEntries RPC to the removed follower stays in flight.
+const HANG: Duration = Duration::from_secs(30);
+
+async fn setup() -> Result<TypedRaftRouter> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    let mut log_index = router.new_cluster(btreeset! {0, 1, 2}, btreeset! {}).await?;
+
+    // After the cluster is formed, make every AppendEntries to node 2 hang.
+    router
+        .set_rpc_pre_hook(RPCTypes::AppendEntries, move |_router, _req, _from, target| {
+            // let hang = target == 2;
+            Box::pin(async move {
+                if target == 2 {
+                    TypeConfig::sleep(HANG).await;
+                }
+                Ok::<(), RPCError<TypeConfig, Infallible>>(())
+            })
+        })
+        .await;
+
+    // A write commits via the {0,1} quorum and leaves node 2's replication task
+    // parked inside the hung AppendEntries RPC.
+    router.client_request(0, "before-remove", 1).await?;
+    log_index += 1;
+    router
+        .wait(&0, timeout())
+        .applied_index(Some(log_index), "write commits via the {0,1} quorum")
+        .await?;
+
+    Ok(router)
+}
+
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn remove_hung_follower_must_not_block_raft_core_loop_1() -> Result<()> {
+    let router = setup().await?;
+
+    // Remove the hung follower.
+    let leader = router.get_raft_handle(&0)?;
+    let membership_change = leader.change_membership([0, 1], false);
+    TypeConfig::timeout(Duration::from_secs(10), membership_change)
+        .await
+        .expect("membership change completed within the window")?;
+
+    Ok(())
+}
+
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn remove_hung_follower_must_not_block_raft_core_loop_2() -> Result<()> {
+    let router = setup().await?;
+
+    // Remove the hung follower in separate task.
+    let leader = router.get_raft_handle(&0)?;
+    let _membership = TypeConfig::spawn(async move {
+        let _ = leader.change_membership([0, 1], false).await;
+    });
+
+    // HACK: wait for the leader to reach `close_membership()` to await the replication task.
+    TypeConfig::sleep(Duration::from_millis(500)).await;
+
+    // The leader should still serve the surviving quorum.
+    let write = router.client_request(0, "after-remove", 2);
+    TypeConfig::timeout(Duration::from_secs(10), write)
+        .await
+        .expect("write completed within the window")?;
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
+}

--- a/tests/tests/membership/t51_remove_unreachable_follower.rs
+++ b/tests/tests/membership/t51_remove_unreachable_follower.rs
@@ -49,14 +49,6 @@ async fn stop_replication_to_removed_unreachable_follower_network_failure() -> R
                 )
                 .await?;
         }
-
-        router
-            .wait(&3, timeout())
-            .metrics(
-                |x| x.last_log_index >= Some(log_index - 1),
-                "node-3 recv at least 1 change-membership log",
-            )
-            .await?;
     }
 
     tracing::info!(log_index, "--- replication to node 4 will be removed");


### PR DESCRIPTION

## Changelog

##### fix: avoid blocking RaftCore on closed replication
# Summary

Removed replication tasks are now signaled and joined asynchronously, so
a hung follower RPC cannot stop RaftCore from processing membership
changes or new writes.

# Details

Replication progress notifications now carry the stream id at the
notification level. RaftCore forwards that id to the replication
handler, which ignores stale progress from detached tasks after a stream
has been replaced.

The replication response loop now also watches the close signal while
waiting for responses, allowing cooperative shutdown when the transport
future is still polling.

- Fix: #1810


##### test: reproduce hung-follower freeze of RaftCore loop
Add a regression test showing that removing a follower whose
AppendEntries RPC hangs freezes the leader's RaftCore loop. The loop
blocks inline on close_replication() awaiting the replication task,
which is parked in a hung RPC that openraft never bounds with
RPCOption::hard_ttl.

---

- Bug Fix
- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1811)
<!-- Reviewable:end -->
