### PR TITLE
test: wait for all followers before restart

### DIFF
--- a/tests/tests/life_cycle/t50_leader_restart_clears_state.rs
+++ b/tests/tests/life_cycle/t50_leader_restart_clears_state.rs
@@ -53,6 +53,8 @@ async fn leader_restart_clears_state() -> anyhow::Result<()> {
     tracing::info!(log_index, "--- write to 1 log");
     {
         log_index += router.client_request_many(0, "foo", 1).await?;
+        router.wait(&1, timeout()).applied_index(Some(log_index), "node-1 applied log").await?;
+        router.wait(&2, timeout()).applied_index(Some(log_index), "node-2 applied log").await?;
     }
 
     tracing::info!(log_index, "--- stop and restart node-0");


### PR DESCRIPTION

## Changelog

##### test: wait for all followers before restart
# Summary

The leader-restart state-loss test now establishes that both surviving voters hold the committed entry before the former leader is reset.

# Details

Without this synchronization, network delay can leave a follower empty, allowing it to grant the reset node a valid vote and making the assertion timing-dependent.

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1826)
<!-- Reviewable:end -->
