### PR TITLE
fix: lint all standalone crates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,10 +98,15 @@ lint:
 	cargo fmt --manifest-path rt-compio/Cargo.toml
 	cargo fmt --manifest-path rt-monoio/Cargo.toml
 	cargo fmt --manifest-path rt-tokio/Cargo.toml
+	cargo fmt --manifest-path metrics-otel/Cargo.toml
+	cargo fmt --manifest-path benchmarks/minimal/Cargo.toml
 	cargo fmt --manifest-path examples/app-http/Cargo.toml
+	cargo fmt --manifest-path examples/network-v1-http/Cargo.toml
+	cargo fmt --manifest-path examples/network-v2-http/Cargo.toml
 	cargo fmt --manifest-path examples/log-mem/Cargo.toml
 	cargo fmt --manifest-path examples/sm-mem/Cargo.toml
 	cargo fmt --manifest-path examples/rocksstore/Cargo.toml
+	cargo fmt --manifest-path examples/types-kv/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-memstore-grpc/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-memstore-network-v2/Cargo.toml
 	cargo fmt --manifest-path examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
@@ -115,10 +120,15 @@ lint:
 	cargo clippy --no-deps --manifest-path rt-compio/Cargo.toml                                       --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path rt-monoio/Cargo.toml                                       --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path rt-tokio/Cargo.toml                                        --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path metrics-otel/Cargo.toml                                    --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path benchmarks/minimal/Cargo.toml                               --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/app-http/Cargo.toml                               --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path examples/network-v1-http/Cargo.toml                         --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path examples/network-v2-http/Cargo.toml                         --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/log-mem/Cargo.toml                                --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/sm-mem/Cargo.toml                                --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/rocksstore/Cargo.toml                                --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path examples/types-kv/Cargo.toml                               --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/raft-kv-memstore-grpc/Cargo.toml                  --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/raft-kv-memstore-network-v2/Cargo.toml            --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml --all-targets -- -D warnings

--- a/benchmarks/minimal/src/bin/bench.rs
+++ b/benchmarks/minimal/src/bin/bench.rs
@@ -76,11 +76,11 @@ impl Display for BenchConfig {
 /// Format a number in human-readable form: "20m (20_000_000)"
 fn format_number(n: u64) -> String {
     let with_underscores = format_with_underscores(n);
-    let short = if n >= 1_000_000_000 && n % 1_000_000_000 == 0 {
+    let short = if n >= 1_000_000_000 && n.is_multiple_of(1_000_000_000) {
         format!("{}g", n / 1_000_000_000)
-    } else if n >= 1_000_000 && n % 1_000_000 == 0 {
+    } else if n >= 1_000_000 && n.is_multiple_of(1_000_000) {
         format!("{}m", n / 1_000_000)
-    } else if n >= 1_000 && n % 1_000 == 0 {
+    } else if n >= 1_000 && n.is_multiple_of(1_000) {
         format!("{}k", n / 1_000)
     } else {
         return with_underscores;

--- a/examples/network-v1-http/src/lib.rs
+++ b/examples/network-v1-http/src/lib.rs
@@ -169,14 +169,7 @@ where C: RaftTypeConfig
         //     serde_json::to_string_pretty(&req).unwrap()
         // );
 
-        let resp = self
-            .client
-            .post(url.clone())
-            .json(&req)
-            .timeout(option.soft_ttl())
-            .send()
-            .await
-            .map_err(|e| {
+        let resp = self.client.post(url.clone()).json(&req).timeout(option.soft_ttl()).send().await.map_err(|e| {
             if e.is_connect() {
                 // `Unreachable` informs the caller to backoff for a short while to avoid error log flush.
                 RPCError::Unreachable(Unreachable::new(&e))
@@ -206,10 +199,7 @@ where C: RaftTypeConfig
         req: AppendEntriesRequest<C>,
         option: RPCOption,
     ) -> Result<AppendEntriesResponse<C>, RPCError<C, RaftError<C>>> {
-        let res = self
-            .request::<_, _, Infallible>("append", req, &option)
-            .await
-            .map_err(RPCError::with_raft_error)?;
+        let res = self.request::<_, _, Infallible>("append", req, &option).await.map_err(RPCError::with_raft_error)?;
         Ok(res.unwrap())
     }
 
@@ -235,10 +225,7 @@ where C: RaftTypeConfig
         req: VoteRequest<C>,
         option: RPCOption,
     ) -> Result<VoteResponse<C>, RPCError<C, RaftError<C>>> {
-        let res = self
-            .request::<_, _, Infallible>("vote", req, &option)
-            .await
-            .map_err(RPCError::with_raft_error)?;
+        let res = self.request::<_, _, Infallible>("vote", req, &option).await.map_err(RPCError::with_raft_error)?;
         Ok(res.unwrap())
     }
 }

--- a/examples/network-v2-http/src/server.rs
+++ b/examples/network-v2-http/src/server.rs
@@ -102,7 +102,7 @@ where
         "/append" => {
             let req = serde_json::from_slice(&body).map_err(bad_request)?;
 
-            json_response(&raft.append_entries(req).await)
+            Ok(json_response(&raft.append_entries(req).await))
         }
         "/snapshot" => {
             let (vote, meta, data) = serde_json::from_slice(&body).map_err(bad_request)?;
@@ -113,28 +113,29 @@ where
             let res: Result<SnapshotResponse<C>, RaftError<C>> =
                 raft.install_full_snapshot(vote, snapshot).await.map_err(RaftError::Fatal);
 
-            json_response(&res)
+            Ok(json_response(&res))
         }
         "/transfer-leader" => {
             let req = serde_json::from_slice(&body).map_err(bad_request)?;
             let res: Result<TransferLeaderResponse<C>, RaftError<C>> =
                 raft.handle_transfer_leader(req).await.map_err(RaftError::Fatal);
 
-            json_response(&res)
+            Ok(json_response(&res))
         }
         "/vote" => {
             let req = serde_json::from_slice(&body).map_err(bad_request)?;
 
-            json_response(&raft.vote(req).await)
+            Ok(json_response(&raft.vote(req).await))
         }
         _ => Err(error_response(StatusCode::NOT_FOUND, "not found")),
     }
 }
 
-fn json_response<T: Serialize>(value: &T) -> Result<Response<Full<Bytes>>, Response<Full<Bytes>>> {
-    let body = serde_json::to_vec(value).map_err(internal_server_error)?;
-
-    Ok(response(StatusCode::OK, "application/json", Bytes::from(body)))
+fn json_response<T: Serialize>(value: &T) -> Response<Full<Bytes>> {
+    match serde_json::to_vec(value) {
+        Ok(body) => response(StatusCode::OK, "application/json", Bytes::from(body)),
+        Err(e) => internal_server_error(e),
+    }
 }
 
 fn bad_request(e: impl Display) -> Response<Full<Bytes>> {

--- a/metrics-otel/src/lib.rs
+++ b/metrics-otel/src/lib.rs
@@ -7,33 +7,33 @@
 //! # Usage
 //!
 //! 1. Add this crate to your `Cargo.toml`:
-//!    ```toml
-//!    [dependencies]
-//!    openraft = "0.10"
-//!    openraft-metrics-otel = "0.1"
-//!    opentelemetry = "0.30"
-//!    opentelemetry_sdk = "0.30"  # For configuring exporters
-//!    ```
+//!   ```toml
+//!   [dependencies]
+//!   openraft = "0.10"
+//!   openraft-metrics-otel = "0.1"
+//!   opentelemetry = "0.30"
+//!   opentelemetry_sdk = "0.30"  # For configuring exporters
+//!   ```
 //!
 //! 2. Configure the OpenTelemetry SDK in your application:
-//!    ```rust,ignore
-//!    use opentelemetry_sdk::metrics::MeterProvider;
+//!   ```rust,ignore
+//!   use opentelemetry_sdk::metrics::MeterProvider;
 //!
-//!    let meter_provider = MeterProvider::builder()
-//!        .with_reader(/* your exporter */)
-//!        .build();
+//!   let meter_provider = MeterProvider::builder()
+//!       .with_reader(/* your exporter */)
+//!       .build();
 //!
-//!    opentelemetry::global::set_meter_provider(meter_provider);
-//!    ```
+//!   opentelemetry::global::set_meter_provider(meter_provider);
+//!   ```
 //!
 //! 3. Install the recorder in your Raft instance:
-//!    ```rust,ignore
-//!    use std::sync::Arc;
-//!    use openraft_metrics_otel::Instruments;
+//!   ```rust,ignore
+//!   use std::sync::Arc;
+//!   use openraft_metrics_otel::Instruments;
 //!
-//!    let raft = Raft::new(...).await?;
-//!    raft.set_metrics_recorder(Some(Arc::new(Instruments::new()))).await?;
-//!    ```
+//!   let raft = Raft::new(...).await?;
+//!   raft.set_metrics_recorder(Some(Arc::new(Instruments::new()))).await?;
+//!   ```
 //!
 //! # Metrics
 //!
@@ -155,8 +155,10 @@ impl Instruments {
         let snapshot_index =
             meter.u64_gauge("openraft.snapshot.index").with_description("Index of last snapshot").build();
 
-        let purged_index =
-            meter.u64_gauge("openraft.log.index.purged").with_description("Index of last purged log entry").build();
+        let purged_index = meter
+            .u64_gauge("openraft.log.index.purged")
+            .with_description("Index of last purged log entry")
+            .build();
 
         let server_state = meter
             .u64_gauge("openraft.server.state")


### PR DESCRIPTION
The hand-maintained lint list skipped standalone crates. Local checks could therefore miss formatting and Clippy failures caught by CI.

Include every standalone crate and resolve the warnings exposed by the expanded checks.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1849)
<!-- Reviewable:end -->
