### PR TITLE
fix: reject stale replication acks after log reversion

### DIFF
--- a/openraft/src/progress/entry/update.rs
+++ b/openraft/src/progress/entry/update.rs
@@ -121,7 +121,14 @@ where C: RaftTypeConfig
         );
 
         if let Some(inflight_id) = inflight_id {
-            self.entry.inflight.ack(matching.clone(), inflight_id);
+            let applied = self.entry.inflight.ack(matching.clone(), inflight_id);
+            if !applied {
+                // Stale payload ack: a newer request superseded this one, or a concurrent log
+                // reversion cleared the inflight to `None` (see `update_conflicting`). Do not
+                // advance `matching`: the follower no longer holds the acked logs, and counting
+                // them as matched could form a false quorum over data the follower has reverted.
+                return;
+            }
         }
 
         // If it is not a response of an actual replication(such as replicating commit log id),

--- a/openraft/src/progress/inflight/mod.rs
+++ b/openraft/src/progress/inflight/mod.rs
@@ -154,42 +154,51 @@ where C: RaftTypeConfig
 
     /// Update inflight state when log up to `upto` is acknowledged by a follower/learner.
     ///
-    /// If `from_inflight_id` doesn't match the current `InflightId`,
-    /// the ack is ignored as a stale response.
-    pub(crate) fn ack(&mut self, upto: Option<LogIdOf<C>>, from_inflight_id: InflightId) {
+    /// Returns `true` if the ack matched the current inflight request and was applied; `false` if
+    /// it was stale and ignored. An ack is stale when its `from_inflight_id` does not match the
+    /// current request, or when there is no inflight request at all ([`Inflight::None`]): in
+    /// pipeline ([`Inflight::LogsSince`]) mode several acks share one [`InflightId`], and a
+    /// concurrent log reversion can clear the inflight to `None` (see
+    /// [`Updater::update_conflicting`]) while acks queued before the reset are still arriving. The
+    /// caller must not advance `matching` when this returns `false`: the follower state such an ack
+    /// reports no longer holds.
+    ///
+    /// [`Updater::update_conflicting`]: crate::progress::entry::update::Updater::update_conflicting
+    pub(crate) fn ack(&mut self, upto: Option<LogIdOf<C>>, from_inflight_id: InflightId) -> bool {
         match self {
-            Inflight::None => {
-                unreachable!("no inflight data")
-            }
+            Inflight::None => false,
             Inflight::Logs {
                 log_id_range,
                 inflight_id,
             } => {
                 if *inflight_id != from_inflight_id {
-                    return;
+                    return false;
                 }
 
                 *self = {
                     debug_assert!(upto >= log_id_range.prev);
                     debug_assert!(upto <= log_id_range.last);
                     Inflight::logs(upto, log_id_range.last.clone(), *inflight_id)
-                }
+                };
+                true
             }
             Inflight::Snapshot { inflight_id } => {
                 if *inflight_id != from_inflight_id {
-                    return;
+                    return false;
                 }
 
                 *self = Inflight::None;
+                true
             }
             Inflight::LogsSince { prev, inflight_id } => {
                 if *inflight_id != from_inflight_id {
-                    return;
+                    return false;
                 }
 
                 debug_assert!(&upto >= prev);
 
                 *prev = upto;
+                true
             }
         }
     }

--- a/openraft/src/progress/inflight/tests.rs
+++ b/openraft/src/progress/inflight/tests.rs
@@ -136,7 +136,8 @@ fn test_inflight_ack_inflight_id_mismatch() -> anyhow::Result<()> {
         let mut f = Inflight::<UTConfig>::logs(Some(log_id(5)), Some(log_id(10)), InflightId::new(1));
         let original = f;
 
-        f.ack(Some(log_id(7)), InflightId::new(2));
+        let applied = f.ack(Some(log_id(7)), InflightId::new(2));
+        assert!(!applied, "ack with mismatched inflight_id is stale");
         assert_eq!(original, f, "ack with mismatched inflight_id should be ignored");
     }
 
@@ -145,12 +146,28 @@ fn test_inflight_ack_inflight_id_mismatch() -> anyhow::Result<()> {
         let mut f = Inflight::<UTConfig>::snapshot(InflightId::new(1));
         let original = f;
 
-        f.ack(Some(log_id(5)), InflightId::new(2));
+        let applied = f.ack(Some(log_id(5)), InflightId::new(2));
+        assert!(!applied, "snapshot ack with mismatched inflight_id is stale");
         assert_eq!(
             original, f,
             "snapshot ack with mismatched inflight_id should be ignored"
         );
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_inflight_ack_none_is_stale() -> anyhow::Result<()> {
+    // A log reversion can clear the inflight to `None` while acks queued before the reset are
+    // still arriving (in pipeline mode many acks share one `InflightId`). Such an ack must be
+    // reported as stale and ignored -- it must never panic, and it must not mutate the inflight.
+    let mut f = Inflight::<UTConfig>::None;
+
+    let applied = f.ack(Some(log_id(5)), InflightId::new(1));
+
+    assert!(!applied, "ack on a cleared (None) inflight is stale");
+    assert_eq!(Inflight::<UTConfig>::None, f, "stale ack must not mutate inflight");
 
     Ok(())
 }

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -233,7 +233,12 @@ where
                 // If there is new data to send, even when the current data is not yet finished sending
                 // discard the current data, start to send the new data.
                 // When data is reverted in LogsSince mode, it needs such a mechanism.
-                let new_data = self.event_watcher.replicate_rx.borrow_watched().clone();
+                //
+                // `borrow_and_update()` marks the value as seen; a plain `borrow_watched()`
+                // would leave the change notification pending, and `drain_events()` would
+                // later observe it and replay the same command, re-running an
+                // already-acknowledged payload.
+                let new_data = self.event_watcher.replicate_rx.borrow_and_update().clone();
                 if self.inflight_id != Some(new_data.inflight_id) {
                     tracing::info!(
                         "ReplicationCore replaced current data with inflight id {:?} with new {}",
@@ -495,7 +500,9 @@ where
         futures_util::select! {
             entries_res = entries.fuse() => {
                 entries_res.map_err(|_e| ReplicationClosed::new("replicate_rx closed"))?;
-                let data = self.event_watcher.replicate_rx.borrow_watched().clone();
+                // This read delivers the command: `borrow_and_update()` marks it as seen so a
+                // value arriving after `changed()` resolved is not delivered a second time.
+                let data = self.event_watcher.replicate_rx.borrow_and_update().clone();
                 self.inflight_id = Some(data.inflight_id);
                 self.next_action = Some(data.payload);
             }
@@ -503,7 +510,8 @@ where
                 committed_res.map_err(|_e| ReplicationClosed::new("committed_rx closed"))?;
 
                 // Committed update: create an empty-range payload to sync commit index.
-                let committed = self.event_watcher.committed_rx.borrow_watched().clone();
+                // This read delivers the event, thus it marks the value as seen.
+                let committed = self.event_watcher.committed_rx.borrow_and_update().clone();
                 self.replication_progress.local_committed = committed;
 
                 let m = self.replication_progress.remote_matched.clone();

--- a/openraft/src/replication/stream_state.rs
+++ b/openraft/src/replication/stream_state.rs
@@ -180,7 +180,8 @@ where
                     _committed_change = committed_change.fuse() => {
                         tracing::debug!("committed_rx changed");
                         // A notification may force an RPC even if no new readable logs are available.
-                        self.leader_committed = self.event_watcher.committed_rx.borrow_watched().clone();
+                        // This read delivers the event, thus it marks the value as seen.
+                        self.leader_committed = self.event_watcher.committed_rx.borrow_and_update().clone();
                         return Some(non_reversed_log_id_range(prev, last_log_id));
                     }
                     cancel_res = cancel.fuse() => {

--- a/rt-compio/src/watch.rs
+++ b/rt-compio/src/watch.rs
@@ -86,6 +86,11 @@ where T: OptionalSend + OptionalSync
     fn borrow_watched(&self) -> <See as watch::Watch>::Ref<'_, T> {
         SeeRef(self.0.borrow())
     }
+
+    #[inline]
+    fn borrow_and_update(&mut self) -> <See as watch::Watch>::Ref<'_, T> {
+        SeeRef(self.0.borrow_and_update())
+    }
 }
 
 impl<T> Deref for SeeRef<'_, T> {

--- a/rt-monoio/src/watch.rs
+++ b/rt-monoio/src/watch.rs
@@ -80,6 +80,11 @@ where T: OptionalSend + OptionalSync
     fn borrow_watched(&self) -> <TokioWatch as watch::Watch>::Ref<'_, T> {
         TokioWatchRef(self.0.borrow())
     }
+
+    #[inline]
+    fn borrow_and_update(&mut self) -> <TokioWatch as watch::Watch>::Ref<'_, T> {
+        TokioWatchRef(self.0.borrow_and_update())
+    }
 }
 
 impl<'a, T> Deref for TokioWatchRef<'a, T> {

--- a/rt-tokio/src/watch.rs
+++ b/rt-tokio/src/watch.rs
@@ -66,4 +66,8 @@ where T: OptionalSend + OptionalSync
     fn borrow_watched(&self) -> <TokioWatch as watch::Watch>::Ref<'_, T> {
         self.0.borrow()
     }
+
+    fn borrow_and_update(&mut self) -> <TokioWatch as watch::Watch>::Ref<'_, T> {
+        self.0.borrow_and_update()
+    }
 }

--- a/rt/src/testing.rs
+++ b/rt/src/testing.rs
@@ -68,6 +68,7 @@ impl<Rt: AsyncRuntime> Suite<Rt> {
             Self::test_watch_wait_until_ge().await;
             Self::test_watch_wait_until().await;
             Self::test_watch_changed_marks_as_seen().await;
+            Self::test_watch_borrow_and_update_marks_seen().await;
             Self::test_watch_changed_returns_immediately_when_unseen().await;
             Self::test_watch_multiple_borrow_then_changed().await;
             Self::test_watch_wait_loop_pattern().await;
@@ -614,6 +615,45 @@ impl<Rt: AsyncRuntime> Suite<Rt> {
             let val = rx.borrow_watched();
             assert_eq!(*val, 2);
         }
+
+        drop(tx);
+    }
+
+    /// Test that `borrow_and_update()` returns the latest value and marks it as seen.
+    ///
+    /// Per the trait contract: after `borrow_and_update()`, a following `changed()`
+    /// sleeps until a newer value is sent, instead of returning immediately for the
+    /// value already returned.
+    pub async fn test_watch_borrow_and_update_marks_seen() {
+        let (tx, mut rx) = Rt::Watch::channel(0i32);
+
+        // A plain borrow does not mark the value as seen: changed() still fires.
+        tx.send(1).unwrap();
+        {
+            let val = rx.borrow_watched();
+            assert_eq!(*val, 1);
+        }
+        assert!(is_ready(rx.changed()));
+
+        // borrow_and_update() returns the latest value and marks it as seen.
+        tx.send(2).unwrap();
+        {
+            let val = rx.borrow_and_update();
+            assert_eq!(*val, 2);
+        }
+        assert!(is_pending(rx.changed()));
+
+        // A newer value makes changed() fire again.
+        tx.send(3).unwrap();
+        assert!(is_ready(rx.changed()));
+
+        // On an already-seen value, borrow_and_update() still returns it, and
+        // changed() stays pending.
+        {
+            let val = rx.borrow_and_update();
+            assert_eq!(*val, 3);
+        }
+        assert!(is_pending(rx.changed()));
 
         drop(tx);
     }

--- a/rt/src/watch/mod.rs
+++ b/rt/src/watch/mod.rs
@@ -3,6 +3,7 @@
 mod watch_error;
 
 use openraft_macros::add_async_trait;
+use openraft_macros::since;
 pub use watch_error::RecvError;
 pub use watch_error::SendError;
 
@@ -163,6 +164,20 @@ where
     /// See: [`Watch::Ref`]
     #[track_caller]
     fn borrow_watched(&self) -> W::Ref<'_, T>;
+
+    /// Returns a reference to the most recently sent value and marks that value as seen.
+    ///
+    /// Unlike [`borrow_watched()`](Self::borrow_watched), this marks the returned value as
+    /// seen: a following call to [`changed()`](Self::changed) sleeps until a newer value is
+    /// sent, instead of returning immediately for the value already returned here.
+    ///
+    /// Use this method when the read value is consumed (acted upon), so that no pending
+    /// change notification is left behind to deliver the same value again.
+    ///
+    /// See: [`Watch::Ref`] for caveats about holding the returned reference.
+    #[since(version = "0.10.0")]
+    #[track_caller]
+    fn borrow_and_update(&mut self) -> W::Ref<'_, T>;
 
     /// Waits until the watched value is greater than or equal to the given value.
     ///


### PR DESCRIPTION

## Changelog

##### fix: reject stale replication acks after log reversion
# Summary

In pipeline (`LogsSince`) mode many acks share one `InflightId`, so a log
reversion can clear the inflight to `None` while acks queued before the
reset are still arriving. Acting on such stale signals is unsafe: advancing
the follower's matched index over logs it has reverted could form a false
quorum, and re-reading an already-consumed command would replay an
acknowledged payload. Both are now suppressed.

# Details

- `Inflight::ack()` returns whether the ack matched the live request. A
  stale ack -- mismatched `InflightId`, or `Inflight::None` after a reversion
  cleared it -- now returns `false` instead of hitting `unreachable!`, and
  the progress updater skips advancing `matching` for it.
- Replication reads of the replicate and committed watch channels switch to
  `borrow_and_update()`, marking the value seen so a notification still
  pending after `changed()` resolves does not deliver and replay the same
  command twice.
- Add a test that acking a cleared (`None`) inflight is reported stale and
  leaves the inflight untouched.


##### feat: add borrow_and_update() to the Watch trait
# Summary

The Watch receiver gains a `borrow_and_update()` method that returns the
most recently sent value and marks it as seen, so a following `changed()`
sleeps until a newer value arrives instead of firing immediately for the
value already consumed. This mirrors tokio's `watch::Receiver`.

# Details

- Add the `borrow_and_update()` method to the public `Watch` trait,
  annotated `#[since(version = "0.10.0")]`, for consumers that read and act
  on a value in one step and must not be re-notified for it.
- Implement it in the tokio, monoio, and compio backends by delegating to
  the underlying tokio watch receiver.
- Add `test_watch_borrow_and_update_marks_seen()` to the shared runtime
  test suite, asserting that a plain borrow leaves `changed()` ready while
  `borrow_and_update()` leaves it pending until a newer value is sent.

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1823)
<!-- Reviewable:end -->
