### PR TITLE
test: tolerate the injected fatal in the 1795 replication test

### DIFF
--- a/tests/tests/replication/t99_issue_1795_storage_error_stops_replication.rs
+++ b/tests/tests/replication/t99_issue_1795_storage_error_stops_replication.rs
@@ -85,7 +85,12 @@ async fn storage_error_stops_replication() -> Result<()> {
     router.set_fail_next_limited_get(&0, true)?;
 
     let leader = router.get_raft_handle(&0)?;
-    leader.add_learner(1, (), false).await?;
+    // Adding the learner starts replication to node 1, which reads the live suffix and hits the
+    // injected one-shot read error. That error is reported to RaftCore as a fatal `StorageError`,
+    // so `add_learner` races the shutdown: it returns `Ok` when the membership response wins, or the
+    // injected `StorageError` when the fatal wins. Both outcomes are expected here; the behavior
+    // under test is whether replication retried with a malformed AppendEntries, asserted below.
+    let _ = leader.add_learner(1, (), false).await;
 
     TypeConfig::sleep(Duration::from_millis(800)).await;
 


### PR DESCRIPTION

## Changelog

##### test: tolerate the injected fatal in the 1795 replication test
# Summary

Fix a latent race in `storage_error_stops_replication` that made it fail
intermittently in CI. The test injects a one-shot storage read error and then
propagated the result of `add_learner` with `?`, but that injected error is by
design fatal to RaftCore, so `add_learner` can legitimately return it instead
of `Ok`.

# Details

The injected `limited_get_log_entries` error is read by the replication stream
to the new learner, reported to RaftCore as `Notification::StorageError`, and
converted into `Fatal::StorageError`, which stops the core and fails any
in-flight `add_learner` with the same error. The call therefore races the
shutdown: it returns `Ok` when the membership response wins and the injected
`StorageError` when the fatal wins. Discard the result instead of using `?`;
the assertion that replication never retried with a malformed AppendEntries is
the actual behavior under test and holds in both outcomes.

- Fixes #1795 test flakiness

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1822)
<!-- Reviewable:end -->
