### PR TITLE
feat: byte-based cap on AppendEntries payload (max_payload_size)

### DIFF
--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -218,6 +218,27 @@ pub struct Config {
     #[cfg_attr(feature = "clap", clap(long, default_value_t = DEFAULTS.max_payload_entries))]
     pub max_payload_entries: u64,
 
+    /// The maximum number of bytes of entries allowed in a single `AppendEntries` RPC payload.
+    ///
+    /// This bounds the **serialized size** of the entries batched into one replication RPC,
+    /// complementing [`max_payload_entries`](Self::max_payload_entries) (the count limit):
+    /// whichever limit is reached first caps the batch. At least one entry is always included, so
+    /// a single entry larger than this limit does not stall replication.
+    ///
+    /// Because Openraft does not serialize entries itself, byte-size enforcement is delegated to
+    /// the log store's [`limited_get_log_entries`] implementation, which receives this value as
+    /// its `max_bytes` argument (the store is where the serialized bytes are known). Stores that
+    /// do not honor `max_bytes` — including the default implementation — ignore this limit.
+    ///
+    /// Accepts a size with an optional unit on the command line, e.g. `1MiB`. Defaults to `None`,
+    /// meaning no byte-size limit is applied.
+    ///
+    /// [`limited_get_log_entries`]: crate::storage::RaftLogReader::limited_get_log_entries
+    #[since(version = "0.10.0")]
+    #[cfg_attr(feature = "serde", serde(default))]
+    #[cfg_attr(feature = "clap", clap(long, value_parser = parse_bytes_with_unit))]
+    pub max_payload_size: Option<u64>,
+
     /// The maximum number of log entries per append I/O operation.
     ///
     /// When multiple `AppendEntries` commands are queued, Openraft can merge them into
@@ -550,6 +571,7 @@ impl Default for Config {
             install_snapshot_timeout: DEFAULTS.install_snapshot_timeout,
             send_snapshot_timeout: DEFAULTS.send_snapshot_timeout,
             max_payload_entries: DEFAULTS.max_payload_entries,
+            max_payload_size: None,
             max_append_entries: Some(DEFAULTS.max_append_entries),
             replication_lag_threshold: DEFAULTS.replication_lag_threshold,
             snapshot_policy: DEFAULTS.snapshot_policy.clone(),

--- a/openraft/src/config/config_clap_test.rs
+++ b/openraft/src/config/config_clap_test.rs
@@ -20,6 +20,7 @@ fn test_build() -> anyhow::Result<()> {
         "--send-snapshot-timeout=199",
         "--install-snapshot-timeout=200",
         "--max-payload-entries=201",
+        "--max-payload-size=1KiB",
         "--snapshot-policy=since_last:202",
         "--replication-lag-threshold=203",
         "--snapshot-max-chunk-size=204",
@@ -40,6 +41,7 @@ fn test_build() -> anyhow::Result<()> {
     }
     assert_eq!(200, config.install_snapshot_timeout);
     assert_eq!(201, config.max_payload_entries);
+    assert_eq!(Some(1024), config.max_payload_size);
     assert_eq!(SnapshotPolicy::LogsSinceLast(202), config.snapshot_policy);
     assert_eq!(203, config.replication_lag_threshold);
     assert_eq!(204, config.snapshot_max_chunk_size);

--- a/openraft/src/config/config_test.rs
+++ b/openraft/src/config/config_test.rs
@@ -12,6 +12,7 @@ fn test_config_defaults() {
 
     assert_eq!(50, cfg.heartbeat_interval);
     assert_eq!(300, cfg.max_payload_entries);
+    assert_eq!(None, cfg.max_payload_size);
     assert_eq!(5000, cfg.replication_lag_threshold);
 
     assert_eq!(3 * 1024 * 1024, cfg.snapshot_max_chunk_size);

--- a/openraft/src/replication/stream_state.rs
+++ b/openraft/src/replication/stream_state.rs
@@ -262,8 +262,12 @@ where
             let max_entries = self.replication_context.config.max_payload_entries;
             let end = std::cmp::min(end, start + max_entries);
 
+            // Optional byte-size cap on the payload; the store enforces it (see
+            // `RaftLogReader::limited_get_log_entries`), since it knows the serialized size.
+            let max_bytes = self.replication_context.config.max_payload_size;
+
             // limited_get_log_entries will return logs smaller than the range [start, end).
-            let logs = self.log_reader.limited_get_log_entries(start, end).await.sto_read_logs()?;
+            let logs = self.log_reader.limited_get_log_entries(start, end, max_bytes).await.sto_read_logs()?;
 
             // Handle empty result gracefully: treat as heartbeat.
             // This violates the API contract but we don't panic.

--- a/openraft/src/storage/v2/raft_log_reader.rs
+++ b/openraft/src/storage/v2/raft_log_reader.rs
@@ -241,11 +241,25 @@ where C: RaftTypeConfig
     /// If the specified range is too large, the implementation may return only the first few log
     /// entries to ensure the result is not excessively large.
     ///
+    /// `max_bytes` is an optional cap on the **total serialized size** of the returned entries,
+    /// sourced from [`Config::max_payload_size`](crate::Config::max_payload_size). When set, the
+    /// implementation should stop accumulating once including the next entry would exceed this many
+    /// bytes. It must, however, always return at least one entry for a non-empty range, so a single
+    /// entry larger than `max_bytes` cannot stall replication. Because Openraft does not serialize
+    /// entries itself, only stores that know their serialized size can honor this; the default
+    /// implementation ignores `max_bytes`.
+    ///
     /// It must not return an empty result if the input range is not empty.
     ///
     /// The default implementation just returns the full range of log entries.
     #[since(version = "0.10.0")]
-    async fn limited_get_log_entries(&mut self, start: u64, end: u64) -> Result<Vec<C::Entry>, io::Error> {
+    async fn limited_get_log_entries(
+        &mut self,
+        start: u64,
+        end: u64,
+        max_bytes: Option<u64>,
+    ) -> Result<Vec<C::Entry>, io::Error> {
+        let _ = max_bytes;
         self.try_get_log_entries(start..end).await
     }
 

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -80,8 +80,13 @@ where C: RaftTypeConfig
     }
 
     /// Proxy method to invoke [`RaftLogReader::limited_get_log_entries`].
-    async fn limited_get_log_entries(&mut self, start: u64, end: u64) -> Result<Vec<C::Entry>, io::Error> {
-        self.get_log_reader().await.limited_get_log_entries(start, end).await
+    async fn limited_get_log_entries(
+        &mut self,
+        start: u64,
+        end: u64,
+        max_bytes: Option<u64>,
+    ) -> Result<Vec<C::Entry>, io::Error> {
+        self.get_log_reader().await.limited_get_log_entries(start, end, max_bytes).await
     }
 }
 
@@ -960,17 +965,33 @@ where
 
         tracing::info!("--- get start == stop");
         {
-            let logs = store.limited_get_log_entries(3, 3).await?;
+            let logs = store.limited_get_log_entries(3, 3, None).await?;
             assert_eq!(logs.len(), 0, "expected no logs to be returned");
         }
 
         tracing::info!("--- get start < stop");
         {
-            let logs = store.limited_get_log_entries(5, 7).await?;
+            let logs = store.limited_get_log_entries(5, 7, None).await?;
 
             assert!(!logs.is_empty());
             assert!(logs.len() <= 2);
             assert_eq!(logs[0].log_id(), log_id_0::<C>(1, 5));
+        }
+
+        tracing::info!("--- max_bytes is an optional cap; assert only the universal contract");
+        {
+            let unlimited = store.limited_get_log_entries(5, 11, None).await?;
+
+            // A tiny budget must still return at least one entry: a single oversized entry must
+            // never stall replication. Stores that do not honor `max_bytes` simply return more.
+            let tiny = store.limited_get_log_entries(5, 11, Some(1)).await?;
+            assert!(!tiny.is_empty(), "must return >= 1 entry even below one entry's size");
+            assert!(tiny.len() <= unlimited.len());
+            assert_eq!(tiny[0].log_id(), log_id_0::<C>(1, 5));
+
+            // A huge budget must never truncate.
+            let huge = store.limited_get_log_entries(5, 11, Some(u64::MAX)).await?;
+            assert_eq!(huge.len(), unlimited.len(), "huge budget must behave like no limit");
         }
 
         Ok(())

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -302,7 +302,12 @@ impl RaftLogReader<TypeConfig> for Arc<MemLogStore> {
         Ok(*self.vote.read().await)
     }
 
-    async fn limited_get_log_entries(&mut self, start: u64, end: u64) -> Result<Vec<EntryOf<TypeConfig>>, io::Error> {
+    async fn limited_get_log_entries(
+        &mut self,
+        start: u64,
+        end: u64,
+        max_bytes: Option<u64>,
+    ) -> Result<Vec<EntryOf<TypeConfig>>, io::Error> {
         if self.fail_next_limited_get.swap(false, Ordering::Relaxed) {
             tracing::info!(
                 "limited_get_log_entries({}, {}): returning io::Error for testing",
@@ -320,7 +325,28 @@ impl RaftLogReader<TypeConfig> for Arc<MemLogStore> {
             );
             return Ok(vec![]);
         }
-        self.try_get_log_entries(start..end).await
+
+        // Entries are stored already serialized, so the byte budget is enforced cheaply here.
+        let log = self.log.read().await;
+        let mut entries = Vec::new();
+        let mut total_bytes: u64 = 0;
+        for (_, serialized) in log.range(start..end) {
+            let entry_bytes = serialized.len() as u64;
+            // Always include at least one entry so a single oversized entry cannot stall
+            // replication; otherwise stop once including this entry would exceed the budget.
+            if !entries.is_empty()
+                && let Some(max) = max_bytes
+                && total_bytes + entry_bytes > max
+            {
+                break;
+            }
+            let ent = serde_json::from_str(serialized)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+            entries.push(ent);
+            total_bytes += entry_bytes;
+        }
+
+        Ok(entries)
     }
 }
 

--- a/stores/memstore/src/test.rs
+++ b/stores/memstore/src/test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use openraft::StorageError;
+use openraft::storage::RaftLogReader;
 use openraft::testing::log::StoreBuilder;
 use openraft::testing::log::Suite;
 use openraft::type_config::TypeConfigExt;
@@ -22,5 +23,43 @@ impl StoreBuilder<TypeConfig, Arc<MemLogStore>, Arc<MemStateMachine>, ()> for Me
 pub fn test_mem_store() {
     TypeConfig::run(async {
         Suite::test_all(MemStoreBuilder {}).await.unwrap();
+    });
+}
+
+/// `MemLogStore` honors the `max_bytes` argument of `limited_get_log_entries`: it stops
+/// accumulating once the byte budget would be exceeded, but always returns at least one entry.
+#[test]
+pub fn test_limited_get_log_entries_max_bytes() {
+    TypeConfig::run(async {
+        let (mut log_store, _sm) = crate::new_mem_store();
+
+        // Feeds blank entries at indices 0..=10.
+        Suite::<TypeConfig, Arc<MemLogStore>, Arc<MemStateMachine>, MemStoreBuilder, ()>::feed_10_logs_vote_self(
+            &mut log_store,
+        )
+        .await
+        .unwrap();
+
+        // No byte limit: the whole range [1, 11) is returned.
+        let all = log_store.limited_get_log_entries(1, 11, None).await.unwrap();
+        assert_eq!(10, all.len());
+
+        // A budget below a single entry still returns exactly one entry (progress guarantee).
+        let one = log_store.limited_get_log_entries(1, 11, Some(1)).await.unwrap();
+        assert_eq!(1, one.len());
+
+        // A budget that exactly fits the first two entries returns exactly two.
+        let two_bytes =
+            (serde_json::to_string(&all[0]).unwrap().len() + serde_json::to_string(&all[1]).unwrap().len()) as u64;
+        let two = log_store.limited_get_log_entries(1, 11, Some(two_bytes)).await.unwrap();
+        assert_eq!(2, two.len());
+
+        // One byte short of the second entry truncates back to one.
+        let one_again = log_store.limited_get_log_entries(1, 11, Some(two_bytes - 1)).await.unwrap();
+        assert_eq!(1, one_again.len());
+
+        // A huge budget behaves like no limit.
+        let huge = log_store.limited_get_log_entries(1, 11, Some(u64::MAX)).await.unwrap();
+        assert_eq!(10, huge.len());
     });
 }

--- a/tests-turmoil/src/store.rs
+++ b/tests-turmoil/src/store.rs
@@ -80,7 +80,12 @@ impl RaftLogReader<TypeConfig> for Arc<LogStore> {
         Ok(*self.vote.lock().unwrap())
     }
 
-    async fn limited_get_log_entries(&mut self, start: u64, end: u64) -> Result<Vec<Entry>, io::Error> {
+    async fn limited_get_log_entries(
+        &mut self,
+        start: u64,
+        end: u64,
+        _max_bytes: Option<u64>,
+    ) -> Result<Vec<Entry>, io::Error> {
         self.try_get_log_entries(start..end).await
     }
 }


### PR DESCRIPTION
## Summary

Adds an optional **byte-size cap** on the entries batched into a single `AppendEntries` RPC, complementing the existing count cap `max_payload_entries`. Whichever limit is reached first caps the batch, and at least one entry is always sent so a single oversized entry cannot stall replication.

Closes the gap where the only replication payload knob was entry *count* — a handful of large entries could still produce an oversized RPC.

## Design

Openraft does not serialize entries itself (the application's `RaftNetwork` does), so the core cannot measure an entry's wire size. Byte-size enforcement is therefore **delegated to the log store**, which is where the serialized bytes are known:

- New config `Config::max_payload_size: Option<u64>` (bytes; `None` = no limit, the default).
- `RaftLogReader::limited_get_log_entries` gains a `max_bytes: Option<u64>` argument, sourced from `max_payload_size`. The default trait impl ignores it; stores that know their serialized size honor it (stop accumulating once the next entry would exceed the budget, but always return ≥1 entry for a non-empty range).

The replication read path (`stream_state::read_log_entries`) passes the budget through. The existing short-read reconciliation already advances the replication cursor by the *actual* returned range, so no progress-accounting changes were needed — a byte-truncated batch behaves like the already-supported count-truncated short read.

This was chosen over measuring in the core (would require a size method on `RaftEntry`/`AppData`, plus read-then-discard waste) so that measurement stays where the bytes actually are.

## Changes

- **`config.rs`**: new `max_payload_size` field (CLI accepts units, e.g. `--max-payload-size=1MiB`), docs, `#[since]`, serde default, added to `Default`.
- **`raft_log_reader.rs`** + **`stream_state.rs`**: `limited_get_log_entries(start, end, max_bytes)`; budget plumbed from config.
- **`stores/memstore`**: honors `max_bytes` as a reference implementation (it stores entries as serialized JSON, so size is measured cheaply).
- **`tests-turmoil`, testing suite proxy**: signature updates. Example stores use the default impl and are unchanged.

## Compatibility

- `max_payload_size` defaults to `None` → behavior is unchanged unless explicitly configured.
- `limited_get_log_entries` is a `#[since(0.10.0)]` method (unreleased alpha); the added parameter affects only stores that override it. Stores using the default impl need no change.

## Testing

- Config default (`None`) and CLI parsing (`1KiB` → `Some(1024)`).
- Storage suite: universal contract assertions all stores must satisfy (tiny budget still returns ≥1; huge budget == unlimited).
- `memstore`: strict truncation test (budget for exactly 2 entries → 2; one byte short → 1; tiny → 1; huge → all).
- `make lint` clean; `append_entries` + `replication` integration suites pass; full workspace builds `--all-targets`.

## Open question

Left `max_payload_entries` in place (byte cap *complements* the count cap). Happy to deprecate it in favor of the byte cap instead if maintainers prefer a single knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1815)
<!-- Reviewable:end -->
