### PR TITLE
fix: resample election timeout per campaign

### DIFF
--- a/openraft/src/engine/engine_config.rs
+++ b/openraft/src/engine/engine_config.rs
@@ -1,5 +1,8 @@
 use std::time::Duration;
 
+use rand::RngExt;
+
+use crate::AsyncRuntime;
 use crate::Config;
 use crate::RaftTypeConfig;
 use crate::engine::time_state;
@@ -23,6 +26,12 @@ pub(crate) struct EngineConfig<C: RaftTypeConfig> {
 
     pub(crate) allow_log_reversion: bool,
 
+    /// Inclusive lower bound for a sampled election timeout, in milliseconds.
+    pub(crate) election_timeout_min: u64,
+
+    /// Exclusive upper bound for a sampled election timeout, in milliseconds.
+    pub(crate) election_timeout_max: u64,
+
     pub(crate) timer_config: time_state::Config,
 
     pub(crate) enable_leader_restore: bool,
@@ -39,6 +48,8 @@ where C: RaftTypeConfig
             purge_batch_size: config.purge_batch_size,
             max_payload_entries: config.max_payload_entries,
             allow_log_reversion: config.get_allow_log_reversion(),
+            election_timeout_min: config.election_timeout_min,
+            election_timeout_max: config.election_timeout_max,
 
             timer_config: time_state::Config {
                 election_timeout,
@@ -58,8 +69,17 @@ where C: RaftTypeConfig
             purge_batch_size: 256,
             max_payload_entries: 300,
             allow_log_reversion: false,
+            election_timeout_min: 150,
+            election_timeout_max: 300,
             timer_config: time_state::Config::default(),
             enable_leader_restore: true,
         }
+    }
+
+    /// Sample the timeout that gates the next election campaign.
+    pub(crate) fn resample_election_timeout(&mut self) {
+        let election_timeout =
+            AsyncRuntimeOf::<C>::thread_rng().random_range(self.election_timeout_min..self.election_timeout_max);
+        self.timer_config.election_timeout = Duration::from_millis(election_timeout);
     }
 }

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -263,6 +263,10 @@ where
     }
 
     fn do_elect(&mut self, leadership_transfer: bool) {
+        // A real campaign consumes the timeout selected before it. Sample the
+        // timeout that will gate the next campaign before entering this one.
+        self.config.resample_election_timeout();
+
         // A real election supersedes any in-flight Pre-Vote round.
         self.pre_candidate = None;
 
@@ -299,6 +303,10 @@ where
     /// follows.
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) fn pre_elect(&mut self) {
+        // Pre-Vote does not advance the persisted vote timestamp. Give every
+        // new Pre-Vote round a fresh timeout instead of retaining one sample.
+        self.config.resample_election_timeout();
+
         let new_term = self.state.vote.term().next();
         let leader_id = LeaderIdOf::<C>::new(new_term, self.config.id.clone());
         let pre_vote = VoteOf::<C>::from_leader_id(leader_id, false);

--- a/openraft/src/engine/tests/elect_test.rs
+++ b/openraft/src/engine/tests/elect_test.rs
@@ -3,20 +3,29 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
+use openraft_rt::deterministic_rng::DeterministicRng;
+use openraft_rt_tokio::TokioRuntime;
 use pretty_assertions::assert_eq;
+use rand::RngExt;
 
+use crate::AsyncRuntime;
+use crate::Config;
 use crate::Membership;
 use crate::Vote;
 use crate::core::ServerState;
 use crate::engine::Command;
 use crate::engine::Engine;
+use crate::engine::EngineConfig;
 use crate::engine::LogIdList;
 use crate::engine::testing::UTConfig;
 use crate::engine::testing::log_id;
 use crate::raft::VoteRequest;
 use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::LeaderIdOf;
+use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::StoredMembershipOf;
 use crate::utime::Leased;
+use crate::vote::RaftLeaderIdExt;
 
 fn m1() -> Membership<u64, ()> {
     Membership::new_with_defaults(vec![btreeset! {1}], [])
@@ -31,6 +40,162 @@ fn eng() -> Engine<UTConfig> {
     eng.state.log_ids = LogIdList::new(None, [log_id(0, 0, 0)]);
     eng.state.enable_validation(false); // Disable validation for incomplete state
     eng
+}
+
+type SeededRuntime = DeterministicRng<TokioRuntime>;
+
+crate::declare_raft_types!(
+    SeededConfig:
+        D = u64,
+        R = (),
+        Node = (),
+        AsyncRuntime = SeededRuntime,
+);
+
+fn run_seeded<T>(seed: u64, test: impl FnOnce() -> T) -> T
+where T: Send {
+    let mut runtime = TokioRuntime::new(1);
+    runtime.block_on(SeededRuntime::scope(seed, async move { test() }))
+}
+
+fn seeded_log_id(term: u64, node_id: u64, index: u64) -> LogIdOf<SeededConfig> {
+    LogIdOf::<SeededConfig>::new(LeaderIdOf::<SeededConfig>::new_committed(term, node_id), index)
+}
+
+fn seeded_engine(id: u64, config: EngineConfig<SeededConfig>) -> Engine<SeededConfig> {
+    let mut engine = Engine::<SeededConfig>::testing_default(id);
+    engine.config = config;
+    engine.state.log_ids = LogIdList::new(None, [seeded_log_id(0, 0, 0)]);
+    engine.state.enable_validation(false);
+    engine.state.membership_state.set_effective(Arc::new(StoredMembershipOf::<SeededConfig>::new(
+        Some(seeded_log_id(0, 1, 1)),
+        m12(),
+    )));
+    engine
+}
+
+fn election_config() -> Config {
+    Config {
+        election_timeout_min: 100,
+        election_timeout_max: 108,
+        ..Default::default()
+    }
+    .validate()
+    .expect("valid election timing bounds")
+}
+
+fn reference_timeouts(seed: u64, count: usize) -> Vec<Duration> {
+    let config = election_config();
+    run_seeded(seed, move || {
+        (0..count)
+            .map(|_| {
+                let millis =
+                    SeededRuntime::thread_rng().random_range(config.election_timeout_min..config.election_timeout_max);
+                Duration::from_millis(millis)
+            })
+            .collect()
+    })
+}
+
+#[test]
+fn test_default_election_timer_bounds_are_coherent() {
+    let config = EngineConfig::<UTConfig>::new_default(1);
+    let minimum = Duration::from_millis(config.election_timeout_min);
+    let maximum = Duration::from_millis(config.election_timeout_max);
+
+    assert!(minimum <= config.timer_config.election_timeout);
+    assert!(config.timer_config.election_timeout < maximum);
+    assert_eq!(maximum, config.timer_config.leader_lease);
+    assert_eq!(maximum * 2, config.timer_config.smaller_log_timeout);
+}
+
+#[test]
+fn test_direct_transfer_and_pre_vote_campaigns_resample_timeout() {
+    const SEED: u64 = 44;
+    let expected = reference_timeouts(SEED, 4);
+    assert_eq!(4, expected.iter().collect::<BTreeSet<_>>().len(), "{expected:?}");
+
+    let observed = run_seeded(SEED, || {
+        let config = EngineConfig::new(1, &election_config());
+        let leader_lease = config.timer_config.leader_lease;
+        let smaller_log_timeout = config.timer_config.smaller_log_timeout;
+        let mut observed = vec![config.timer_config.election_timeout];
+        let mut engine = seeded_engine(1, config);
+
+        engine.elect();
+        observed.push(engine.config.timer_config.election_timeout);
+
+        engine.elect_by_leadership_transfer();
+        observed.push(engine.config.timer_config.election_timeout);
+
+        engine.pre_elect();
+        observed.push(engine.config.timer_config.election_timeout);
+
+        assert_eq!(Vote::new(2, 1), *engine.state.vote_ref());
+        assert_eq!(leader_lease, engine.config.timer_config.leader_lease);
+        assert_eq!(smaller_log_timeout, engine.config.timer_config.smaller_log_timeout);
+        observed
+    });
+
+    assert_eq!(expected, observed);
+}
+
+#[test]
+fn test_tied_initial_samples_can_diverge_after_resampling() {
+    const SEED_ONE: u64 = 0;
+    const SEED_TWO: u64 = 5;
+    let expected_one = reference_timeouts(SEED_ONE, 3);
+    let expected_two = reference_timeouts(SEED_TWO, 3);
+    assert_eq!(expected_one[0], expected_two[0]);
+    assert_ne!(expected_one[1..], expected_two[1..]);
+
+    let observe = |seed, id| {
+        run_seeded(seed, || {
+            let config = EngineConfig::new(id, &election_config());
+            let mut observed = vec![config.timer_config.election_timeout];
+            let mut engine = seeded_engine(id, config);
+            engine.pre_elect();
+            observed.push(engine.config.timer_config.election_timeout);
+            engine.pre_elect();
+            observed.push(engine.config.timer_config.election_timeout);
+            observed
+        })
+    };
+
+    let observed_one = observe(SEED_ONE, 1);
+    let observed_two = observe(SEED_TWO, 2);
+    assert_eq!(expected_one, observed_one);
+    assert_eq!(expected_two, observed_two);
+    assert_eq!(observed_one[0], observed_two[0]);
+
+    // Fresh independent draws permit tied nodes to diverge; they do not
+    // guarantee that two nodes can never sample the same timeout again.
+    assert_ne!(observed_one[1..], observed_two[1..]);
+}
+
+#[test]
+fn test_successful_pre_vote_resamples_the_real_campaign() {
+    const SEED: u64 = 44;
+    let expected = reference_timeouts(SEED, 3);
+    assert_eq!(3, expected.iter().collect::<BTreeSet<_>>().len(), "{expected:?}");
+
+    let observed = run_seeded(SEED, || {
+        let config = EngineConfig::new(1, &election_config());
+        let initial = config.timer_config.election_timeout;
+        let mut engine = seeded_engine(1, config);
+        engine.state.membership_state.set_effective(Arc::new(StoredMembershipOf::<SeededConfig>::new(
+            Some(seeded_log_id(0, 1, 1)),
+            m1(),
+        )));
+
+        engine.pre_elect();
+
+        assert_eq!(Vote::new(1, 1), *engine.state.vote_ref());
+        [initial, engine.config.timer_config.election_timeout]
+    });
+
+    assert_eq!(expected[0], observed[0]);
+    assert_eq!(expected[2], observed[1]);
 }
 
 #[test]

--- a/openraft/src/engine/time_state.rs
+++ b/openraft/src/engine/time_state.rs
@@ -3,8 +3,9 @@ use std::time::Duration;
 #[derive(Clone, Debug)]
 #[derive(PartialEq, Eq)]
 pub(crate) struct Config {
-    /// The time interval after which the next election will be initiated once the current lease has
-    /// expired.
+    /// The sampled time interval after which the next election will be initiated once the current
+    /// lease has expired. A new interval is sampled whenever a Pre-Vote or election campaign
+    /// begins.
     pub(crate) election_timeout: Duration,
 
     /// If this node has a smaller last-log-id than others, it will be less likely to be elected as
@@ -32,8 +33,8 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             election_timeout: Duration::from_millis(150),
-            smaller_log_timeout: Duration::from_millis(200),
-            leader_lease: Duration::from_millis(150),
+            smaller_log_timeout: Duration::from_millis(600),
+            leader_lease: Duration::from_millis(300),
         }
     }
 }


### PR DESCRIPTION
## Summary

`EngineConfig` currently samples one election timeout when an engine is constructed and reuses it for every later campaign. Nodes that begin with equal or near-equal samples can therefore remain synchronized across repeated split votes after a leader loss.

This change:

- retains the validated minimum and maximum election bounds in the private engine configuration;
- samples a fresh timeout whenever a real-election or Pre-Vote campaign begins, including leadership transfer;
- leaves leader-lease and smaller-log delays fixed at their existing configured values; and
- uses the existing deterministic runtime to cover direct election, transfer, Pre-Vote, successful Pre-Vote to real-election sequencing, initial ties, and later divergence.

The random draw removes deterministic reuse of the construction-time timeout; it does not claim that future random collisions are impossible. There are no public API, wire, or storage-format changes.

## Validation

- `make fmt`
- focused election tests: 8/8
- serde/single-threaded election tests: 8/8
- Pre-Vote integration tests: 7/7
- strict Openraft all-target Clippy
- full Openraft library and integration suites from the initial port review

**Checklist**

- [x] Updated pertinent internal timer documentation; no public guide or API change is required.
- [x] Squashed to one logical commit based on current `main`.
- [x] Added deterministic unit coverage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1838)
<!-- Reviewable:end -->
