### PR TITLE
refactor: keep IdValData local to vec_progress tests

### DIFF
--- a/openraft/src/progress/id_val.rs
+++ b/openraft/src/progress/id_val.rs
@@ -1,23 +1,12 @@
 use std::fmt;
 
 use crate::progress::VecProgressEntry;
-#[cfg(test)]
-use crate::progress::VecProgressEntryData;
 
 /// An ID and its associated value.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct IdVal<ID, Val> {
     pub(crate) id: ID,
     pub(crate) val: Val,
-}
-
-/// An ID, progress, and application-owned data.
-#[cfg(test)]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct IdValData<ID, Val, Data> {
-    pub(crate) id: ID,
-    pub(crate) val: Val,
-    pub(crate) data: Data,
 }
 
 impl<ID, Val> fmt::Display for IdVal<ID, Val>
@@ -27,18 +16,6 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}: {}", self.id, self.val)
-    }
-}
-
-#[cfg(test)]
-impl<ID, Val, Data> fmt::Display for IdValData<ID, Val, Data>
-where
-    ID: fmt::Display,
-    Val: fmt::Display,
-    Data: fmt::Display,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {}: {}", self.id, self.val, self.data)
     }
 }
 
@@ -54,13 +31,6 @@ where Val: Default
     /// Create an [`IdVal`] with the provided ID and `Val::default()`.
     pub(crate) fn new_default(id: ID) -> Self {
         Self::new(id, Default::default())
-    }
-}
-
-#[cfg(test)]
-impl<ID, Val, Data> IdValData<ID, Val, Data> {
-    pub(crate) fn new(id: ID, val: Val, data: Data) -> Self {
-        Self { id, val, data }
     }
 }
 
@@ -82,44 +52,5 @@ where
 
     fn progress_mut(&mut self) -> &mut Self::Progress {
         &mut self.val
-    }
-}
-
-#[cfg(test)]
-impl<ID, Val, Data> VecProgressEntry for IdValData<ID, Val, Data>
-where
-    ID: 'static + PartialEq,
-    Val: Clone + Default + Ord,
-{
-    type Id = ID;
-    type Progress = Val;
-
-    fn id(&self) -> &Self::Id {
-        &self.id
-    }
-
-    fn progress(&self) -> &Self::Progress {
-        &self.val
-    }
-
-    fn progress_mut(&mut self) -> &mut Self::Progress {
-        &mut self.val
-    }
-}
-
-#[cfg(test)]
-impl<ID, Val, Data> VecProgressEntryData for IdValData<ID, Val, Data>
-where
-    ID: 'static + PartialEq,
-    Val: Clone + Default + Ord,
-{
-    type Data = Data;
-
-    fn data(&self) -> &Self::Data {
-        &self.data
-    }
-
-    fn data_mut(&mut self) -> &mut Self::Data {
-        &mut self.data
     }
 }

--- a/openraft/src/progress/vec_progress.rs
+++ b/openraft/src/progress/vec_progress.rs
@@ -442,11 +442,62 @@ mod tests {
     use maplit::btreeset;
 
     use super::VecProgress;
-    use crate::progress::id_val::IdValData;
+    use crate::progress::VecProgressEntry;
+    use crate::progress::VecProgressEntryData;
     use crate::quorum::QuorumSet;
 
     const LCG_A: u64 = 6364136223846793005;
     const LCG_C: u64 = 1442695040888963407;
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct IdValData<ID, Val, Data> {
+        id: ID,
+        val: Val,
+        data: Data,
+    }
+
+    impl<ID, Val, Data> IdValData<ID, Val, Data> {
+        fn new(id: ID, val: Val, data: Data) -> Self {
+            Self { id, val, data }
+        }
+    }
+
+    impl<ID, Val, Data> VecProgressEntry for IdValData<ID, Val, Data>
+    where
+        ID: 'static + PartialEq,
+        Val: Clone + Default + Ord,
+    {
+        type Id = ID;
+        type Progress = Val;
+
+        fn id(&self) -> &Self::Id {
+            &self.id
+        }
+
+        fn progress(&self) -> &Self::Progress {
+            &self.val
+        }
+
+        fn progress_mut(&mut self) -> &mut Self::Progress {
+            &mut self.val
+        }
+    }
+
+    impl<ID, Val, Data> VecProgressEntryData for IdValData<ID, Val, Data>
+    where
+        ID: 'static + PartialEq,
+        Val: Clone + Default + Ord,
+    {
+        type Data = Data;
+
+        fn data(&self) -> &Self::Data {
+            &self.data
+        }
+
+        fn data_mut(&mut self) -> &mut Self::Data {
+            &mut self.data
+        }
+    }
 
     #[derive(Clone, Debug)]
     struct RequiredSetQuorum {

--- a/tests/tests/membership/t51_hung_follower_blocks_loop.rs
+++ b/tests/tests/membership/t51_hung_follower_blocks_loop.rs
@@ -21,6 +21,7 @@ async fn setup() -> Result<TypedRaftRouter> {
     let config = Arc::new(
         Config {
             enable_heartbeat: false,
+            enable_elect: false,
             ..Default::default()
         }
         .validate()?,


### PR DESCRIPTION

## Changelog

##### refactor: keep IdValData local to vec_progress tests
# Summary

Move the test-only `IdValData` fixture out of the shared progress helper and define it beside the vec_progress tests that need application-owned data.

# Details

The shared progress entry helper now contains only `IdVal`, reducing test-only surface in the progress module.

The local fixture keeps `VecProgressEntryData` coverage unchanged while dropping the unused `Display` implementation.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1821)
<!-- Reviewable:end -->
