### PR TITLE
chore: silence lint recipe comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,10 +127,10 @@ lint:
 	cargo clippy --no-deps --manifest-path examples/raft-kv-rocksdb/Cargo.toml                        --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/multi-raft-kv/Cargo.toml                          --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path tests-turmoil/Cargo.toml                                   --all-targets -- -D warnings
-	# Bug: clippy --all-targets reports false warning about unused dep in
-	# `[dev-dependencies]`:
-	# https://github.com/rust-lang/rust/issues/72686#issuecomment-635539688
-	# Thus we only check unused deps for lib
+	@# Bug: clippy --all-targets reports false warning about unused dep in
+	@# `[dev-dependencies]`:
+	@# https://github.com/rust-lang/rust/issues/72686#issuecomment-635539688
+	@# Thus we only check unused deps for lib
 	RUSTFLAGS=-Wunused-crate-dependencies cargo clippy --no-deps  --lib -- -D warnings
 
 unused_dep:


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

This PR hides internal Makefile comments from the `make lint` output.

The `lint` recipe has a few comments explaining why `unused_crate_dependencies` is only checked for the lib target. Because those comments were written as recipe lines, `make lint` printed them during normal runs. Prefixing them with `@#` keeps the explanation in the Makefile without adding noise to the command output.


**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1844)
<!-- Reviewable:end -->
