### PR TITLE
Support versioned-based CAS in examples

### DIFF
--- a/examples/app-http/src/client.rs
+++ b/examples/app-http/src/client.rs
@@ -72,7 +72,7 @@ where C: RaftTypeConfig<Node = NodeInfo>
     /// Read value by key, in an inconsistent mode.
     ///
     /// This method may return stale value because it does not force to read on a legal leader.
-    pub async fn read(&self, req: &String) -> Result<String, RPCError<C>> {
+    pub async fn read(&self, req: &String) -> Result<C::R, RPCError<C>> {
         let res = self.send::<_, _, Infallible>("read", Some(req)).await?;
         Ok(res.unwrap())
     }
@@ -80,10 +80,7 @@ where C: RaftTypeConfig<Node = NodeInfo>
     /// Consistent Read value by key, in an inconsistent mode.
     ///
     /// This method MUST return consistent value or LinearizableReadError.
-    pub async fn linearizable_read(
-        &self,
-        req: &String,
-    ) -> Result<Result<String, LinearizableReadError<C>>, RPCError<C>> {
+    pub async fn linearizable_read(&self, req: &String) -> Result<Result<C::R, LinearizableReadError<C>>, RPCError<C>> {
         self.send_with_forwarding("linearizable_read", Some(req), 0).await
     }
 
@@ -92,7 +89,7 @@ where C: RaftTypeConfig<Node = NodeInfo>
     pub async fn linearizable_read_auto_forward(
         &self,
         req: &String,
-    ) -> Result<Result<String, LinearizableReadError<C>>, RPCError<C>> {
+    ) -> Result<Result<C::R, LinearizableReadError<C>>, RPCError<C>> {
         self.send_with_forwarding("linearizable_read", Some(req), 3).await
     }
 
@@ -102,7 +99,7 @@ where C: RaftTypeConfig<Node = NodeInfo>
     /// waits for the local state machine to catch up, then reads from the local state machine.
     ///
     /// Returns the value if successful, or an error from the follower.
-    pub async fn follower_read(&self, req: &String) -> Result<Result<String, FollowerReadError>, RPCError<C>> {
+    pub async fn follower_read(&self, req: &String) -> Result<Result<C::R, FollowerReadError>, RPCError<C>> {
         self.send("follower_read", Some(req)).await
     }
 

--- a/examples/multi-raft-kv/src/api.rs
+++ b/examples/multi-raft-kv/src/api.rs
@@ -31,7 +31,7 @@ pub async fn read(app: &mut GroupApp, req: String) -> String {
             linearizer.await_ready(&app.raft).await.unwrap();
             let value = app.state_machine.get(&key).await;
 
-            let res: Result<String, RaftError<LinearizableReadError>> = Ok(value.unwrap_or_default());
+            let res: Result<types_kv::Response, RaftError<LinearizableReadError>> = Ok(types_kv::Response { value });
             res
         }
         Err(e) => Err(e),

--- a/examples/raft-kv-memstore-network-v2/src/api.rs
+++ b/examples/raft-kv-memstore-network-v2/src/api.rs
@@ -3,15 +3,15 @@ use std::sync::Arc;
 use crate::app::App;
 use crate::typ::*;
 
-pub async fn read(app: Arc<App>, key: String) -> Result<String, Infallible> {
+pub async fn read(app: Arc<App>, key: String) -> Result<types_kv::Response, Infallible> {
     let value = app.data.get(&key).await;
 
-    Ok(value.unwrap_or_default())
+    Ok(types_kv::Response { value })
 }
 
-pub async fn linearizable_read(app: Arc<App>, key: String) -> Result<String, LinearizableReadError> {
+pub async fn linearizable_read(app: Arc<App>, key: String) -> Result<types_kv::Response, LinearizableReadError> {
     app.ensure_linearizable().await?;
     let value = app.data.get(&key).await;
 
-    Ok(value.unwrap_or_default())
+    Ok(types_kv::Response { value })
 }

--- a/examples/raft-kv-memstore-network-v2/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-memstore-network-v2/tests/cluster/test_cluster.rs
@@ -91,12 +91,14 @@ async fn run_test(rafts: &[Raft]) {
     }
 
     println!("=== write 2 logs");
-    {
+    let expected_foo2 = {
         let resp = client.write(&types_kv::Request::set("foo1", "bar1")).await.unwrap().unwrap();
         println!("write resp: {:#?}", resp);
         let resp = client.write(&types_kv::Request::set("foo2", "bar2")).await.unwrap().unwrap();
         println!("write resp: {:#?}", resp);
-    }
+        assert_eq!(resp.log_id.index(), resp.data.value.as_ref().unwrap().version);
+        resp.data
+    };
 
     println!("=== let node-1 take a snapshot");
     {
@@ -138,6 +140,9 @@ async fn run_test(rafts: &[Raft]) {
         println!("node 2 metrics: {:#?}", metrics);
         assert_eq!(Some(3), metrics.snapshot.map(|x| x.index));
         assert_eq!(Some(3), metrics.purged.map(|x| x.index));
+
+        let got = client2.read(&"foo2".to_string()).await.unwrap();
+        assert_eq!(expected_foo2, got);
     }
 
     // In this example, the snapshot is just a copy of the state machine.

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/api.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/api.rs
@@ -30,7 +30,7 @@ pub async fn read(app: &mut App, req: String) -> String {
             let state_machine = app.state_machine.state_machine.lock().await;
             let value = state_machine.data.get(&key).cloned();
 
-            let res: Result<String, RaftError<LinearizableReadError>> = Ok(value.unwrap_or_default());
+            let res: Result<types_kv::Response, RaftError<LinearizableReadError>> = Ok(types_kv::Response { value });
             res
         }
         Err(e) => Err(e),

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -40,7 +40,7 @@ pub struct StateMachineData {
     pub last_membership: StoredMembership,
 
     /// Application data.
-    pub data: BTreeMap<String, String>,
+    pub data: BTreeMap<String, types_kv::VersionedValue>,
 }
 
 /// Defines a state machine for the Raft cluster. This state machine represents a copy of the
@@ -145,14 +145,18 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
         while let Some((entry, responder)) = entries.try_next().await? {
             tracing::debug!(%entry.log_id, "replicate to sm");
 
+            let version = entry.log_id.index();
             sm.last_applied = Some(entry.log_id);
 
             let response = match entry.payload {
                 EntryPayload::Blank => types_kv::Response::none(),
                 EntryPayload::Normal(ref req) => match req {
                     types_kv::Request::Set { key, value, .. } => {
-                        sm.data.insert(key.clone(), value.clone());
-                        types_kv::Response::new(value.clone())
+                        sm.data.insert(key.clone(), types_kv::VersionedValue {
+                            value: value.clone(),
+                            version,
+                        });
+                        types_kv::Response::new(value.clone(), version)
                     }
                 },
                 EntryPayload::Membership(ref mem) => {

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -158,6 +158,23 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
                         });
                         types_kv::Response::new(value.clone(), version)
                     }
+                    types_kv::Request::CompareAndSet {
+                        key,
+                        expected_version,
+                        value,
+                    } => {
+                        let matches = sm.data.get(key).is_some_and(|current| current.version == *expected_version);
+
+                        if matches {
+                            sm.data.insert(key.clone(), types_kv::VersionedValue {
+                                value: value.clone(),
+                                version,
+                            });
+                            types_kv::Response::new(value.clone(), version)
+                        } else {
+                            types_kv::Response::none()
+                        }
+                    }
                 },
                 EntryPayload::Membership(ref mem) => {
                     sm.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());

--- a/examples/raft-kv-memstore/src/http_api.rs
+++ b/examples/raft-kv-memstore/src/http_api.rs
@@ -13,22 +13,22 @@ use crate::typ::*;
  *
  *  - `POST - /read` attempt to find a value from a given key.
  */
-pub async fn read(app: Arc<App>, key: String) -> Result<String, Infallible> {
+pub async fn read(app: Arc<App>, key: String) -> Result<types_kv::Response, Infallible> {
     let value = app.data.get(&key).await;
 
-    Ok(value.unwrap_or_default())
+    Ok(types_kv::Response { value })
 }
 
-pub async fn linearizable_read(app: Arc<App>, key: String) -> Result<String, LinearizableReadError> {
+pub async fn linearizable_read(app: Arc<App>, key: String) -> Result<types_kv::Response, LinearizableReadError> {
     app.ensure_linearizable().await?;
     let value = app.data.get(&key).await;
 
-    Ok(value.unwrap_or_default())
+    Ok(types_kv::Response { value })
 }
 
-pub async fn follower_read(app: Arc<App>, key: String) -> Result<String, FollowerReadError> {
+pub async fn follower_read(app: Arc<App>, key: String) -> Result<types_kv::Response, FollowerReadError> {
     app.ensure_follower_read_ready().await?;
     let value = app.data.get(&key).await;
 
-    Ok(value.unwrap_or_default())
+    Ok(types_kv::Response { value })
 }

--- a/examples/raft-kv-memstore/tests/cluster/test_basic.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_basic.rs
@@ -42,5 +42,33 @@ async fn test_basic_inner() -> anyhow::Result<()> {
     let got = client.read(&"foo".to_string()).await?;
     assert_eq!(second.data, got);
 
+    println!("=== compare and set foo=bar to foo=baz");
+    let cas = client.write(&types_kv::Request::compare_and_set("foo", second_version, "baz")).await??;
+    let cas_value = cas.data.value.as_ref().unwrap();
+    assert_eq!("baz", cas_value.value);
+    assert!(cas_value.version > second_version);
+
+    println!("=== reject a stale compare and set");
+    let stale = client.write(&types_kv::Request::compare_and_set("foo", second_version, "stale")).await??;
+    assert_eq!(types_kv::Response::none(), stale.data);
+    assert_eq!(cas.data, client.read(&"foo".to_string()).await?);
+
+    println!("=== reject a compare and set for a missing key");
+    let missing = client.write(&types_kv::Request::compare_and_set("missing", 0, "value")).await??;
+    assert_eq!(types_kv::Response::none(), missing.data);
+    assert_eq!(types_kv::Response::none(), client.read(&"missing".to_string()).await?);
+
+    println!("=== reject a compare and set after ABA");
+    let original = client.write(&types_kv::Request::set("aba", "A")).await??;
+    let original_version = original.data.value.as_ref().unwrap().version;
+    client.write(&types_kv::Request::set("aba", "B")).await??;
+    let restored = client.write(&types_kv::Request::set("aba", "A")).await??;
+    let restored_version = restored.data.value.as_ref().unwrap().version;
+    assert!(restored_version > original_version);
+
+    let stale = client.write(&types_kv::Request::compare_and_set("aba", original_version, "C")).await??;
+    assert_eq!(types_kv::Response::none(), stale.data);
+    assert_eq!(restored.data, client.read(&"aba".to_string()).await?);
+
     Ok(())
 }

--- a/examples/raft-kv-memstore/tests/cluster/test_basic.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_basic.rs
@@ -18,18 +18,29 @@ async fn test_basic_inner() -> anyhow::Result<()> {
     let client = util::bootstrap(PORT_BASE).await?;
 
     println!("=== write foo=bar");
-    client
+    let first = client
         .write(&types_kv::Request::Set {
             key: "foo".to_string(),
             value: "bar".to_string(),
         })
         .await??;
+    let first_version = first.data.value.as_ref().unwrap().version;
+
+    println!("=== write foo=bar again");
+    let second = client
+        .write(&types_kv::Request::Set {
+            key: "foo".to_string(),
+            value: "bar".to_string(),
+        })
+        .await??;
+    let second_version = second.data.value.as_ref().unwrap().version;
+    assert!(second_version > first_version);
 
     TypeConfig::sleep(Duration::from_millis(500)).await;
 
     println!("=== read foo");
     let got = client.read(&"foo".to_string()).await?;
-    assert_eq!("bar", got);
+    assert_eq!(second.data, got);
 
     Ok(())
 }

--- a/examples/raft-kv-memstore/tests/cluster/test_read_modes.rs
+++ b/examples/raft-kv-memstore/tests/cluster/test_read_modes.rs
@@ -20,12 +20,13 @@ async fn test_read_modes_inner() -> anyhow::Result<()> {
     let leader = util::bootstrap(PORT_BASE).await?;
 
     println!("=== write foo=bar on the leader");
-    leader
+    let write_response = leader
         .write(&types_kv::Request::Set {
             key: "foo".to_string(),
             value: "bar".to_string(),
         })
         .await??;
+    let expected = write_response.data;
     TypeConfig::sleep(Duration::from_millis(1_000)).await;
 
     let follower2 = Client::<TypeConfig>::new(2, util::api_addr(PORT_BASE, 2));
@@ -33,11 +34,11 @@ async fn test_read_modes_inner() -> anyhow::Result<()> {
 
     // 1. Local read: any node answers from its own state machine (may be stale).
     println!("=== /read on a follower");
-    assert_eq!("bar", follower2.read(&"foo".to_string()).await?);
+    assert_eq!(expected, follower2.read(&"foo".to_string()).await?);
 
     // 2. Linearizable read: only the leader can serve it.
     println!("=== /linearizable_read on the leader");
-    assert_eq!("bar", leader.linearizable_read(&"foo".to_string()).await??);
+    assert_eq!(expected, leader.linearizable_read(&"foo".to_string()).await??);
 
     println!("=== /linearizable_read on a follower must forward to the leader");
     match follower2.linearizable_read(&"foo".to_string()).await? {
@@ -55,12 +56,15 @@ async fn test_read_modes_inner() -> anyhow::Result<()> {
     // 3. Follower read: a follower serves a linearizable read by first syncing to the leader's read
     //    index.
     println!("=== /follower_read on the followers");
-    assert_eq!("bar", follower2.follower_read(&"foo".to_string()).await??);
-    assert_eq!("bar", follower3.follower_read(&"foo".to_string()).await??);
+    assert_eq!(expected, follower2.follower_read(&"foo".to_string()).await??);
+    assert_eq!(expected, follower3.follower_read(&"foo".to_string()).await??);
 
-    // A missing key reads back as an empty string.
+    // A missing key has no versioned value.
     println!("=== /follower_read of a missing key");
-    assert_eq!("", follower2.follower_read(&"missing".to_string()).await??);
+    assert_eq!(
+        types_kv::Response::none(),
+        follower2.follower_read(&"missing".to_string()).await??
+    );
 
     Ok(())
 }

--- a/examples/raft-kv-rocksdb/src/app.rs
+++ b/examples/raft-kv-rocksdb/src/app.rs
@@ -3,6 +3,6 @@ use std::sync::Arc;
 
 use futures::lock::Mutex;
 
-pub type KeyValues = Arc<Mutex<BTreeMap<String, String>>>;
+pub type KeyValues = Arc<Mutex<BTreeMap<String, types_kv::VersionedValue>>>;
 
 pub type App = app_http::App<crate::TypeConfig, crate::StateMachineStore, KeyValues>;

--- a/examples/raft-kv-rocksdb/src/network/api.rs
+++ b/examples/raft-kv-rocksdb/src/network/api.rs
@@ -3,18 +3,18 @@ use std::sync::Arc;
 use crate::app::App;
 use crate::typ::*;
 
-pub async fn read(app: Arc<App>, key: String) -> Result<String, Infallible> {
+pub async fn read(app: Arc<App>, key: String) -> Result<types_kv::Response, Infallible> {
     let kvs = app.data.lock().await;
     let value = kvs.get(&key);
 
-    Ok(value.cloned().unwrap_or_default())
+    Ok(types_kv::Response { value: value.cloned() })
 }
 
-pub async fn linearizable_read(app: Arc<App>, key: String) -> Result<String, LinearizableReadError> {
+pub async fn linearizable_read(app: Arc<App>, key: String) -> Result<types_kv::Response, LinearizableReadError> {
     app.ensure_linearizable().await?;
 
     let kvs = app.data.lock().await;
     let value = kvs.get(&key);
 
-    Ok(value.cloned().unwrap_or_default())
+    Ok(types_kv::Response { value: value.cloned() })
 }

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -52,7 +52,7 @@ pub struct StateMachineData {
     pub last_membership: StoredMembership,
 
     /// State built from applying the raft logs
-    pub kvs: Arc<Mutex<BTreeMap<String, String>>>,
+    pub kvs: Arc<Mutex<BTreeMap<String, types_kv::VersionedValue>>>,
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for StateMachineStore {
@@ -114,7 +114,7 @@ impl StateMachineStore {
     }
 
     async fn update_state_machine_(&mut self, snapshot: StoredSnapshot) -> Result<(), io::Error> {
-        let kvs: BTreeMap<String, String> =
+        let kvs: BTreeMap<String, types_kv::VersionedValue> =
             serde_json::from_slice(&snapshot.data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         self.data.last_applied_log_id = snapshot.meta.last_log_id;
@@ -158,6 +158,7 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
     async fn apply<Strm>(&mut self, mut entries: Strm) -> Result<(), io::Error>
     where Strm: Stream<Item = Result<EntryResponder<TypeConfig>, io::Error>> + Unpin + OptionalSend {
         while let Some((entry, responder)) = entries.try_next().await? {
+            let version = entry.log_id.index();
             self.data.last_applied_log_id = Some(entry.log_id);
 
             let response = match entry.payload {
@@ -165,8 +166,11 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
                 EntryPayload::Normal(req) => match req {
                     types_kv::Request::Set { key, value } => {
                         let mut st = self.data.kvs.lock().await;
-                        st.insert(key, value.clone());
-                        types_kv::Response::new(value)
+                        st.insert(key, types_kv::VersionedValue {
+                            value: value.clone(),
+                            version,
+                        });
+                        types_kv::Response::new(value, version)
                     }
                 },
                 EntryPayload::Membership(mem) => {

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -172,6 +172,24 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
                         });
                         types_kv::Response::new(value, version)
                     }
+                    types_kv::Request::CompareAndSet {
+                        key,
+                        expected_version,
+                        value,
+                    } => {
+                        let mut st = self.data.kvs.lock().await;
+                        let matches = st.get(&key).is_some_and(|current| current.version == expected_version);
+
+                        if matches {
+                            st.insert(key, types_kv::VersionedValue {
+                                value: value.clone(),
+                                version,
+                            });
+                            types_kv::Response::new(value, version)
+                        } else {
+                            types_kv::Response::none()
+                        }
+                    }
                 },
                 EntryPayload::Membership(mem) => {
                     self.data.last_membership = StoredMembership::new(Some(entry.log_id), mem);

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -191,12 +191,14 @@ async fn test_cluster_inner() -> Result<(), Box<dyn std::error::Error + Send + S
     // --- Try to write some application data through the leader.
 
     println!("=== write `foo=bar`");
-    leader
+    let write_bar = leader
         .write(&types_kv::Request::Set {
             key: "foo".to_string(),
             value: "bar".to_string(),
         })
         .await??;
+    assert_eq!(write_bar.log_id.index(), write_bar.data.value.as_ref().unwrap().version);
+    let expected_bar = write_bar.data;
 
     // --- Wait for a while to let the replication get done.
 
@@ -206,25 +208,30 @@ async fn test_cluster_inner() -> Result<(), Box<dyn std::error::Error + Send + S
 
     println!("=== read `foo=bar` on node 1");
     let x = leader.read(&("foo".to_string())).await?;
-    assert_eq!("bar", x);
+    assert_eq!(expected_bar, x);
 
     println!("=== read `foo=bar` on node 2");
     let client2 = Client::<TypeConfig>::new(2, get_api_addr(2));
     let x = client2.read(&("foo".to_string())).await?;
-    assert_eq!("bar", x);
+    assert_eq!(expected_bar, x);
 
     println!("=== read `foo=bar` on node 3");
     let client3 = Client::<TypeConfig>::new(3, get_api_addr(3));
     let x = client3.read(&("foo".to_string())).await?;
-    assert_eq!("bar", x);
+    assert_eq!(expected_bar, x);
 
     println!("=== write `foo=wow` on leader");
-    leader
+    let write_wow = leader
         .write(&types_kv::Request::Set {
             key: "foo".to_string(),
             value: "wow".to_string(),
         })
         .await??;
+    let bar_version = expected_bar.value.as_ref().unwrap().version;
+    let wow_version = write_wow.data.value.as_ref().unwrap().version;
+    assert_eq!(write_wow.log_id.index(), wow_version);
+    assert!(wow_version > bar_version);
+    let expected_wow = write_wow.data;
 
     TypeConfig::sleep(Duration::from_millis(500)).await;
 
@@ -232,21 +239,21 @@ async fn test_cluster_inner() -> Result<(), Box<dyn std::error::Error + Send + S
 
     println!("=== read `foo=wow` on node 1");
     let x = leader.read(&("foo".to_string())).await?;
-    assert_eq!("wow", x);
+    assert_eq!(expected_wow, x);
 
     println!("=== read `foo=wow` on node 2");
     let client2 = Client::<TypeConfig>::new(2, get_api_addr(2));
     let x = client2.read(&("foo".to_string())).await?;
-    assert_eq!("wow", x);
+    assert_eq!(expected_wow, x);
 
     println!("=== read `foo=wow` on node 3");
     let client3 = Client::<TypeConfig>::new(3, get_api_addr(3));
     let x = client3.read(&("foo".to_string())).await?;
-    assert_eq!("wow", x);
+    assert_eq!(expected_wow, x);
 
     println!("=== linearizable_read `foo=wow` on node 1");
     let x = leader.linearizable_read(&("foo".to_string())).await??;
-    assert_eq!("wow", x);
+    assert_eq!(expected_wow, x);
 
     println!("=== linearizable_read `foo=wow` on node 2 MUST return LinearizableReadError");
     let x = client2.linearizable_read(&("foo".to_string())).await?;

--- a/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
+++ b/examples/raft-kv-rocksdb/tests/cluster/test_cluster.rs
@@ -197,7 +197,6 @@ async fn test_cluster_inner() -> Result<(), Box<dyn std::error::Error + Send + S
             value: "bar".to_string(),
         })
         .await??;
-    assert_eq!(write_bar.log_id.index(), write_bar.data.value.as_ref().unwrap().version);
     let expected_bar = write_bar.data;
 
     // --- Wait for a while to let the replication get done.
@@ -229,7 +228,6 @@ async fn test_cluster_inner() -> Result<(), Box<dyn std::error::Error + Send + S
         .await??;
     let bar_version = expected_bar.value.as_ref().unwrap().version;
     let wow_version = write_wow.data.value.as_ref().unwrap().version;
-    assert_eq!(write_wow.log_id.index(), wow_version);
     assert!(wow_version > bar_version);
     let expected_wow = write_wow.data;
 
@@ -268,6 +266,19 @@ async fn test_cluster_inner() -> Result<(), Box<dyn std::error::Error + Send + S
         }
         Ok(_) => panic!("MUST return LinearizableReadError"),
     }
+
+    println!("=== compare and set `foo=wow` to `foo=cas`");
+    let cas = leader.write(&types_kv::Request::compare_and_set("foo", wow_version, "cas")).await??;
+    let cas_value = cas.data.value.as_ref().unwrap();
+    assert_eq!("cas", cas_value.value);
+    assert!(cas_value.version > wow_version);
+
+    println!("=== reject a stale compare and set");
+    let stale = leader.write(&types_kv::Request::compare_and_set("foo", wow_version, "stale")).await??;
+    assert_eq!(types_kv::Response::none(), stale.data);
+
+    let got = leader.linearizable_read(&"foo".to_string()).await??;
+    assert_eq!(cas.data, got);
 
     Ok(())
 }

--- a/examples/rocksstore/src/state_machine.rs
+++ b/examples/rocksstore/src/state_machine.rs
@@ -1,5 +1,6 @@
 //! RocksDB-backed state machine implementation.
 
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::fs;
 use std::io;
@@ -182,6 +183,7 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
         let mut batch = rocksdb::WriteBatch::default();
         let mut last_applied_log = None;
         let mut last_membership: Option<StoredMembershipOf<TypeConfig>> = None;
+        let mut pending_values = BTreeMap::<String, types_kv::VersionedValue>::new();
         let mut responses = Vec::new();
 
         while let Some((entry, responder)) = entries.try_next().await? {
@@ -201,7 +203,37 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
                         };
 
                         batch.put_cf(cf_data, key.as_bytes(), serialize(&versioned_value)?);
+                        pending_values.insert(key.clone(), versioned_value);
                         types_kv::Response::new(value.clone(), version)
+                    }
+                    types_kv::Request::CompareAndSet {
+                        key,
+                        expected_version,
+                        value,
+                    } => {
+                        let current = if let Some(current) = pending_values.get(key) {
+                            Some(current.clone())
+                        } else {
+                            self.db
+                                .get_cf(self.cf_sm_data(), key.as_bytes())
+                                .map_err(|e| io::Error::other(e.to_string()))?
+                                .map(|bytes| deserialize(&bytes))
+                                .transpose()
+                                .map_err(|e| io::Error::other(e.to_string()))?
+                        };
+
+                        if current.is_some_and(|current| current.version == *expected_version) {
+                            let versioned_value = types_kv::VersionedValue {
+                                value: value.clone(),
+                                version,
+                            };
+
+                            batch.put_cf(self.cf_sm_data(), key.as_bytes(), serialize(&versioned_value)?);
+                            pending_values.insert(key.clone(), versioned_value);
+                            types_kv::Response::new(value.clone(), version)
+                        } else {
+                            types_kv::Response::none()
+                        }
                     }
                 },
                 EntryPayload::Membership(ref mem) => {
@@ -361,5 +393,60 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
             meta: snapshot_file.meta,
             snapshot: Cursor::new(data_bytes),
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::stream;
+    use openraft::entry::RaftEntry;
+    use openraft::type_config::alias::EntryOf;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn cas_sees_earlier_write_in_same_batch() {
+        TypeConfig::run(async {
+            let td = TempDir::new().unwrap();
+            let (_, mut state_machine) = crate::new::<TypeConfig, _>(td.path()).await.unwrap();
+
+            let initial: Vec<Result<EntryResponder<TypeConfig>, io::Error>> = vec![Ok((
+                EntryOf::<TypeConfig>::new_normal(
+                    openraft::testing::log_id::<TypeConfig>(1, 1, 1),
+                    types_kv::Request::set("key", "A"),
+                ),
+                None,
+            ))];
+            state_machine.apply(stream::iter(initial)).await.unwrap();
+
+            let bytes = state_machine.db.get_cf(state_machine.cf_sm_data(), "key").unwrap().unwrap();
+            let initial_value: types_kv::VersionedValue = deserialize(&bytes).unwrap();
+
+            let entries: Vec<Result<EntryResponder<TypeConfig>, io::Error>> = vec![
+                Ok((
+                    EntryOf::<TypeConfig>::new_normal(
+                        openraft::testing::log_id::<TypeConfig>(1, 1, 2),
+                        types_kv::Request::compare_and_set("key", initial_value.version, "B"),
+                    ),
+                    None,
+                )),
+                Ok((
+                    EntryOf::<TypeConfig>::new_normal(
+                        openraft::testing::log_id::<TypeConfig>(1, 1, 3),
+                        types_kv::Request::compare_and_set("key", initial_value.version, "C"),
+                    ),
+                    None,
+                )),
+            ];
+
+            state_machine.apply(stream::iter(entries)).await.unwrap();
+
+            let bytes = state_machine.db.get_cf(state_machine.cf_sm_data(), "key").unwrap().unwrap();
+            let value: types_kv::VersionedValue = deserialize(&bytes).unwrap();
+
+            assert_eq!("B", value.value);
+            assert!(value.version > initial_value.version);
+        });
     }
 }

--- a/examples/rocksstore/src/state_machine.rs
+++ b/examples/rocksstore/src/state_machine.rs
@@ -187,6 +187,7 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
         while let Some((entry, responder)) = entries.try_next().await? {
             tracing::debug!(%entry.log_id, "replicate to sm");
 
+            let version = entry.log_id().index();
             last_applied_log = Some(entry.log_id());
 
             let response = match entry.payload {
@@ -194,9 +195,13 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
                 EntryPayload::Normal(ref req) => match req {
                     types_kv::Request::Set { key, value } => {
                         let cf_data = self.cf_sm_data();
+                        let versioned_value = types_kv::VersionedValue {
+                            value: value.clone(),
+                            version,
+                        };
 
-                        batch.put_cf(cf_data, key.as_bytes(), value.as_bytes());
-                        types_kv::Response::new(value.clone())
+                        batch.put_cf(cf_data, key.as_bytes(), serialize(&versioned_value)?);
+                        types_kv::Response::new(value.clone(), version)
                     }
                 },
                 EntryPayload::Membership(ref mem) => {

--- a/examples/sm-mem/src/lib.rs
+++ b/examples/sm-mem/src/lib.rs
@@ -167,6 +167,27 @@ where C: RaftTypeConfig<D = types_kv::Request, R = types_kv::Response, Entry = D
                         });
                         types_kv::Response::new(value.clone(), version)
                     }
+                    types_kv::Request::CompareAndSet {
+                        key,
+                        expected_version,
+                        value,
+                    } => {
+                        let matches = inner
+                            .state_machine
+                            .data
+                            .get(key)
+                            .is_some_and(|current| current.version == *expected_version);
+
+                        if matches {
+                            inner.state_machine.data.insert(key.clone(), types_kv::VersionedValue {
+                                value: value.clone(),
+                                version,
+                            });
+                            types_kv::Response::new(value.clone(), version)
+                        } else {
+                            types_kv::Response::none()
+                        }
+                    }
                 },
                 EntryPayload::Membership(mem) => {
                     inner.last_membership = StoredMembershipOf::<C>::new(Some(entry.log_id.clone()), mem.clone());

--- a/examples/sm-mem/src/lib.rs
+++ b/examples/sm-mem/src/lib.rs
@@ -36,7 +36,7 @@ pub struct StoredSnapshot<C: RaftTypeConfig> {
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct StateMachineData {
     /// Application data.
-    pub data: BTreeMap<String, String>,
+    pub data: BTreeMap<String, types_kv::VersionedValue>,
 }
 
 /// Inner storage for the state machine.
@@ -89,7 +89,7 @@ impl<C: RaftTypeConfig> Default for StateMachineStore<C> {
 
 impl<C: RaftTypeConfig> StateMachineStore<C> {
     /// Get a value from the state machine by key, locking the state machine.
-    pub async fn get(&self, key: &str) -> Option<String> {
+    pub async fn get(&self, key: &str) -> Option<types_kv::VersionedValue> {
         let inner = self.0.lock().await;
         inner.state_machine.data.get(key).cloned()
     }
@@ -154,14 +154,18 @@ where C: RaftTypeConfig<D = types_kv::Request, R = types_kv::Response, Entry = D
         while let Some((entry, responder)) = entries.try_next().await? {
             tracing::debug!(%entry.log_id, "replicate to sm");
 
+            let version = entry.log_id.index();
             inner.last_applied_log = Some(entry.log_id.clone());
 
             let response = match &entry.payload {
                 EntryPayload::Blank => types_kv::Response::none(),
                 EntryPayload::Normal(req) => match req {
                     types_kv::Request::Set { key, value } => {
-                        inner.state_machine.data.insert(key.clone(), value.clone());
-                        types_kv::Response::new(value.clone())
+                        inner.state_machine.data.insert(key.clone(), types_kv::VersionedValue {
+                            value: value.clone(),
+                            version,
+                        });
+                        types_kv::Response::new(value.clone(), version)
                     }
                 },
                 EntryPayload::Membership(mem) => {
@@ -198,7 +202,7 @@ where C: RaftTypeConfig<D = types_kv::Request, R = types_kv::Response, Entry = D
             data: snapshot.into_inner(),
         };
 
-        let updated_state_machine_data: BTreeMap<String, String> =
+        let updated_state_machine_data: BTreeMap<String, types_kv::VersionedValue> =
             serde_json::from_slice(&new_snapshot.data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         let mut inner = self.0.lock().await;

--- a/examples/types-kv/README.md
+++ b/examples/types-kv/README.md
@@ -4,5 +4,5 @@ Shared KV request/response types for openraft example crates.
 
 ## Types
 
-- `Request` - KV store write operations (currently `Set { key, value }`)
+- `Request` - KV store write operations (`Set` and version-based `CompareAndSet`)
 - `Response` - KV store operation results with an optional versioned value

--- a/examples/types-kv/README.md
+++ b/examples/types-kv/README.md
@@ -5,4 +5,4 @@ Shared KV request/response types for openraft example crates.
 ## Types
 
 - `Request` - KV store write operations (currently `Set { key, value }`)
-- `Response` - KV store operation results with optional value
+- `Response` - KV store operation results with an optional versioned value

--- a/examples/types-kv/src/lib.rs
+++ b/examples/types-kv/src/lib.rs
@@ -8,7 +8,15 @@ use serde::Serialize;
 /// A request to the KV store.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Request {
-    Set { key: String, value: String },
+    Set {
+        key: String,
+        value: String,
+    },
+    CompareAndSet {
+        key: String,
+        expected_version: u64,
+        value: String,
+    },
 }
 
 impl Request {
@@ -18,17 +26,37 @@ impl Request {
             value: value.into(),
         }
     }
+
+    pub fn compare_and_set(key: impl Into<String>, expected_version: u64, value: impl Into<String>) -> Self {
+        Request::CompareAndSet {
+            key: key.into(),
+            expected_version,
+            value: value.into(),
+        }
+    }
 }
 
 impl fmt::Display for Request {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Request::Set { key, value } => write!(f, "Set {{ key: {}, value: {} }}", key, value),
+            Request::CompareAndSet {
+                key,
+                expected_version,
+                value,
+            } => write!(
+                f,
+                "CompareAndSet {{ key: {}, expected_version: {}, value: {} }}",
+                key, expected_version, value
+            ),
         }
     }
 }
 
 /// A response from the KV store.
+///
+/// A compare-and-set operation returns the updated value on success and `None` when the expected
+/// version does not match.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Response {
     pub value: Option<VersionedValue>,

--- a/examples/types-kv/src/lib.rs
+++ b/examples/types-kv/src/lib.rs
@@ -29,19 +29,29 @@ impl fmt::Display for Request {
 }
 
 /// A response from the KV store.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Response {
-    pub value: Option<String>,
+    pub value: Option<VersionedValue>,
 }
 
 impl Response {
-    pub fn new(value: impl Into<String>) -> Self {
+    pub fn new(value: impl Into<String>, version: u64) -> Self {
         Response {
-            value: Some(value.into()),
+            value: Some(VersionedValue {
+                value: value.into(),
+                version,
+            }),
         }
     }
 
     pub fn none() -> Self {
         Response { value: None }
     }
+}
+
+/// The current value of a key and its version.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct VersionedValue {
+    pub value: String,
+    pub version: u64,
 }


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

This PR adds version-based CAS support to the KV examples:

- Uses the applied Raft log index as the version of each updated value.
- Returns `VersionedValue` from both write and read operations.
- Adds `CompareAndSet` to the existing `/write` API. CAS compares the   expected version atomically during state-machine apply, preventing ABA   issues.

For `rocksstore`, writes in a `WriteBatch` are not visible through RocksDB until the batch is committed. A temporary `pending_values` map ensures that CAS operations can observe earlier updates from the same apply batch.

Closes #1847 

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1848)
<!-- Reviewable:end -->
