### PR TITLE
fix: ignore election trigger on the current Leader

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1742,16 +1742,22 @@ where
 
                 match cmd {
                     ExternalCommand::Elect { pre_vote } => {
-                        if self.engine.state.membership_state.effective().is_voter(&self.id) {
-                            // TODO: reject if it is already a leader?
-                            if pre_vote {
-                                self.engine.pre_elect();
-                            } else {
-                                self.engine.elect();
-                            }
-                            tracing::debug!("ExternalCommand: triggered election, pre_vote: {}", pre_vote);
+                        if self.engine.leader.is_some() {
+                            // A Leader can not win a campaign it starts: its own heartbeats keep
+                            // refreshing the voters' leader lease, and a lease that has not expired
+                            // rejects the vote request. Leave the established leadership alone.
+                            tracing::info!("ExternalCommand: already a Leader, ignore election trigger");
                         } else {
-                            // Node is switched to learner.
+                            if self.engine.state.membership_state.effective().is_voter(&self.id) {
+                                if pre_vote {
+                                    self.engine.pre_elect();
+                                } else {
+                                    self.engine.elect();
+                                }
+                                tracing::debug!("ExternalCommand: triggered election, pre_vote: {}", pre_vote);
+                            } else {
+                                // Node is switched to learner.
+                            }
                         }
                     }
                     ExternalCommand::Heartbeat => {

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -263,6 +263,15 @@ where
     }
 
     fn do_elect(&mut self, leadership_transfer: bool) {
+        // Leadership must be relinquished before campaigning: a Leader that campaigns keeps
+        // `leader.committed_vote` at the old term while `state.vote` moves to the new one, which
+        // breaks the invariant `LeaderHandler` relies on.
+        debug_assert!(
+            self.leader.is_none(),
+            "elect() requires leadership to be relinquished: leader.vote({})",
+            self.leader.as_ref().map(|l| l.committed_vote.to_string()).unwrap_or_default()
+        );
+
         // A real campaign consumes the timeout selected before it. Sample the
         // timeout that will gate the next campaign before entering this one.
         self.config.resample_election_timeout();

--- a/openraft/src/engine/tests/elect_test.rs
+++ b/openraft/src/engine/tests/elect_test.rs
@@ -20,11 +20,9 @@ use crate::engine::LogIdList;
 use crate::engine::testing::UTConfig;
 use crate::engine::testing::log_id;
 use crate::raft::VoteRequest;
-use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::LeaderIdOf;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::StoredMembershipOf;
-use crate::utime::Leased;
 use crate::vote::RaftLeaderIdExt;
 
 fn m1() -> Membership<u64, ()> {
@@ -275,8 +273,8 @@ fn test_elect_by_leadership_transfer_sets_flag() -> anyhow::Result<()> {
 }
 
 #[test]
-fn test_elect_single_node_elect_again() -> anyhow::Result<()> {
-    tracing::info!("--- single node: electing again will override previous state");
+fn test_elect_again_overrides_previous_campaign() -> anyhow::Result<()> {
+    tracing::info!("--- electing again bumps the term off the current vote and overrides the previous campaign");
     {
         let mut eng = eng();
         eng.config.id = 1;
@@ -285,14 +283,11 @@ fn test_elect_single_node_elect_again() -> anyhow::Result<()> {
             m1(),
         )));
 
-        // Build in-progress election state
-        eng.state.vote = Leased::new(
-            UTConfig::<()>::now(),
-            Duration::from_millis(500),
-            Vote::new_committed(1, 2),
-        );
-        eng.testing_new_leader();
-        eng.candidate_mut().map(|candidate| candidate.grant_by(&1));
+        // The first campaign, to be overridden by the second one.
+        eng.elect();
+        assert_eq!(Vote::new(1, 1), *eng.state.vote_ref());
+        assert_eq!(Vote::new(1, 1), *eng.candidate_ref().unwrap().vote_ref());
+        eng.output.take_commands();
 
         eng.elect();
 

--- a/openraft/src/raft/trigger.rs
+++ b/openraft/src/raft/trigger.rs
@@ -44,9 +44,12 @@ where C: RaftTypeConfig
 
     /// Trigger election at once and return at once.
     ///
-    /// With `pre_vote = false`, a real election starts immediately: the term is incremented and the
-    /// node votes for itself. This bypasses both `enable_elect` and Pre-Vote, so the term climbs
-    /// even when the node cannot win — which may step down a healthy leader of a lower term.
+    /// If this node is already a leader, this is a no-op.
+    ///
+    /// Otherwise, with `pre_vote = false`, a real election starts immediately: the term is
+    /// incremented and the node votes for itself. This bypasses both `enable_elect` and
+    /// Pre-Vote, so the term climbs even when the node cannot win — which may step down a
+    /// healthy leader of a lower term.
     ///
     /// With `pre_vote = true`, a Pre-Vote round runs first and the real election proceeds only if a
     /// quorum would grant a vote. A live leader holding its lease causes the Pre-Vote to be

--- a/tests/tests/elect/main.rs
+++ b/tests/tests/elect/main.rs
@@ -10,3 +10,4 @@ mod fixtures;
 mod t10_elect_compare_last_log;
 mod t11_elect_seize_leadership;
 mod t12_pre_vote;
+mod t13_elect_while_leader;

--- a/tests/tests/elect/t13_elect_while_leader.rs
+++ b/tests/tests/elect/t13_elect_while_leader.rs
@@ -1,0 +1,76 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::ServerState;
+use openraft::async_runtime::WatchReceiver;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::ut_harness;
+
+/// Triggering an election on the current Leader is ignored.
+///
+/// A Leader can not win a campaign it starts: its own heartbeats keep refreshing the voters' leader
+/// lease, and `handle_vote_req()` rejects a vote request while the lease has not expired. Entering
+/// Candidate would therefore only strip the node of leadership and inflate the term for as long as
+/// it keeps heartbeating, leaving the group without a Leader.
+///
+/// Instead the trigger is a no-op: the established leadership is left alone.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn elect_on_leader_is_ignored() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: true,
+            enable_elect: true,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- create cluster of 0,1,2; node 0 becomes leader");
+    router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    n0.wait(timeout()).state(ServerState::Leader, "node 0 is the initial leader").await?;
+
+    let term_before = n0.metrics().borrow_watched().current_term;
+
+    tracing::info!("--- trigger an election on the current leader, with and without Pre-Vote");
+    n0.trigger().elect(false).await?;
+    n0.trigger().elect(true).await?;
+
+    TypeConfig::sleep(Duration::from_millis(500)).await;
+
+    tracing::info!("--- node 0 is still the leader of the same term");
+    {
+        let m = n0.metrics().borrow_watched().clone();
+        assert_eq!(ServerState::Leader, m.state, "node 0 remains a Leader");
+        assert_eq!(term_before, m.current_term, "the term is not inflated");
+        assert_eq!(Some(0), m.current_leader, "node 0 remains the leader");
+    }
+
+    tracing::info!("--- the followers still see node 0 as the leader");
+    for id in [1, 2] {
+        router
+            .get_raft_handle(&id)?
+            .wait(timeout())
+            .metrics(|m| m.current_leader == Some(0), "follower still follows node 0")
+            .await?;
+    }
+
+    tracing::info!("--- and the leader still serves writes");
+    router.client_request_many(0, "foo", 1).await?;
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(2000))
+}


### PR DESCRIPTION

## Changelog

##### fix: ignore election trigger on the current Leader
# Summary

`Raft::trigger().elect()` on a node that is already the Leader is now a no-op.
It previously started a campaign the Leader could not win, costing the group its
Leader and inflating the term for nothing.

# Details

Campaigning does not tear down the internal Leader. `state.vote` moves to the
new, uncommitted term, but the node is still leading under that vote, so
`leader` survives with `committed_vote` at the old term. The node keeps
heartbeating from that stale leadership, which keeps refreshing the voters'
leader leases -- and an unexpired lease is exactly what makes them reject the
vote request the campaign just sent. The campaign cannot succeed, and repeating
the trigger only repeats the loop. The old code acknowledged the gap with a
`// TODO: reject if it is already a leader?`.

That split state is invalid on its own terms as well: `LeaderHandler` does not
expect `leader.committed_vote` to trail `state.vote`. `do_elect()` now asserts
that leadership is relinquished before a campaign begins, so a future caller
that reintroduces the state fails loudly in debug builds. Leadership transfer is
unaffected: the broadcast skips the sender, so the target is still a Follower
when it campaigns.

The unit test for repeated campaigns built its starting state out of a Leader,
which the new precondition forbids; it now drives two real campaigns instead. A
new integration test covers triggering on a live Leader, with and without
Pre-Vote.

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1840)
<!-- Reviewable:end -->
