### PR TITLE
docs: clarify that ApplyResponder::send must be called

### DIFF
--- a/openraft/src/storage/v2/apply_responder.rs
+++ b/openraft/src/storage/v2/apply_responder.rs
@@ -11,8 +11,8 @@ use crate::storage::v2::apply_responder_inner::ApplyResponderInner;
 ///
 /// This type cannot be constructed by user code. Instances are provided by
 /// Openraft when entries are passed to [`RaftStateMachine::apply`](super::RaftStateMachine::apply).
-/// State machine implementations should call [`send()`](Self::send) to
-/// return the response after applying each entry.
+/// State machine implementations must call [`send()`](Self::send) after applying each entry.
+/// Failure to call `send()` will cause [`client_write`](crate::Raft::client_write) to hang.
 ///
 /// # Example
 ///
@@ -54,6 +54,10 @@ pub struct ApplyResponder<C: RaftTypeConfig> {
 
 impl<C: RaftTypeConfig> ApplyResponder<C> {
     /// Send the response after applying an entry.
+    ///
+    /// The response will be returned by [`Raft::client_write`](crate::Raft::client_write).
+    /// This method must be called by [`RaftStateMachine::apply`](super::RaftStateMachine::apply),
+    /// otherwise [`Raft::client_write`](crate::Raft::client_write) will never return.
     pub fn send(self, response: C::R) {
         self.inner.send(response)
     }

--- a/openraft/src/storage/v2/raft_state_machine.rs
+++ b/openraft/src/storage/v2/raft_state_machine.rs
@@ -57,12 +57,13 @@ where C: RaftTypeConfig
     /// application-specific transaction is being started, or perhaps committed. This may be
     /// where a key/value is being stored.
     ///
-    /// For every entry to apply, an implementation should:
+    /// For every entry to apply, an implementation must:
     /// - Store the log id as last-applied log id.
     /// - Deal with the business logic log.
     /// - Store membership config if `RaftEntry::get_membership()` returns `Some`.
     /// - Call [`ApplyResponder::send`](crate::storage::ApplyResponder::send) with the response
-    ///   immediately after applying the entry.
+    ///   immediately after applying the entry. If this is not called,
+    ///   [`Raft::client_write`](crate::Raft::client_write) will never return.
     ///
     /// Note that for a membership log, the implementation needs to do nothing about it, except
     /// storing it.


### PR DESCRIPTION
# Summary

Change "should" to "must" to clarify that calling ApplyResponder::send() is required, not optional. Dropping a responder without calling send() causes the the originating client_write to block forever.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:) (not relevant: doc only change)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1816)
<!-- Reviewable:end -->
