### PR TITLE
docs: add features overview to docs module

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,14 @@ For benchmark detail, go to the [./benchmarks/minimal](./benchmarks/minimal) fol
 ## Functionality:
 
 - ✅ **Leader election**: by policy or manually ([`Trigger::elect()`][]).
+- ✅ **Leader transfer**: [`Trigger::transfer_leader()`][].
+- ✅ **Pre-vote**: avoid unnecessary term increments by enabling [`Config::enable_pre_vote`][].
 - ✅ **Non-voter(learner) Role**: refer to [`add_learner()`][].
 - ✅ **Log Compaction**(snapshot of state machine): by policy or manually ([`Trigger::snapshot()`][]).
 - ✅ **Snapshot replication**.
 - ✅ **Dynamic Membership**: using joint membership config change. Refer to [dynamic membership](https://docs.rs/openraft/0.10.0-alpha.29/openraft/docs/cluster_control/dynamic_membership/index.html)
 - ✅ **Linearizable read**: [`ensure_linearizable()`][].
+- ✅ **Metrics**: [`Raft::metrics()`][], [`Raft::data_metrics()`][], and [`Raft::server_metrics()`][].
 - ⛔️ **Won't support**: Single-step config change. Single-step membership change is a restricted subset of joint consensus that only allows changing one node at a time. Openraft uses the more general [joint consensus](https://docs.rs/openraft/0.10.0-alpha.29/openraft/docs/cluster_control/dynamic_membership/index.html) approach which supports arbitrary membership changes in a single operation.
 - ✅ Toggle heartbeat / election: [`RuntimeConfigHandle::heartbeat()`][] / [`RuntimeConfigHandle::elect()`][].
 - ✅ Trigger snapshot / election manually: [`Trigger::snapshot()`][] / [`Trigger::elect()`][].
@@ -192,4 +195,9 @@ or the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0), at your
 
 [`Trigger::elect()`]: https://docs.rs/openraft/0.10.0-alpha.29/openraft/raft/trigger/struct.Trigger.html#method.elect
 [`Trigger::snapshot()`]: https://docs.rs/openraft/0.10.0-alpha.29/openraft/raft/trigger/struct.Trigger.html#method.snapshot
+[`Trigger::transfer_leader()`]: https://docs.rs/openraft/0.10.0-alpha.29/openraft/raft/trigger/struct.Trigger.html#method.transfer_leader
+[`Config::enable_pre_vote`]: https://docs.rs/openraft/0.10.0-alpha.29/openraft/struct.Config.html#structfield.enable_pre_vote
+[`Raft::metrics()`]: https://docs.rs/openraft/0.10.0-alpha.29/openraft/raft/struct.Raft.html#method.metrics
+[`Raft::data_metrics()`]: https://docs.rs/openraft/0.10.0-alpha.29/openraft/raft/struct.Raft.html#method.data_metrics
+[`Raft::server_metrics()`]: https://docs.rs/openraft/0.10.0-alpha.29/openraft/raft/struct.Raft.html#method.server_metrics
 [`ensure_linearizable()`]: https://docs.rs/openraft/0.10.0-alpha.29/openraft/raft/struct.Raft.html#method.ensure_linearizable

--- a/openraft/src/docs/docs.md
+++ b/openraft/src/docs/docs.md
@@ -4,6 +4,9 @@ If you're starting to build an application with Openraft, check out
 - [`getting_started`](crate::docs::getting_started).
 - [`faq`](crate::docs::faq),
 
+For an overview of Openraft's capabilities and their APIs, see
+- [`features`](crate::docs::features).
+
 To maintain an Openraft cluster, e.g., add or remove nodes, refer to
 - [`cluster_control`](crate::docs::cluster_control) :
   - [`cluster_formation`](`crate::docs::cluster_control::cluster_formation`) describes how to form a cluster;

--- a/openraft/src/docs/features.md
+++ b/openraft/src/docs/features.md
@@ -1,0 +1,39 @@
+# OpenRaft features
+
+OpenRaft is an asynchronous, event-driven Raft implementation for distributed
+storage systems. Use this page to find each capability's primary API and
+detailed guide.
+
+| Area | Provides | Main APIs and guides |
+| --- | --- | --- |
+| Core integration | Processes Raft events without periodic ticks and batches messages for throughput. Applications implement `RaftLogStorage`, `RaftStateMachine`, and `RaftNetworkV2`; [`Raft`][] is the primary application API. | [`Raft`][] |
+| Cluster formation and membership | Initializes a cluster, adds non-voting learners, and changes membership through joint configuration. Joint consensus supports arbitrary membership changes in one operation; single-step configuration changes are intentionally unsupported. | [`Raft::initialize()`][], [`Raft::add_learner()`][], [`Raft::change_membership()`][], [cluster formation][], [dynamic membership][] |
+| Leadership and elections | Elects leaders by policy or manually, transfers leadership, and offers Pre-Vote to avoid unnecessary term increments. | [`Trigger::elect()`][], [`Trigger::transfer_leader()`][], [`Config::enable_pre_vote`][], [Pre-Vote protocol][] |
+| Logs and snapshots | Compacts logs by snapshotting the state machine, replicates snapshots, and purges logs by policy or on demand. | [`Trigger::snapshot()`][], [`Trigger::purge_log()`][], [snapshot replication][] |
+| Reads | Performs linearizable reads with `ReadPolicy::ReadIndex` or `ReadPolicy::LeaseRead`. | [`Raft::ensure_linearizable()`][], [read protocol][] |
+| Monitoring | Exposes full, data, and server metrics through watch receivers. [`tracing`][] provides logging and distributed tracing with [compile-time verbosity controls][]. | [`Raft::metrics()`][], [`Raft::data_metrics()`][], [`Raft::server_metrics()`][], [monitoring and maintenance][] |
+| Runtime controls | Enables or disables heartbeat and election behavior for testing and special operational cases. | [`RuntimeConfigHandle::heartbeat()`][], [`RuntimeConfigHandle::elect()`][] |
+
+[`Raft`]: crate::Raft
+[`Raft::initialize()`]: crate::Raft::initialize
+[`Raft::add_learner()`]: crate::Raft::add_learner
+[`Raft::change_membership()`]: crate::Raft::change_membership
+[`Raft::ensure_linearizable()`]: crate::Raft::ensure_linearizable
+[`Raft::metrics()`]: crate::Raft::metrics
+[`Raft::data_metrics()`]: crate::Raft::data_metrics
+[`Raft::server_metrics()`]: crate::Raft::server_metrics
+[`Trigger::elect()`]: crate::raft::trigger::Trigger::elect
+[`Trigger::snapshot()`]: crate::raft::trigger::Trigger::snapshot
+[`Trigger::purge_log()`]: crate::raft::trigger::Trigger::purge_log
+[`Trigger::transfer_leader()`]: crate::raft::trigger::Trigger::transfer_leader
+[`Config::enable_pre_vote`]: crate::Config::enable_pre_vote
+[`RuntimeConfigHandle::heartbeat()`]: crate::raft::RuntimeConfigHandle::heartbeat
+[`RuntimeConfigHandle::elect()`]: crate::raft::RuntimeConfigHandle::elect
+[cluster formation]: crate::docs::cluster_control::cluster_formation
+[dynamic membership]: crate::docs::cluster_control::dynamic_membership
+[Pre-Vote protocol]: crate::docs::protocol::pre_vote
+[snapshot replication]: crate::docs::protocol::replication::snapshot_replication
+[read protocol]: crate::docs::protocol::read
+[monitoring and maintenance]: crate::docs::cluster_control::monitoring_maintenance
+[`tracing`]: https://docs.rs/tracing/
+[compile-time verbosity controls]: https://docs.rs/tracing/latest/tracing/level_filters/index.html

--- a/openraft/src/docs/mod.rs
+++ b/openraft/src/docs/mod.rs
@@ -5,6 +5,10 @@ pub mod faq;
 
 pub mod getting_started;
 
+pub mod features {
+    #![doc = include_str!("features.md")]
+}
+
 pub mod cluster_control;
 
 pub mod feature_flags;

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -32,6 +32,21 @@ CRATES=(
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+INDEX_POLL_INTERVAL=3
+INDEX_TIMEOUT=180
+
+# crates.io rejects API requests without a descriptive User-Agent (403),
+# per https://crates.io/data-access.
+USER_AGENT="openraft-publish-script (https://github.com/databendlabs/openraft)"
+
+crate_version_exists() {
+    local url="https://crates.io/api/v1/crates/$1/$2"
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" -A "$USER_AGENT" "$url")
+    echo "DEBUG: GET $url -> HTTP $http_code" >&2
+    [ "$http_code" = "200" ]
+}
+
 for crate in "${CRATES[@]}"; do
     manifest="$ROOT_DIR/$crate/Cargo.toml"
     name=$(grep -m1 '^name' "$manifest" | sed 's/name *= *"\(.*\)"/\1/')
@@ -41,17 +56,34 @@ for crate in "${CRATES[@]}"; do
     echo ""
     echo "--- $name $version ($crate/) ---"
 
-    # Check if this version already exists on crates.io (query remote API)
-    if curl -sf "https://crates.io/api/v1/crates/${name}/${version}" -o /dev/null; then
+    # Check if this version already exists on crates.io
+    if crate_version_exists "$name" "$version"; then
         echo "Already published, skipping."
         continue
     fi
 
-    cargo publish --manifest-path "$manifest" $DRY_RUN
+    publish_ok=1
+    publish_output=$(cargo publish --manifest-path "$manifest" $DRY_RUN 2>&1) || publish_ok=0
+    echo "$publish_output"
+
+    if [ "$publish_ok" -eq 0 ]; then
+        if ! echo "$publish_output" | grep -q "already exists on crates.io index"; then
+            exit 1
+        fi
+        echo "Already published, continuing."
+    fi
 
     if [ -z "$DRY_RUN" ]; then
         echo "Waiting for crates.io to index $name $version..."
-        sleep 30
+        elapsed=0
+        until crate_version_exists "$name" "$version"; do
+            if [ "$elapsed" -ge "$INDEX_TIMEOUT" ]; then
+                echo "Error: $name $version not indexed after ${INDEX_TIMEOUT}s" >&2
+                exit 1
+            fi
+            sleep "$INDEX_POLL_INTERVAL"
+            elapsed=$((elapsed + INDEX_POLL_INTERVAL))
+        done
     fi
 done
 


### PR DESCRIPTION

## Changelog

##### docs: add features overview to docs module
# Summary

Openraft's capabilities were scattered across separate guides with no
single entry point. This adds a features page that maps each capability
area to its primary API and guide, reachable via rustdoc as
`crate::docs::features`.

# Details

- Add `openraft/src/docs/features.md`: a table covering core integration,
  cluster formation/membership, leadership/elections, logs/snapshots,
  reads, monitoring, and runtime controls, each linking to its primary
  API and guide.
- Wire the page into `openraft/src/docs/mod.rs` as `pub mod features`.
- Link the new page from the top-level index in
  `openraft/src/docs/docs.md`.


##### docs: add leader transfer, pre-vote, and metrics to feature list
# Summary

The Functionality section only listed a subset of what openraft already
implements. Three shipped capabilities were missing entirely: leader
transfer, pre-vote, and the metrics APIs.

# Details

- Add "Leader transfer" bullet linking to `Trigger::transfer_leader()`.
- Add "Pre-vote" bullet linking to `Config::enable_pre_vote`.
- Add "Metrics" bullet linking to `Raft::metrics()`, `Raft::data_metrics()`,
  and `Raft::server_metrics()`.


##### fix: don't abort publish script for already-published crates
# Summary

crates.io rejects API requests without a descriptive User-Agent (403),
so every existence check in the publish script silently read as "not
published." Re-running the script after a partial publish therefore
always retried `cargo publish` and aborted the whole run instead of
skipping the crate that was already there.

# Details

- Send a descriptive User-Agent on the crates.io API check, fixing the
  false negatives that made already-published crates look unpublished.
- If `cargo publish` still fails, inspect its output for "already
  exists on crates.io index" and treat that as success rather than
  aborting, covering the race between our own check and the publish
  attempt.
- Replace the flat 30s post-publish sleep with a poll loop that checks
  crates.io every few seconds (up to a bounded timeout), so the script
  moves on as soon as the new version is actually indexed.
- Log the resolved HTTP status on every existence check so a future
  failure is self-diagnosing instead of requiring another investigation.

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1833)
<!-- Reviewable:end -->
