### PR TITLE
fix: send snapshot to a follower behind a fully-purged log

### DIFF
--- a/openraft/src/progress/entry/mod.rs
+++ b/openraft/src/progress/entry/mod.rs
@@ -189,14 +189,48 @@ where C: RaftTypeConfig
         }
     }
 
-    /// Initialize a replication action: sending log entries or sending snapshot.
+    /// Initialize a replication action: sending log entries or sending a snapshot.
     ///
     /// If there is an action in progress, i.e., `inflight` is not None, it returns an `Err`
     /// containing the current `inflight` data.
     ///
     /// See: [Algorithm to find the last matching log id on a Follower][algo].
     ///
+    /// # Decision logic
+    ///
+    /// The follower's last log id matching the leader's log is known to lie in the range
+    /// `[matching, searching_end)`; the invariant `matching.next_index() <= searching_end`
+    /// always holds. This puts the progress in one of two regimes:
+    ///
+    /// - **Probing** (`matching.next_index() < searching_end`): the exact matching point is not yet
+    ///   determined. Send a fixed range of logs `(prev, last]` ([`Inflight::Logs`]) with `prev` at
+    ///   a binary-search midpoint: a success response raises `matching`, a conflict response lowers
+    ///   `searching_end`, until the range collapses.
+    ///
+    /// - **Pipeline** (`matching.next_index() == searching_end`): the matching point is exactly
+    ///   `matching`. Stream all logs after it, with no fixed upper bound ([`Inflight::LogsSince`]).
+    ///
+    /// Purging constrains what AppendEntries can be built: log entries at index
+    /// `<= purge_upto` are deleted, and only the log id at `purge_upto` itself is still
+    /// known, as the snapshot's last log id. Thus the lowest usable `prev` is `purge_upto`.
+    /// A snapshot must be sent instead of logs in exactly two situations:
+    ///
+    /// 1. `searching_end < purge_upto_next`, in either regime: every candidate matching position
+    ///    lies strictly below the purge boundary. The lowest possible probe, `prev = purge_upto`,
+    ///    sits at an index `>= searching_end` — a position already known not to match — so the
+    ///    follower would reply with a conflict at that same index, which carries no new information
+    ///    and is discarded (see [`Updater::update_conflicting`]): log replication cannot make
+    ///    progress. `searching_end == purge_upto_next` is excluded: `prev = purge_upto` is then at
+    ///    index `searching_end - 1`, still a candidate position worth probing.
+    ///
+    /// 2. Probing while the leader log is fully purged (`purge_upto == last_log_id`, which makes
+    ///    the send range empty: `start == end`): the probe cannot carry any entry, and
+    ///    [`Inflight::logs`] cannot represent an AppendEntries without payload — an empty range
+    ///    collapses to [`Inflight::None`]. Pipeline mode is not affected: [`Inflight::LogsSince`]
+    ///    is an open-ended stream, and an empty tail is valid.
+    ///
     /// [algo]: crate::docs::protocol::replication::log_replication#algorithm-to-find-the-last-matching-log-id-on-a-follower
+    /// [`Updater::update_conflicting`]: crate::progress::entry::update::Updater::update_conflicting
     pub(crate) fn next_send(
         &mut self,
         log_state: &mut RaftState<C>,
@@ -214,50 +248,44 @@ where C: RaftTypeConfig
             last_next
         );
 
-        let purge_upto_next = {
-            let purge_upto = log_state.purge_upto();
-            purge_upto.next_index()
-        };
+        let purge_upto_next = log_state.purge_upto().next_index();
+        let inflight_id = log_state.new_inflight_id();
 
-        // `searching_end` is the max value for `start`.
-
-        // The log the follower needs is purged.
-        // Replicate by snapshot.
+        // Snapshot condition 1: all candidate matching positions are purged.
         if self.searching_end < purge_upto_next {
-            let inflight_id = log_state.new_inflight_id();
             self.inflight = Inflight::snapshot(inflight_id);
             return Ok(&self.inflight);
         }
 
         let matching_next = self.matching().next_index();
+        let is_probing = matching_next < self.searching_end;
 
-        // Replicate by logs.
-        // Run a binary search to find the matching log id, if matching log id is not determined.
-        let mut start = Self::calc_mid(matching_next, self.searching_end);
-        if start < purge_upto_next {
-            start = purge_upto_next;
-        }
+        if is_probing {
+            // Probe at the binary-search midpoint, but not below the purge boundary.
+            // `start <= searching_end` still holds: `mid <= searching_end` by construction,
+            // and `purge_upto_next <= searching_end` by snapshot condition 1 above.
+            let mid = Self::calc_mid(matching_next, self.searching_end);
+            let start = std::cmp::max(mid, purge_upto_next);
+            let end = std::cmp::min(start + max_entries, last_next);
 
-        // Enter pipeline mode
-        if start == matching_next && matching_next == self.searching_end {
+            // Snapshot condition 2: the leader log is fully purged; there is no entry
+            // for the probe to carry.
+            if start == end {
+                self.inflight = Inflight::snapshot(inflight_id);
+                return Ok(&self.inflight);
+            }
+
             let prev = log_state.prev_log_id(start);
-            let inflight_id = log_state.new_inflight_id();
-            self.inflight = Inflight::LogsSince { prev, inflight_id };
-            return Ok(&self.inflight);
+            let last = log_state.prev_log_id(end);
+            self.inflight = Inflight::logs(prev, last, inflight_id);
+        } else {
+            // Pipeline: stream every log after the known matching point.
+            // Snapshot condition 1 ensured `matching >= purge_upto`: no needed log is purged.
+            self.inflight = Inflight::LogsSince {
+                prev: self.matching.clone(),
+                inflight_id,
+            };
         }
-
-        let end = std::cmp::min(start + max_entries, last_next);
-
-        if start == end {
-            self.inflight = Inflight::None;
-            return Err(&self.inflight);
-        }
-
-        let prev = log_state.prev_log_id(start);
-        let last = log_state.prev_log_id(end);
-
-        let inflight_id = log_state.new_inflight_id();
-        self.inflight = Inflight::logs(prev, last, inflight_id);
 
         Ok(&self.inflight)
     }

--- a/openraft/src/progress/entry/tests.rs
+++ b/openraft/src/progress/entry/tests.rs
@@ -115,244 +115,367 @@ fn new_raft_state(purge_upto: u64, snap_last: u64, last: u64) -> RaftState<UTCon
 }
 
 #[test]
-fn test_next_send() -> anyhow::Result<()> {
+fn test_next_send_inflight_busy() -> anyhow::Result<()> {
     // There is already inflight data, return it in an Error
-    {
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
-        pe.inflight = inflight_logs(10, 11);
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
-        assert_eq!(Err(&inflight_logs(10, 11)), res);
-    }
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
+    pe.inflight = inflight_logs(10, 11);
 
-    {
-        //    matching,end
-        //    4,5
-        //    v
-        // -----+------+-----+--->
-        //      purged snap  last
-        //      6      10    20
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(Err(&inflight_logs(10, 11)), res);
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 4);
-        pe.matching = Some(log_id(4));
-
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
-        assert_eq!(Ok(&Inflight::snapshot(InflightId::new(1))), res);
-    }
-    {
-        //    matching,end
-        //    4 6
-        //    v-v
-        // -----+------+-----+--->
-        //      purged snap  last
-        //      6      10    20
-
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 6);
-        pe.matching = Some(log_id(4));
-
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
-        assert_eq!(Ok(&Inflight::snapshot(InflightId::new(1))), res);
-    }
-
-    {
-        //    matching,end
-        //    4  7
-        //    v--v
-        // -----+------+-----+--->
-        //      purged snap  last
-        //      6      10    20
-
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 7);
-        pe.matching = Some(log_id(4));
-
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
-        assert_eq!(Ok(&inflight_logs(6, 20).with_id(1)), res);
-    }
-
-    {
-        //    matching,end
-        //    4              20
-        //    v--------------v
-        // -----+------+-----+--->
-        //      purged snap  last
-        //      6      10    20
-
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
-        pe.matching = Some(log_id(4));
-
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
-        assert_eq!(Ok(&inflight_logs(6, 20).with_id(1)), res);
-    }
-
-    //-----------
-
-    {
-        //      matching,end
-        //      6,7
-        //      v
-        // -----+------+-----+--->
-        //      purged snap  last
-        //      6      10    20
-        //
-        // matching.next_index() == searching_end, enter pipeline mode
-
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 7);
-        pe.matching = Some(log_id(6));
-
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
-        assert_eq!(
-            Ok(&Inflight::logs_since(Some(log_id(6)), InflightId::new(1))),
-            res,
-            "pipeline mode: matching.next == searching_end"
-        );
-    }
-
-    {
-        //      matching,end
-        //      6, 8
-        //      v--v
-        // -----+------+-----+--->
-        //      purged snap  last
-        //      6      10    20
-
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 8);
-        pe.matching = Some(log_id(6));
-
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
-        assert_eq!(Ok(&inflight_logs(6, 20).with_id(1)), res);
-    }
-
-    {
-        //      matching,end
-        //      6,           20
-        //      v------------v
-        // -----+------+-----+--->
-        //      purged snap  last
-        //      6      10    20
-
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
-        pe.matching = Some(log_id(6));
-
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
-        assert_eq!(Ok(&inflight_logs(6, 20).with_id(1)), res);
-    }
-
-    {
-        //       matching,end
-        //       7,          20
-        //       v-----------v
-        // -----+------+-----+--->
-        //      purged snap  last
-        //      6      10    20
-
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
-        pe.matching = Some(log_id(7));
-
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
-        assert_eq!(Ok(&inflight_logs(7, 20).with_id(1)), res);
-    }
-
-    {
-        //          matching,end
-        //          7,8
-        //          v
-        // -----+------+-----+--->
-        //      purged snap  last
-        //      6      10    20
-        //
-        // matching.next_index() == searching_end, enter pipeline mode
-
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 8);
-        pe.matching = Some(log_id(7));
-
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
-        assert_eq!(
-            Ok(&Inflight::logs_since(Some(log_id(7)), InflightId::new(1))),
-            res,
-            "pipeline mode: matching.next == searching_end"
-        );
-    }
-
-    {
-        //                   matching,end
-        //                   20,21
-        //                   v
-        // -----+------+-----+--->
-        //      purged snap  last
-        //      6      10    20
-        //
-        // matching.next_index() == searching_end, enter pipeline mode
-        // (even though follower is fully caught up)
-
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 21);
-        pe.matching = Some(log_id(20));
-
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
-        assert_eq!(
-            Ok(&Inflight::logs_since(Some(log_id(20)), InflightId::new(1))),
-            res,
-            "pipeline mode: fully caught up"
-        );
-    }
-
-    // Test max_entries
-    {
-        //       matching,end
-        //       7,          20
-        //       v-----------v
-        // -----+------+-----+--->
-        //      purged snap  last
-        //      6      10    20
-
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
-        pe.matching = Some(log_id(7));
-
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 5);
-        assert_eq!(Ok(&inflight_logs(7, 12).with_id(1)), res);
-    }
     Ok(())
 }
 
 #[test]
-fn test_next_send_pipeline_mode() -> anyhow::Result<()> {
-    // Pipeline mode: when matching.next_index() == searching_end,
-    // enter streaming mode with LogsSince instead of fixed-range Logs.
-    // Basic pipeline mode cases are already covered in test_next_send().
-    // This test covers additional edge cases.
+fn test_next_send_snapshot_matching_purged() -> anyhow::Result<()> {
+    //    matching,end
+    //    4,5
+    //    v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // Pipeline regime (matching.next_index() == searching_end): the matching point is
+    // known to be 4, but the logs the follower needs next (5..=6) are purged.
+    // Snapshot condition 1.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 5);
+    pe.matching = Some(log_id(4));
 
-    // NOT pipeline mode: matching.next_index() != searching_end
-    {
-        //       matching  searching_end
-        //       7         20
-        //       v---------v
-        // -----+------+-----+--->
-        //      purged snap  last
-        //      6      10    20
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(Ok(&Inflight::snapshot(InflightId::new(1))), res);
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
-        pe.matching = Some(log_id(7));
-        pe.searching_end = 20;
+    Ok(())
+}
 
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
-        assert_eq!(Ok(&inflight_logs(7, 20).with_id(1)), res, "not pipeline: gap exists");
-    }
+#[test]
+fn test_next_send_snapshot_search_range_purged() -> anyhow::Result<()> {
+    //    matching,end
+    //    4 6
+    //    v-v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // Probing regime: every candidate matching position (4, 5) lies strictly below
+    // the purge boundary (6). Snapshot condition 1.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 6);
+    pe.matching = Some(log_id(4));
 
-    // NOT pipeline mode: no matching yet
-    {
-        //  matching=None  searching_end
-        //                 20
-        //                 v
-        // -----+------+-----+--->
-        //      purged snap  last
-        //      6      10    20
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(Ok(&Inflight::snapshot(InflightId::new(1))), res);
 
-        let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
-        pe.matching = None;
-        pe.searching_end = 20;
+    Ok(())
+}
 
-        let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
-        // calc_mid(0, 20) = 10, so start = 10
-        assert!(matches!(res, Ok(Inflight::Logs { .. })), "not pipeline: no matching");
-    }
+#[test]
+fn test_next_send_probe_at_purge_boundary() -> anyhow::Result<()> {
+    //    matching,end
+    //    4  7
+    //    v--v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // searching_end == purge_upto_next: the purge boundary (6) is itself still a
+    // candidate matching position, and its log id is known as the snapshot's last
+    // log id. Probe with prev at the boundary instead of falling back to a snapshot.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 7);
+    pe.matching = Some(log_id(4));
+
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(Ok(&inflight_logs(6, 20).with_id(1)), res);
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_probe_clamped_to_purge_boundary() -> anyhow::Result<()> {
+    //    matching,end
+    //    4              20
+    //    v--------------v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // The binary-search midpoint, calc_mid(5, 20) = 5, is below the purge boundary;
+    // the probe start is clamped up to the boundary: prev = log id 6.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
+    pe.matching = Some(log_id(4));
+
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(Ok(&inflight_logs(6, 20).with_id(1)), res);
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_pipeline_at_purge_boundary() -> anyhow::Result<()> {
+    //      matching,end
+    //      6,7
+    //      v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // matching.next_index() == searching_end, enter pipeline mode
+    // (the matching point is exactly the purge boundary: nothing needed is purged)
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 7);
+    pe.matching = Some(log_id(6));
+
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(
+        Ok(&Inflight::logs_since(Some(log_id(6)), InflightId::new(1))),
+        res,
+        "pipeline mode: matching.next == searching_end"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_probe_from_matching_next_short_range() -> anyhow::Result<()> {
+    //      matching,end
+    //      6, 8
+    //      v--v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // Probing: the search range [7, 8) is too narrow for a non-zero binary-search
+    // offset, so the probe starts right after matching: prev = log id 6.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 8);
+    pe.matching = Some(log_id(6));
+
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(Ok(&inflight_logs(6, 20).with_id(1)), res);
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_probe_from_matching_next_wide_range() -> anyhow::Result<()> {
+    //      matching,end
+    //      6,           20
+    //      v------------v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // Probing: calc_mid(7, 20) = 7 (offset (20-7)/16*8 = 0), so the probe still
+    // starts right after matching: prev = log id 6.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
+    pe.matching = Some(log_id(6));
+
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(Ok(&inflight_logs(6, 20).with_id(1)), res);
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_probe_from_matching_next_above_boundary() -> anyhow::Result<()> {
+    //       matching,end
+    //       7,          20
+    //       v-----------v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // Probing with matching above the purge boundary: no clamping is involved;
+    // the probe starts right after matching: prev = log id 7.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
+    pe.matching = Some(log_id(7));
+
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(Ok(&inflight_logs(7, 20).with_id(1)), res);
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_pipeline_above_purge_boundary() -> anyhow::Result<()> {
+    //          matching,end
+    //          7,8
+    //          v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // matching.next_index() == searching_end, enter pipeline mode
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 8);
+    pe.matching = Some(log_id(7));
+
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(
+        Ok(&Inflight::logs_since(Some(log_id(7)), InflightId::new(1))),
+        res,
+        "pipeline mode: matching.next == searching_end"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_pipeline_caught_up() -> anyhow::Result<()> {
+    //                   matching,end
+    //                   20,21
+    //                   v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // matching.next_index() == searching_end, enter pipeline mode
+    // (even though follower is fully caught up: an empty open-ended stream is valid)
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 21);
+    pe.matching = Some(log_id(20));
+
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(
+        Ok(&Inflight::logs_since(Some(log_id(20)), InflightId::new(1))),
+        res,
+        "pipeline mode: fully caught up"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_probe_capped_by_max_entries() -> anyhow::Result<()> {
+    //       matching,end
+    //       7,          20
+    //       v-----------v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // max_entries = 5 caps the probe range: entries 8..=12 are sent.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
+    pe.matching = Some(log_id(7));
+
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 5);
+    assert_eq!(Ok(&inflight_logs(7, 12).with_id(1)), res);
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_fully_purged_unknown_follower() -> anyhow::Result<()> {
+    //                     end
+    //                     21
+    //                     v
+    // ----------------+--->
+    //     purged/snap/last
+    //                20
+    //
+    // matching = None; probing, but the leader log is fully purged
+    // (purge_upto == last_log == 20): there is no entry for a probe to carry.
+    // Snapshot condition 2.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 21);
+
+    let res = pe.next_send(&mut new_raft_state(20, 20, 20), 100);
+    assert_eq!(Ok(&Inflight::snapshot(InflightId::new(1))), res);
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_not_pipeline_when_gap_exists() -> anyhow::Result<()> {
+    //       matching  searching_end
+    //       7         20
+    //       v---------v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // NOT pipeline mode: matching.next_index() != searching_end — the exact matching
+    // point is not determined yet, so this is a probing Logs, not a LogsSince stream.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
+    pe.matching = Some(log_id(7));
+
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(Ok(&inflight_logs(7, 20).with_id(1)), res, "not pipeline: gap exists");
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_not_pipeline_without_matching() -> anyhow::Result<()> {
+    //  matching=None  searching_end
+    //                 20
+    //                 v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // NOT pipeline mode: no matching yet.
+    // calc_mid(0, 20) = 0 + 20/16*8 = 8, so the probe starts at 8: prev = log id 7.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 20);
+
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(Ok(&inflight_logs(7, 20).with_id(1)), res, "not pipeline: no matching");
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_probe_from_mid_of_search_range() -> anyhow::Result<()> {
+    //    matching,end
+    //    4               21
+    //    v---------------v
+    // -----+------+-----+--->
+    //      purged snap  last
+    //      6      10    20
+    //
+    // The search range [5, 21) is wide enough for a non-zero binary-search offset:
+    // calc_mid(5, 21) = 5 + 16/16*8 = 13. The probe starts from the midpoint,
+    // not right after matching: prev = log id 12.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 21);
+    pe.matching = Some(log_id(4));
+
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(Ok(&inflight_logs(12, 20).with_id(1)), res);
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_snapshot_fully_purged_matching_behind() -> anyhow::Result<()> {
+    //          matching   end
+    //          15         21
+    //          v----------v
+    // ----------------+--->
+    //     purged/snap/last
+    //                20
+    //
+    // Fully purged leader with a known lower bound (matching = 15): still probing
+    // (matching.next_index() < searching_end) and still no entry to probe with.
+    // Snapshot condition 2.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 21);
+    pe.matching = Some(log_id(15));
+
+    let res = pe.next_send(&mut new_raft_state(20, 20, 20), 100);
+    assert_eq!(Ok(&Inflight::snapshot(InflightId::new(1))), res);
+
+    Ok(())
+}
+
+#[test]
+fn test_next_send_pipeline_fully_purged_caught_up() -> anyhow::Result<()> {
+    //             matching,end
+    //             20,21
+    //             v
+    // ----------------+--->
+    //     purged/snap/last
+    //                20
+    //
+    // Fully purged leader with a fully caught-up follower: the matching point is
+    // known, so this is pipeline, not probing — snapshot condition 2 must not fire.
+    // An empty open-ended stream is valid.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 21);
+    pe.matching = Some(log_id(20));
+
+    let res = pe.next_send(&mut new_raft_state(20, 20, 20), 100);
+    assert_eq!(Ok(&Inflight::logs_since(Some(log_id(20)), InflightId::new(1))), res);
 
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### fix: send snapshot to a follower behind a fully-purged log
# Summary

When the leader had purged its entire log (`purge_upto == last_log_id`)
and a follower's progress was freshly reset (`matching = None`),
`next_send` returned `Err(Inflight::None)` on every call -- never
probing, never reaching the snapshot branch -- so the follower could
never converge until a new entry was proposed. It now sends a snapshot
in that dead-end.

# Details

- Reorganize the decision logic into two explicit regimes, probing and
  pipeline, plus two named snapshot conditions, so each branch states its
  own precondition instead of leaving it implied by clamp arithmetic.
- The fix lives in the probing regime: when the clamped send range
  collapses to empty (`start == end`), the leader is fully purged and the
  probe can carry no entry, so send a snapshot instead of reporting
  "nothing to replicate". The pipeline path (`LogsSince`) is untouched, so
  a follower legitimately matched at the purge boundary still streams its
  tail rather than taking a needless snapshot.
- Add `test_next_send_fully_purged_unknown_follower` covering the
  fully-purged, unknown-matching dead-end.

- Fix: #1828

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1830)
<!-- Reviewable:end -->
