### PR TITLE
refactor: map API errors to status in app-http

### DIFF
--- a/examples/app-http/src/http_status.rs
+++ b/examples/app-http/src/http_status.rs
@@ -1,0 +1,87 @@
+use hyper::StatusCode;
+use openraft::NodeId;
+use openraft::RaftTypeConfig;
+use openraft::errors::ChangeMembershipError;
+use openraft::errors::ClientWriteError;
+use openraft::errors::Infallible;
+use openraft::errors::InitializeError;
+use openraft::errors::LinearizableReadError;
+use openraft::vote::RaftCommittedLeaderId;
+
+use crate::client::FollowerReadError;
+
+pub trait HttpStatus {
+    fn status_code(&self) -> StatusCode;
+}
+
+impl<T, E> HttpStatus for Result<T, E>
+where E: HttpStatus
+{
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Ok(_) => StatusCode::OK,
+            Err(e) => e.status_code(),
+        }
+    }
+}
+
+impl HttpStatus for Infallible {
+    fn status_code(&self) -> StatusCode {
+        match *self {}
+    }
+}
+
+impl<C> HttpStatus for ClientWriteError<C>
+where C: RaftTypeConfig
+{
+    fn status_code(&self) -> StatusCode {
+        match self {
+            ClientWriteError::ForwardToLeader(_) => StatusCode::SERVICE_UNAVAILABLE,
+            ClientWriteError::ChangeMembershipError(e) => e.status_code(),
+        }
+    }
+}
+
+impl<CLID, NID> HttpStatus for ChangeMembershipError<CLID, NID>
+where
+    CLID: RaftCommittedLeaderId,
+    NID: NodeId,
+{
+    fn status_code(&self) -> StatusCode {
+        match self {
+            ChangeMembershipError::InProgress(_) => StatusCode::CONFLICT,
+            ChangeMembershipError::EmptyMembership(_) | ChangeMembershipError::LearnerNotFound(_) => {
+                StatusCode::BAD_REQUEST
+            }
+        }
+    }
+}
+
+impl<C> HttpStatus for InitializeError<C>
+where C: RaftTypeConfig
+{
+    fn status_code(&self) -> StatusCode {
+        match self {
+            InitializeError::NotAllowed(_) => StatusCode::CONFLICT,
+            InitializeError::NotInMembers(_) => StatusCode::BAD_REQUEST,
+        }
+    }
+}
+
+impl<C> HttpStatus for LinearizableReadError<C>
+where C: RaftTypeConfig
+{
+    fn status_code(&self) -> StatusCode {
+        match self {
+            LinearizableReadError::ForwardToLeader(_) | LinearizableReadError::QuorumNotEnough(_) => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+        }
+    }
+}
+
+impl HttpStatus for FollowerReadError {
+    fn status_code(&self) -> StatusCode {
+        StatusCode::SERVICE_UNAVAILABLE
+    }
+}

--- a/examples/app-http/src/lib.rs
+++ b/examples/app-http/src/lib.rs
@@ -1,5 +1,6 @@
 mod app;
 mod client;
+mod http_status;
 mod server;
 
 pub use app::AddLearnerRequest;
@@ -7,4 +8,5 @@ pub use app::App;
 pub use app::LinearizerData;
 pub use client::Client;
 pub use client::FollowerReadError;
+pub use http_status::HttpStatus;
 pub use server::Server;

--- a/examples/app-http/src/server.rs
+++ b/examples/app-http/src/server.rs
@@ -26,6 +26,7 @@ use serde::de::DeserializeOwned;
 use tokio::net::TcpListener;
 
 use crate::App;
+use crate::HttpStatus;
 
 type HandlerFuture = Pin<Box<dyn Future<Output = Response<Full<Bytes>>> + Send>>;
 type Handler = Arc<dyn Fn(Bytes) -> HandlerFuture + Send + Sync>;
@@ -51,7 +52,7 @@ where D: Send + Sync + 'static
     pub fn post<Req, Resp, Fut, F>(mut self, path: impl Into<String>, handler: F) -> Self
     where
         Req: DeserializeOwned + Send + 'static,
-        Resp: Serialize + Send + 'static,
+        Resp: Serialize + HttpStatus + Send + 'static,
         Fut: Future<Output = Resp> + Send + 'static,
         F: Fn(Arc<D>, Req) -> Fut + Send + Sync + 'static,
     {
@@ -62,7 +63,7 @@ where D: Send + Sync + 'static
 
     pub fn get<Resp, Fut, F>(mut self, path: impl Into<String>, handler: F) -> Self
     where
-        Resp: Serialize + Send + 'static,
+        Resp: Serialize + HttpStatus + Send + 'static,
         Fut: Future<Output = Resp> + Send + 'static,
         F: Fn(Arc<D>) -> Fut + Send + Sync + 'static,
     {
@@ -111,7 +112,7 @@ fn wrap<D, Req, Resp, Fut, F>(app: Arc<D>, handler: F) -> Handler
 where
     D: Send + Sync + 'static,
     Req: DeserializeOwned + Send + 'static,
-    Resp: Serialize + Send + 'static,
+    Resp: Serialize + HttpStatus + Send + 'static,
     Fut: Future<Output = Resp> + Send + 'static,
     F: Fn(Arc<D>, Req) -> Fut + Send + Sync + 'static,
 {
@@ -159,9 +160,10 @@ fn normalize_path(path: impl Into<String>) -> String {
     }
 }
 
-fn json_response<T: Serialize>(value: &T) -> Response<Full<Bytes>> {
+fn json_response<T>(value: &T) -> Response<Full<Bytes>>
+where T: Serialize + HttpStatus {
     match serde_json::to_vec(value) {
-        Ok(body) => response(StatusCode::OK, "application/json", Bytes::from(body)),
+        Ok(body) => response(value.status_code(), "application/json", Bytes::from(body)),
         Err(e) => internal_server_error(e),
     }
 }


### PR DESCRIPTION
This PR maps OpenRaft app-http API errors to HTTP status codes.

The app-http server used to return `200 OK` whenever it could serialize the handler response, even when the response body was `Result::Err`. That forced external clients to parse the JSON body before they could tell whether an API
request had failed.

This change keeps the existing `Ok` / `Err` JSON response shape, but derives the HTTP status from the response value:

- `Ok(_)` returns `200 OK`
- redirect-to-leader and quorum errors return `503 Service Unavailable`
- invalid membership requests return `400 Bad Request`
- conflicting cluster operations return `409 Conflict`

This makes the example APIs easier to use from black-box clients such as Jepsen, where HTTP status should match the request outcome.

Refs #1597


<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1845)
<!-- Reviewable:end -->
