### PR TITLE
docs: refresh top-level documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Openraft Development Guidelines
+# OpenRaft Development Guidelines
 
 ## Code Quality Checks
 
@@ -15,38 +15,38 @@ make basic_check
 make test
 ```
 
-**Never run `cargo clippy` or `cargo fmt` directly** - use the Makefile targets which ensure consistent settings across all workspace crates.
+Do not run `cargo clippy` or `cargo fmt` directly. The Makefile targets apply the same settings across every workspace crate.
 
 ## Key Makefile Targets
 
-- `make lint` - Format all crates and run clippy
-- `make basic_check` - Full validation (lint + tests + doc)
-- `make test` - Run all tests
-- `make doc` - Build documentation
+- `make lint`: format all crates and run Clippy
+- `make basic_check`: run linting, tests, and documentation checks
+- `make test`: run all tests
+- `make doc`: build documentation
 
 ## Rust Style
 
-- Always use `where` clauses for trait bounds instead of inline bounds. This applies everywhere: functions, methods, structs, enums, impls, and trait definitions.
+- Use `where` clauses for trait bounds instead of inline bounds. This applies to functions, methods, structs, enums, `impl` blocks, and trait definitions.
   - Correct: `fn foo<T>(x: T) where T: RaftLeaderId`
   - Wrong: `fn foo<T: RaftLeaderId>(x: T)`
   - Correct: `fn partial_cmp<V>(&self, other: &V) -> Option<Ordering> where V: RaftVote`
   - Wrong: `fn partial_cmp<V: RaftVote>(&self, other: &V) -> Option<Ordering>`
 
-- Use proper trait bounds on structs, not expanded individual bounds. When a trait (e.g., `RaftLeaderId`) implies a set of bounds (`Debug + Display + Clone + ...`), use the trait name directly instead of listing the individual bounds.
+- Use the narrowest named trait bound available. When a trait such as `RaftLeaderId` implies `Debug + Display + Clone + ...`, use the trait instead of expanding its component bounds.
   - Correct: `struct Foo<T> where T: RaftLeaderId`
   - Wrong: `struct Foo<T> where T: OptionalFeatures + PartialOrd + Eq + Clone + Debug + Display + 'static`
 
 ## Public API Change Annotations
 
-Any change to a public type, trait, or associated type must have a `#[since]` attribute describing the change. Use `#[since(version = "0.10.0", change = "description")]` placed above any existing `#[since]` attribute.
+Any change to a public type, trait, or associated type needs a `#[since]` attribute. Add `#[since(version = "0.10.0", change = "description")]` above any existing `#[since]` attribute.
 
-- Add `#[since]` for: new public items, changed struct generic parameters, changed trait bounds on associated types, new associated types.
-- Do NOT add `#[since]` on methods whose signatures only changed as a mechanical consequence of a parent type's generic parameter change (e.g., `Vote<LID>` methods that just replaced `C::Term` with `LID::Term`).
+- Add `#[since]` for new public items, changed struct generic parameters, changed trait bounds on associated types, and new associated types.
+- Do not add `#[since]` to methods whose signatures changed only as a mechanical consequence of a parent type's generic parameter change, such as `Vote<LID>` methods that replace `C::Term` with `LID::Term`.
 - `pub(crate)` items do not need `#[since]`.
 
 ## Code Organization Convention
 
-Each file should contain just one main trait or type, along with its associated implementations. This rule applies automatically when adding **new** types or traits — do not reorganize existing files unless explicitly asked.
+Each file should contain one main trait or type and its implementations. Apply this rule when adding new types or traits. Do not reorganize existing files unless explicitly asked.
 
 ## Project Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,43 +1,39 @@
 # Contributing to OpenRaft
 
+## Validate your changes
+
+Run `make basic_check` before opening a pull request. It runs the project's formatting, lint, test, and documentation checks.
+
 ## Code style
 
-Beyond `rustfmt`, OpenRaft follows a few conventions. The authoritative list lives in [`CLAUDE.md`](CLAUDE.md); the essentials:
+Beyond `rustfmt`, OpenRaft follows the conventions in [`CLAUDE.md`](CLAUDE.md). The essentials are:
 
-- **Trait bounds** always use `where` clauses, never inline bounds — `fn f<T>() where T: RaftLeaderId`, not `fn f<T: RaftLeaderId>()`. This applies to functions, structs, enums, impls, and traits.
-
-- **One main type per file.** Each file holds a single main trait or type with its `impl`s. Don't reorganize existing files unless asked.
-
-- **Public API changes** carry a `#[since(version = "...", change = "...")]` attribute describing the change.
+- Trait bounds use `where` clauses, never inline bounds: `fn f<T>() where T: RaftLeaderId`, not `fn f<T: RaftLeaderId>()`. This applies to functions, structs, enums, `impl` blocks, and traits.
+- Each file has one main trait or type and its implementations. Do not reorganize existing files unless the change requires it.
+- Public API changes include a `#[since(version = "...", change = "...")]` attribute that describes the change.
 
 ## Documentation
 
-The docs are rustdoc comments under `openraft/src/docs/`, published at [docs.rs/openraft](https://docs.rs/openraft/latest/openraft/docs/index.html).
+Public documentation lives in Rustdoc comments under `openraft/src/docs/` and is published on [docs.rs](https://docs.rs/openraft/0.10.0-alpha.28/openraft/docs/index.html). Update it when a public API or user-facing behavior changes.
 
 ## Working with git
 
-- **Write the commit message like an email to your friends.** This [git commit format guide](https://cbea.ms/git-commit/) is a great reference.
-
-- **Rebase and squash** your branch onto the latest `main`, into one or two logical commits, before publishing a PR.
-
-- Do **not** rebase a PR after publishing it; merge `main` in instead.
+- Write commit messages as concise notes to collaborators. The [git commit format guide](https://cbea.ms/git-commit/) is a useful reference.
+- Before opening a pull request, rebase and squash your branch onto the latest `main` into one or two logical commits.
+- Do not rebase a published pull request. Merge `main` into it instead.
 
 ## AI-assisted contributions
 
-AI tools are welcome as a drafting aid, but **you own every line you submit**.
+AI tools can help draft a change, but you own every submitted line.
 
-- **Understand** each change well enough to defend it in review, as if you had written it by hand.
-
-- **Simplify** generated output: drop redundant wrappers, needless abstractions, and comments that restate the code or describe behavior it does not have.
-
-- **Match** the surrounding style and the rest of this guide.
+- Understand each change well enough to defend it in review.
+- Simplify generated output. Remove redundant wrappers, unnecessary abstractions, and comments that repeat the code or claim behavior it does not have.
+- Match the surrounding code and this guide.
 
 PRs that read as unreviewed AI output will be sent back for a cleanup pass before review.
 
 ## Release checklist
 
-- `make basic_check` passes: unit tests, format, and clippy.
-
-- The workspace version is bumped: the `[workspace.package]` version in the root `Cargo.toml` plus every sibling `path` dependency that pins it. See a previous `chore: bump version` commit for the full set.
-
-- After the release CI finishes, open the release page, update the release notes, and publish.
+- `make basic_check` passes.
+- The `[workspace.package]` version in the root `Cargo.toml` and every sibling `path` dependency that pins it are updated. Use a prior `chore: bump version` commit as the complete reference.
+- After release CI finishes, open the release page, update the release notes, and publish.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Crates.io](https://img.shields.io/crates/v/openraft.svg)](https://crates.io/crates/openraft)
 [![docs.rs](https://docs.rs/openraft/badge.svg)](https://docs.rs/openraft)
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-openraft-blue.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==)](https://deepwiki.com/databendlabs/openraft)
-[![guides](https://img.shields.io/badge/guide-%E2%86%97-brightgreen)](https://docs.rs/openraft/latest/openraft/docs/index.html)
+[![guides](https://img.shields.io/badge/guide-%E2%86%97-brightgreen)](https://docs.rs/openraft/0.10.0-alpha.28/openraft/docs/index.html)
 [![Discord Chat](https://img.shields.io/discord/1015845055434588200?logo=discord)](https://discord.gg/ZKw3WG7FQ9)
 <br/>
 [![CI](https://github.com/databendlabs/openraft/actions/workflows/ci.yaml/badge.svg)](https://github.com/databendlabs/openraft/actions/workflows/ci.yaml)
@@ -25,9 +25,9 @@ Currently, openraft is the consensus engine of meta-service cluster in [databend
 
 
 - 🚀 **Get started**:
-    - [OpenRaft guide](https://docs.rs/openraft/latest/openraft/docs/getting_started/index.html) is the best place to get started,
-    - [OpenRaft docs](https://docs.rs/openraft/latest/openraft/docs/index.html) for more in-depth details,
-    - [OpenRaft FAQ](https://docs.rs/openraft/latest/openraft/docs/faq/index.html) explains some common questions.
+    - [OpenRaft guide](https://docs.rs/openraft/0.10.0-alpha.28/openraft/docs/getting_started/index.html) is the best place to get started,
+    - [OpenRaft docs](https://docs.rs/openraft/0.10.0-alpha.28/openraft/docs/index.html) for more in-depth details,
+    - [OpenRaft FAQ](https://docs.rs/openraft/0.10.0-alpha.28/openraft/docs/faq/index.html) explains some common questions.
     - [OpenRaft on DeepWiki](https://deepwiki.com/databendlabs/openraft) provides detailed architectural documentation to help understand OpenRaft internals.
 
 - 💡 **Example Applications**:
@@ -36,7 +36,7 @@ Currently, openraft is the consensus engine of meta-service cluster in [databend
     - [Examples with OpenRaft 0.9](https://github.com/databendlabs/openraft/tree/release-0.9/examples) require OpenRaft 0.9 on [crates.io/openraft](https://crates.io/crates/openraft).
 
 - 🙌 **Questions**?
-    - Why not take a peek at our [FAQ](https://docs.rs/openraft/latest/openraft/docs/faq/index.html)? You might find just what you need.
+    - Why not take a peek at our [FAQ](https://docs.rs/openraft/0.10.0-alpha.28/openraft/docs/faq/index.html)? You might find just what you need.
     - Wanna chat? Come hang out with us on [Discord](https://discord.gg/ZKw3WG7FQ9)!
     - Or start a new discussion over on [GitHub](https://github.com/databendlabs/openraft/discussions/new).
     - Or join our [Feishu group](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=d20l9084-6d36-4470-bac5-4bad7378d003).
@@ -50,7 +50,7 @@ Whatever your style, we're here to support you. 🚀 Let's make something awesom
 # Status
 
 - The features are almost complete for building an application.
-- Performance: Supports 70,000 writes/sec for a single writer, and 5,600,000 writes/sec with batch writes. See: [Performance](#performance)
+- Performance: Supports 33,000 writes/sec for a single writer and 5,615,000 writes/sec with batch writes. See: [Performance](#performance)
 - Unit test coverage stands at 92%.
 - The chaos test has not yet been completed, and further testing is needed to ensure the application's robustness and reliability.
 
@@ -93,10 +93,10 @@ Whatever your style, we're here to support you. 🚀 Let's make something awesom
 
 # Roadmap
 
-- [x] **2022-10-31** [Extended joint membership](https://docs.rs/openraft/latest/openraft/docs/data/extended_membership/index.html)
+- [x] **2022-10-31** [Extended joint membership](https://docs.rs/openraft/0.10.0-alpha.28/openraft/docs/data/extended_membership/index.html)
 - [x] **2023-02-14** Minimize confliction rate when electing;
-  See: [OpenRaft Vote design](https://docs.rs/openraft/latest/openraft/docs/data/vote/index.html);
-  Or use standard raft mode with [feature flag `single-term-leader`](https://docs.rs/openraft/latest/openraft/docs/feature_flags/index.html).
+  See: [OpenRaft Vote design](https://docs.rs/openraft/0.10.0-alpha.28/openraft/docs/data/vote/index.html);
+  Or use [standard Raft leader-ID mode](https://docs.rs/openraft/0.10.0-alpha.28/openraft/docs/data/leader_id/index.html).
 - [x] **2023-04-26** Goal performance is 1,000,000 put/sec.
 - [ ] Reduce the complexity of vote and pre-vote: [get rid of pre-vote RPC](https://github.com/databendlabs/openraft/discussions/15);
 - [ ] Support flexible quorum, e.g.: [Hierarchical Quorums](https://zookeeper.apache.org/doc/r3.5.9/zookeeperHierarchicalQuorums.html)
@@ -136,23 +136,23 @@ For benchmark detail, go to the [./benchmarks/minimal](./benchmarks/minimal) fol
 # Features
 
 - **Async and Event-Driven**: Operates based on Raft events without reliance on periodic ticks, optimizing message batching for high throughput.
-- **Extensible Storage and Networking**: Customizable via `RaftLogStorage`, `RaftStateMachine` and `RaftNetwork` traits, allowing flexibility in choosing storage and network solutions.
+- **Extensible Storage and Networking**: Customizable via `RaftLogStorage`, `RaftStateMachine` and `RaftNetworkV2` traits, allowing flexibility in choosing storage and network solutions.
 - **Unified Raft API**: Offers a single `Raft` type for creating and interacting with Raft tasks, with a straightforward API.
-- **Cluster Formation**: Provides strategies for initial cluster setup as detailed in the [cluster formation guide](https://docs.rs/openraft/latest/openraft/docs/cluster_control/cluster_formation/index.html).
+- **Cluster Formation**: Provides strategies for initial cluster setup as detailed in the [cluster formation guide](https://docs.rs/openraft/0.10.0-alpha.28/openraft/docs/cluster_control/cluster_formation/index.html).
 - **Built-In Tracing Instrumentation**: The codebase integrates [tracing](https://docs.rs/tracing/) for logging and distributed tracing, with the option to [set verbosity levels at compile time](https://docs.rs/tracing/latest/tracing/level_filters/index.html).
 
 ## Functionality:
 
-- ✅ **Leader election**: by policy or manually([`trigger_elect()`][]).
+- ✅ **Leader election**: by policy or manually ([`Trigger::elect()`][]).
 - ✅ **Non-voter(learner) Role**: refer to [`add_learner()`][].
-- ✅ **Log Compaction**(snapshot of state machine): by policy or manually([`trigger_snapshot()`]).
+- ✅ **Log Compaction**(snapshot of state machine): by policy or manually ([`Trigger::snapshot()`][]).
 - ✅ **Snapshot replication**.
-- ✅ **Dynamic Membership**: using joint membership config change. Refer to [dynamic membership](https://docs.rs/openraft/latest/openraft/docs/cluster_control/dynamic_membership/index.html)
+- ✅ **Dynamic Membership**: using joint membership config change. Refer to [dynamic membership](https://docs.rs/openraft/0.10.0-alpha.28/openraft/docs/cluster_control/dynamic_membership/index.html)
 - ✅ **Linearizable read**: [`ensure_linearizable()`][].
-- ⛔️ **Won't support**: Single-step config change. Single-step membership change is a restricted subset of joint consensus that only allows changing one node at a time. Openraft uses the more general [joint consensus](https://docs.rs/openraft/latest/openraft/docs/cluster_control/dynamic_membership/index.html) approach which supports arbitrary membership changes in a single operation.
-- ✅ Toggle heartbeat / election: [`enable_heartbeat`][] / [`enable_elect`][].
-- ✅ Trigger snapshot / election manually: [`trigger_snapshot()`][] / [`trigger_elect()`][].
-- ✅ Purge log by policy or manually: [`purge_log()`][].
+- ⛔️ **Won't support**: Single-step config change. Single-step membership change is a restricted subset of joint consensus that only allows changing one node at a time. Openraft uses the more general [joint consensus](https://docs.rs/openraft/0.10.0-alpha.28/openraft/docs/cluster_control/dynamic_membership/index.html) approach which supports arbitrary membership changes in a single operation.
+- ✅ Toggle heartbeat / election: [`RuntimeConfigHandle::heartbeat()`][] / [`RuntimeConfigHandle::elect()`][].
+- ✅ Trigger snapshot / election manually: [`Trigger::snapshot()`][] / [`Trigger::elect()`][].
+- ✅ Purge log by policy or manually: [`Trigger::purge_log()`][].
 
 
 # Who uses it
@@ -183,13 +183,13 @@ OpenRaft is licensed under the terms of the [MIT License](https://en.wikipedia.o
 or the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0), at your choosing.
 
 
-[`change_membership()`]: https://docs.rs/openraft/latest/openraft/raft/struct.Raft.html#method.change_membership
-[`add_learner()`]: https://docs.rs/openraft/latest/openraft/raft/struct.Raft.html#method.add_learner
-[`purge_log()`]: https://docs.rs/openraft/latest/openraft/raft/struct.Raft.html#method.purge_log
+[`change_membership()`]: https://docs.rs/openraft/0.10.0-alpha.28/openraft/raft/struct.Raft.html#method.change_membership
+[`add_learner()`]: https://docs.rs/openraft/0.10.0-alpha.28/openraft/raft/struct.Raft.html#method.add_learner
+[`Trigger::purge_log()`]: https://docs.rs/openraft/0.10.0-alpha.28/openraft/raft/trigger/struct.Trigger.html#method.purge_log
 
-[`enable_heartbeat`]: https://docs.rs/openraft/latest/openraft/struct.Config.html#structfield.enable_heartbeat
-[`enable_elect`]: https://docs.rs/openraft/latest/openraft/struct.Config.html#structfield.enable_elect
+[`RuntimeConfigHandle::heartbeat()`]: https://docs.rs/openraft/0.10.0-alpha.28/openraft/raft/struct.RuntimeConfigHandle.html#method.heartbeat
+[`RuntimeConfigHandle::elect()`]: https://docs.rs/openraft/0.10.0-alpha.28/openraft/raft/struct.RuntimeConfigHandle.html#method.elect
 
-[`trigger_elect()`]: https://docs.rs/openraft/latest/openraft/raft/struct.Raft.html#method.trigger_elect
-[`trigger_snapshot()`]: https://docs.rs/openraft/latest/openraft/raft/struct.Raft.html#method.trigger_snapshot
-[`ensure_linearizable()`]: https://docs.rs/openraft/latest/openraft/raft/struct.Raft.html#method.ensure_linearizable
+[`Trigger::elect()`]: https://docs.rs/openraft/0.10.0-alpha.28/openraft/raft/trigger/struct.Trigger.html#method.elect
+[`Trigger::snapshot()`]: https://docs.rs/openraft/0.10.0-alpha.28/openraft/raft/trigger/struct.Trigger.html#method.snapshot
+[`ensure_linearizable()`]: https://docs.rs/openraft/0.10.0-alpha.28/openraft/raft/struct.Raft.html#method.ensure_linearizable

--- a/derived-from-async-raft.md
+++ b/derived-from-async-raft.md
@@ -1,5 +1,6 @@
-## Openraft is derived from [async-raft](https://docs.rs/crate/async-raft/latest).
-Bugs that are found in async-raft are fixed by openraft:
+# Fixes carried forward from async-raft
+
+OpenRaft began as a fork of [async-raft](https://docs.rs/crate/async-raft/latest). The linked commits below record fixes that were made while carrying that code forward.
 
 -   Fixed: [6c0ccaf3](https://github.com/databendlabs/openraft/commit/6c0ccaf3ab3f262437d8fc021d4b13437fa4c9ac) consider joint config when starting up and committing.; by drdr xp; 2021-12-24
 -   Fixed: [228077a6](https://github.com/databendlabs/openraft/commit/228077a66d5099fd404ae9c68f0977e5f978f102) a restarted follower should not wait too long to elect. Otherwise, the entire cluster hangs; by drdr xp; 2021-11-19
@@ -26,4 +27,4 @@ Bugs that are found in async-raft are fixed by openraft:
 -   Fixed: [39690593](https://github.com/databendlabs/openraft/commit/39690593a07c6b9ded4b7b8f1aca3191fa7641e4) a NonVoter should stay as NonVoter instead of Follower after restart; by drdr xp; 2021-05-14
 
 
-A full list of changes/fixes can be found in the [change-log](https://github.com/databendlabs/openraft/blob/main/change-log.md).
+The [changelog](change-log.md) records the full release history.

--- a/raft-essentials.md
+++ b/raft-essentials.md
@@ -19,7 +19,7 @@ This document presents the essential details of the Raft protocol as an aid for 
 
 ## terms
 - time is divided into terms of arbitrary length. §5.1
-- each server stores a current term number, which increases monotonically over time. 5.1
+- each server stores a current term number, which increases monotonically over time. §5.1
 - each term begins with an election, in which one or more candidates attempt to become leader. §5.1
 - if a candidate wins the election, then it serves as leader for the rest of the term. §5.1
 - in some situations an election will result in a split vote. In this case the term will end with no leader; a new term (with a new election) will begin shortly. Raft ensures that there is at most one leader in a given term. §5.1
@@ -39,7 +39,7 @@ Follower servers simply respond to requests from leaders and candidates. §5.1
 - if a follower receives no communication during the election timeout window, then it assumes there is no viable leader, transitions to the candidate state, and begins campaigning to become the new leader. §5.2
 
 ### learner
-learners are the same as followers, except are not considered for votes, and do not have election timeouts. §6
+Learners are the same as followers, except that they are not considered for votes and do not have election timeouts. §6
 
 ### candidate
 Candidate servers campaign to become the cluster leader using the RequestVote RPC. §5.1
@@ -54,7 +54,7 @@ Candidate servers campaign to become the cluster leader using the RequestVote RP
 - each server will vote for at most one candidate in a given term, on a first-come-first-served basis. §5.2
 - once a candidate wins an election, it becomes leader. §5.2
 
-#### loosing elections
+#### losing elections
 - while waiting for votes, a candidate may receive an AppendEntries RPC from another server claiming to be leader. §5.2
 - if the leader's term (included in its RPC) is at least as large as the candidate's current term, then the candidate recognizes the leader as legitimate and returns to follower state. §5.2
 - if the term in the RPC is smaller than the candidate's current term, then the candidate rejects the RPC and continues in candidate state. §5.2
@@ -92,7 +92,7 @@ The follower can include the term of the conflicting entry and the first index i
 
 ##### receiver implementation: AppendEntries RPC
 1. Reply false if term < currentTerm (§5.1).
-2. Reply false if log doesn't contain an entry at prevLogIndex whose term matches prevLogTerm (§5.3) Use the log consistency check optimization when possible.
+2. Reply false if log doesn't contain an entry at prevLogIndex whose term matches prevLogTerm (§5.3). Use the log consistency check optimization when possible.
 3. If an existing entry conflicts with a new one (same index but different terms), delete the existing entry and all that follow it (§5.3).
 4. Append any new entries not already in the log.
 5. If leaderCommit > commitIndex, set commitIndex to min(leaderCommit, index of last new entry).
@@ -141,7 +141,7 @@ Clients of Raft send all of their requests to the leader.
 
 - when a client first starts up, it connects to a randomly-chosen server. §8
 - if the client's first choice is not the leader, that server will reject the client's request and supply information about the most recent leader it has heard from. §8
-- if the leader crashes, client requests will timeout; clients then try again with randomly-chosen servers. §8
+- if the leader crashes, client requests will time out; clients then try again with randomly-chosen servers. §8
 
 ### request forwarding
 A non-spec pattern may be used to satisfy the requirements of the spec: request forwarding. Non-leader servers may forward client requests to the leader instead of rejecting the request. If the leader is not currently known, due to being in an election, the request may be buffered for some period of time to wait for a new leader to be elected. Worst case scenario, the request times out, and the client needs to send the request again.
@@ -152,7 +152,7 @@ Our goal for Raft is to implement linearizable semantics. If the leader crashes 
 
 The solution is for clients to assign unique serial numbers to every command. Then, the state machine tracks the latest serial number processed for each client, along with the associated response. If it receives a command whose serial number has already been executed, it responds immediately without reexecuting the request. §8
 
-Note well: this is an application specific requirement, and must be implemented on the application-level.
+Note well: this is an application-specific requirement and must be implemented at the application level.
 
 #### reads
 Linearizable reads must not return stale data.


### PR DESCRIPTION

## Changelog

##### docs: refresh top-level documentation
# Summary

Refresh the repository's entry-point and contributor documentation so it
matches the current OpenRaft API, release line, and protocol guidance.

# Details

- Point README guidance at the 0.10 alpha API, update renamed trigger and
  runtime-configuration references, and align its performance summary with
  the benchmark table.
- Clarify contributor and development guidance, preserve the historical release
  record, and correct mechanical errors in the Raft essentials reference.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1827)
<!-- Reviewable:end -->
