### PR TITLE
refactor: reshape VecProgress around entries

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -83,6 +83,7 @@ use crate::network::NetVote;
 use crate::network::RPCOption;
 use crate::network::RPCTypes;
 use crate::network::RaftNetworkFactory;
+use crate::progress::VecProgressEntry;
 use crate::progress::stream_id::StreamId;
 use crate::quorum::QuorumSet;
 use crate::raft::AppendEntriesRequest;
@@ -400,7 +401,7 @@ where
 
         for item in voter_progresses {
             let target = item.id.clone();
-            let progress = &item.val;
+            let progress = item;
 
             if target == my_id {
                 continue;
@@ -706,7 +707,7 @@ where
 
         let (replication, heartbeat) = if let Some(leader) = self.engine.leader.as_ref() {
             let replication_prog = &leader.progress;
-            let replication = Some(replication_prog.collect_mapped(|item| item.to_matching_tuple()));
+            let replication = Some(replication_prog.collect_mapped(|item| item.id_progress_owned()));
 
             let clock_prog = &leader.clock_progress;
             let heartbeat = Some(clock_prog.collect_mapped(|item| (item.id.clone(), item.val.map(SerdeInstant::new))));
@@ -2167,7 +2168,7 @@ where
                 .map(|progress_entry| {
                     (progress_entry.id.clone(), HeartbeatEvent {
                         time: now,
-                        matching: progress_entry.val.matching.clone(),
+                        matching: progress_entry.matching.clone(),
                         cluster_committed: cluster_committed.clone(),
                     })
                 });

--- a/openraft/src/engine/command_name.rs
+++ b/openraft/src/engine/command_name.rs
@@ -263,7 +263,7 @@ mod tests {
             targets: vec![TargetProgress {
                 target: 1,
                 target_node: (),
-                progress: ProgressEntry::empty(StreamId::new(1), 1),
+                progress: ProgressEntry::empty(1, StreamId::new(1), 1),
             }],
             close_old_streams: false,
         };

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -304,7 +304,7 @@ fn test_leader_append_entries_with_membership_log() -> anyhow::Result<()> {
                 targets: vec![TargetProgress {
                     target: 2,
                     target_node: (),
-                    progress: ProgressEntry::empty(StreamId::new(8), 7),
+                    progress: ProgressEntry::empty(2, StreamId::new(6), 7),
                 }],
                 close_old_streams: false,
             },

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -92,12 +92,12 @@ fn test_leader_append_membership_for_leader() -> anyhow::Result<()> {
                     TargetProgress {
                         target: 3,
                         target_node: (),
-                        progress: ProgressEntry::empty(StreamId::new(2), 0),
+                        progress: ProgressEntry::empty(3, StreamId::new(2), 0),
                     },
                     TargetProgress {
                         target: 4,
                         target_node: (),
-                        progress: ProgressEntry::empty(StreamId::new(5), 0),
+                        progress: ProgressEntry::empty(4, StreamId::new(4), 0),
                     }
                 ], /* node-2 is leader,
                     * won't be removed */
@@ -150,19 +150,19 @@ fn test_leader_append_membership_update_learner_process() -> anyhow::Result<()> 
     eng.testing_new_leader();
 
     if let Some(l) = &mut eng.leader.as_mut() {
-        assert_eq!(&ProgressEntry::empty(StreamId::new(3), 11), l.progress.get(&4));
-        assert_eq!(&ProgressEntry::empty(StreamId::new(4), 11), l.progress.get(&5));
+        assert_eq!(&ProgressEntry::empty(4, StreamId::new(3), 11), l.progress.get(&4));
+        assert_eq!(&ProgressEntry::empty(5, StreamId::new(4), 11), l.progress.get(&5));
 
-        let p = ProgressEntry::testing_new(Some(log_id(1, 1, 4)));
-        l.progress.update(&4, p.clone()).ok();
+        let p = ProgressEntry::testing_new(4, Some(log_id(1, 1, 4)));
+        l.progress.update_entry_with(&4, |entry| *entry = p.clone()).ok();
         assert_eq!(&p, l.progress.get(&4));
 
-        let p = ProgressEntry::testing_new(Some(log_id(1, 1, 5)));
-        l.progress.update(&5, p.clone()).ok();
+        let p = ProgressEntry::testing_new(5, Some(log_id(1, 1, 5)));
+        l.progress.update_entry_with(&5, |entry| *entry = p.clone()).ok();
         assert_eq!(&p, l.progress.get(&5));
 
-        let p = ProgressEntry::testing_new(Some(log_id(1, 1, 3)));
-        l.progress.update(&3, p.clone()).ok();
+        let p = ProgressEntry::testing_new(3, Some(log_id(1, 1, 3)));
+        l.progress.update_entry_with(&3, |entry| *entry = p.clone()).ok();
         assert_eq!(&p, l.progress.get(&3));
     } else {
         unreachable!("leader should not be None");
@@ -181,21 +181,21 @@ fn test_leader_append_membership_update_learner_process() -> anyhow::Result<()> 
     if let Some(l) = &mut eng.leader.as_mut() {
         // Progress entries with matching.next_index() == searching_end enter pipeline mode
         assert_eq!(
-            &ProgressEntry::testing_new(Some(log_id(1, 1, 4)))
+            &ProgressEntry::testing_new(4, Some(log_id(1, 1, 4)))
                 .with_inflight(Inflight::logs_since(Some(log_id(1, 1, 4)), InflightId::new(1))),
             l.progress.get(&4),
             "learner-4 progress should be transferred to voter progress (pipeline mode)"
         );
 
         assert_eq!(
-            &ProgressEntry::testing_new(Some(log_id(1, 1, 3)))
+            &ProgressEntry::testing_new(3, Some(log_id(1, 1, 3)))
                 .with_inflight(Inflight::logs_since(Some(log_id(1, 1, 3)), InflightId::new(2))),
             l.progress.get(&3),
             "voter-3 progress should be transferred to learner progress (pipeline mode)"
         );
 
         assert_eq!(
-            &ProgressEntry::testing_new(Some(log_id(1, 1, 5)))
+            &ProgressEntry::testing_new(5, Some(log_id(1, 1, 5)))
                 .with_inflight(Inflight::logs_since(Some(log_id(1, 1, 5)), InflightId::new(3))),
             l.progress.get(&5),
             "learner-5 has previous value (pipeline mode)"
@@ -204,7 +204,7 @@ fn test_leader_append_membership_update_learner_process() -> anyhow::Result<()> 
         // Node 6 is new, with matching=None and searching_end=11
         // matching.next_index()=0 != searching_end=11, so NOT pipeline mode
         assert_eq!(
-            &ProgressEntry::empty(StreamId::new(9), 11).with_inflight(Inflight::logs(
+            &ProgressEntry::empty(6, StreamId::new(8), 11).with_inflight(Inflight::logs(
                 None,
                 Some(log_id(5, 1, 10)),
                 InflightId::new(4)

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use display_more::DisplayOptionExt;
 use display_more::DisplayResultExt;
+use progress::entry::update::Updater;
 
 use crate::LogIdOptionExt;
 use crate::Membership;
@@ -19,6 +20,7 @@ use crate::errors::Operation;
 use crate::progress;
 use crate::progress::Inflight;
 use crate::progress::entry::ProgressEntry;
+use crate::progress::id_val::IdVal;
 use crate::progress::inflight_id::InflightId;
 use crate::progress::stream_id::StreamId;
 use crate::proposer::Leader;
@@ -107,20 +109,23 @@ where C: RaftTypeConfig
             let old_progress = self.leader.progress.clone();
 
             let id_gen = self.state.progress_id_gen.clone();
-            let default_v = || {
+            let default_entry = |id| {
                 let progress_id = StreamId::new(id_gen.next_id());
-                ProgressEntry::empty(progress_id, end)
+                ProgressEntry::empty(id, progress_id, end)
             };
 
-            self.leader.progress =
-                old_progress.upgrade_quorum_set(Arc::new((*em.membership()).clone()), learner_ids.clone(), default_v);
+            self.leader.progress = old_progress.upgrade_quorum_set(
+                Arc::new((*em.membership()).clone()),
+                learner_ids.clone(),
+                default_entry,
+            );
         }
 
         {
             let old_progress = self.leader.clock_progress.clone();
 
             self.leader.clock_progress =
-                old_progress.upgrade_quorum_set(Arc::new((*em.membership()).clone()), learner_ids, || None);
+                old_progress.upgrade_quorum_set(Arc::new((*em.membership()).clone()), learner_ids, IdVal::new_default);
         }
     }
 
@@ -150,9 +155,9 @@ where C: RaftTypeConfig
         tracing::debug!(
             "granted leader vote clock after updating: granted: {}; clock_progress: {}",
             granted.as_ref().map(|x| x.display()).display(),
-            self.leader
-                .clock_progress
-                .display_with(|f, id, v| { write!(f, "{}: {}", id, v.as_ref().map(|x| x.display()).display()) })
+            self.leader.clock_progress.display_with(|f, item| {
+                write!(f, "{}: {}", item.id, item.val.as_ref().map(|x| x.display()).display())
+            })
         );
 
         // When membership changes, the granted value may revert to a previous value.
@@ -182,8 +187,8 @@ where C: RaftTypeConfig
 
         // The value granted by a quorum may not yet be a committed.
         // A committed is **granted** and also is in the current term.
-        let Ok(quorum_accepted) = self.leader.progress.update_with(&node_id, |prog_entry| {
-            prog_entry.new_updater(&*self.config).update_matching(log_id, inflight_id)
+        let Ok(quorum_accepted) = self.leader.progress.update_entry_with(&node_id, |entry| {
+            entry.new_updater(&*self.config).update_matching(log_id, inflight_id)
         }) else {
             // the node does not exist anymore
             return;
@@ -234,6 +239,12 @@ where C: RaftTypeConfig
     ///
     /// If `has_payload` is true, the `inflight` state is reset because AppendEntries RPC
     /// manages the inflight state.
+    ///
+    /// This method intentionally bypasses `VecProgress::update_entry_with()`: when log
+    /// reversion is explicitly allowed, [`Updater::update_conflicting()`] may reset
+    /// `matching` to `None`. `VecProgress::reset_entry_with()` moves the entry down to
+    /// keep the progress ordering, but deliberately does not lower the recorded
+    /// quorum-accepted value: a value accepted by a quorum must never be withdrawn.
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn update_conflicting(
         &mut self,
@@ -243,13 +254,10 @@ where C: RaftTypeConfig
     ) {
         // TODO(2): test it?
 
-        let Some(prog_entry) = self.leader.progress.get_mut(&target) else {
-            return;
-        };
-
-        let mut updater = progress::entry::update::Updater::new(self.config, prog_entry);
-
-        updater.update_conflicting(conflict.index(), inflight_id);
+        self.leader.progress.reset_entry_with(&target, |entry| {
+            let mut updater = Updater::new(&*self.config, entry);
+            updater.update_conflicting(conflict.index(), inflight_id);
+        });
     }
 
     /// Enable one-time replication reset for a specific node upon log reversion detection.
@@ -266,16 +274,16 @@ where C: RaftTypeConfig
     ///   reset.
     /// - If the node is not found in the progress tracker, this method ignore it.
     pub(crate) fn allow_next_revert(&mut self, target: C::NodeId, allow: bool) -> Result<(), NodeNotFound<C::NodeId>> {
-        let Some(prog_entry) = self.leader.progress.get_mut(&target) else {
+        let res = self.leader.progress.update_data_with(&target, |data| data.allow_log_reversion = allow);
+
+        if res.is_none() {
             tracing::warn!(
                 "target node {} not found in progress tracker, when {}",
                 target,
                 func_name!()
             );
             return Err(NodeNotFound::new(target, Operation::AllowNextRevert));
-        };
-
-        prog_entry.allow_log_reversion = allow;
+        }
 
         Ok(())
     }
@@ -316,9 +324,7 @@ where C: RaftTypeConfig
                 tracing::warn!("update progress error: {}", err_str);
 
                 // Reset inflight state and it will retry.
-                if let Some(p) = self.leader.progress.get_mut(&target) {
-                    p.inflight = Inflight::None;
-                };
+                self.leader.progress.update_data_with(&target, |data| data.inflight = Inflight::None);
             }
         };
 
@@ -334,10 +340,10 @@ where C: RaftTypeConfig
 
         let membership = self.state.membership_state.effective();
 
-        for item in self.leader.progress.iter_mut() {
+        for item in self.leader.progress.iter_mut_without_reorder() {
             if item.id != self.config.id {
                 if close_old {
-                    item.val.inflight = Inflight::None;
+                    item.inflight = Inflight::None;
                 }
 
                 let target_node = membership.get_node(&item.id).unwrap().clone();
@@ -345,7 +351,7 @@ where C: RaftTypeConfig
                 targets.push(TargetProgress {
                     target: item.id.clone(),
                     target_node,
-                    progress: item.val.clone(),
+                    progress: item.clone(),
                 });
             }
         }
@@ -363,23 +369,24 @@ where C: RaftTypeConfig
     pub(crate) fn initiate_replication(&mut self) {
         tracing::debug!("{}: progress: {:?}", func_name!(), self.leader.progress);
 
-        for item in self.leader.progress.iter_mut() {
+        for item in self.leader.progress.iter_mut_without_reorder() {
             // TODO: update matching should be done here for leader
             //       or updating matching should be queued in commands?
             if item.id == self.config.id {
                 continue;
             }
 
-            let t = item.val.next_send(self.state, self.config.max_payload_entries);
-            tracing::debug!("next send: target: {}, send: {:?}", item.id, t);
+            let target = item.id.clone();
+            let t = item.next_send(self.state, self.config.max_payload_entries);
+            tracing::debug!("next send: target: {}, send: {:?}", target, t);
 
             match t {
                 Ok(inflight) => {
                     let leader_vote = self.leader.committed_vote.clone();
-                    Self::send_to_target(self.output, leader_vote, &item.id, inflight);
+                    Self::send_to_target(self.output, leader_vote, &target, inflight);
                 }
                 Err(e) => {
-                    tracing::debug!("no data to replicate for node-{}: current inflight: {:?}", item.id, e,);
+                    tracing::debug!("no data to replicate for node-{}: current inflight: {:?}", target, e,);
                 }
             }
         }
@@ -447,7 +454,7 @@ where C: RaftTypeConfig
         // Check if any replication task is going to use the log that is going to purge.
         let mut in_use = false;
         for item in self.leader.progress.iter() {
-            if item.val.is_log_range_inflight(&purge_upto) {
+            if item.is_log_range_inflight(&purge_upto) {
                 tracing::debug!("log {} is in use by {}", purge_upto, item.id);
                 in_use = true;
             }
@@ -478,19 +485,26 @@ where C: RaftTypeConfig
         let id = self.config.id.clone();
 
         // The leader may not be in membership anymore
-        if let Some(prog_entry) = self.leader.progress.try_get(&id) {
-            tracing::debug!("update progress: self_matching: {}", prog_entry.matching().display());
+        if let Some(entry) = self.leader.progress.try_get(&id) {
+            tracing::debug!("update progress: self_matching: {}", entry.matching().display());
 
-            if prog_entry.matching() >= upto.as_ref() {
+            if entry.matching() >= upto.as_ref() {
                 return;
             }
         }
 
-        if let Some(prog_entry) = self.leader.progress.get_mut(&id) {
-            // TODO: It should be self.state.last_log_id() but None is ok.
-            prog_entry.inflight = Inflight::logs(None, upto.clone(), InflightId::new(0));
+        let inflight_id = InflightId::new(0);
 
-            self.update_matching(id, upto, Some(InflightId::new(0)));
+        if self
+            .leader
+            .progress
+            .update_data_with(&id, |data| {
+                // TODO: It should be self.state.last_log_id() but None is ok.
+                data.inflight = Inflight::logs(None, upto.clone(), inflight_id);
+            })
+            .is_some()
+        {
+            self.update_matching(id, upto, Some(inflight_id));
         }
     }
 

--- a/openraft/src/engine/handler/replication_handler/update_matching_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_matching_test.rs
@@ -64,18 +64,17 @@ fn test_update_matching() -> anyhow::Result<()> {
     eng.output.take_commands();
 
     let mut rh = eng.replication_handler();
-    {
-        let prog_entry = rh.leader.progress.get_mut(&1).unwrap();
-        prog_entry.inflight = Inflight::logs(Some(log_id(2, 1, 3)), Some(log_id(2, 1, 4)), InflightId::new(1));
+    let mut set_inflight = |id, prev| {
+        let inflight = Inflight::logs(prev, Some(log_id(2, 1, 4)), InflightId::new(1));
+        assert_eq!(
+            Some(&inflight),
+            rh.leader.progress.update_data_with(&id, |data| data.inflight = inflight).map(|data| &data.inflight)
+        );
     };
-    {
-        let prog_entry = rh.leader.progress.get_mut(&2).unwrap();
-        prog_entry.inflight = Inflight::logs(Some(log_id(1, 1, 0)), Some(log_id(2, 1, 4)), InflightId::new(1));
-    };
-    {
-        let prog_entry = rh.leader.progress.get_mut(&3).unwrap();
-        prog_entry.inflight = Inflight::logs(Some(log_id(1, 1, 1)), Some(log_id(2, 1, 4)), InflightId::new(1));
-    };
+
+    set_inflight(1, Some(log_id(2, 1, 3)));
+    set_inflight(2, Some(log_id(1, 1, 0)));
+    set_inflight(3, Some(log_id(1, 1, 1)));
 
     // progress: None, None, (1,2)
     {

--- a/openraft/src/engine/handler/vote_handler/become_leader_test.rs
+++ b/openraft/src/engine/handler/vote_handler/become_leader_test.rs
@@ -72,7 +72,7 @@ fn test_become_leader() -> anyhow::Result<()> {
             targets: vec![TargetProgress {
                 target: 0,
                 target_node: (),
-                progress: ProgressEntry::empty(StreamId::new(1), 0),
+                progress: ProgressEntry::empty(0, StreamId::new(1), 0),
             }],
             close_old_streams: true,
         },

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -219,7 +219,7 @@ fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
                     targets: vec![TargetProgress {
                         target: 2,
                         target_node: (),
-                        progress: ProgressEntry::empty(StreamId::new(2), 1),
+                        progress: ProgressEntry::empty(2, StreamId::new(2), 1),
                     }],
                     close_old_streams: true,
                 },

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -16,7 +16,6 @@ use crate::engine::testing::UTConfig;
 use crate::engine::testing::log_id;
 use crate::entry::RaftEntry;
 use crate::log_id_range::LogIdRange;
-use crate::progress::Inflight;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::inflight_id::InflightId;
 use crate::progress::stream_id::StreamId;
@@ -83,13 +82,7 @@ fn test_startup_as_leader_without_logs() -> anyhow::Result<()> {
                 targets: vec![TargetProgress {
                     target: 3,
                     target_node: (),
-                    progress: ProgressEntry {
-                        stream_id: StreamId::new(2),
-                        matching: None,
-                        inflight: Inflight::None,
-                        searching_end: 4,
-                        allow_log_reversion: false,
-                    },
+                    progress: ProgressEntry::empty(3, StreamId::new(2), 4),
                 }],
                 close_old_streams: true,
             },
@@ -143,13 +136,7 @@ fn test_startup_as_leader_with_proposed_logs() -> anyhow::Result<()> {
                 targets: vec![TargetProgress {
                     target: 3,
                     target_node: (),
-                    progress: ProgressEntry {
-                        stream_id: StreamId::new(2),
-                        matching: None,
-                        inflight: Inflight::None,
-                        searching_end: 7,
-                        allow_log_reversion: false,
-                    },
+                    progress: ProgressEntry::empty(3, StreamId::new(2), 7),
                 }],
                 close_old_streams: true,
             },

--- a/openraft/src/engine/tests/trigger_purge_log_test.rs
+++ b/openraft/src/engine/tests/trigger_purge_log_test.rs
@@ -114,7 +114,11 @@ fn test_trigger_purge_log_in_used_wont_be_delete() -> anyhow::Result<()> {
     // Make it a leader and mark the logs are in flight.
     eng.testing_new_leader();
     let l = eng.leader.as_mut().unwrap();
-    let _ = l.progress.get_mut(&2).unwrap().next_send(eng.state.deref_mut(), 10).unwrap();
+    l.progress
+        .update_entry_with(&2, |entry| {
+            entry.next_send(eng.state.deref_mut(), 10).unwrap();
+        })
+        .unwrap();
 
     eng.trigger_purge_log(5);
 

--- a/openraft/src/progress/bench/vec_progress_update.rs
+++ b/openraft/src/progress/bench/vec_progress_update.rs
@@ -9,7 +9,7 @@ use crate::progress::VecProgress;
 #[bench]
 fn progress_update_01234_567(b: &mut Bencher) {
     let quorum_set = vec![btreeset! {0, 1, 2, 3, 4}, btreeset! {5, 6, 7}];
-    let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, 0..=7, || 0);
+    let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, 0..=7, |id| (id, 0));
 
     let mut id = 0u64;
     let mut values = [0, 1, 2, 3, 4, 5, 6, 7];

--- a/openraft/src/progress/display_vec_progress.rs
+++ b/openraft/src/progress/display_vec_progress.rs
@@ -1,27 +1,25 @@
-use std::borrow::Borrow;
 use std::fmt::Display;
 use std::fmt::Formatter;
 
+use super::VecProgressEntry;
 use super::vec_progress::VecProgress;
 use crate::quorum::QuorumSet;
 
-pub(crate) struct DisplayVecProgress<'a, ID, Ent, Prog, QS, Fmt>
+pub(crate) struct DisplayVecProgress<'a, Entry, QS, Fmt>
 where
-    ID: 'static,
-    QS: QuorumSet<Id = ID>,
-    Fmt: Fn(&mut Formatter<'_>, &ID, &Ent) -> std::fmt::Result,
+    Entry: VecProgressEntry,
+    QS: QuorumSet<Id = Entry::Id>,
+    Fmt: Fn(&mut Formatter<'_>, &Entry) -> std::fmt::Result,
 {
-    pub(crate) inner: &'a VecProgress<ID, Ent, Prog, QS>,
+    pub(crate) inner: &'a VecProgress<Entry, QS>,
     pub(crate) f: Fmt,
 }
 
-impl<ID, Ent, Prog, QS, Fmt> Display for DisplayVecProgress<'_, ID, Ent, Prog, QS, Fmt>
+impl<Entry, QS, Fmt> Display for DisplayVecProgress<'_, Entry, QS, Fmt>
 where
-    ID: PartialEq + 'static,
-    Ent: Borrow<Prog>,
-    Prog: PartialOrd + Copy,
-    QS: QuorumSet<Id = ID>,
-    Fmt: Fn(&mut Formatter<'_>, &ID, &Ent) -> std::fmt::Result,
+    Entry: VecProgressEntry,
+    QS: QuorumSet<Id = Entry::Id>,
+    Fmt: Fn(&mut Formatter<'_>, &Entry) -> std::fmt::Result,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{{")?;
@@ -29,7 +27,7 @@ where
             if i > 0 {
                 write!(f, ", ")?;
             }
-            (self.f)(f, &item.id, &item.val)?;
+            (self.f)(f, item)?;
         }
         write!(f, "}}")?;
 

--- a/openraft/src/progress/entry/mod.rs
+++ b/openraft/src/progress/entry/mod.rs
@@ -1,10 +1,11 @@
 pub(crate) mod update;
 
-use std::borrow::Borrow;
 use std::error::Error;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::ops::Deref;
+use std::ops::DerefMut;
 
 use display_more::DisplayOptionExt;
 use validit::Validate;
@@ -13,6 +14,8 @@ use crate::LogIdOptionExt;
 use crate::RaftState;
 use crate::RaftTypeConfig;
 use crate::engine::EngineConfig;
+use crate::progress::VecProgressEntry;
+use crate::progress::VecProgressEntryData;
 use crate::progress::entry::update::Updater;
 use crate::progress::inflight::Inflight;
 use crate::progress::stream_id::StreamId;
@@ -25,10 +28,21 @@ use crate::type_config::alias::LogIdOf;
 pub(crate) struct ProgressEntry<C>
 where C: RaftTypeConfig
 {
-    pub(crate) stream_id: StreamId,
+    pub(crate) id: C::NodeId,
 
     /// The id of the last matching log on the target following node.
     pub(crate) matching: Option<LogIdOf<C>>,
+
+    pub(crate) data: ProgressData<C>,
+}
+
+/// Application-owned replication state that is not used for quorum calculation.
+#[derive(Clone, Debug)]
+#[derive(PartialEq, Eq)]
+pub(crate) struct ProgressData<C>
+where C: RaftTypeConfig
+{
+    pub(crate) stream_id: StreamId,
 
     /// The data being transmitted in flight.
     ///
@@ -38,7 +52,7 @@ where C: RaftTypeConfig
     /// One plus the max log index on the following node that might match the leader log.
     pub(crate) searching_end: u64,
 
-    /// If true, reset the progress by setting [`Self::matching`] to `None` when the follower's
+    /// If true, reset the progress by setting matching to `None` when the follower's
     /// log is found reverted to an early state.
     ///
     /// This allows the target node to clean its data and wait for the leader to replicate all data
@@ -52,27 +66,27 @@ impl<C> ProgressEntry<C>
 where C: RaftTypeConfig
 {
     #[allow(dead_code)]
-    pub(crate) fn testing_new(matching: Option<LogIdOf<C>>) -> Self {
+    pub(crate) fn testing_new(id: C::NodeId, matching: Option<LogIdOf<C>>) -> Self {
         Self {
-            stream_id: StreamId::new(0),
+            id,
             matching: matching.clone(),
-            inflight: Inflight::None,
-            searching_end: matching.next_index(),
-            allow_log_reversion: false,
+            data: ProgressData::new(StreamId::new(0), matching.next_index()),
         }
     }
 
     /// Create a progress entry that does not have any matching log id.
     ///
     /// It's going to initiate a binary search to find the minimal matching log id.
-    pub(crate) fn empty(stream_id: StreamId, end: u64) -> Self {
+    pub(crate) fn empty(id: C::NodeId, stream_id: StreamId, end: u64) -> Self {
         Self {
-            stream_id,
+            id,
             matching: None,
-            inflight: Inflight::None,
-            searching_end: end,
-            allow_log_reversion: false,
+            data: ProgressData::new(stream_id, end),
         }
+    }
+
+    pub(crate) fn matching(&self) -> Option<&LogIdOf<C>> {
+        self.matching.as_ref()
     }
 
     // This method is only used by tests.
@@ -87,11 +101,75 @@ where C: RaftTypeConfig
     pub(crate) fn new_updater<'a>(&'a mut self, engine_config: &'a EngineConfig<C>) -> Updater<'a, C> {
         Updater::new(engine_config, self)
     }
+}
 
-    pub(crate) fn matching(&self) -> Option<&LogIdOf<C>> {
-        self.matching.as_ref()
+impl<C> ProgressData<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(stream_id: StreamId, searching_end: u64) -> Self {
+        Self {
+            stream_id,
+            inflight: Inflight::None,
+            searching_end,
+            allow_log_reversion: false,
+        }
+    }
+}
+
+impl<C> VecProgressEntry for ProgressEntry<C>
+where C: RaftTypeConfig
+{
+    type Id = C::NodeId;
+    type Progress = Option<LogIdOf<C>>;
+
+    fn id(&self) -> &Self::Id {
+        &self.id
     }
 
+    fn progress(&self) -> &Self::Progress {
+        &self.matching
+    }
+
+    fn progress_mut(&mut self) -> &mut Self::Progress {
+        &mut self.matching
+    }
+}
+
+impl<C> VecProgressEntryData for ProgressEntry<C>
+where C: RaftTypeConfig
+{
+    type Data = ProgressData<C>;
+
+    fn data(&self) -> &Self::Data {
+        &self.data
+    }
+
+    fn data_mut(&mut self) -> &mut Self::Data {
+        &mut self.data
+    }
+}
+
+impl<C> Deref for ProgressEntry<C>
+where C: RaftTypeConfig
+{
+    type Target = ProgressData<C>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+impl<C> DerefMut for ProgressEntry<C>
+where C: RaftTypeConfig
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
+}
+
+impl<C> ProgressEntry<C>
+where C: RaftTypeConfig
+{
     /// Return if a range of log id `..=log_id` is inflight sending.
     ///
     /// `prev_log_id` is never inflight.
@@ -198,14 +276,6 @@ where C: RaftTypeConfig
         let d = end - matching_next;
         let offset = d / 16 * 8;
         matching_next + offset
-    }
-}
-
-impl<C> Borrow<Option<LogIdOf<C>>> for ProgressEntry<C>
-where C: RaftTypeConfig
-{
-    fn borrow(&self) -> &Option<LogIdOf<C>> {
-        &self.matching
     }
 }
 

--- a/openraft/src/progress/entry/tests.rs
+++ b/openraft/src/progress/entry/tests.rs
@@ -1,5 +1,3 @@
-use std::borrow::Borrow;
-
 use crate::LogId;
 use crate::RaftState;
 use crate::engine::EngineConfig;
@@ -28,7 +26,7 @@ fn inflight_logs(prev_index: u64, last_index: u64) -> Inflight<UTConfig> {
 
 #[test]
 fn test_is_log_range_inflight() -> anyhow::Result<()> {
-    let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 20);
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
     assert_eq!(false, pe.is_log_range_inflight(&log_id(2)));
 
     pe.inflight = inflight_logs(2, 4);
@@ -57,7 +55,7 @@ fn test_update_matching() -> anyhow::Result<()> {
 
     // Update matching and inflight
     {
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
         pe.inflight = inflight_logs(5, 10);
         pe.new_updater(&engine_config).update_matching(Some(log_id(6)), Some(InflightId::new(0)));
         assert_eq!(inflight_logs(6, 10), pe.inflight);
@@ -72,7 +70,7 @@ fn test_update_matching() -> anyhow::Result<()> {
 
     // `searching_end` should be updated
     {
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
         pe.matching = Some(log_id(6));
         pe.inflight = inflight_logs(5, 20);
 
@@ -85,7 +83,7 @@ fn test_update_matching() -> anyhow::Result<()> {
 
 #[test]
 fn test_update_conflicting() -> anyhow::Result<()> {
-    let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 20);
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
     pe.matching = Some(log_id(3));
     pe.inflight = inflight_logs(5, 10);
 
@@ -93,7 +91,7 @@ fn test_update_conflicting() -> anyhow::Result<()> {
     pe.new_updater(&engine_config).update_conflicting(5, Some(InflightId::new(0)));
 
     assert_eq!(Inflight::None, pe.inflight);
-    assert_eq!(&Some(log_id(3)), pe.borrow());
+    assert_eq!(Some(&log_id(3)), pe.matching());
     assert_eq!(5, pe.searching_end);
 
     Ok(())
@@ -120,7 +118,7 @@ fn new_raft_state(purge_upto: u64, snap_last: u64, last: u64) -> RaftState<UTCon
 fn test_next_send() -> anyhow::Result<()> {
     // There is already inflight data, return it in an Error
     {
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
         pe.inflight = inflight_logs(10, 11);
         let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
         assert_eq!(Err(&inflight_logs(10, 11)), res);
@@ -134,7 +132,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 4);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 4);
         pe.matching = Some(log_id(4));
 
         let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
@@ -148,7 +146,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 6);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 6);
         pe.matching = Some(log_id(4));
 
         let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
@@ -163,7 +161,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 7);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 7);
         pe.matching = Some(log_id(4));
 
         let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
@@ -178,7 +176,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
         pe.matching = Some(log_id(4));
 
         let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
@@ -197,7 +195,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //
         // matching.next_index() == searching_end, enter pipeline mode
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 7);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 7);
         pe.matching = Some(log_id(6));
 
         let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
@@ -216,7 +214,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 8);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 8);
         pe.matching = Some(log_id(6));
 
         let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
@@ -231,7 +229,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
         pe.matching = Some(log_id(6));
 
         let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
@@ -246,7 +244,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
         pe.matching = Some(log_id(7));
 
         let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
@@ -263,7 +261,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //
         // matching.next_index() == searching_end, enter pipeline mode
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 8);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 8);
         pe.matching = Some(log_id(7));
 
         let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
@@ -285,7 +283,7 @@ fn test_next_send() -> anyhow::Result<()> {
         // matching.next_index() == searching_end, enter pipeline mode
         // (even though follower is fully caught up)
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 21);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 21);
         pe.matching = Some(log_id(20));
 
         let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
@@ -305,7 +303,7 @@ fn test_next_send() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
         pe.matching = Some(log_id(7));
 
         let res = pe.next_send(&mut new_raft_state(6, 10, 20), 5);
@@ -330,7 +328,7 @@ fn test_next_send_pipeline_mode() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
         pe.matching = Some(log_id(7));
         pe.searching_end = 20;
 
@@ -347,7 +345,7 @@ fn test_next_send_pipeline_mode() -> anyhow::Result<()> {
         //      purged snap  last
         //      6      10    20
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(StreamId::new(0), 20);
+        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
         pe.matching = None;
         pe.searching_end = 20;
 

--- a/openraft/src/progress/entry/update.rs
+++ b/openraft/src/progress/entry/update.rs
@@ -38,6 +38,12 @@ where C: RaftTypeConfig
     ///
     /// To allow follower log reversion, enable [`Config::allow_log_reversion`].
     ///
+    /// When log reversion is allowed and the conflict is before the last known matching log,
+    /// this method resets `matching` to `None`. This lowers the progress value, so the caller
+    /// must apply it via `VecProgress::reset_entry_with()`, which moves the entry down to keep
+    /// the progress ordering while keeping the already quorum-accepted value: a value accepted
+    /// by a quorum must never be withdrawn.
+    ///
     /// [`Config::allow_log_reversion`]: `crate::config::Config::allow_log_reversion`
     pub(crate) fn update_conflicting(&mut self, conflict: u64, inflight_id: Option<InflightId>) {
         tracing::debug!(
@@ -79,6 +85,9 @@ where C: RaftTypeConfig
                     self.entry.matching().display(),
                 );
 
+                // This is the only place replication progress is allowed to move backward.
+                // The caller applies it via `VecProgress::reset_entry_with()`, which restores
+                // the progress ordering without lowering the quorum-accepted value.
                 self.entry.matching = None;
                 self.entry.allow_log_reversion = false;
 

--- a/openraft/src/progress/id_val.rs
+++ b/openraft/src/progress/id_val.rs
@@ -1,13 +1,23 @@
 use std::fmt;
 
-use crate::progress::entry;
-use crate::type_config::alias::LogIdOf;
+use crate::progress::VecProgressEntry;
+#[cfg(test)]
+use crate::progress::VecProgressEntryData;
 
 /// An ID and its associated value.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct IdVal<ID, Val> {
     pub(crate) id: ID,
     pub(crate) val: Val,
+}
+
+/// An ID, progress, and application-owned data.
+#[cfg(test)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct IdValData<ID, Val, Data> {
+    pub(crate) id: ID,
+    pub(crate) val: Val,
+    pub(crate) data: Data,
 }
 
 impl<ID, Val> fmt::Display for IdVal<ID, Val>
@@ -20,19 +30,96 @@ where
     }
 }
 
+#[cfg(test)]
+impl<ID, Val, Data> fmt::Display for IdValData<ID, Val, Data>
+where
+    ID: fmt::Display,
+    Val: fmt::Display,
+    Data: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}: {}", self.id, self.val, self.data)
+    }
+}
+
 impl<ID, Val> IdVal<ID, Val> {
     pub(crate) fn new(id: ID, val: Val) -> Self {
         Self { id, val }
     }
 }
 
-impl<ID, C> IdVal<ID, entry::ProgressEntry<C>>
-where
-    C: crate::RaftTypeConfig,
-    ID: Clone,
+impl<ID, Val> IdVal<ID, Val>
+where Val: Default
 {
-    /// Return a tuple of (cloned id, cloned matching log id).
-    pub(crate) fn to_matching_tuple(&self) -> (ID, Option<LogIdOf<C>>) {
-        (self.id.clone(), self.val.matching().cloned())
+    /// Create an [`IdVal`] with the provided ID and `Val::default()`.
+    pub(crate) fn new_default(id: ID) -> Self {
+        Self::new(id, Default::default())
+    }
+}
+
+#[cfg(test)]
+impl<ID, Val, Data> IdValData<ID, Val, Data> {
+    pub(crate) fn new(id: ID, val: Val, data: Data) -> Self {
+        Self { id, val, data }
+    }
+}
+
+impl<ID, Val> VecProgressEntry for IdVal<ID, Val>
+where
+    ID: 'static + PartialEq,
+    Val: Clone + Default + Ord,
+{
+    type Id = ID;
+    type Progress = Val;
+
+    fn id(&self) -> &Self::Id {
+        &self.id
+    }
+
+    fn progress(&self) -> &Self::Progress {
+        &self.val
+    }
+
+    fn progress_mut(&mut self) -> &mut Self::Progress {
+        &mut self.val
+    }
+}
+
+#[cfg(test)]
+impl<ID, Val, Data> VecProgressEntry for IdValData<ID, Val, Data>
+where
+    ID: 'static + PartialEq,
+    Val: Clone + Default + Ord,
+{
+    type Id = ID;
+    type Progress = Val;
+
+    fn id(&self) -> &Self::Id {
+        &self.id
+    }
+
+    fn progress(&self) -> &Self::Progress {
+        &self.val
+    }
+
+    fn progress_mut(&mut self) -> &mut Self::Progress {
+        &mut self.val
+    }
+}
+
+#[cfg(test)]
+impl<ID, Val, Data> VecProgressEntryData for IdValData<ID, Val, Data>
+where
+    ID: 'static + PartialEq,
+    Val: Clone + Default + Ord,
+{
+    type Data = Data;
+
+    fn data(&self) -> &Self::Data {
+        &self.data
+    }
+
+    fn data_mut(&mut self) -> &mut Self::Data {
+        &mut self.data
     }
 }

--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -16,8 +16,11 @@ pub(crate) mod inflight_id;
 pub(crate) mod progress_stats;
 pub(crate) mod stream_id;
 pub(crate) mod vec_progress;
+pub(crate) mod vec_progress_entry;
 
 // TODO: remove it
 #[allow(unused_imports)]
 pub(crate) use inflight::Inflight;
 pub(crate) use vec_progress::VecProgress;
+pub(crate) use vec_progress_entry::VecProgressEntry;
+pub(crate) use vec_progress_entry::VecProgressEntryData;

--- a/openraft/src/progress/vec_progress.rs
+++ b/openraft/src/progress/vec_progress.rs
@@ -1,35 +1,33 @@
-use std::borrow::Borrow;
-use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::slice::Iter;
 use std::slice::IterMut;
 
+use super::VecProgressEntry;
+use super::VecProgressEntryData;
 use super::display_vec_progress::DisplayVecProgress;
-use super::id_val::IdVal;
 use super::progress_stats::ProgressStats;
 use crate::quorum::QuorumSet;
 
 /// Track the progress of several incremental values.
 ///
 /// When one of the values is updated, it uses a `QuorumSet` to calculate the quorum-accepted
-/// value. `ID` is the identifier of every progress value.
-/// `Ent` is a type of progress entry.
-/// `Prog` is the progress data of `Ent`, a progress entry `Ent` could contain other user data.
+/// value.
+/// `Entry` stores an ID, a progress value, and application-owned user data.
 /// `QS` is a quorum set implementation.
 ///
 /// Internally it uses a vector as storage, thus it is suitable for a small quorum set.
 #[derive(Clone, Debug)]
-pub(crate) struct VecProgress<ID, Ent, Prog, QS>
+pub(crate) struct VecProgress<Entry, QS>
 where
-    ID: 'static,
-    QS: QuorumSet<Id = ID>,
+    Entry: VecProgressEntry,
+    QS: QuorumSet<Id = Entry::Id>,
 {
     /// Quorum set to determine if a set of `id` constitutes a quorum.
     quorum_set: QS,
 
     /// The max value that is accepted by a quorum.
-    quorum_accepted: Prog,
+    quorum_accepted: Entry::Progress,
 
     /// Number of voters
     voter_count: usize,
@@ -43,25 +41,20 @@ where
     /// Learner elements are always still.
     /// A voter element will be moved up to keep them in descending order when a new value is
     /// updated.
-    entries: Vec<IdVal<ID, Ent>>,
+    entries: Vec<Entry>,
 
     /// Statistics of how it runs.
     stat: ProgressStats,
 }
 
-impl<ID, Ent, Prog, QS> Display for VecProgress<ID, Ent, Prog, QS>
+impl<Entry, QS> Display for VecProgress<Entry, QS>
 where
-    ID: PartialEq + Debug + Clone + 'static,
-    Ent: Clone + 'static,
-    Ent: Borrow<Prog>,
-    Prog: PartialOrd + Ord + Clone + 'static,
-    QS: QuorumSet<Id = ID> + 'static,
-    ID: Display,
-    Ent: Display,
+    Entry: VecProgressEntry + Display,
+    QS: QuorumSet<Id = Entry::Id> + 'static,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{{")?;
-        for (i, item) in self.iter().enumerate() {
+        for (i, item) in self.entries.iter().enumerate() {
             if i > 0 {
                 write!(f, ", ")?;
             }
@@ -73,23 +66,26 @@ where
     }
 }
 
-impl<ID, Ent, Prog, QS> VecProgress<ID, Ent, Prog, QS>
+impl<Entry, QS> VecProgress<Entry, QS>
 where
-    ID: 'static,
-    Ent: Borrow<Prog>,
-    QS: QuorumSet<Id = ID>,
-    Prog: Clone,
+    Entry: VecProgressEntry,
+    QS: QuorumSet<Id = Entry::Id>,
 {
-    pub(crate) fn new(quorum_set: QS, learner_ids: impl IntoIterator<Item = ID>, default_v: impl Fn() -> Ent) -> Self {
-        let mut entries = quorum_set.ids().map(|id| IdVal::new(id, default_v())).collect::<Vec<_>>();
+    /// Create a progress tracker from quorum and learner IDs.
+    pub(crate) fn new(
+        quorum_set: QS,
+        learner_ids: impl IntoIterator<Item = Entry::Id>,
+        mut default_entry: impl FnMut(Entry::Id) -> Entry,
+    ) -> Self {
+        let mut entries = quorum_set.ids().map(&mut default_entry).collect::<Vec<_>>();
 
         let voter_count = entries.len();
 
-        entries.extend(learner_ids.into_iter().map(|id| IdVal::new(id, default_v())));
+        entries.extend(learner_ids.into_iter().map(default_entry));
 
         Self {
             quorum_set,
-            quorum_accepted: default_v().borrow().clone(),
+            quorum_accepted: Default::default(),
             voter_count,
             entries,
             stat: Default::default(),
@@ -98,19 +94,17 @@ where
 
     /// Find the index of the specified id.
     #[inline(always)]
-    pub(crate) fn index(&self, target: &ID) -> Option<usize>
-    where ID: PartialEq {
-        self.entries.iter().position(|item| &item.id == target)
+    pub(crate) fn index(&self, target: &Entry::Id) -> Option<usize> {
+        self.entries.iter().position(|item| item.id() == target)
     }
 
     /// Move an element at `index` up so that all the values greater than `quorum_accepted` are
     /// sorted.
     #[inline(always)]
-    fn move_up(&mut self, index: usize) -> usize
-    where Prog: PartialOrd {
+    fn move_up(&mut self, index: usize) -> usize {
         self.stat.move_count += 1;
         for i in (0..index).rev() {
-            if self.entries[i].val.borrow() < self.entries[i + 1].val.borrow() {
+            if self.entries[i].progress() < self.entries[i + 1].progress() {
                 self.entries.swap(i, i + 1);
             } else {
                 return i + 1;
@@ -120,11 +114,32 @@ where
         0
     }
 
-    pub(crate) fn iter_mut(&mut self) -> IterMut<'_, IdVal<ID, Ent>> {
+    /// Move a voter element at `index` down so that all the values greater than `quorum_accepted`
+    /// stay sorted after its progress value is lowered.
+    ///
+    /// It is the counterpart of [`Self::move_up`], used by [`Self::reset_entry_with()`].
+    fn move_down(&mut self, index: usize) -> usize {
+        self.stat.move_count += 1;
+        let mut i = index;
+        while i + 1 < self.voter_count && self.entries[i].progress() < self.entries[i + 1].progress() {
+            self.entries.swap(i, i + 1);
+            i += 1;
+        }
+
+        i
+    }
+
+    /// Return mutable entries without maintaining the progress ordering.
+    ///
+    /// Mutating progress values through this iterator can leave the internal
+    /// ordering and quorum-accepted value stale. Normal progress updates must
+    /// use `update()`, `update_with()`, or `update_entry_with()` instead.
+    /// Mutating entry IDs can corrupt membership lookup.
+    pub(crate) fn iter_mut_without_reorder(&mut self) -> IterMut<'_, Entry> {
         self.entries.iter_mut()
     }
 
-    pub(crate) fn into_iter(self) -> impl Iterator<Item = IdVal<ID, Ent>> {
+    pub(crate) fn into_iter(self) -> impl Iterator<Item = Entry> {
         self.entries.into_iter()
     }
 
@@ -133,18 +148,16 @@ where
         &self.stat
     }
 
-    pub(crate) fn display_with<Fmt>(&self, f: Fmt) -> DisplayVecProgress<'_, ID, Ent, Prog, QS, Fmt>
-    where Fmt: Fn(&mut Formatter<'_>, &ID, &Ent) -> std::fmt::Result {
+    pub(crate) fn display_with<Fmt>(&self, f: Fmt) -> DisplayVecProgress<'_, Entry, QS, Fmt>
+    where Fmt: Fn(&mut Formatter<'_>, &Entry) -> std::fmt::Result {
         DisplayVecProgress { inner: self, f }
     }
 }
 
-impl<ID, Ent, Prog, QS> VecProgress<ID, Ent, Prog, QS>
+impl<Entry, QS> VecProgress<Entry, QS>
 where
-    ID: PartialEq + 'static,
-    Ent: Borrow<Prog>,
-    Prog: PartialOrd + Clone,
-    QS: QuorumSet<Id = ID>,
+    Entry: VecProgressEntry,
+    QS: QuorumSet<Id = Entry::Id>,
 {
     /// Update one of the scalar values and re-calculate the quorum-accepted value.
     ///
@@ -180,8 +193,18 @@ where
     /// - update(c, 3): nothing to do: quorum-accepted is still 3;
     /// - update(c, 4): re-calc:       quorum-accepted becomes 4;
     /// - update(c, 6): re-calc:       quorum-accepted becomes 5;
-    pub(crate) fn update_with<F>(&mut self, id: &ID, f: F) -> Result<&Prog, &Prog>
-    where F: FnOnce(&mut Ent) {
+    pub(crate) fn update_with<F>(&mut self, id: &Entry::Id, f: F) -> Result<&Entry::Progress, &Entry::Progress>
+    where F: FnOnce(&mut Entry::Progress) {
+        self.update_entry_with(id, |entry| f(entry.progress_mut()))
+    }
+
+    /// Update an entry and re-calculate the quorum-accepted value.
+    ///
+    /// This is for application-owned fields that have to be mutated together
+    /// with the progress value. The progress update must still be monotonic.
+    /// The entry ID must not be changed.
+    pub(crate) fn update_entry_with<F>(&mut self, id: &Entry::Id, f: F) -> Result<&Entry::Progress, &Entry::Progress>
+    where F: FnOnce(&mut Entry) {
         self.stat.update_count += 1;
 
         let index = match self.index(id) {
@@ -191,18 +214,72 @@ where
             Some(x) => x,
         };
 
-        let ent = &mut self.entries[index];
+        let prev_progress = self.entries[index].progress().clone();
 
-        let prev_progress = ent.val.borrow().clone();
+        f(&mut self.entries[index]);
 
-        f(&mut ent.val);
+        debug_assert!(self.entries[index].id() == id);
 
-        let new_progress = ent.val.borrow();
+        self.update_at(index, prev_progress)
+    }
 
-        debug_assert!(new_progress >= &prev_progress,);
+    /// Update application-owned data without recalculating quorum-accepted progress.
+    ///
+    /// This method only exposes [`VecProgressEntryData::Data`], so it cannot
+    /// change progress or invalidate the ordering maintained by `VecProgress`.
+    ///
+    /// It returns the updated data after update if the `id` is found, otherwise returns `None`.
+    pub(crate) fn update_data_with<F>(&mut self, id: &Entry::Id, f: F) -> Option<&Entry::Data>
+    where
+        Entry: VecProgressEntryData,
+        F: FnOnce(&mut Entry::Data),
+    {
+        let index = self.index(id)?;
+
+        f(self.entries[index].data_mut());
+
+        Some(self.entries[index].data())
+    }
+
+    /// Update an entry whose progress value may move backward, e.g., when replication progress
+    /// is reset upon log reversion.
+    ///
+    /// If the progress value is lowered, the entry is moved down to keep the values greater than
+    /// `quorum_accepted` sorted. The recorded quorum-accepted value is deliberately not
+    /// recalculated: a value accepted by a quorum must never be withdrawn.
+    /// The entry ID must not be changed.
+    ///
+    /// It returns the updated entry if the `id` is found, otherwise returns `None`.
+    pub(crate) fn reset_entry_with<F>(&mut self, id: &Entry::Id, f: F) -> Option<&Entry>
+    where F: FnOnce(&mut Entry) {
+        let index = self.index(id)?;
+
+        let prev_progress = self.entries[index].progress().clone();
+
+        f(&mut self.entries[index]);
+
+        debug_assert!(self.entries[index].id() == id);
+        debug_assert!(self.entries[index].progress() <= &prev_progress);
+
+        // Learners are never reordered.
+        let new_index = if index < self.voter_count && self.entries[index].progress() < &prev_progress {
+            self.move_down(index)
+        } else {
+            index
+        };
+
+        Some(&self.entries[new_index])
+    }
+
+    fn update_at(
+        &mut self,
+        index: usize,
+        prev_progress: Entry::Progress,
+    ) -> Result<&Entry::Progress, &Entry::Progress> {
+        debug_assert!(self.entries[index].progress() >= &prev_progress,);
 
         // No change, return early
-        if &prev_progress == new_progress {
+        if &prev_progress == self.entries[index].progress() {
             return Ok(&self.quorum_accepted);
         }
 
@@ -213,7 +290,7 @@ where
         }
 
         let prev_le_qa = prev_progress <= self.quorum_accepted;
-        let new_gt_qa = new_progress > &self.quorum_accepted;
+        let new_gt_qa = self.entries[index].progress() > &self.quorum_accepted;
 
         // Sort and find the greatest value accepted by a quorum set.
 
@@ -223,7 +300,7 @@ where
             if prev_le_qa {
                 // From high to low, find the max value that has constituted a quorum.
                 for i in new_index..self.voter_count {
-                    let prog = self.entries[i].val.borrow();
+                    let prog = self.entries[i].progress();
 
                     // No need to re-calculate already quorum-accepted value.
                     if prog <= &self.quorum_accepted {
@@ -231,7 +308,7 @@ where
                     }
 
                     // Ids of the target that has value GE `entries[i]`
-                    let it = self.entries[0..=i].iter().map(|item| &item.id);
+                    let it = self.entries[0..=i].iter().map(|item| item.id());
 
                     self.stat.is_quorum_count += 1;
 
@@ -249,15 +326,22 @@ where
     /// Update one of the scalar values and re-calculate the quorum-accepted value.
     ///
     /// It returns `Err(quorum_accepted)` if the `id` is not found.
-    pub(crate) fn update(&mut self, id: &ID, value: Ent) -> Result<&Prog, &Prog> {
+    pub(crate) fn update(
+        &mut self,
+        id: &Entry::Id,
+        value: Entry::Progress,
+    ) -> Result<&Entry::Progress, &Entry::Progress> {
         self.update_with(id, |x| *x = value)
     }
 
     /// Update the value if the new value is greater than the current value.
     ///
     /// It returns `Err(quorum_accepted)` if the `id` is not found.
-    pub(crate) fn increase_to(&mut self, id: &ID, value: Ent) -> Result<&Prog, &Prog>
-    where Ent: PartialOrd {
+    pub(crate) fn increase_to(
+        &mut self,
+        id: &Entry::Id,
+        value: Entry::Progress,
+    ) -> Result<&Entry::Progress, &Entry::Progress> {
         self.update_with(id, |x| {
             if value > *x {
                 *x = value;
@@ -266,23 +350,17 @@ where
     }
 
     /// Try to get the value by `id`.
-    pub(crate) fn try_get(&self, id: &ID) -> Option<&Ent> {
+    pub(crate) fn try_get(&self, id: &Entry::Id) -> Option<&Entry> {
         let index = self.index(id)?;
-        Some(&self.entries[index].val)
-    }
-
-    /// Returns a mutable reference to the value corresponding to the `id`.
-    pub(crate) fn get_mut(&mut self, id: &ID) -> Option<&mut Ent> {
-        let index = self.index(id)?;
-        Some(&mut self.entries[index].val)
+        Some(&self.entries[index])
     }
 
     // TODO: merge `get` and `try_get`
     /// Get the value by `id`.
     #[cfg(test)]
-    pub(crate) fn get(&self, id: &ID) -> &Ent {
+    pub(crate) fn get(&self, id: &Entry::Id) -> &Entry {
         let index = self.index(id).unwrap();
-        &self.entries[index].val
+        &self.entries[index]
     }
 
     /// Get the greatest value that is accepted by the quorum set.
@@ -291,25 +369,19 @@ where
     /// To commit a value, the value has to be **accepted by a quorum** and has to be the greatest
     /// value every proposed.
     #[cfg(test)]
-    pub(crate) fn quorum_accepted(&self) -> &Prog {
+    pub(crate) fn quorum_accepted(&self) -> &Entry::Progress {
         &self.quorum_accepted
     }
 
-    /// Returns the reference to the quorum set
-    #[allow(dead_code)]
-    pub(crate) fn quorum_set(&self) -> &QS {
-        &self.quorum_set
-    }
-
     /// Iterate over all id and values, voters first followed by learners.
-    pub(crate) fn iter(&self) -> Iter<'_, IdVal<ID, Ent>> {
+    pub(crate) fn iter(&self) -> Iter<'_, Entry> {
         self.entries.as_slice().iter()
     }
 
     /// Map each item to a value and collect into a collection.
     pub(crate) fn collect_mapped<F, T, C>(&self, f: F) -> C
     where
-        F: Fn(&IdVal<ID, Ent>) -> T,
+        F: Fn(&Entry) -> T,
         C: FromIterator<T>,
     {
         self.iter().map(f).collect()
@@ -319,17 +391,35 @@ where
     pub(crate) fn upgrade_quorum_set(
         self,
         quorum_set: QS,
-        learner_ids: impl IntoIterator<Item = ID>,
-        default_v: impl Fn() -> Ent,
+        learner_ids: impl IntoIterator<Item = Entry::Id>,
+        default_entry: impl FnMut(Entry::Id) -> Entry,
     ) -> Self {
-        let mut new_prog = Self::new(quorum_set, learner_ids, default_v);
+        let mut new_prog = Self::new(quorum_set, learner_ids, default_entry);
 
         new_prog.stat = self.stat.clone();
 
         for item in self.into_iter() {
-            new_prog.update(&item.id, item.val).ok();
+            new_prog.replace(item).ok();
         }
         new_prog
+    }
+
+    /// Replace the entry for the same ID and update quorum-accepted progress.
+    fn replace(&mut self, entry: Entry) -> Result<&Entry::Progress, &Entry::Progress> {
+        self.stat.update_count += 1;
+
+        let index = match self.index(entry.id()) {
+            None => {
+                return Err(&self.quorum_accepted);
+            }
+            Some(x) => x,
+        };
+
+        let prev_progress = self.entries[index].progress().clone();
+
+        self.entries[index] = entry;
+
+        self.update_at(index, prev_progress)
     }
 
     /// Return if the given id is a voter.
@@ -338,7 +428,7 @@ where
     /// A learner's progress is also tracked, but it will never grant a value.
     ///
     /// If the given id is not in this `VecProgress`, it returns `None`.
-    pub(crate) fn is_voter(&self, id: &ID) -> Option<bool> {
+    pub(crate) fn is_voter(&self, id: &Entry::Id) -> Option<bool> {
         let index = self.index(id)?;
         Some(index < self.voter_count)
     }
@@ -346,14 +436,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Borrow;
     use std::collections::BTreeMap;
     use std::collections::BTreeSet;
 
     use maplit::btreeset;
 
     use super::VecProgress;
-    use crate::progress::id_val::IdVal;
+    use crate::progress::id_val::IdValData;
     use crate::quorum::QuorumSet;
 
     const LCG_A: u64 = 6364136223846793005;
@@ -428,9 +517,9 @@ mod tests {
     /// This intentionally ignores `VecProgress`'s internal ordering optimization:
     /// it tries candidate progress values from high to low and returns the first
     /// value whose reached node IDs form a quorum.
-    fn model_quorum_accepted<QS>(quorum_set: &QS, entries: &[IdVal<u64, u64>]) -> u64
+    fn model_quorum_accepted<QS>(quorum_set: &QS, entries: &[(u64, u64)]) -> u64
     where QS: QuorumSet<Id = u64> {
-        let values = entries.iter().map(|item| (item.id, item.val)).collect::<BTreeMap<_, _>>();
+        let values = entries.iter().map(|item| (item.0, item.1)).collect::<BTreeMap<_, _>>();
         let mut candidates = quorum_set.ids().map(|id| values[&id]).collect::<Vec<_>>();
 
         candidates.sort_unstable_by(|a, b| b.cmp(a));
@@ -450,7 +539,7 @@ mod tests {
     ///
     /// This checks both the externally visible quorum-accepted value and the
     /// internal ordering invariant relied on by the optimized update algorithm.
-    fn assert_matches_model<QS>(progress: &VecProgress<u64, u64, u64, QS>, context: &str)
+    fn assert_matches_model<QS>(progress: &VecProgress<(u64, u64), QS>, context: &str)
     where QS: QuorumSet<Id = u64> {
         let want = model_quorum_accepted(&progress.quorum_set, &progress.entries);
         assert_eq!(
@@ -467,14 +556,14 @@ mod tests {
     ///
     /// Voter entries above `quorum_accepted` must form a descending prefix.
     /// Learners are excluded because learner progress does not grant quorum.
-    fn assert_voter_prefix_is_sorted<QS>(progress: &VecProgress<u64, u64, u64, QS>, context: &str)
+    fn assert_voter_prefix_is_sorted<QS>(progress: &VecProgress<(u64, u64), QS>, context: &str)
     where QS: QuorumSet<Id = u64> {
         let quorum_accepted = *progress.quorum_accepted();
         let mut previous = None;
         let mut seen_not_above_quorum = false;
 
         for item in &progress.entries[..progress.voter_count] {
-            if item.val <= quorum_accepted {
+            if item.1 <= quorum_accepted {
                 seen_not_above_quorum = true;
                 continue;
             }
@@ -485,36 +574,44 @@ mod tests {
                 context, progress.entries
             );
             if let Some(prev) = previous {
-                assert!(prev >= item.val, "{}: unsorted voters: {:?}", context, progress.entries);
+                assert!(prev >= item.1, "{}: unsorted voters: {:?}", context, progress.entries);
             }
-            previous = Some(item.val);
+            previous = Some(item.1);
         }
     }
 
     #[test]
     fn vec_progress_new() {
         let quorum_set = vec![btreeset! {0, 1, 2, 3, 4}];
-        let progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [6, 7], || 0);
+        let progress = VecProgress::<(u64, u64), _>::new(quorum_set, [6, 7], |id| (id, 0));
 
         assert_eq!(
-            vec![
-                IdVal::new(0, 0),
-                IdVal::new(1, 0),
-                IdVal::new(2, 0),
-                IdVal::new(3, 0),
-                IdVal::new(4, 0),
-                IdVal::new(6, 0),
-                IdVal::new(7, 0),
-            ],
+            vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (6, 0), (7, 0),],
             progress.entries
         );
         assert_eq!(5, progress.voter_count);
     }
 
     #[test]
+    fn vec_progress_tuple_entry() {
+        let quorum_set = vec![btreeset! {0, 1, 2}];
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [3], |id| (id, 0));
+
+        assert_eq!(
+            vec![(0, 0), (1, 0), (2, 0), (3, 0)],
+            progress.iter().cloned().collect::<Vec<_>>()
+        );
+        assert_eq!(Ok(&0), progress.update(&0, 5));
+        assert_eq!(Ok(&5), progress.update(&1, 5));
+        assert_eq!(Some(&(0, 5)), progress.try_get(&0));
+        assert_eq!(Some(&(1, 5)), progress.try_get(&1));
+        assert_eq!(&5, progress.quorum_accepted());
+    }
+
+    #[test]
     fn vec_progress_index() {
         let quorum_set = vec![btreeset! {0, 1, 2, 3, 4}];
-        let progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [6, 7], || 0);
+        let progress = VecProgress::<(u64, u64), _>::new(quorum_set, [6, 7], |id| (id, 0));
 
         assert_eq!(Some(0), progress.index(&0));
         assert_eq!(Some(1), progress.index(&1));
@@ -528,41 +625,28 @@ mod tests {
     #[test]
     fn vec_progress_get() {
         let quorum_set = vec![btreeset! {0, 1, 2, 3, 4}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [6, 7], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [6, 7], |id| (id, 0));
 
         progress.update(&6, 5).ok();
-        assert_eq!(&5, progress.get(&6));
-        assert_eq!(Some(&5), progress.try_get(&6));
+        assert_eq!(&5, &progress.get(&6).1);
+        assert_eq!(Some(&5), progress.try_get(&6).map(|x| &x.1));
         assert_eq!(None, progress.try_get(&9));
 
-        {
-            let x = progress.get_mut(&6);
-            if let Some(x) = x {
-                *x = 10;
-            }
-        }
-        assert_eq!(Some(&10), progress.try_get(&6));
+        progress.update(&6, 10).ok();
+        assert_eq!(Some(&10), progress.try_get(&6).map(|x| &x.1));
     }
 
     #[test]
     fn vec_progress_iter() {
         let quorum_set = vec![btreeset! {0, 1, 2, 3, 4}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [6, 7], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [6, 7], |id| (id, 0));
 
         progress.update(&7, 7).ok();
         progress.update(&3, 3).ok();
         progress.update(&1, 1).ok();
 
         assert_eq!(
-            vec![
-                IdVal::new(3, 3),
-                IdVal::new(1, 1),
-                IdVal::new(0, 0),
-                IdVal::new(2, 0),
-                IdVal::new(4, 0),
-                IdVal::new(6, 0),
-                IdVal::new(7, 7),
-            ],
+            vec![(3, 3), (1, 1), (0, 0), (2, 0), (4, 0), (6, 0), (7, 7),],
             progress.iter().cloned().collect::<Vec<_>>(),
             "iter() returns voter first, followed by learners"
         );
@@ -571,75 +655,20 @@ mod tests {
     #[test]
     fn vec_progress_move_up() {
         let quorum_set = vec![btreeset! {0, 1, 2, 3, 4}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [6], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [6], |id| (id, 0));
 
         // initial: 0-0, 1-0, 2-0, 3-0, 4-0
         let cases = [
-            (
-                (1, 2),
-                vec![
-                    IdVal::new(1, 2),
-                    IdVal::new(0, 0),
-                    IdVal::new(2, 0),
-                    IdVal::new(3, 0),
-                    IdVal::new(4, 0),
-                    IdVal::new(6, 0),
-                ],
-                0,
-            ),
-            (
-                (2, 3),
-                vec![
-                    IdVal::new(2, 3),
-                    IdVal::new(1, 2),
-                    IdVal::new(0, 0),
-                    IdVal::new(3, 0),
-                    IdVal::new(4, 0),
-                    IdVal::new(6, 0),
-                ],
-                0,
-            ),
-            (
-                (1, 3),
-                vec![
-                    IdVal::new(2, 3),
-                    IdVal::new(1, 3),
-                    IdVal::new(0, 0),
-                    IdVal::new(3, 0),
-                    IdVal::new(4, 0),
-                    IdVal::new(6, 0),
-                ],
-                1,
-            ), // no move
-            (
-                (4, 8),
-                vec![
-                    IdVal::new(4, 8),
-                    IdVal::new(2, 3),
-                    IdVal::new(1, 3),
-                    IdVal::new(0, 0),
-                    IdVal::new(3, 0),
-                    IdVal::new(6, 0),
-                ],
-                0,
-            ),
-            (
-                (0, 5),
-                vec![
-                    IdVal::new(4, 8),
-                    IdVal::new(0, 5),
-                    IdVal::new(2, 3),
-                    IdVal::new(1, 3),
-                    IdVal::new(3, 0),
-                    IdVal::new(6, 0),
-                ],
-                1,
-            ), // move to 1st
+            ((1, 2), vec![(1, 2), (0, 0), (2, 0), (3, 0), (4, 0), (6, 0)], 0),
+            ((2, 3), vec![(2, 3), (1, 2), (0, 0), (3, 0), (4, 0), (6, 0)], 0),
+            ((1, 3), vec![(2, 3), (1, 3), (0, 0), (3, 0), (4, 0), (6, 0)], 1), // no move
+            ((4, 8), vec![(4, 8), (2, 3), (1, 3), (0, 0), (3, 0), (6, 0)], 0),
+            ((0, 5), vec![(4, 8), (0, 5), (2, 3), (1, 3), (3, 0), (6, 0)], 1), // move to 1st
         ];
         for (ith, ((id, v), want_vec, want_new_index)) in cases.iter().enumerate() {
             // Update a value and move it up to keep the order.
             let index = progress.index(id).unwrap();
-            progress.entries[index].val = *v;
+            progress.entries[index].1 = *v;
             let got = progress.move_up(index);
 
             assert_eq!(want_vec, &progress.entries, "{}-th case: idx:{}, v:{}", ith, *id, *v);
@@ -650,7 +679,7 @@ mod tests {
     #[test]
     fn vec_progress_update() {
         let quorum_set = vec![btreeset! {0, 1, 2, 3, 4}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [6], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [6], |id| (id, 0));
 
         // initial: 0,0,0,0,0
         let cases = vec![
@@ -682,13 +711,15 @@ mod tests {
         for (case_id, (quorum_set, learners)) in cases.into_iter().enumerate() {
             for seed in 0..32 {
                 let mut seed = seed + 1;
-                let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set.clone(), learners.clone(), || 0);
+                let mut progress =
+                    VecProgress::<(u64, u64), _>::new(quorum_set.clone(), learners.clone(), |id| (id, 0));
 
                 assert_matches_model(&progress, &format!("case-{case_id} seed-{seed} initial"));
 
                 for step in 0..128 {
                     let id = next_random(&mut seed) % 8;
-                    let value = progress.try_get(&id).copied().unwrap_or_default() + next_random(&mut seed) % 7 + 1;
+                    let value =
+                        progress.try_get(&id).map(|entry| entry.1).unwrap_or_default() + next_random(&mut seed) % 7 + 1;
                     let got = copy_result(progress.update(&id, value));
                     let want = model_quorum_accepted(&progress.quorum_set, &progress.entries);
                     let want_result = progress.try_get(&id).map(|_| want).ok_or(want);
@@ -716,14 +747,16 @@ mod tests {
             let mut seed = seed + 11;
             let quorum_set = quorum_sets[0].clone();
             let learner_ids = learner_ids_for(&quorum_set, known_ids.clone());
-            let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, learner_ids, || 0);
+            let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, learner_ids, |id| (id, 0));
 
             assert_matches_model(&progress, &format!("seed-{seed} initial"));
 
             for round in 0..24 {
                 for step in 0..16 {
                     let id = next_random(&mut seed) % 10;
-                    let value = progress.try_get(&id).copied().unwrap_or_default() + next_random(&mut seed) % 11 + 1;
+                    let value = progress.try_get(&id).map(|entry| entry.1).unwrap_or_default()
+                        + next_random(&mut seed) % 11
+                        + 1;
                     progress.update(&id, value).ok();
                     assert_matches_model(&progress, &format!("seed-{seed} round-{round} step-{step} update"));
                 }
@@ -732,7 +765,7 @@ mod tests {
                 let quorum_set = quorum_sets[quorum_index].clone();
                 let learner_ids = learner_ids_for(&quorum_set, known_ids.clone());
 
-                progress = progress.upgrade_quorum_set(quorum_set, learner_ids, || 0);
+                progress = progress.upgrade_quorum_set(quorum_set, learner_ids, |id| (id, 0));
                 assert_matches_model(&progress, &format!("seed-{seed} round-{round} upgrade-{quorum_index}"));
             }
         }
@@ -741,7 +774,7 @@ mod tests {
     #[test]
     fn vec_progress_joint_quorum_update() {
         let quorum_set = vec![btreeset! {0, 1, 2}, btreeset! {2, 3, 4}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [5, 6], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [5, 6], |id| (id, 0));
 
         let cases = [
             (0, 5, 0),
@@ -767,26 +800,16 @@ mod tests {
             assert_matches_model(&progress, &context);
         }
 
-        let entries: Vec<_> = progress.collect_mapped(|item| (item.id, item.val));
+        let entries: Vec<_> = progress.collect_mapped(|item| (item.0, item.1));
         assert_eq!(vec![(2, 7), (0, 7), (4, 6), (3, 6), (1, 5), (5, 0), (6, 0)], entries);
     }
 
     #[test]
     fn vec_progress_non_member_and_learner_edge_cases() {
         let quorum_set = vec![btreeset! {0, 1, 2}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [1, 3, 3], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [1, 3, 3], |id| (id, 0));
 
-        assert_eq!(
-            vec![
-                IdVal::new(0, 0),
-                IdVal::new(1, 0),
-                IdVal::new(2, 0),
-                IdVal::new(1, 0),
-                IdVal::new(3, 0),
-                IdVal::new(3, 0),
-            ],
-            progress.entries
-        );
+        assert_eq!(vec![(0, 0), (1, 0), (2, 0), (1, 0), (3, 0), (3, 0),], progress.entries);
         assert_eq!(3, progress.voter_count);
         assert_eq!(Some(true), progress.is_voter(&1));
         assert_eq!(Some(false), progress.is_voter(&3));
@@ -794,91 +817,55 @@ mod tests {
 
         assert_eq!(Ok(0), copy_result(progress.update(&3, 7)));
         assert_eq!(
-            vec![
-                IdVal::new(0, 0),
-                IdVal::new(1, 0),
-                IdVal::new(2, 0),
-                IdVal::new(1, 0),
-                IdVal::new(3, 7),
-                IdVal::new(3, 0),
-            ],
+            vec![(0, 0), (1, 0), (2, 0), (1, 0), (3, 7), (3, 0),],
             progress.entries,
             "only the first duplicate learner is updated"
         );
 
         assert_eq!(Ok(0), copy_result(progress.update(&1, 5)));
         assert_eq!(
-            vec![
-                IdVal::new(1, 5),
-                IdVal::new(0, 0),
-                IdVal::new(2, 0),
-                IdVal::new(1, 0),
-                IdVal::new(3, 7),
-                IdVal::new(3, 0),
-            ],
+            vec![(1, 5), (0, 0), (2, 0), (1, 0), (3, 7), (3, 0),],
             progress.entries,
             "a learner ID that is also a voter resolves to the voter entry"
         );
 
         assert_eq!(Ok(4), copy_result(progress.update(&2, 4)));
-        assert_eq!(
-            vec![
-                IdVal::new(1, 5),
-                IdVal::new(2, 4),
-                IdVal::new(0, 0),
-                IdVal::new(1, 0),
-                IdVal::new(3, 7),
-                IdVal::new(3, 0),
-            ],
-            progress.entries
-        );
+        assert_eq!(vec![(1, 5), (2, 4), (0, 0), (1, 0), (3, 7), (3, 0),], progress.entries);
 
         let quorum_set = vec![btreeset! {0, 1, 2}];
-        let mut no_learners = VecProgress::<u64, u64, u64, _>::new(quorum_set, [], || 0);
+        let mut no_learners = VecProgress::<(u64, u64), _>::new(quorum_set, [], |id| (id, 0));
 
-        assert_eq!(
-            vec![IdVal::new(0, 0), IdVal::new(1, 0), IdVal::new(2, 0)],
-            no_learners.entries
-        );
+        assert_eq!(vec![(0, 0), (1, 0), (2, 0)], no_learners.entries);
         assert_eq!(3, no_learners.voter_count);
         assert_eq!(Err(0), copy_result(no_learners.update(&9, 5)));
-        assert_eq!(
-            vec![IdVal::new(0, 0), IdVal::new(1, 0), IdVal::new(2, 0)],
-            no_learners.entries
-        );
+        assert_eq!(vec![(0, 0), (1, 0), (2, 0)], no_learners.entries);
     }
 
     #[test]
     fn vec_progress_custom_quorum_set() {
         let quorum_set = RequiredSetQuorum::new([0, 1, 2, 3], [0, 3]);
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [], |id| (id, 0));
 
         assert_eq!(Ok(0), copy_result(progress.update(&1, 10)));
         assert_eq!(Ok(0), copy_result(progress.update(&2, 9)));
         assert_eq!(Ok(0), copy_result(progress.update(&0, 8)));
         assert_matches_model(&progress, "custom quorum before required set is reached");
 
-        assert_eq!(
-            vec![IdVal::new(1, 10), IdVal::new(2, 9), IdVal::new(0, 8), IdVal::new(3, 0)],
-            progress.entries
-        );
+        assert_eq!(vec![(1, 10), (2, 9), (0, 8), (3, 0)], progress.entries);
 
         assert_eq!(Ok(7), copy_result(progress.update(&3, 7)));
         assert_eq!(&7, progress.quorum_accepted());
         assert_matches_model(&progress, "custom quorum reaches required set");
 
         assert_eq!(Ok(8), copy_result(progress.update(&3, 11)));
-        assert_eq!(
-            vec![IdVal::new(3, 11), IdVal::new(1, 10), IdVal::new(2, 9), IdVal::new(0, 8)],
-            progress.entries
-        );
+        assert_eq!(vec![(3, 11), (1, 10), (2, 9), (0, 8)], progress.entries);
         assert_matches_model(&progress, "custom quorum follows required set threshold");
     }
 
     #[test]
     fn vec_progress_update_with() {
         let quorum_set = vec![btreeset! {0, 1, 2, 3, 4}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [6], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [6], |id| (id, 0));
 
         // Test that update_with can use closures to modify values
         // Case 0: 0,2,0,0,0,0
@@ -913,70 +900,60 @@ mod tests {
         assert_eq!(Ok(&4), got, "case 6: id:1, *=2");
 
         // Verify final values
-        assert_eq!(&4, progress.get(&0));
-        assert_eq!(&4, progress.get(&1));
-        assert_eq!(&3, progress.get(&2));
-        assert_eq!(&2, progress.get(&3));
-        assert_eq!(&5, progress.get(&4));
-        assert_eq!(&0, progress.get(&6));
+        assert_eq!(&4, &progress.get(&0).1);
+        assert_eq!(&4, &progress.get(&1).1);
+        assert_eq!(&3, &progress.get(&2).1);
+        assert_eq!(&2, &progress.get(&3).1);
+        assert_eq!(&5, &progress.get(&4).1);
+        assert_eq!(&0, &progress.get(&6).1);
 
         // Test nonexistent id returns Err with current quorum-accepted
         let got = progress.update_with(&9, |x| *x = 10);
         assert_eq!(Err(&4), got, "nonexistent id returns Err");
     }
 
-    /// Progress entry for testing
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    struct ProgressEntry {
-        progress: u64,
-        user_data: &'static str,
-    }
-
-    impl Borrow<u64> for ProgressEntry {
-        fn borrow(&self) -> &u64 {
-            &self.progress
-        }
-    }
-
     #[test]
-    fn vec_progress_update_struct_value() {
-        let pv = |p, user_data| ProgressEntry { progress: p, user_data };
-
+    fn vec_progress_update_data_with() {
         let quorum_set = vec![btreeset! {0, 1, 2}];
-        let mut progress = VecProgress::<u64, ProgressEntry, u64, _>::new(quorum_set, [3], || pv(0, "foo"));
+        let mut progress = VecProgress::<IdValData<u64, u64, &'static str>, _>::new(quorum_set, [3], |id| {
+            IdValData::new(id, 0, "foo")
+        });
 
-        // initial: 0,0,0,0
-        let cases = [
-            (3, pv(9, "a"), Ok(&0)), // 0,0,0,9 // learner won't affect quorum-accepted
-            (1, pv(2, "b"), Ok(&0)), // 0,2,0,9
-            (2, pv(3, "c"), Ok(&2)), // 0,2,3,9
-            (1, pv(2, "d"), Ok(&2)), // 0,2,3,9 // No new quorum-accepted, just update user data.
-        ];
+        assert_eq!(Ok(&0), progress.update(&1, 2));
 
-        for (ith, (id, v, want_quorum_accepted)) in cases.iter().enumerate() {
-            let got = progress.update(id, *v);
-            assert_eq!(
-                want_quorum_accepted.clone(),
-                got,
-                "{}-th case: id:{}, v:{:?}",
-                ith,
-                id,
-                v
-            );
-        }
+        let stats_before = (
+            progress.stat().update_count,
+            progress.stat().move_count,
+            progress.stat().is_quorum_count,
+        );
 
-        // Check progress data
+        assert_eq!(Some(&"bar"), progress.update_data_with(&1, |data| *data = "bar"));
+        assert_eq!(None, progress.update_data_with(&9, |data| *data = "unknown"));
 
-        assert_eq!(pv(0, "foo"), *progress.get(&0),);
-        assert_eq!(pv(2, "d"), *progress.get(&1),);
-        assert_eq!(pv(3, "c"), *progress.get(&2),);
-        assert_eq!(pv(9, "a"), *progress.get(&3),);
+        assert_eq!(
+            vec![
+                IdValData::new(1, 2, "bar"),
+                IdValData::new(0, 0, "foo"),
+                IdValData::new(2, 0, "foo"),
+                IdValData::new(3, 0, "foo"),
+            ],
+            progress.iter().cloned().collect::<Vec<_>>()
+        );
+        assert_eq!(&0, progress.quorum_accepted());
+        assert_eq!(
+            stats_before,
+            (
+                progress.stat().update_count,
+                progress.stat().move_count,
+                progress.stat().is_quorum_count,
+            )
+        );
     }
 
     #[test]
     fn vec_progress_update_does_not_move_learner_elt() {
         let quorum_set = vec![btreeset! {0, 1, 2, 3, 4}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [6], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [6], |id| (id, 0));
 
         assert_eq!(Some(5), progress.index(&6));
 
@@ -995,7 +972,7 @@ mod tests {
 
         // Initially, quorum-accepted is 5
 
-        let mut p012 = VecProgress::<u64, u64, u64, _>::new(qs012, [5], || 0);
+        let mut p012 = VecProgress::<(u64, u64), _>::new(qs012, [5], |id| (id, 0));
 
         p012.update(&0, 5).ok();
         p012.update(&1, 6).ok();
@@ -1004,13 +981,13 @@ mod tests {
 
         // After upgrading to a bigger quorum set, quorum-accepted fall back to 0
 
-        let mut p012_345 = p012.upgrade_quorum_set(qs012_345, [6], || 0);
+        let mut p012_345 = p012.upgrade_quorum_set(qs012_345, [6], |id| (id, 0));
         assert_eq!(
             &0,
             p012_345.quorum_accepted(),
             "quorum extended from 012 to 012_345, quorum-accepted falls back"
         );
-        assert_eq!(&9, p012_345.get(&5), "inherit learner progress");
+        assert_eq!(&9, &p012_345.get(&5).1, "inherit learner progress");
 
         // When quorum set shrinks, quorum-accepted becomes greater.
 
@@ -1018,14 +995,14 @@ mod tests {
         p012_345.update(&4, 8).ok();
         assert_eq!(&5, p012_345.quorum_accepted());
 
-        let p345 = p012_345.upgrade_quorum_set(qs345, [1], || 0);
+        let p345 = p012_345.upgrade_quorum_set(qs345, [1], |id| (id, 0));
 
         assert_eq!(
             &8,
             p345.quorum_accepted(),
             "shrink quorum set, greater value becomes quorum-accepted"
         );
-        assert_eq!(&6, p345.get(&1), "inherit voter progress");
+        assert_eq!(&6, &p345.get(&1).1, "inherit voter progress");
     }
 
     #[test]
@@ -1034,7 +1011,7 @@ mod tests {
         let qs012_234 = vec![btreeset! {0, 1, 2}, btreeset! {2, 3, 4}];
         let qs345 = vec![btreeset! {3, 4, 5}];
 
-        let mut p = VecProgress::<u64, u64, u64, _>::new(qs01234, [5], || 0);
+        let mut p = VecProgress::<(u64, u64), _>::new(qs01234, [5], |id| (id, 0));
 
         for (id, value) in [(0, 9), (1, 8), (2, 7), (3, 2), (4, 1), (5, 10)] {
             p.update(&id, value).ok();
@@ -1042,10 +1019,10 @@ mod tests {
 
         assert_eq!(&7, p.quorum_accepted());
 
-        let mut joint = p.upgrade_quorum_set(qs012_234, [5, 6], || 0);
+        let mut joint = p.upgrade_quorum_set(qs012_234, [5, 6], |id| (id, 0));
 
         assert_eq!(&2, joint.quorum_accepted(), "joint quorum lowers the accepted value");
-        let entries: Vec<_> = joint.collect_mapped(|item| (item.id, item.val));
+        let entries: Vec<_> = joint.collect_mapped(|item| (item.0, item.1));
         assert_eq!(vec![(0, 9), (1, 8), (2, 7), (3, 2), (4, 1), (5, 10), (6, 0)], entries);
         assert_matches_model(&joint, "after upgrade to joint quorum");
 
@@ -1054,10 +1031,10 @@ mod tests {
         assert_eq!(&8, joint.quorum_accepted());
         assert_matches_model(&joint, "after joint quorum catches up");
 
-        let shrunk = joint.upgrade_quorum_set(qs345, [0], || 0);
+        let shrunk = joint.upgrade_quorum_set(qs345, [0], |id| (id, 0));
 
         assert_eq!(&8, shrunk.quorum_accepted());
-        let entries: Vec<_> = shrunk.collect_mapped(|item| (item.id, item.val));
+        let entries: Vec<_> = shrunk.collect_mapped(|item| (item.0, item.1));
         assert_eq!(vec![(5, 10), (3, 8), (4, 8), (0, 9)], entries);
         assert_matches_model(&shrunk, "after shrinking joint quorum");
     }
@@ -1065,7 +1042,7 @@ mod tests {
     #[test]
     fn vec_progress_is_voter() {
         let quorum_set = vec![btreeset! {0, 1, 2, 3, 4}];
-        let progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [6, 7], || 0);
+        let progress = VecProgress::<(u64, u64), _>::new(quorum_set, [6, 7], |id| (id, 0));
 
         assert_eq!(Some(true), progress.is_voter(&1));
         assert_eq!(Some(true), progress.is_voter(&3));
@@ -1076,36 +1053,39 @@ mod tests {
     #[test]
     fn vec_progress_display() {
         let quorum_set = vec![btreeset! {0, 1, 2}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [3], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [3], |id| (id, 0));
 
         progress.update(&1, 5).ok();
         progress.update(&2, 3).ok();
 
-        let display = format!("{}", progress);
+        let display = format!(
+            "{}",
+            progress.display_with(|f, item| write!(f, "{}: {}", item.0, item.1))
+        );
         assert_eq!("{1: 5, 2: 3, 0: 0, 3: 0}", display);
     }
 
     #[test]
-    fn vec_progress_iter_mut() {
+    fn vec_progress_iter_mut_without_reorder() {
         let quorum_set = vec![btreeset! {0, 1, 2}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [3], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [3], |id| (id, 0));
 
-        // Mutate values through iter_mut
-        for item in progress.iter_mut() {
-            if item.id == 1 {
-                item.val = 10;
+        // Mutate values through iter_mut_without_reorder
+        for item in progress.iter_mut_without_reorder() {
+            if item.0 == 1 {
+                item.1 = 10;
             }
         }
 
-        assert_eq!(&10, progress.get(&1));
-        assert_eq!(&0, progress.get(&0));
-        assert_eq!(&0, progress.get(&2));
+        assert_eq!(&10, &progress.get(&1).1);
+        assert_eq!(&0, &progress.get(&0).1);
+        assert_eq!(&0, &progress.get(&2).1);
     }
 
     #[test]
     fn vec_progress_stat() {
         let quorum_set = vec![btreeset! {0, 1, 2}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [3], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [3], |id| (id, 0));
 
         assert_eq!(
             (0, 0, 0),
@@ -1170,12 +1150,12 @@ mod tests {
     #[test]
     fn vec_progress_display_with() {
         let quorum_set = vec![btreeset! {0, 1, 2}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [3], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [3], |id| (id, 0));
 
         progress.update(&1, 5).ok();
         progress.update(&2, 3).ok();
 
-        let display = progress.display_with(|f, id, val| write!(f, "{}={}", id, val));
+        let display = progress.display_with(|f, item| write!(f, "{}={}", item.0, item.1));
 
         let output = format!("{}", display);
         assert_eq!("{1=5, 2=3, 0=0, 3=0}", output);
@@ -1184,19 +1164,19 @@ mod tests {
     #[test]
     fn vec_progress_increase_to() {
         let quorum_set = vec![btreeset! {0, 1, 2, 3, 4}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [6], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [6], |id| (id, 0));
 
         // Increase from 0 to 5
         progress.increase_to(&1, 5).ok();
-        assert_eq!(&5, progress.get(&1));
+        assert_eq!(&5, &progress.get(&1).1);
 
         // Try to decrease from 5 to 3 - should not change
         progress.increase_to(&1, 3).ok();
-        assert_eq!(&5, progress.get(&1));
+        assert_eq!(&5, &progress.get(&1).1);
 
         // Increase from 5 to 7
         progress.increase_to(&1, 7).ok();
-        assert_eq!(&7, progress.get(&1));
+        assert_eq!(&7, &progress.get(&1).1);
 
         // Try with nonexistent id
         let result = progress.increase_to(&9, 10);
@@ -1206,34 +1186,117 @@ mod tests {
     #[test]
     fn vec_progress_collect_mapped() {
         let quorum_set = vec![btreeset! {0, 1, 2}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [3], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [3], |id| (id, 0));
 
         progress.update(&1, 5).ok();
         progress.update(&2, 3).ok();
 
         // Collect ids as Vec - order matters after updates (sorted by value descending)
-        let ids: Vec<u64> = progress.collect_mapped(|item| item.id);
+        let ids: Vec<u64> = progress.collect_mapped(|item| item.0);
         assert_eq!(vec![1, 2, 0, 3], ids);
 
         // Collect values as Vec - order matters after updates (sorted descending)
-        let values: Vec<u64> = progress.collect_mapped(|item| item.val);
+        let values: Vec<u64> = progress.collect_mapped(|item| item.1);
         assert_eq!(vec![5, 3, 0, 0], values);
 
         // Collect as Vec of tuples - order matters after updates
-        let pairs: Vec<(u64, u64)> = progress.collect_mapped(|item| (item.id, item.val));
+        let pairs: Vec<(u64, u64)> = progress.collect_mapped(|item| (item.0, item.1));
         assert_eq!(vec![(1, 5), (2, 3), (0, 0), (3, 0)], pairs);
+    }
+
+    #[test]
+    fn vec_progress_reset_entry_with() {
+        // 7 voters, majority = 4.
+        let quorum_set = vec![btreeset! {0, 1, 2, 3, 4, 5, 6}];
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [7], |id| (id, 0));
+
+        progress.update(&0, 12).ok();
+        progress.update(&1, 11).ok();
+        progress.update(&2, 10).ok();
+        progress.update(&3, 9).ok();
+        assert_eq!(&9, progress.quorum_accepted());
+
+        // Node 1 log-reverts: its progress falls back to the default value and the
+        // entry is moved down, while the quorum-accepted value must be kept.
+        let entry = progress.reset_entry_with(&1, |entry| entry.1 = 0);
+        assert_eq!(Some(&(1, 0)), entry);
+        assert_eq!(&9, progress.quorum_accepted(), "reset never lowers quorum-accepted");
+        assert_eq!(
+            vec![(0, 12), (2, 10), (3, 9), (1, 0), (4, 0), (5, 0), (6, 0), (7, 0)],
+            progress.entries
+        );
+        assert_voter_prefix_is_sorted(&progress, "after reset");
+
+        // Node 4 catches up to exactly 10: without the move-down, the reverted node 1
+        // would be counted spuriously and 10 would be accepted with only 3 real grants.
+        assert_eq!(Ok(9), copy_result(progress.update(&4, 10)));
+        assert_matches_model(&progress, "after catching up to 10");
+
+        // A real quorum at 10: {0, 2, 4, 5}.
+        assert_eq!(Ok(10), copy_result(progress.update(&5, 10)));
+        assert_matches_model(&progress, "after a real quorum at 10");
+
+        // Resetting a learner or a nonexistent id does not reorder anything.
+        assert_eq!(Some(&(7, 0)), progress.reset_entry_with(&7, |entry| entry.1 = 0));
+        assert_eq!(None, progress.reset_entry_with(&9, |entry| entry.1 = 0));
+    }
+
+    #[test]
+    fn vec_progress_matches_reference_model_with_resets() {
+        let cases = [
+            (vec![btreeset! {0, 1, 2, 3, 4, 5, 6}], vec![7]),
+            (vec![btreeset! {0, 1, 2}, btreeset! {2, 3, 4}], vec![5, 6]),
+        ];
+
+        for (case_id, (quorum_set, learners)) in cases.into_iter().enumerate() {
+            for seed in 0..32 {
+                let mut seed = seed + 3;
+                let mut progress =
+                    VecProgress::<(u64, u64), _>::new(quorum_set.clone(), learners.clone(), |id| (id, 0));
+
+                // The quorum-accepted value never moves backward, so the reference
+                // is the running max of the instantaneous model value.
+                let mut want = 0;
+
+                for step in 0..128 {
+                    // Use high bits: the low bits of this LCG have a short period,
+                    // which makes power-of-two moduli cycle in lock-step.
+                    let id = (next_random(&mut seed) >> 32) % 8;
+                    let context = format!("case-{case_id} seed-{seed} step-{step} id-{id}");
+
+                    if (next_random(&mut seed) >> 32).is_multiple_of(8) {
+                        progress.reset_entry_with(&id, |entry| entry.1 = 0);
+                    } else {
+                        let value = progress.try_get(&id).map(|entry| entry.1).unwrap_or_default()
+                            + next_random(&mut seed) % 7
+                            + 1;
+                        progress.update(&id, value).ok();
+                    }
+
+                    want = want.max(model_quorum_accepted(&progress.quorum_set, &progress.entries));
+                    assert_eq!(
+                        &want,
+                        progress.quorum_accepted(),
+                        "{context}: entries: {:?}",
+                        progress.entries
+                    );
+                    assert_voter_prefix_is_sorted(&progress, &context);
+                }
+            }
+        }
     }
 
     #[test]
     fn vec_progress_sub_quorum_commit_regression() {
         let quorum_set = vec![btreeset! {0, 1, 2, 3, 4}];
-        let mut progress = VecProgress::<u64, u64, u64, _>::new(quorum_set, [], || 0);
+        let mut progress = VecProgress::<(u64, u64), _>::new(quorum_set, [], |id| (id, 0));
 
         progress.update(&0, 5).ok(); // qa = 0
         progress.update(&1, 3).ok(); // qa = 0
         progress.update(&2, 4).ok(); // qa = 3 ; above-qa region = [0:5, 2:4] (descending, ok)
         progress.update(&2, 10).ok(); // voter 2 was already > qa(3) and advances further:
-        //   move_up is SKIPPED, region becomes [0:5, 2:10] (NOT descending)
+        //   move_up must still run; if it were skipped, the region would become
+        //   [0:5, 2:10] (NOT descending) and the next update would falsely accept 6.
         let qa = progress.update(&3, 6).ok();
 
         // True match values: {0:5, 1:3, 2:10, 3:6, 4:0}; sorted desc = 10,6,5,3,0 -> 3rd-largest = 5.

--- a/openraft/src/progress/vec_progress_entry.rs
+++ b/openraft/src/progress/vec_progress_entry.rs
@@ -1,0 +1,63 @@
+/// Entry stored in [`VecProgress`].
+///
+/// `VecProgress` only uses the ID and progress value. Other entry fields are
+/// application-owned state.
+///
+/// [`VecProgress`]: crate::progress::VecProgress
+pub(crate) trait VecProgressEntry {
+    type Id: 'static + PartialEq;
+    type Progress: Clone + Default + Ord;
+
+    /// Return the ID this entry belongs to.
+    fn id(&self) -> &Self::Id;
+
+    /// Return the monotonic progress value used to calculate quorum acceptance.
+    fn progress(&self) -> &Self::Progress;
+
+    /// Return the mutable monotonic progress value.
+    fn progress_mut(&mut self) -> &mut Self::Progress;
+
+    /// Return the ID and progress value as references.
+    fn id_progress(&self) -> (&Self::Id, &Self::Progress) {
+        (self.id(), self.progress())
+    }
+
+    /// Return cloned ID and progress value.
+    fn id_progress_owned(&self) -> (Self::Id, Self::Progress)
+    where Self::Id: Clone {
+        let (id, progress) = self.id_progress();
+        (id.clone(), progress.clone())
+    }
+}
+
+/// Entry with application-owned data stored beside progress.
+pub(crate) trait VecProgressEntryData: VecProgressEntry {
+    type Data;
+
+    /// Return the application-owned data.
+    fn data(&self) -> &Self::Data;
+
+    /// Return mutable application-owned data.
+    fn data_mut(&mut self) -> &mut Self::Data;
+}
+
+impl<ID, Progress> VecProgressEntry for (ID, Progress)
+where
+    ID: 'static + PartialEq,
+    Progress: Clone + Default + Ord,
+{
+    type Id = ID;
+    type Progress = Progress;
+
+    fn id(&self) -> &Self::Id {
+        &self.0
+    }
+
+    fn progress(&self) -> &Self::Progress {
+        &self.1
+    }
+
+    fn progress_mut(&mut self) -> &mut Self::Progress {
+        &mut self.1
+    }
+}

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -7,6 +7,7 @@ use crate::base::shared_id_generator::SharedIdGenerator;
 use crate::display_ext::DisplayInstantExt;
 use crate::engine::leader_log_ids::LeaderLogIds;
 use crate::progress::VecProgress;
+use crate::progress::id_val::IdVal;
 use crate::proposer::Leader;
 use crate::quorum::QuorumSet;
 use crate::type_config::alias::InstantOf;
@@ -31,7 +32,7 @@ where
     last_log_id: Option<LogIdOf<C>>,
 
     /// Which nodes have granted the vote at certain time point.
-    progress: VecProgress<C::NodeId, bool, bool, QS>,
+    progress: VecProgress<IdVal<C::NodeId, bool>, QS>,
 
     quorum_set: QS,
 
@@ -74,7 +75,7 @@ where
             starting_time,
             vote,
             last_log_id,
-            progress: VecProgress::new(quorum_set.clone(), [], || false),
+            progress: VecProgress::new(quorum_set.clone(), [], IdVal::new_default),
             quorum_set,
             learner_ids: learner_ids.into_iter().collect::<Vec<_>>(),
             progress_id_gen,
@@ -97,7 +98,7 @@ where
         self.starting_time
     }
 
-    pub(crate) fn progress(&self) -> &VecProgress<C::NodeId, bool, bool, QS> {
+    pub(crate) fn progress(&self) -> &VecProgress<IdVal<C::NodeId, bool>, QS> {
         &self.progress
     }
 

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -7,6 +7,7 @@ use crate::display_ext::DisplayInstantExt;
 use crate::engine::leader_log_ids::LeaderLogIds;
 use crate::progress::VecProgress;
 use crate::progress::entry::ProgressEntry;
+use crate::progress::id_val::IdVal;
 use crate::progress::stream_id::StreamId;
 use crate::quorum::QuorumSet;
 use crate::type_config::TypeConfigExt;
@@ -60,7 +61,7 @@ where C: RaftTypeConfig
     pub(crate) noop_log_id: LogIdOf<C>,
 
     /// Tracks the replication progress and committed index
-    pub(crate) progress: VecProgress<C::NodeId, ProgressEntry<C>, Option<LogIdOf<C>>, QS>,
+    pub(crate) progress: VecProgress<ProgressEntry<C>, QS>,
 
     /// Tracks the clock time acknowledged by other nodes.
     ///
@@ -75,7 +76,7 @@ where C: RaftTypeConfig
     /// See [`docs::leader_lease`] for more details.
     ///
     /// [`docs::leader_lease`]: `crate::docs::protocol::replication::leader_lease`
-    pub(crate) clock_progress: VecProgress<C::NodeId, Option<InstantOf<C>>, Option<InstantOf<C>>, QS>,
+    pub(crate) clock_progress: VecProgress<IdVal<C::NodeId, Option<InstantOf<C>>>, QS>,
 }
 
 impl<C, QS> Leader<C, QS>
@@ -138,11 +139,11 @@ where
             next_heartbeat: C::now(),
             last_log_id: last_log_id.clone(),
             noop_log_id,
-            progress: VecProgress::new(quorum_set.clone(), learner_ids.iter().cloned(), || {
+            progress: VecProgress::new(quorum_set.clone(), learner_ids.iter().cloned(), |id| {
                 let stream_id = StreamId::new(id_gen.next_id());
-                ProgressEntry::empty(stream_id, last_log_id.next_index())
+                ProgressEntry::empty(id, stream_id, last_log_id.next_index())
             }),
-            clock_progress: VecProgress::new(quorum_set, learner_ids, || None),
+            clock_progress: VecProgress::new(quorum_set, learner_ids, IdVal::new_default),
         }
     }
 
@@ -228,8 +229,8 @@ where
     }
 
     pub(crate) fn is_replication_stream_valid(&self, target: &C::NodeId, stream_id: StreamId) -> bool {
-        if let Some(prog_ent) = self.progress.try_get(target)
-            && prog_ent.stream_id == stream_id
+        if let Some(entry) = self.progress.try_get(target)
+            && entry.stream_id == stream_id
         {
             return true;
         }

--- a/openraft/src/quorum/quorum_set.rs
+++ b/openraft/src/quorum/quorum_set.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 ///
 /// A quorum is a collection of nodes that a read or write operation in a distributed system has to
 /// contact. See: <http://web.mit.edu/6.033/2005/wwwdocs/quorum_note.html>
+///
+/// Implementations must be upward-closed: adding more IDs to a quorum must still be a quorum.
 pub(crate) trait QuorumSet {
     type Id: 'static;
 


### PR DESCRIPTION

## Changelog

##### refactor: reshape VecProgress around entries
# Summary

Refactor VecProgress so it stores entry types that expose their ID and
quorum progress, while keeping application-owned state beside the
progress value without making it part of quorum ordering.

# Details

Introduce VecProgressEntry and VecProgressEntryData as the entry
contract for progress tracking. This removes the separate ID, value, and
payload type parameters from VecProgress and lets simple callers use
IdVal while replication uses a richer ProgressEntry.

Split replication progress into the quorum-visible matching value and
ProgressData for stream IDs, inflight state, search bounds, and
log-reversion flags. This keeps normal progress updates routed through
ordering-aware APIs while data-only updates can avoid unnecessary quorum
recalculation.

Document and rename the mutable escape hatches that intentionally bypass
ordering maintenance. Allowed log reversion can reset matching progress
to None without reordering or lowering quorum-accepted state, so those
APIs now make the stale-ordering risk explicit.

Update proposer, replication, metrics, benchmarks, and tests to use the
entry-based API and to avoid direct mutable progress access unless the
caller explicitly opts into the no-reorder path.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1820)
<!-- Reviewable:end -->
