### PR TITLE
fix: cancel stale pre-votes after leadership wins

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -263,21 +263,17 @@ where
     }
 
     fn do_elect(&mut self, leadership_transfer: bool) {
-        // Leadership must be relinquished before campaigning: a Leader that campaigns keeps
-        // `leader.committed_vote` at the old term while `state.vote` moves to the new one, which
-        // breaks the invariant `LeaderHandler` relies on.
-        debug_assert!(
-            self.leader.is_none(),
-            "elect() requires leadership to be relinquished: leader.vote({})",
-            self.leader.as_ref().map(|l| l.committed_vote.to_string()).unwrap_or_default()
-        );
+        // An election attempt supersedes any in-flight Pre-Vote round.
+        self.pre_candidate = None;
+
+        if self.leader.is_some() {
+            tracing::info!("skip election, already a leader");
+            return;
+        }
 
         // A real campaign consumes the timeout selected before it. Sample the
         // timeout that will gate the next campaign before entering this one.
         self.config.resample_election_timeout();
-
-        // A real election supersedes any in-flight Pre-Vote round.
-        self.pre_candidate = None;
 
         let new_term = self.state.vote.term().next();
         let leader_id = LeaderIdOf::<C>::new(new_term, self.config.id.clone());
@@ -893,6 +889,10 @@ where
 
         let vote = leader.committed_vote_ref().clone();
         let last_log_id = leader.last_log_id().cloned();
+
+        // The winning campaign may overlap a later Pre-Vote round. Cancel it so delayed responses
+        // cannot trigger another election after becoming Leader.
+        self.pre_candidate = None;
 
         self.replication_handler().rebuild_replication_streams(true);
 

--- a/openraft/src/engine/tests/elect_test.rs
+++ b/openraft/src/engine/tests/elect_test.rs
@@ -20,6 +20,7 @@ use crate::engine::LogIdList;
 use crate::engine::testing::UTConfig;
 use crate::engine::testing::log_id;
 use crate::raft::VoteRequest;
+use crate::raft::VoteResponse;
 use crate::type_config::alias::LeaderIdOf;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::StoredMembershipOf;
@@ -313,6 +314,36 @@ fn test_elect_again_overrides_previous_campaign() -> anyhow::Result<()> {
             eng.output.take_commands()
         );
     }
+    Ok(())
+}
+
+#[test]
+fn test_election_on_leader_is_ignored() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.config.id = 1;
+    eng.state.membership_state.set_effective(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        Some(log_id(0, 1, 1)),
+        m12(),
+    )));
+
+    eng.elect();
+    eng.candidate_mut().unwrap().grant_by(&1);
+    eng.handle_vote_resp(2, VoteResponse::new(Vote::new(1, 1), Some(log_id(0, 0, 0)), true));
+    eng.output.take_commands();
+
+    eng.new_pre_candidate(Vote::new(2, 1));
+    assert_eq!(Vote::new(2, 1), *eng.pre_candidate_ref().unwrap().vote_ref());
+
+    eng.elect();
+    eng.elect_by_leadership_transfer();
+
+    assert_eq!(Vote::new_committed(1, 1), *eng.state.vote_ref());
+    assert!(eng.leader.is_some(), "leadership is preserved");
+    assert!(eng.candidate_ref().is_none(), "no campaign is created");
+    assert!(eng.pre_candidate_ref().is_none(), "no pre-vote is retained");
+    assert_eq!(ServerState::Leader, eng.state.server_state);
+    assert_eq!(Vec::<Command<UTConfig>>::new(), eng.output.take_commands());
+
     Ok(())
 }
 

--- a/openraft/src/engine/tests/handle_pre_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_pre_vote_resp_test.rs
@@ -71,6 +71,59 @@ fn test_handle_pre_vote_resp_quorum_starts_real_election() -> anyhow::Result<()>
 }
 
 #[test]
+fn test_winning_election_cancels_overlapping_pre_vote() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    // Pre-vote A succeeds and starts election A.
+    eng.pre_elect();
+    eng.handle_pre_vote_resp(2, VoteResponse::new(Vote::new(0, 0), Some(log_id(1, 1, 1)), true));
+    eng.candidate_mut().unwrap().grant_by(&1);
+
+    // Election A is still pending when the next election tick starts pre-vote B.
+    eng.pre_elect();
+
+    assert_eq!(Vote::new(1, 1), *eng.candidate_ref().unwrap().vote_ref());
+    assert_eq!(Vote::new(2, 1), *eng.pre_candidate_ref().unwrap().vote_ref());
+    assert_eq!(
+        vec![
+            Command::SendPreVote {
+                vote_req: VoteRequest::new(Vote::new(1, 1), Some(log_id(1, 1, 1))),
+            },
+            Command::SaveVote { vote: Vote::new(1, 1) },
+            Command::SendVote {
+                vote_req: VoteRequest::new(Vote::new(1, 1), Some(log_id(1, 1, 1))),
+            },
+            Command::SendPreVote {
+                vote_req: VoteRequest::new(Vote::new(2, 1), Some(log_id(1, 1, 1))),
+            },
+        ],
+        eng.output.take_commands()
+    );
+
+    // Election A wins before the delayed response for pre-vote B is received.
+    eng.handle_vote_resp(2, VoteResponse::new(Vote::new(1, 1), Some(log_id(1, 1, 1)), true));
+
+    assert_eq!(Vote::new_committed(1, 1), *eng.state.vote_ref());
+    assert!(eng.leader.is_some(), "election A established a leader");
+    assert!(eng.candidate_ref().is_none(), "election A is complete");
+    assert!(
+        eng.pre_candidate_ref().is_none(),
+        "winning election A must cancel overlapping pre-vote B"
+    );
+
+    eng.output.take_commands();
+
+    // A delayed success for B must not start a new election on the leader.
+    eng.handle_pre_vote_resp(2, VoteResponse::new(Vote::new(1, 1), Some(log_id(1, 1, 1)), true));
+
+    assert_eq!(Vote::new_committed(1, 1), *eng.state.vote_ref());
+    assert_eq!(ServerState::Leader, eng.state.server_state);
+    assert_eq!(Vec::<Command<UTConfig>>::new(), eng.output.take_commands());
+
+    Ok(())
+}
+
+#[test]
 fn test_handle_pre_vote_resp_reject_keeps_waiting() -> anyhow::Result<()> {
     let mut eng = eng();
 


### PR DESCRIPTION

## Changelog

##### fix: cancel stale pre-votes after leadership wins
# Summary

Prevent an overlapping Pre-Vote round from starting another campaign after its
earlier election has established the node as Leader.

# Details

- Cancel the obsolete Pre-Vote when an election establishes leadership, so its
  delayed responses are ignored.
- Make every election entry clear an in-flight Pre-Vote and leave an existing
  Leader unchanged.
- Cover the overlapping-election race and direct election attempts on a
  Leader.

- Fix: https://github.com/databendlabs/openraft/pull/1839#issuecomment-4996486298

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1846)
<!-- Reviewable:end -->
