### PR TITLE
test(jepsen): add Docker smoke harness

### DIFF
--- a/jepsen/.gitignore
+++ b/jepsen/.gitignore
@@ -1,0 +1,15 @@
+/target
+/store
+/classes
+/checkouts
+/docker/ssh/
+profiles.clj
+pom.xml
+pom.xml.asc
+*.jar
+*.swp
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/jepsen/Makefile
+++ b/jepsen/Makefile
@@ -1,0 +1,33 @@
+COMPOSE := docker compose -f docker/docker-compose.yml
+NODES ?= n1,n2,n3
+CONCURRENCY ?= 1
+SSH_KEY ?= /root/.ssh/openraft-jepsen
+ARGS ?= --nodes $(NODES) --concurrency $(CONCURRENCY) --ssh-private-key $(SSH_KEY)
+
+jepsen: build
+	@echo "[jepsen] starting containers"
+	@$(COMPOSE) up -d --force-recreate
+	@echo "[jepsen] running smoke test"
+	@$(COMPOSE) exec control lein run test $(ARGS)
+
+key:
+	@echo "[jepsen] preparing SSH key"
+	@sh docker/init-ssh-key.sh
+
+build: key
+	@echo "[jepsen] building Docker images"
+	@$(COMPOSE) build
+
+up: key
+	@echo "[jepsen] starting containers"
+	@$(COMPOSE) up -d --force-recreate
+
+test:
+	@echo "[jepsen] running smoke test"
+	@$(COMPOSE) exec control lein run test $(ARGS)
+
+down:
+	@echo "[jepsen] stopping containers"
+	@$(COMPOSE) down
+
+.PHONY: jepsen key build up test down

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -1,0 +1,105 @@
+# OpenRaft Jepsen Tests
+
+This directory contains Jepsen black-box tests for OpenRaft. The tests target the runnable OpenRaft key-value example service, rather than OpenRaft's internal Rust APIs, so they can validate externally observable behavior through real client requests, process lifecycle, and network behavior.
+
+These tests cover a different layer from OpenRaft's deterministic simulation tests. Simulation tests run inside a controlled Rust environment. Jepsen drives a running KV service through its external API and records a client history for later checking. Jepsen runs are not deterministic, and a Jepsen failure is not expected to replay directly in the simulation harness.
+
+## Organization
+
+This is a standalone Clojure/Leiningen project inside the OpenRaft repository. It is not part of the Cargo workspace and should not be required for normal Rust builds or tests.
+
+The Docker test environment separates the Jepsen control plane from the OpenRaft data plane:
+
+```text
+                         control container
+                         Jepsen + Leiningen
+                                  |
+          SSH: setup / start / stop / logs
+                                  |
+        +-------------------------+-------------------------+
+        |                         |                         |
+        v                         v                         v
++---------------+         +---------------+         +---------------+
+| n1 db node    |         | n2 db node    |         | n3 db node    |
+| raft-kv-rocks |         | raft-kv-rocks |         | raft-kv-rocks |
++-------+-------+         +-------+-------+         +-------+-------+
+        |                         |                         |
+        | app_http API            | app_http API            | app_http API
+        | /init /write /read      | /metrics                | /metrics
+        |                         |                         |
+        +----------- Raft RPC: /append /vote /snapshot -----+
+```
+
+The control container is not an OpenRaft member. It runs the Jepsen process, controls the db nodes over SSH, and sends client operations to the KV service API. The OpenRaft cluster itself runs on `n1`, `n2`, and `n3`; those nodes communicate with each other over the Raft RPC port.
+
+The intended layout is:
+
+```text
+jepsen/
+  Makefile
+  project.clj
+  README.md
+  docker/
+    docker-compose.yml
+    control.Dockerfile
+    control.Dockerfile.dockerignore
+    node.Dockerfile
+    node.Dockerfile.dockerignore
+    init-ssh-key.sh
+  src/jepsen/openraft/
+    cli.clj
+    client.clj
+    db.clj
+    cluster.clj
+    workload.clj
+```
+
+The `jepsen.openraft` namespace contains the OpenRaft-specific Jepsen code:
+
+- `cli.clj`: command-line entry point.
+- `client.clj`: HTTP client for the OpenRaft KV example APIs.
+- `db.clj`: Jepsen DB lifecycle for starting and stopping OpenRaft nodes.
+- `cluster.clj`: cluster bootstrap helpers.
+- `workload.clj`: generators and checkers for client operations.
+
+## Running
+
+### Prerequisites
+
+- Docker with Compose support
+
+### Run The Harness
+
+From the repository root:
+
+```bash
+# Build images, start containers, and run the smoke test.
+$ make -C jepsen jepsen
+
+# Generate the local Docker SSH key and build the Jepsen images.
+$ make -C jepsen build
+
+# Start or recreate the Jepsen containers.
+$ make -C jepsen up
+
+# Run the smoke test against the running containers.
+$ make -C jepsen test
+
+# Stop and remove the Jepsen containers.
+$ make -C jepsen down
+```
+
+This starts three Docker node containers, then runs the Jepsen control process from the control container. The current smoke test starts the OpenRaft processes, bootstraps a three-node cluster, writes one key, reads it back, and then tears the cluster down.
+
+## TODO
+
+- [x] Add the Leiningen project definition and CLI skeleton.
+- [x] Add Docker-based Jepsen control and node containers.
+- [x] Add a multi-stage node image for the RocksDB KV example.
+- [x] Add an HTTP client for the OpenRaft KV APIs.
+- [x] Add Jepsen process lifecycle management for OpenRaft nodes.
+- [x] Bootstrap a three-node OpenRaft cluster.
+- [ ] Record acknowledged write, read, and info operation counts in each run.
+- [ ] Add nemeses for network partitions and process kill/restart.
+- [ ] Add linearizability checking.
+- [ ] Add snapshot pressure and membership churn workloads.

--- a/jepsen/docker/control.Dockerfile
+++ b/jepsen/docker/control.Dockerfile
@@ -1,0 +1,17 @@
+FROM clojure:temurin-21-lein
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      git \
+      openssh-client \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /root/.ssh \
+ && chmod 700 /root/.ssh
+
+WORKDIR /openraft/jepsen
+
+COPY jepsen/project.clj ./project.clj
+RUN lein deps
+
+CMD ["sleep", "infinity"]

--- a/jepsen/docker/control.Dockerfile.dockerignore
+++ b/jepsen/docker/control.Dockerfile.dockerignore
@@ -1,0 +1,2 @@
+jepsen/docker/ssh/*
+!jepsen/docker/ssh/openraft-jepsen.pub

--- a/jepsen/docker/docker-compose.yml
+++ b/jepsen/docker/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  control:
+    image: openraft-jepsen-control
+    build:
+      context: ../..
+      dockerfile: jepsen/docker/control.Dockerfile
+    command: ["sleep", "infinity"]
+    depends_on:
+      - n1
+      - n2
+      - n3
+    volumes:
+      - ../..:/openraft
+      - ./ssh/openraft-jepsen:/root/.ssh/openraft-jepsen:ro
+    working_dir: /openraft/jepsen
+
+  n1: &node
+    image: openraft-jepsen-node
+    build:
+      context: ../..
+      dockerfile: jepsen/docker/node.Dockerfile
+    cap_add:
+      - NET_ADMIN
+    hostname: n1
+    init: true
+
+  n2:
+    <<: *node
+    hostname: n2
+
+  n3:
+    <<: *node
+    hostname: n3

--- a/jepsen/docker/init-ssh-key.sh
+++ b/jepsen/docker/init-ssh-key.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+key_dir="$script_dir/ssh"
+key_path="$key_dir/openraft-jepsen"
+
+mkdir -p "$key_dir"
+chmod 700 "$key_dir"
+
+if [ -f "$key_path" ]; then
+  if [ ! -f "$key_path.pub" ]; then
+    ssh-keygen -y -f "$key_path" > "$key_path.pub"
+  fi
+
+  chmod 600 "$key_path"
+  chmod 644 "$key_path.pub"
+  echo "Jepsen SSH key already exists: $key_path"
+  exit 0
+fi
+
+if [ -f "$key_path.pub" ]; then
+  echo "Refusing to overwrite $key_path.pub without $key_path" >&2
+  exit 1
+fi
+
+ssh-keygen \
+  -t ed25519 \
+  -N "" \
+  -C "openraft-jepsen-docker" \
+  -f "$key_path"
+
+chmod 600 "$key_path"
+chmod 644 "$key_path.pub"
+
+echo "Generated Jepsen SSH key: $key_path"

--- a/jepsen/docker/node.Dockerfile
+++ b/jepsen/docker/node.Dockerfile
@@ -1,0 +1,49 @@
+FROM rust:bookworm AS builder
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      build-essential \
+      clang \
+      cmake \
+      libclang-dev \
+      libssl-dev \
+      pkg-config \
+      protobuf-compiler \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /openraft
+COPY . .
+
+RUN cargo build --release \
+      --manifest-path examples/raft-kv-rocksdb/Cargo.toml
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      iproute2 \
+      libgcc-s1 \
+      libstdc++6 \
+      netcat-openbsd \
+      openssh-server \
+      procps \
+      psmisc \
+      sudo \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /run/sshd /var/lib/openraft /var/log/openraft /root/.ssh \
+ && chmod 700 /root/.ssh \
+ && echo "root:root" | chpasswd \
+ && printf "\nPermitRootLogin prohibit-password\nPasswordAuthentication no\nPubkeyAuthentication yes\n" >> /etc/ssh/sshd_config
+
+COPY jepsen/docker/ssh/openraft-jepsen.pub /root/.ssh/authorized_keys
+RUN chmod 600 /root/.ssh/authorized_keys
+
+COPY --from=builder \
+  /openraft/examples/raft-kv-rocksdb/target/release/raft-key-value-rocks \
+  /usr/local/bin/raft-key-value-rocks
+
+EXPOSE 22 21001 22001
+
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/jepsen/docker/node.Dockerfile.dockerignore
+++ b/jepsen/docker/node.Dockerfile.dockerignore
@@ -1,0 +1,1 @@
+control.Dockerfile.dockerignore

--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -1,0 +1,13 @@
+(defproject jepsen.openraft "0.1.0-SNAPSHOT"
+  :description "Jepsen tests for OpenRaft"
+  :url "https://github.com/databendlabs/openraft"
+  :license {:name "Apache License 2.0"
+            :url "https://www.apache.org/licenses/LICENSE-2.0"}
+  :dependencies [[org.clojure/clojure "1.12.5"]
+                 [jepsen "0.3.12-SNAPSHOT"]
+                 [cheshire "5.6.3"]]
+  :jvm-opts ["-Djava.awt.headless=true"
+             "-server"]
+  :repl-options {:init-ns jepsen.openraft.cli}
+  :aot [jepsen.openraft.cli]
+  :main jepsen.openraft.cli)

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -1,0 +1,35 @@
+(ns jepsen.openraft.cli
+  (:gen-class)
+  (:require [jepsen [checker :as checker]
+                    [cli :as cli]
+                    [nemesis :as nemesis]
+                    [tests :as tests]]
+            [jepsen.openraft [db :as openraft-db]
+                             [workload :as workload]]))
+
+(def cli-opts
+  [[nil "--api-port PORT" "OpenRaft application HTTP port."
+    :default 21001
+    :parse-fn parse-long]
+
+   [nil "--raft-port PORT" "OpenRaft internal Raft RPC port."
+    :default 22001
+    :parse-fn parse-long]])
+
+(defn openraft-test [opts]
+  (let [workload (workload/workload opts)]
+    (merge tests/noop-test
+           opts
+           workload
+           {:name "openraft cluster smoke"
+            :db (openraft-db/db opts)
+            :nemesis nemesis/noop
+            :checker (checker/compose
+                        {:stats (checker/stats)
+                         :workload (:checker workload)})})))
+
+(defn -main [& args]
+  (cli/run! (cli/single-test-cmd {:test-fn openraft-test
+                                  :opt-spec cli-opts
+                                  :usage (cli/test-usage)})
+            args))

--- a/jepsen/src/jepsen/openraft/client.clj
+++ b/jepsen/src/jepsen/openraft/client.clj
@@ -1,0 +1,120 @@
+(ns jepsen.openraft.client
+  (:require [cheshire.core :as json]
+            [clojure.string :as str])
+  (:import (java.net URI)
+           (java.net.http HttpClient
+                          HttpRequest
+                          HttpRequest$BodyPublishers
+                          HttpResponse$BodyHandlers)
+           (java.time Duration)))
+
+(def default-api-port 21001)
+(def default-raft-port 22001)
+
+(def ^:private http-client
+  (-> (HttpClient/newBuilder)
+      (.connectTimeout (Duration/ofSeconds 2))
+      (.build)))
+
+(defn node-host [node]
+  (if (keyword? node)
+    (name node)
+    (str node)))
+
+(defn api-endpoint [test node]
+  (str (node-host node) ":" (:api-port test default-api-port)))
+
+(defn raft-addr [test node]
+  (str (node-host node) ":" (:raft-port test default-raft-port)))
+
+(defn- node-url [node path]
+  (let [base (if (re-find #"^https?://" node)
+               node
+               (str "http://" node))]
+    (str (str/replace base #"/+$" "")
+         (if (str/starts-with? path "/")
+           path
+           (str "/" path)))))
+
+(defn- request-builder [endpoint path]
+  (doto (HttpRequest/newBuilder (URI/create (node-url endpoint path)))
+    (.timeout (Duration/ofSeconds 5))))
+
+(defn- send! [request]
+  (let [request-info {:method (.method request)
+                      :uri (str (.uri request))}
+        response (try
+                   (.send http-client request (HttpResponse$BodyHandlers/ofString))
+                   (catch java.io.IOException e
+                     (throw (ex-info "HTTP request failed"
+                                     (assoc request-info :kind :transport-error)
+                                     e)))
+                   (catch InterruptedException e
+                     (.interrupt (Thread/currentThread))
+                     (throw (ex-info "HTTP request interrupted"
+                                     (assoc request-info :kind :transport-error)
+                                     e))))
+        status (.statusCode response)
+        body (.body response)
+        result (assoc request-info
+                      :status status
+                      :body body)]
+    (when-not (= 200 status)
+      (throw (ex-info (str "HTTP request failed with status " status)
+                      (assoc result :kind :http-error))))
+    result))
+
+(defn- parse-body [response]
+  (try
+    (json/parse-string (:body response) true)
+    (catch Exception e
+      (throw (ex-info "Failed to parse OpenRaft API response"
+                      {:kind :invalid-json
+                       :response response}
+                      e)))))
+
+(defn- ok-value [response]
+  (let [body (parse-body response)]
+    (cond
+      (contains? body :Ok) (:Ok body)
+      (contains? body :Err) (throw (ex-info "OpenRaft API returned Err"
+                                            {:kind :openraft-error
+                                             :error (:Err body)
+                                             :response response}))
+      :else body)))
+
+(defn get! [endpoint path]
+  (-> (request-builder endpoint path)
+      (.GET)
+      (.build)
+      send!))
+
+(defn post! [endpoint path body]
+  (-> (request-builder endpoint path)
+      (.header "Content-Type" "application/json")
+      (.POST (HttpRequest$BodyPublishers/ofString (json/generate-string body)))
+      (.build)
+      send!))
+
+(defn metrics! [endpoint]
+  (ok-value (get! endpoint "/metrics")))
+
+(defn init! [endpoint]
+  (ok-value (post! endpoint "/init" [])))
+
+(defn add-learner! [endpoint node-id api-addr raft-addr]
+  (ok-value (post! endpoint "/add-learner"
+                   {:node_id node-id
+                    :api_addr api-addr
+                    :raft_addr raft-addr})))
+
+(defn change-membership! [endpoint node-ids]
+  (ok-value (post! endpoint "/change-membership" node-ids)))
+
+(defn write! [endpoint key value]
+  (ok-value (post! endpoint "/write"
+                   {:Set {:key key
+                          :value value}})))
+
+(defn read! [endpoint key]
+  (ok-value (post! endpoint "/read" key)))

--- a/jepsen/src/jepsen/openraft/cluster.clj
+++ b/jepsen/src/jepsen/openraft/cluster.clj
@@ -1,0 +1,69 @@
+(ns jepsen.openraft.cluster
+  (:require [clojure.tools.logging :refer [info]]
+            [jepsen.core :as jepsen]
+            [jepsen.openraft.client :as client]
+            [jepsen.util :as util]))
+
+(defn node-id [test node]
+  (let [index (.indexOf (:nodes test) node)]
+    (when (neg? index)
+      (throw (ex-info "Node is not part of the test"
+                      {:node node
+                       :nodes (:nodes test)})))
+    (inc index)))
+
+(defn node-info [test node]
+  {:node-id (node-id test node)
+   :api-addr (client/api-endpoint test node)
+   :raft-addr (client/raft-addr test node)})
+
+(defn- ready-state? [state]
+  (#{"Leader" "Follower"} state))
+
+(defn- cluster-ready? [test]
+  (let [leader-id (node-id test (jepsen/primary test))
+        metrics (into {}
+                      (map (fn [node]
+                             [node (client/metrics!
+                                     (client/api-endpoint test node))])
+                           (:nodes test)))]
+    (when (every? (fn [[_ m]]
+                    (and (= leader-id (:current_leader m))
+                         (ready-state? (:state m))))
+                  metrics)
+      metrics)))
+
+(defn await-ready! [test]
+  (util/await-fn
+    #(or (cluster-ready? test)
+         (throw (ex-info "OpenRaft cluster is not ready yet" {})))
+    {:log-message "Waiting for OpenRaft cluster to elect a leader"
+     :timeout 60000}))
+
+(defn bootstrap! [test]
+  (let [leader (jepsen/primary test)
+        leader-id (node-id test leader)
+        leader-endpoint (client/api-endpoint test leader)
+        learners (remove #{leader} (:nodes test))]
+    (info "Initializing OpenRaft cluster on" leader)
+    (client/init! leader-endpoint)
+
+    (util/await-fn
+      #(let [metrics (client/metrics! leader-endpoint)]
+         (if (= leader-id (:current_leader metrics))
+           metrics
+           (throw (ex-info "Initial OpenRaft leader is not ready yet"
+                           {:metrics metrics}))))
+      {:log-message "Waiting for initial OpenRaft leader"
+       :timeout 60000})
+
+    (doseq [node learners
+            :let [{:keys [node-id api-addr raft-addr]} (node-info test node)]]
+      (info "Adding OpenRaft learner" node)
+      (client/add-learner! leader-endpoint node-id api-addr raft-addr))
+
+    (info "Changing OpenRaft membership to" (:nodes test))
+    (client/change-membership! leader-endpoint
+                               (mapv #(node-id test %) (:nodes test)))
+
+    (await-ready! test)))

--- a/jepsen/src/jepsen/openraft/db.clj
+++ b/jepsen/src/jepsen/openraft/db.clj
@@ -1,0 +1,73 @@
+(ns jepsen.openraft.db
+  (:require [clojure.tools.logging :refer [info]]
+            [jepsen [control :as c]
+                    [core :as jepsen]
+                    [db :as db]]
+            [jepsen.control.util :as cu]
+            [jepsen.openraft.client :as client]
+            [jepsen.openraft.cluster :as cluster]))
+
+(def binary "/usr/local/bin/raft-key-value-rocks")
+(def process-name "raft-key-value-rocks")
+(def data-dir "/var/lib/openraft")
+(def log-dir "/var/log/openraft")
+(def log-file (str log-dir "/openraft.log"))
+(def pid-file (str data-dir "/openraft.pid"))
+
+(defn- prepare-dirs! []
+  (c/su
+    (c/exec :mkdir :-p data-dir log-dir)))
+
+(defn- wipe! []
+  (c/su
+    (c/exec :rm :-rf data-dir)
+    (c/exec :rm :-f log-file)
+    (c/exec :mkdir :-p data-dir log-dir)))
+
+(defn db [_opts]
+  (reify
+    db/DB
+    (setup! [this test node]
+      (info node "setting up OpenRaft")
+      (db/kill! this test node)
+      (wipe!)
+      (db/start! this test node)
+      (cu/await-tcp-port (client/node-host node) (:api-port test client/default-api-port)
+                         {:timeout 60000})
+      (jepsen/synchronize test)
+      (when (= node (jepsen/primary test))
+        (cluster/bootstrap! test)))
+
+    (teardown! [this test node]
+      (info node "tearing down OpenRaft")
+      (db/kill! this test node)
+      (wipe!))
+
+    db/LogFiles
+    (log-files [_ _ _]
+      {log-file "openraft.log"})
+
+    db/Kill
+    (start! [_ test node]
+      (prepare-dirs!)
+      (let [node-id (cluster/node-id test node)
+            api-addr (client/api-endpoint test node)
+            raft-addr (client/raft-addr test node)]
+        (info node "starting OpenRaft" {:id node-id
+                                        :api-addr api-addr
+                                        :raft-addr raft-addr})
+        (c/su
+          (cu/start-daemon!
+            {:chdir data-dir
+             :env {:RUST_BACKTRACE "1"
+                   :RUST_LOG "info"}
+             :logfile log-file
+             :pidfile pid-file}
+            binary
+            :--id node-id
+            :--api-addr api-addr
+            :--raft-addr raft-addr))))
+
+    (kill! [_ _ node]
+      (c/su
+        (cu/stop-daemon! process-name pid-file)))))

--- a/jepsen/src/jepsen/openraft/workload.clj
+++ b/jepsen/src/jepsen/openraft/workload.clj
@@ -1,0 +1,50 @@
+(ns jepsen.openraft.workload
+  (:require [jepsen [checker :as checker]
+                    [client :as client]
+                    [core :as jepsen]
+                    [generator :as gen]]
+            [jepsen.openraft.client :as http]))
+
+(def key-name "jepsen-key")
+(def value-name "jepsen-value")
+
+;; KVClient is the Jepsen client. Jepsen workers call invoke! with logical
+;; operations from the generator, and this record translates them into OpenRaft
+;; KV HTTP requests through jepsen.openraft.client.
+(defrecord KVClient [node endpoint]
+  client/Client
+  (open! [this test node]
+    (assoc this
+           :node node
+           :endpoint (http/api-endpoint test (jepsen/primary test))))
+
+  (setup! [this _test]
+    this)
+
+  (invoke! [_ _test op]
+    (case (:f op)
+      :write
+      (let [[k v] (:value op)]
+        (http/write! endpoint k v)
+        (assoc op :type :ok))
+
+      :read
+      (assoc op
+             :type :ok
+             :value (http/read! endpoint (:value op)))))
+
+  (teardown! [_ _test])
+
+  (close! [_ _test]))
+
+(defn workload [_opts]
+  {:client (client/validate (KVClient. nil nil))
+   :generator (gen/clients
+                (gen/phases
+                  (gen/once {:type :invoke
+                             :f :write
+                             :value [key-name value-name]})
+                  (gen/once {:type :invoke
+                             :f :read
+                             :value key-name})))
+   :checker (checker/unbridled-optimism)})


### PR DESCRIPTION
It adds a `jepsen/` Clojure/Leiningen project inside the OpenRaft repo and sets up a Docker-based Jepsen smoke harness for the `raft-kv-rocksdb` example.

The Docker topology has one Jepsen control node and three OpenRaft db nodes. The node image builds the RocksDB KV example with a Linux multi-stage build, then runs `raft-key-value-rocks` on each db node. The control node uses Jepsen to start the cluster, bootstrap membership, and drive a small client workload.

The initial workload writes one key/value pair and reads it back to verify that the three-node OpenRaft cluster is running and serving requests.

Refs #1597

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1843)
<!-- Reviewable:end -->
