### PR TITLE
docs: clarify RPC timeout policy

### DIFF
--- a/examples/network-v1-http/src/lib.rs
+++ b/examples/network-v1-http/src/lib.rs
@@ -131,7 +131,12 @@ where C: RaftTypeConfig
 impl<C> Network<C>
 where C: RaftTypeConfig
 {
-    async fn request<Req, Resp, Err>(&mut self, uri: impl Display, req: Req) -> Result<Result<Resp, Err>, RPCError<C>>
+    async fn request<Req, Resp, Err>(
+        &mut self,
+        uri: impl Display,
+        req: Req,
+        option: &RPCOption,
+    ) -> Result<Result<Resp, Err>, RPCError<C>>
     where
         Req: Serialize + 'static,
         Resp: Serialize + DeserializeOwned,
@@ -144,7 +149,14 @@ where C: RaftTypeConfig
         //     serde_json::to_string_pretty(&req).unwrap()
         // );
 
-        let resp = self.client.post(url.clone()).json(&req).send().await.map_err(|e| {
+        let resp = self
+            .client
+            .post(url.clone())
+            .json(&req)
+            .timeout(option.soft_ttl())
+            .send()
+            .await
+            .map_err(|e| {
             if e.is_connect() {
                 // `Unreachable` informs the caller to backoff for a short while to avoid error log flush.
                 RPCError::Unreachable(Unreachable::new(&e))
@@ -172,9 +184,12 @@ where C: RaftTypeConfig
     async fn append_entries(
         &mut self,
         req: AppendEntriesRequest<C>,
-        _option: RPCOption,
+        option: RPCOption,
     ) -> Result<AppendEntriesResponse<C>, RPCError<C, RaftError<C>>> {
-        let res = self.request::<_, _, Infallible>("append", req).await.map_err(RPCError::with_raft_error)?;
+        let res = self
+            .request::<_, _, Infallible>("append", req, &option)
+            .await
+            .map_err(RPCError::with_raft_error)?;
         Ok(res.unwrap())
     }
 
@@ -182,9 +197,9 @@ where C: RaftTypeConfig
     async fn install_snapshot(
         &mut self,
         req: InstallSnapshotRequest<C>,
-        _option: RPCOption,
+        option: RPCOption,
     ) -> Result<InstallSnapshotResponse<C>, RPCError<C, RaftError<C, InstallSnapshotError>>> {
-        let res = self.request("snapshot", req).await.map_err(RPCError::with_raft_error)?;
+        let res = self.request("snapshot", req, &option).await.map_err(RPCError::with_raft_error)?;
         match res {
             Ok(resp) => Ok(resp),
             Err(e) => Err(RPCError::RemoteError(RemoteError::new(
@@ -198,9 +213,12 @@ where C: RaftTypeConfig
     async fn vote(
         &mut self,
         req: VoteRequest<C>,
-        _option: RPCOption,
+        option: RPCOption,
     ) -> Result<VoteResponse<C>, RPCError<C, RaftError<C>>> {
-        let res = self.request::<_, _, Infallible>("vote", req).await.map_err(RPCError::with_raft_error)?;
+        let res = self
+            .request::<_, _, Infallible>("vote", req, &option)
+            .await
+            .map_err(RPCError::with_raft_error)?;
         Ok(res.unwrap())
     }
 }

--- a/examples/network-v2-http/src/client.rs
+++ b/examples/network-v2-http/src/client.rs
@@ -64,7 +64,12 @@ pub struct Client {
 }
 
 impl Client {
-    async fn request<C, Req, Resp>(&mut self, uri: impl Display, req: Req) -> Result<Resp, RPCError<C>>
+    async fn request<C, Req, Resp>(
+        &mut self,
+        uri: impl Display,
+        req: Req,
+        option: &RPCOption,
+    ) -> Result<Resp, RPCError<C>>
     where
         C: RaftTypeConfig,
         Req: Serialize,
@@ -72,7 +77,7 @@ impl Client {
     {
         let url = format!("http://{}/{}", self.addr, uri);
 
-        let resp = self.client.post(url.clone()).json(&req).send().await.map_err(|e| {
+        let resp = self.client.post(url.clone()).json(&req).timeout(option.soft_ttl()).send().await.map_err(|e| {
             if e.is_connect() {
                 RPCError::Unreachable(Unreachable::new(&e))
             } else {
@@ -98,9 +103,9 @@ where C: RaftTypeConfig<Node = NodeInfo, SnapshotData = Cursor<Vec<u8>>>
     async fn append_entries(
         &mut self,
         req: AppendEntriesRequest<C>,
-        _option: RPCOption,
+        option: RPCOption,
     ) -> Result<AppendEntriesResponse<C>, RPCError<C>> {
-        self.request("append", req).await
+        self.request("append", req, &option).await
     }
 
     async fn full_snapshot(
@@ -108,26 +113,26 @@ where C: RaftTypeConfig<Node = NodeInfo, SnapshotData = Cursor<Vec<u8>>>
         vote: VoteOf<C>,
         snapshot: SnapshotOf<C>,
         cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
-        _option: RPCOption,
+        option: RPCOption,
     ) -> Result<SnapshotResponse<C>, StreamingError<C>> {
         let req = (vote, snapshot.meta, snapshot.snapshot.into_inner());
         tokio::pin!(cancel);
 
         tokio::select! {
             closed = &mut cancel => Err(StreamingError::Closed(closed)),
-            res = self.request("snapshot", req) => Ok(res?),
+            res = self.request("snapshot", req, &option) => Ok(res?),
         }
     }
 
     async fn transfer_leader(
         &mut self,
         req: TransferLeaderRequest<C>,
-        _option: RPCOption,
+        option: RPCOption,
     ) -> Result<TransferLeaderResponse<C>, RPCError<C>> {
-        self.request("transfer-leader", req).await
+        self.request("transfer-leader", req, &option).await
     }
 
-    async fn vote(&mut self, req: VoteRequest<C>, _option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>> {
-        self.request("vote", req).await
+    async fn vote(&mut self, req: VoteRequest<C>, option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>> {
+        self.request("vote", req, &option).await
     }
 }

--- a/openraft/src/docs/getting_started/getting-started.md
+++ b/openraft/src/docs/getting_started/getting-started.md
@@ -215,6 +215,15 @@ An implementation of [`RaftNetworkV2`] can be considered as a wrapper that invok
 the corresponding methods of a remote [`Raft`]. It is responsible for sending
 and receiving messages between Raft nodes.
 
+The `RPCOption` argument carries the timeout budget for an RPC. The network
+implementation is responsible for enforcing `soft_ttl()` with a transport
+timeout, deadline, or reconnect policy. Openraft may shut down an in-flight RPC
+once `hard_ttl()` has elapsed.
+
+For streaming AppendEntries, `hard_ttl()` is not a lifetime limit for the whole
+stream. Use `soft_ttl()` for setup, idle timeout, keepalive, or per-response
+deadline policy to detect a stuck stream.
+
 Here is the list of methods that need to be implemented for the [`RaftNetworkV2`] trait:
 
 

--- a/openraft/src/network/append_trait.rs
+++ b/openraft/src/network/append_trait.rs
@@ -23,6 +23,8 @@ pub trait NetAppend<C>: OptionalSend + OptionalSync + 'static
 where C: RaftTypeConfig
 {
     /// Send an AppendEntries RPC to the target.
+    ///
+    /// The network implementation is responsible for enforcing `option.soft_ttl()`.
     async fn append_entries(
         &mut self,
         rpc: AppendEntriesRequest<C>,

--- a/openraft/src/network/rpc_option.rs
+++ b/openraft/src/network/rpc_option.rs
@@ -6,9 +6,11 @@ use std::time::Duration;
 /// [`RaftNetworkV2`]: `crate::network::RaftNetworkV2`
 #[derive(Clone, Debug)]
 pub struct RPCOption {
-    /// The expected time-to-last for an RPC.
+    /// The hard upper bound for a request-response RPC.
     ///
-    /// The caller will cancel an RPC if it takes longer than this duration.
+    /// Openraft may shut down an in-flight RPC once this duration has elapsed. Network
+    /// implementations may read this value, but should use [`RPCOption::soft_ttl`] to configure
+    /// their transport timeout, deadline, or equivalent mechanism.
     hard_ttl: Duration,
 
     /// The size of the snapshot chunk.
@@ -24,15 +26,18 @@ impl RPCOption {
         }
     }
 
-    /// The moderate max interval an RPC should last for.
+    /// The timeout budget a network implementation should enforce.
     ///
     /// The [`hard_ttl()`] and `soft_ttl()` methods of `RPCOption` set the hard limit and the
-    /// moderate limit of the duration for which an RPC should run. Once the `soft_ttl()` ends,
-    /// the RPC implementation should start to gracefully cancel the RPC, and once the
-    /// `hard_ttl()` ends, Openraft will terminate the ongoing RPC at once.
+    /// application-controlled timeout of a request-response RPC. The network implementation should
+    /// time out the RPC once `soft_ttl()` ends.
     ///
-    /// `soft_ttl` is smaller than [`hard_ttl()`] so that the RPC implementation can cancel the RPC
-    /// gracefully after `soft_ttl` and before `hard_ttl`.
+    /// `soft_ttl` is smaller than [`hard_ttl()`] so that the RPC implementation can return a
+    /// timeout error before Openraft may shut down the in-flight RPC at the hard limit.
+    ///
+    /// For a long-lived stream, [`hard_ttl()`] is not a limit on the stream lifetime. The transport
+    /// should apply `soft_ttl()` to its setup, idle timeout, keepalive, read deadline, or reconnect
+    /// policy.
     ///
     /// `soft_ttl` is 3/4 of `hard_ttl` but it may change in future, do not rely on this ratio.
     ///
@@ -41,9 +46,9 @@ impl RPCOption {
         self.hard_ttl * 3 / 4
     }
 
-    /// The hard limit of the interval an RPC should last for.
+    /// The hard upper bound Openraft may use to shut down an in-flight RPC.
     ///
-    /// When exceeding this limit, the RPC will be dropped by Openraft at once.
+    /// Network implementations should use [`RPCOption::soft_ttl`] to control their own timeout.
     pub fn hard_ttl(&self) -> Duration {
         self.hard_ttl
     }

--- a/openraft/src/network/snapshot_trait.rs
+++ b/openraft/src/network/snapshot_trait.rs
@@ -39,6 +39,7 @@ where C: RaftTypeConfig
     /// [`Raft::install_full_snapshot()`] with this vote.
     ///
     /// `cancel` gets `Ready` when the caller decides to cancel this snapshot transmission.
+    /// The network implementation is also responsible for enforcing `option.soft_ttl()`.
     ///
     /// [`Raft::install_full_snapshot()`]: crate::raft::Raft::install_full_snapshot
     async fn full_snapshot(

--- a/openraft/src/network/stream_append_trait.rs
+++ b/openraft/src/network/stream_append_trait.rs
@@ -44,6 +44,11 @@ where C: RaftTypeConfig
     /// and send back a stream of responses.
     ///
     /// The output stream terminates when the input is exhausted or an error occurs.
+    /// The network implementation is responsible for enforcing `option.soft_ttl()`.
+    ///
+    /// `option.hard_ttl()` is not a hard limit on the lifetime of a long-lived stream. Streaming
+    /// transports should use `soft_ttl()` for setup, per-request-response, or idle-timeout policy,
+    /// and return an error when the connection stops making progress.
     ///
     /// # Note
     ///

--- a/openraft/src/network/v2/network.rs
+++ b/openraft/src/network/v2/network.rs
@@ -71,6 +71,19 @@ use crate::type_config::alias::VoteOf;
 /// See the [network chapter of the guide](crate::docs::getting_started#4-implement-raftnetwork)
 /// for details and discussion on this trait and how to implement it.
 ///
+/// # RPC timeouts
+///
+/// Openraft passes [`RPCOption`] to every network method. Network implementations are responsible
+/// for applying `RPCOption::soft_ttl()` with transport timeouts, deadlines, keepalives, or
+/// reconnect policies.
+///
+/// Openraft may shut down an in-flight RPC once `RPCOption::hard_ttl()` has elapsed, so network
+/// implementations should return timeout errors before the hard limit.
+///
+/// For `stream_append`, `hard_ttl()` is not a hard limit on the lifetime of the whole stream.
+/// A streaming transport should instead use `soft_ttl()` for setup, per-response, or idle-timeout
+/// policy and return an error when the connection stops making progress.
+///
 /// A single network instance is used to connect to a single target node. The network instance is
 /// constructed by the [`RaftNetworkFactory`](`crate::network::RaftNetworkFactory`).
 ///

--- a/openraft/src/network/vote_trait.rs
+++ b/openraft/src/network/vote_trait.rs
@@ -23,6 +23,8 @@ pub trait NetVote<C>: OptionalSend + OptionalSync + 'static
 where C: RaftTypeConfig
 {
     /// Send a RequestVote RPC to the target.
+    ///
+    /// The network implementation is responsible for enforcing `option.soft_ttl()`.
     async fn vote(&mut self, rpc: VoteRequest<C>, option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>>;
 
     /// Send a Pre-Vote RPC to the target.
@@ -31,6 +33,9 @@ where C: RaftTypeConfig
     /// implemented `pre_vote` makes Pre-Vote a no-op and elections proceed as before. A transport
     /// failure must instead be returned as `Err` (it is not counted as a grant). See
     /// [`RaftNetworkV2::pre_vote`](crate::network::v2::RaftNetworkV2::pre_vote).
+    ///
+    /// Implementations that send a real Pre-Vote RPC are responsible for enforcing
+    /// `option.soft_ttl()`.
     async fn pre_vote(&mut self, rpc: VoteRequest<C>, _option: RPCOption) -> Result<VoteResponse<C>, RPCError<C>> {
         Ok(VoteResponse::new(rpc.vote, None, true))
     }


### PR DESCRIPTION

## Changelog

##### docs: clarify RPC timeout policy
# Summary

Clarify that network implementations should enforce RPC timeouts with
`soft_ttl()`, while `hard_ttl()` remains OpenRaft's upper bound for
shutting down an in-flight RPC.

# Details

- Document `RPCOption` as the per-call transport policy passed from
  OpenRaft to network implementations, including the soft and hard TTL
  responsibilities.
- Update the network trait and getting-started docs so stream transports
  treat `hard_ttl()` as an upper bound, not a whole-stream lifetime.
- Make the HTTP examples apply `option.soft_ttl()` to reqwest request
  timeouts.

- Fix: #1810

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1814)
<!-- Reviewable:end -->
