### PR TITLE
fix: Avoid live-lock when leader triggers election

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -270,6 +270,12 @@ where
         // A real election supersedes any in-flight Pre-Vote round.
         self.pre_candidate = None;
 
+        // Entering Candidate state relinquishes any leadership held under the previous vote.
+        if self.leader.is_some() {
+            self.leader = None;
+            self.output.push_command(Command::CloseReplicationStreams);
+        }
+
         let new_term = self.state.vote.term().next();
         let leader_id = LeaderIdOf::<C>::new(new_term, self.config.id.clone());
         let new_vote = VoteOf::<C>::from_leader_id(leader_id, false);

--- a/openraft/src/engine/tests/elect_test.rs
+++ b/openraft/src/engine/tests/elect_test.rs
@@ -305,7 +305,7 @@ fn test_elect_single_node_elect_again() -> anyhow::Result<()> {
 
         assert_eq!(
             vec![
-                //
+                Command::CloseReplicationStreams,
                 Command::SaveVote { vote: Vote::new(2, 1) },
                 Command::SendVote {
                     vote_req: VoteRequest {
@@ -352,6 +352,52 @@ fn test_elect_multi_node_enter_candidate() -> anyhow::Result<()> {
                 Command::SaveVote { vote: Vote::new(1, 1) },
                 Command::SendVote {
                     vote_req: VoteRequest::new(Vote::new(1, 1), Some(log_id(1, 1, 1)))
+                },
+            ],
+            eng.output.take_commands()
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_elect_while_leader_relinquishes_leadership() -> anyhow::Result<()> {
+    tracing::info!("--- electing while leader drops the leader and closes its streams");
+    {
+        let mut eng = eng();
+        eng.config.id = 1;
+        eng.state.membership_state.set_effective(Arc::new(StoredMembershipOf::<UTConfig>::new(
+            Some(log_id(0, 1, 1)),
+            m12(),
+        )));
+
+        // Node 1 is a committed leader of term 2.
+        eng.state.vote = Leased::new(
+            UTConfig::<()>::now(),
+            Duration::from_millis(500),
+            Vote::new_committed(2, 1),
+        );
+        eng.testing_new_leader();
+
+        eng.elect();
+
+        assert_eq!(Vote::new(3, 1), *eng.state.vote_ref());
+        assert!(eng.leader.is_none());
+        assert!(eng.candidate_ref().is_some(), "candidate state is pending");
+
+        assert_eq!(ServerState::Candidate, eng.state.server_state);
+
+        assert_eq!(
+            vec![
+                // Relinquish the term-2 leadership before campaigning for term 3.
+                Command::CloseReplicationStreams,
+                Command::SaveVote { vote: Vote::new(3, 1) },
+                Command::SendVote {
+                    vote_req: VoteRequest {
+                        vote: Vote::new(3, 1),
+                        last_log_id: Some(log_id(0, 0, 0)),
+                        leadership_transfer: false,
+                    },
                 },
             ],
             eng.output.take_commands()

--- a/tests/tests/elect/main.rs
+++ b/tests/tests/elect/main.rs
@@ -10,3 +10,4 @@ mod fixtures;
 mod t10_elect_compare_last_log;
 mod t11_elect_seize_leadership;
 mod t12_pre_vote;
+mod t13_elect_while_leader;

--- a/tests/tests/elect/t13_elect_while_leader.rs
+++ b/tests/tests/elect/t13_elect_while_leader.rs
@@ -1,0 +1,60 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::ServerState;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::ut_harness;
+
+/// Triggering an election on the current leader must not livelock the cluster.
+///
+/// When a node that is already a leader starts a new election, it must relinquish its
+/// leadership: stop the heartbeat and replication workers of the old term. Otherwise it becomes
+/// a Candidate for the new term while its stale heartbeats keep carrying the *old* committed
+/// vote. Those heartbeats keep refreshing the followers' leader lease, so the followers reject
+/// the Candidate's own (pre-)vote requests ("leader lease has not yet expired") for as long as
+/// the node keeps heartbeating. The node can never win, the followers never time out, and the
+/// group stays leaderless forever.
+///
+/// With leadership correctly relinquished, the stale heartbeats stop, the followers' lease
+/// expires, and a new leader is elected.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn elect_on_leader_does_not_livelock() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: true,
+            enable_elect: true,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- create cluster of 0,1,2; node 0 becomes leader");
+    router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    n0.wait(timeout()).state(ServerState::Leader, "node 0 is the initial leader").await?;
+
+    tracing::info!("--- trigger a fresh election on the current leader");
+    n0.trigger().elect(false).await?;
+
+    tracing::info!("--- node 0 leaves the leader state to campaign for the new term");
+    n0.wait(timeout()).state(ServerState::Candidate, "node 0 becomes a candidate").await?;
+
+    tracing::info!("--- the cluster elects a leader again; a livelock would leave node 0 leaderless");
+    n0.wait(Some(Duration::from_secs(5)))
+        .metrics(|m| m.current_leader.is_some(), "an established leader emerges")
+        .await?;
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(2000))
+}


### PR DESCRIPTION
Previously, when an election was triggered on a leader, it would not close its replication stream and clear its leader state. As a consequence, the following would happen:

  1. The leader would go into the Cadidate state.
  2. The leader would continue sending heartbeats to all followers.
  3. The leader would send out vote requests.
  4. The votes would be rejected because the heartbeats were refreshing the leader's lease.

The following would repeat forever and the cluster would enter a live-locked state where there was no leader.

This commit fixes the issue by the leader closing its replication stream and clearing its leader state when an election is triggered.

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1839)
<!-- Reviewable:end -->
