### PR TITLE
examples(rocksdb): add data-dir option

### DIFF
--- a/examples/raft-kv-rocksdb/src/bin/main.rs
+++ b/examples/raft-kv-rocksdb/src/bin/main.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 use raft_kv_rocksdb::start_example_raft_node;
 use tracing_subscriber::EnvFilter;
@@ -13,6 +15,9 @@ pub struct Opt {
 
     #[clap(long)]
     pub raft_addr: String,
+
+    #[clap(long, value_name = "PATH")]
+    pub data_dir: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -28,12 +33,7 @@ async fn main() -> std::io::Result<()> {
 
     // Parse the parameters passed by arguments.
     let options = Opt::parse();
+    let data_dir = options.data_dir.unwrap_or_else(|| PathBuf::from(format!("{}.db", options.api_addr)));
 
-    start_example_raft_node(
-        options.id,
-        format!("{}.db", options.api_addr),
-        options.api_addr,
-        options.raft_addr,
-    )
-    .await
+    start_example_raft_node(options.id, data_dir, options.api_addr, options.raft_addr).await
 }


### PR DESCRIPTION

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

Jepsen needs explicit control over each node's RocksDB state directory so setup can remove old state while restart tests can preserve it. Deriving the path from api_addr makes the harness depend on example-specific naming and changes the storage path when addresses vary.

Keeping the old api_addr.db default preserves existing scripts while allowing tests to pass stable per-node data dirs.


**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1842)
<!-- Reviewable:end -->
