### PR TITLE
docs: expand and reorder the "Who uses it" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,12 +160,22 @@ For benchmark detail, go to the [./benchmarks/minimal](./benchmarks/minimal) fol
 
 # Who uses it
 
-- [Databend](https://github.com/databendlabs/databend) - The Next-Gen Cloud [Data+AI] Analytics
-- [CnosDB](https://github.com/cnosdb/cnosdb) - A cloud-native open source distributed time series database.
-- [yuyang0/rrqlite](https://github.com/yuyang0/rrqlite) - A rust implementation of [rqlite](https://github.com/rqlite/rqlite).
-- [raymondshe/matchengine-raft](https://github.com/raymondshe/matchengine-raft) - A example to demonstrate how openraft persists snapshots/logs to disk.
-- [Helyim](https://github.com/helyim/helyim) - [SeaweedFS](https://github.com/seaweedfs/seaweedfs) implemented in pure Rust.
-- [RobustMQ](https://github.com/robustmq/robustmq) - Next generation cloud-native converged message queue.
+<!-- Star counts as of 2026-07; ordered by stars, Databend first. Comments are invisible on rendered GitHub. -->
+- [Databend](https://github.com/databendlabs/databend) - The Next-Gen Cloud [Data+AI] Analytics <!-- ★9378 -->
+- [Walrus](https://github.com/nubskr/walrus) - Distributed message streaming engine with Raft-based metadata coordination. <!-- ★1900 -->
+- [CnosDB](https://github.com/cnosdb/cnosdb) - A cloud-native open source distributed time series database. <!-- ★1752 -->
+- [RobustMQ](https://github.com/robustmq/robustmq) - Next generation cloud-native converged message queue. <!-- ★1636 -->
+- [RocketMQ-rust](https://github.com/mxsm/rocketmq-rust) - Apache RocketMQ reimplemented in Rust. <!-- ★1495 -->
+- [Hiqlite](https://github.com/sebadob/hiqlite) - Highly-available, embeddable, Raft-based SQLite with caching. <!-- ★460 -->
+- [Octopii](https://github.com/octopii-rs/octopii) - A distributed systems kernel for building replicated, fault-tolerant services. <!-- ★446 -->
+- [Renegade](https://github.com/renegade-fi/renegade) - On-chain dark pool for anonymous trading. <!-- ★252 -->
+- [Helyim](https://github.com/helyim/helyim) - [SeaweedFS](https://github.com/seaweedfs/seaweedfs) implemented in pure Rust. <!-- ★209 -->
+- [Ahnlich](https://github.com/deven96/ahnlich) - In-memory vector database with an AI proxy. <!-- ★204 -->
+- [raymondshe/matchengine-raft](https://github.com/raymondshe/matchengine-raft) - A example to demonstrate how openraft persists snapshots/logs to disk. <!-- ★56 -->
+- [tsoracle](https://github.com/prisma-risk/tsoracle) - Distributed timestamp and sequence oracle serving strictly monotonic, gapless IDs. <!-- ★55 -->
+- [yuyang0/rrqlite](https://github.com/yuyang0/rrqlite) - A rust implementation of [rqlite](https://github.com/rqlite/rqlite). <!-- ★21 -->
+
+📣 Using openraft in your project? We'd love to feature it here — [open an issue](https://github.com/databendlabs/openraft/issues/new) to let us know, or skip the wait and [submit a pull request directly](https://github.com/databendlabs/openraft/edit/main/README.md).
 
 # Contributing
 


### PR DESCRIPTION

## Changelog

##### docs: expand and reorder the "Who uses it" list
# Summary

Broaden the adoption list with verified downstream openraft users, order
it by project popularity with Databend first, and record each entry's
star count as a hidden comment so popularity stays trackable in the raw
file without showing to readers.

# Details

- Add seven downstream users: Walrus, RocketMQ-rust, Hiqlite, Octopii,
  Renegade, Ahnlich, and tsoracle. Each was confirmed to actually depend
  on or embed openraft (its own storage/network trait impls or a declared
  dependency), not merely mention it.
- Reorder the list by GitHub star count, with Databend pinned first as the
  flagship user and maintainer.
- Annotate every entry with an invisible HTML comment carrying its star
  count plus a snapshot date. GitHub strips these on render, so readers see
  a clean list while the ordering rationale stays visible in source.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1834)
<!-- Reviewable:end -->
