### PR TITLE
Add timeout-bounded ensure_linearizable (ReadIndex), clamped below leader_lease

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -375,6 +375,11 @@ where
     /// quorum acks or the budget is exhausted; already-acked voters are not re-contacted and the
     /// call returns as soon as a quorum is reached. When `timeout` is `None` a single round is
     /// performed (one attempt per voter), matching the legacy behavior.
+    ///
+    /// The effective budget is clamped below `leader_lease` regardless of how large the caller's
+    /// `timeout` is: the reply carries a single up-front `read_log_id`, which is only
+    /// linearizable while the granting quorum is still suppressing competing elections. A larger
+    /// wait cannot be answered safely without re-capturing `read_log_id` under a fresh quorum.
     #[tracing::instrument(level = "trace", skip(self, tx))]
     pub(super) async fn handle_ensure_linearizable_read(
         &mut self,
@@ -437,7 +442,24 @@ where
         // Overall budget for gathering a quorum of confirmations. `None` => a single round
         // (legacy behavior); `Some(d)` => keep re-confirming un-acked voters until a quorum
         // acks or the deadline passes.
-        let confirm_deadline = timeout.map(|d| C::now() + d);
+        //
+        // The budget is clamped below `leader_lease`. This confirmation answers with a single
+        // `read_log_id` captured up-front, so it stays linearizable only while the granting
+        // quorum is *still* provably suppressing competing elections: every follower that acks
+        // our heartbeat resets its election timer and will not start an election for
+        // `leader_lease` (see `Leader::clock_progress`). As long as every ack lands within
+        // `leader_lease` of the round start, those suppression windows overlap, so no
+        // higher-term leader can have been elected -- let alone committed past `read_log_id` --
+        // before we answer. If the window were allowed to grow with the full caller budget,
+        // grants could be accumulated across a leadership change and the read could go stale.
+        // Keep a one-heartbeat margin, and never drop below one heartbeat of patience (the
+        // effective window of the legacy single round).
+        let safe_window = {
+            let heartbeat = Duration::from_millis(self.config.heartbeat_interval);
+            let leader_lease = self.engine.config.timer_config.leader_lease;
+            leader_lease.saturating_sub(heartbeat).max(heartbeat)
+        };
+        let confirm_deadline = timeout.map(|d| C::now() + d.min(safe_window));
 
         // Snapshot everything each per-peer probe needs, so the borrow on `self.engine` is
         // released before we take `&mut self.network_factory` to create clients.
@@ -1697,7 +1719,11 @@ where
 
                 self.handle_pre_vote_request(rpc, tx);
             }
-            RaftMsg::GetLinearizer { read_policy, timeout, tx } => {
+            RaftMsg::GetLinearizer {
+                read_policy,
+                timeout,
+                tx,
+            } => {
                 self.handle_ensure_linearizable_read(read_policy, timeout, tx).await;
             }
             RaftMsg::ClientWrite {

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -9,7 +9,6 @@ use display_more::DisplayOptionExt;
 use display_more::DisplaySliceExt;
 use futures_util::FutureExt;
 use futures_util::StreamExt;
-use futures_util::TryFutureExt;
 use futures_util::stream::FuturesUnordered;
 use maplit::btreeset;
 use tracing::Instrument;
@@ -65,9 +64,7 @@ use crate::errors::Fatal;
 use crate::errors::ForwardToLeader;
 use crate::errors::Infallible;
 use crate::errors::InitializeError;
-use crate::errors::NetworkError;
 use crate::errors::QuorumNotEnough;
-use crate::errors::RPCError;
 use crate::errors::StorageIOResult;
 use crate::errors::Timeout;
 use crate::impls::ProgressResponder;
@@ -160,6 +157,18 @@ impl<C: RaftTypeConfig> fmt::Display for ApplyResult<C> {
             self.since, self.end, self.last_applied,
         )
     }
+}
+
+/// The outcome of a single voter's ReadIndex leadership-confirmation probe.
+///
+/// See [`RaftCore::handle_ensure_linearizable_read`].
+enum ConfirmOutcome<C: RaftTypeConfig> {
+    /// The voter acked the current vote (Success or Conflict both confirm leadership).
+    Granted(C::NodeId),
+    /// The voter reported a higher vote: this node is no longer leader.
+    HigherVote { target: C::NodeId, higher: VoteOf<C> },
+    /// The per-peer budget was exhausted without an ack.
+    Exhausted,
 }
 
 /// The core type implementing the Raft protocol.
@@ -360,8 +369,19 @@ where
     /// this node.
     // TODO: the second condition is such a read request can only read from state machine only when the last log it sees
     //       at `T1` is committed.
+    ///
+    /// When `timeout` is `Some`, the confirmation keeps re-probing only the voters that have
+    /// not yet acked (one heartbeat at a time per peer, paced at ~`heartbeat_interval`) until a
+    /// quorum acks or the budget is exhausted; already-acked voters are not re-contacted and the
+    /// call returns as soon as a quorum is reached. When `timeout` is `None` a single round is
+    /// performed (one attempt per voter), matching the legacy behavior.
     #[tracing::instrument(level = "trace", skip(self, tx))]
-    pub(super) async fn handle_ensure_linearizable_read(&mut self, read_policy: ReadPolicy, tx: ClientReadTx<C>) {
+    pub(super) async fn handle_ensure_linearizable_read(
+        &mut self,
+        read_policy: ReadPolicy,
+        timeout: Option<Duration>,
+        tx: ClientReadTx<C>,
+    ) {
         // Setup sentinel values to track when we've received majority confirmation of leadership.
 
         let resp = {
@@ -400,7 +420,9 @@ where
 
         let my_id = self.id.clone();
         let my_vote = self.engine.state.vote_ref().clone();
-        let ttl = Duration::from_millis(self.config.heartbeat_interval);
+        // Per-attempt patience is always one heartbeat interval, regardless of the overall
+        // budget: shrinking it would make a healthy-but-slow peer look unreachable.
+        let per_attempt_ttl = Duration::from_millis(self.config.heartbeat_interval);
         let eff_mem = self.engine.state.membership_state.effective().clone();
         let core_tx = self.tx_notification.clone();
 
@@ -412,137 +434,150 @@ where
             return;
         }
 
-        // Spawn parallel requests, all with the standard timeout for heartbeats.
-        let mut pending = FuturesUnordered::new();
+        // Overall budget for gathering a quorum of confirmations. `None` => a single round
+        // (legacy behavior); `Some(d)` => keep re-confirming un-acked voters until a quorum
+        // acks or the deadline passes.
+        let confirm_deadline = timeout.map(|d| C::now() + d);
 
-        let voter_progresses = {
-            let l = &self.engine.leader.as_ref().unwrap();
-            l.progress.iter().filter(|item| l.progress.is_voter(&item.id) == Some(true))
+        // Snapshot everything each per-peer probe needs, so the borrow on `self.engine` is
+        // released before we take `&mut self.network_factory` to create clients.
+        let leader_commit = self.engine.state.cluster_committed().cloned();
+        let voters = {
+            let l = self.engine.leader.as_ref().unwrap();
+            l.progress
+                .iter()
+                .filter(|item| l.progress.is_voter(&item.id) == Some(true))
+                .map(|item| (item.id.clone(), item.matching().cloned()))
+                .collect::<Vec<_>>()
         };
 
-        for item in voter_progresses {
-            let target = item.id.clone();
-            let progress = item;
+        // One independent, self-pacing confirmation future per voter (excluding self).
+        let mut pending = FuturesUnordered::new();
 
+        for (target, matching) in voters {
             if target == my_id {
                 continue;
             }
-
-            let rpc = AppendEntriesRequest {
-                vote: my_vote.clone(),
-                prev_log_id: progress.matching().cloned(),
-                entries: vec![],
-                leader_commit: self.engine.state.cluster_committed().cloned(),
-            };
 
             // Safe unwrap(): target is in membership
             let target_node = eff_mem.get_node(&target).unwrap().clone();
             let mut client = self.network_factory.new_client(target.clone(), &target_node).await;
 
-            let option = RPCOption::new(ttl);
+            let probe_id = my_id.clone();
+            let target_label = target.to_string();
+            // `AppendEntriesRequest` is not `Clone` (no `C: Clone` bound), so keep the
+            // cloneable parts and rebuild the heartbeat request on each retry.
+            let probe_vote = my_vote.clone();
+            let probe_commit = leader_commit.clone();
 
-            let fu = {
-                let my_id = my_id.clone();
-                let target = target.clone();
+            let fu = async move {
+                loop {
+                    let attempt_start = C::now();
 
-                async move {
-                    let input_stream = Box::pin(futures_util::stream::once(async { rpc }));
+                    let rpc = AppendEntriesRequest {
+                        vote: probe_vote.clone(),
+                        prev_log_id: matching.clone(),
+                        entries: vec![],
+                        leader_commit: probe_commit.clone(),
+                    };
+                    let input_stream = Box::pin(futures_util::stream::once(async move { rpc }));
 
-                    let outer_res = C::timeout(ttl, async {
-                        let mut output = client.stream_append(input_stream, option).await?;
+                    let outer_res = C::timeout(per_attempt_ttl, async {
+                        let mut output = client.stream_append(input_stream, RPCOption::new(per_attempt_ttl)).await?;
                         output.next().await.transpose()
                     })
                     .await;
 
                     match outer_res {
-                        Ok(Ok(Some(stream_result))) => Ok((target, stream_result)),
-                        Ok(Ok(None)) => {
-                            // Stream returned no response - treat as network error
-                            Err((
-                                target,
-                                RPCError::Network(NetworkError::from_string("stream_append returned no response")),
-                            ))
+                        // Got a response from the follower.
+                        Ok(Ok(Some(stream_result))) => {
+                            // A higher vote means this node is no longer leader.
+                            if let Err(StreamAppendError::HigherVote(higher)) = stream_result {
+                                return ConfirmOutcome::<C>::HigherVote { target, higher };
+                            }
+                            // Success or Conflict both confirm leadership.
+                            return ConfirmOutcome::<C>::Granted(target);
                         }
-                        Ok(Err(rpc_err)) => Err((target, rpc_err)),
+                        // No response / network error / timeout: a failed attempt to retry.
+                        Ok(Ok(None)) => {
+                            tracing::debug!("read-index probe to {} returned no response", target);
+                        }
+                        Ok(Err(rpc_err)) => {
+                            tracing::debug!("read-index probe to {} failed: {}", target, rpc_err);
+                        }
                         Err(_timeout) => {
-                            let timeout_err = Timeout {
+                            let timeout_err = Timeout::<C> {
                                 action: RPCTypes::AppendEntries,
-                                id: my_id,
+                                id: probe_id.clone(),
                                 target: target.clone(),
-                                timeout: ttl,
+                                timeout: per_attempt_ttl,
                             };
+                            tracing::debug!("read-index probe timed out: {}", timeout_err);
+                        }
+                    }
 
-                            Err((target, RPCError::Timeout(timeout_err)))
+                    // Attempt failed. Retry only while a budget remains.
+                    let Some(deadline) = confirm_deadline else {
+                        return ConfirmOutcome::<C>::Exhausted;
+                    };
+                    let now = C::now();
+                    if now >= deadline {
+                        return ConfirmOutcome::<C>::Exhausted;
+                    }
+
+                    // Pace retries to ~one heartbeat_interval per peer so a dead peer is probed at
+                    // the normal heartbeat cadence rather than in a busy loop on fast failures.
+                    let elapsed = now.saturating_duration_since(attempt_start);
+                    if elapsed < per_attempt_ttl {
+                        let remaining = deadline.saturating_duration_since(now);
+                        let pause = (per_attempt_ttl - elapsed).min(remaining);
+                        if !pause.is_zero() {
+                            C::sleep(pause).await;
                         }
                     }
                 }
             };
 
-            let fu = fu.instrument(tracing::debug_span!("spawn_is_leader", target = target.to_string()));
-            let task = C::spawn(fu).map_err(move |err| (target, err));
-
-            pending.push(task);
+            pending.push(fu.instrument(tracing::debug_span!("read_index_probe", target = target_label)));
         }
 
         let waiting_fu = async move {
-            // Handle responses as they return.
-            while let Some(res) = pending.next().await {
-                let (target, stream_result) = match res {
-                    Ok(Ok(res)) => res,
-                    Ok(Err((target, err))) => {
-                        tracing::error!(
-                            "timeout while confirming leadership for read request, target: {}, error: {}",
-                            target,
-                            err
-                        );
-                        continue;
+            // Handle per-peer outcomes as they resolve.
+            while let Some(outcome) = pending.next().await {
+                match outcome {
+                    // If any peer reports a greater vote, revert to follower and abort.
+                    ConfirmOutcome::HigherVote { target, higher } => {
+                        let send_res = core_tx
+                            .send(Notification::HigherVote {
+                                target,
+                                higher,
+                                leader_vote: my_vote.clone().into_committed(),
+                            })
+                            .await;
+
+                        if let Err(_e) = send_res {
+                            tracing::error!("failed to send HigherVote to RaftCore");
+                        }
+
+                        // we are no longer leader so error out early
+                        let err = ForwardToLeader::empty();
+                        tx.send(Err(err.into())).ok();
+                        return;
                     }
-                    Err((target, err)) => {
-                        tracing::error!("failed to join task: {}, target: {}", err, target);
-                        continue;
+                    ConfirmOutcome::Granted(target) => {
+                        granted.insert(target);
+                        if eff_mem.is_quorum(granted.iter()) {
+                            tx.send(Ok(resp)).ok();
+                            return;
+                        }
                     }
-                };
-
-                // If we receive a response with a greater vote, then revert to follower and abort this
-                // request.
-                if let Err(StreamAppendError::HigherVote(vote)) = stream_result {
-                    debug_assert!(
-                        vote.as_ref_vote() > my_vote.as_ref_vote(),
-                        "committed vote({}) has total order relation with other votes({})",
-                        my_vote,
-                        vote
-                    );
-
-                    let send_res = core_tx
-                        .send(Notification::HigherVote {
-                            target,
-                            higher: vote,
-                            leader_vote: my_vote.into_committed(),
-                        })
-                        .await;
-
-                    if let Err(_e) = send_res {
-                        tracing::error!("failed to send HigherVote to RaftCore");
+                    ConfirmOutcome::Exhausted => {
+                        // This voter gave up within the budget; keep waiting on the others.
                     }
-
-                    // we are no longer leader so error out early
-                    let err = ForwardToLeader::empty();
-                    tx.send(Err(err.into())).ok();
-                    return;
-                }
-
-                // Success or Conflict both confirm leadership (got valid response from follower)
-                granted.insert(target);
-
-                if eff_mem.is_quorum(granted.iter()) {
-                    tx.send(Ok(resp)).ok();
-                    return;
                 }
             }
 
-            // If we've hit this location, then we've failed to gather needed confirmations due to
-            // request failures.
-
+            // Every voter resolved without reaching a quorum.
             tx.send(Err(QuorumNotEnough {
                 cluster: eff_mem.membership().to_string(),
                 got: granted,
@@ -1662,8 +1697,8 @@ where
 
                 self.handle_pre_vote_request(rpc, tx);
             }
-            RaftMsg::GetLinearizer { read_policy, tx } => {
-                self.handle_ensure_linearizable_read(read_policy, tx).await;
+            RaftMsg::GetLinearizer { read_policy, timeout, tx } => {
+                self.handle_ensure_linearizable_read(read_policy, timeout, tx).await;
             }
             RaftMsg::ClientWrite {
                 payloads,

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -90,6 +90,11 @@ where C: RaftTypeConfig
         /// `Config::heartbeat_interval`). `Some(d)` keeps re-confirming the
         /// still-unacked voters, one heartbeat at a time per peer, until a
         /// quorum acks or the budget `d` is exhausted.
+        ///
+        /// `d` is clamped below `leader_lease`: the reply carries a single
+        /// up-front `read_log_id` that only stays linearizable while the
+        /// granting quorum keeps suppressing competing elections, so a longer
+        /// wait cannot be honored without re-capturing under a fresh quorum.
         timeout: Option<Duration>,
         tx: ClientReadTx<C>,
     },

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt;
+use std::time::Duration;
 
 use display_more::DisplayOptionExt;
 
@@ -83,6 +84,13 @@ where C: RaftTypeConfig
 
     GetLinearizer {
         read_policy: ReadPolicy,
+        /// Overall budget for confirming leadership (ReadIndex).
+        ///
+        /// `None` performs a single heartbeat round (per-peer timeout is
+        /// `Config::heartbeat_interval`). `Some(d)` keeps re-confirming the
+        /// still-unacked voters, one heartbeat at a time per peer, until a
+        /// quorum acks or the budget `d` is exhausted.
+        timeout: Option<Duration>,
         tx: ClientReadTx<C>,
     },
 

--- a/openraft/src/raft/api/app.rs
+++ b/openraft/src/raft/api/app.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use openraft_macros::since;
 
@@ -48,9 +49,10 @@ where C: RaftTypeConfig
     pub(crate) async fn get_read_linearizer(
         &self,
         read_policy: ReadPolicy,
+        timeout: Option<Duration>,
     ) -> Result<Result<Linearizer<C>, LinearizableReadError<C>>, Fatal<C>> {
         let (tx, rx) = C::oneshot();
-        self.inner.call_core(RaftMsg::GetLinearizer { read_policy, tx }, rx).await
+        self.inner.call_core(RaftMsg::GetLinearizer { read_policy, timeout, tx }, rx).await
     }
 
     #[since(version = "0.10.0")]

--- a/openraft/src/raft/api/app.rs
+++ b/openraft/src/raft/api/app.rs
@@ -52,7 +52,16 @@ where C: RaftTypeConfig
         timeout: Option<Duration>,
     ) -> Result<Result<Linearizer<C>, LinearizableReadError<C>>, Fatal<C>> {
         let (tx, rx) = C::oneshot();
-        self.inner.call_core(RaftMsg::GetLinearizer { read_policy, timeout, tx }, rx).await
+        self.inner
+            .call_core(
+                RaftMsg::GetLinearizer {
+                    read_policy,
+                    timeout,
+                    tx,
+                },
+                rx,
+            )
+            .await
     }
 
     #[since(version = "0.10.0")]

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -1080,9 +1080,43 @@ where
         &self,
         read_policy: ReadPolicy,
     ) -> Result<Option<LogIdOf<C>>, RaftError<C, LinearizableReadError<C>>> {
-        let linearizer = self.app_api().get_read_linearizer(read_policy).await.into_raft_result()?;
+        let linearizer = self.app_api().get_read_linearizer(read_policy, None).await.into_raft_result()?;
 
         // Safe unwrap: it never times out.
+        let state = linearizer.await_ready(self).await?;
+        Ok(Some(state.read_log_id().clone()))
+    }
+
+    /// Same as [`ensure_linearizable`](Self::ensure_linearizable) but bounds the
+    /// leadership-confirmation step (ReadIndex) by an overall `timeout`.
+    ///
+    /// Without a timeout, ReadIndex performs a single heartbeat round: every voter is
+    /// contacted once with a per-peer timeout of
+    /// [`Config::heartbeat_interval`](crate::Config::heartbeat_interval), and if a quorum
+    /// does not ack within that one round the call fails with
+    /// [`LinearizableReadError::QuorumNotEnough`]. A transient blip on the one healthy peer
+    /// that carries the quorum therefore fails the read even though the caller had a much
+    /// larger request budget to spend.
+    ///
+    /// With `timeout`, the confirmation keeps re-contacting only the voters that have **not**
+    /// yet acked — one heartbeat at a time per peer, paced at roughly
+    /// `Config::heartbeat_interval` so a dead peer is not hammered — until a quorum acks or
+    /// the budget is exhausted. A peer that has already acked is not contacted again, and the
+    /// call returns as soon as a quorum is reached, so this does not fan extra load onto
+    /// healthy replicas. A higher vote from any peer still aborts immediately with
+    /// [`ForwardToLeader`](crate::error::ForwardToLeader).
+    ///
+    /// Returns the same result as [`ensure_linearizable`](Self::ensure_linearizable).
+    #[since(version = "0.10.0", change = "add timeout-bounded ReadIndex confirmation")]
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn ensure_linearizable_with_timeout(
+        &self,
+        read_policy: ReadPolicy,
+        timeout: Duration,
+    ) -> Result<Option<LogIdOf<C>>, RaftError<C, LinearizableReadError<C>>> {
+        let linearizer =
+            self.app_api().get_read_linearizer(read_policy, Some(timeout)).await.into_raft_result()?;
+
         let state = linearizer.await_ready(self).await?;
         Ok(Some(state.read_log_id().clone()))
     }
@@ -1100,7 +1134,7 @@ where
         &self,
         read_policy: ReadPolicy,
     ) -> Result<(Option<LogIdOf<C>>, Option<LogIdOf<C>>), RaftError<C, LinearizableReadError<C>>> {
-        let linearizer = self.app_api().get_read_linearizer(read_policy).await.into_raft_result()?;
+        let linearizer = self.app_api().get_read_linearizer(read_policy, None).await.into_raft_result()?;
 
         let read_log_id = linearizer.read_log_id();
         let applied = linearizer.applied();
@@ -1158,7 +1192,7 @@ where
         &self,
         read_policy: ReadPolicy,
     ) -> Result<Linearizer<C>, RaftError<C, LinearizableReadError<C>>> {
-        self.app_api().get_read_linearizer(read_policy).await.into_raft_result()
+        self.app_api().get_read_linearizer(read_policy, None).await.into_raft_result()
     }
 
     /// Submit a mutating client request to Raft to update the state of the system (§5.1).

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -1106,6 +1106,16 @@ where
     /// healthy replicas. A higher vote from any peer still aborts immediately with
     /// [`ForwardToLeader`](crate::error::ForwardToLeader).
     ///
+    /// # Effective upper bound
+    ///
+    /// `timeout` is an upper bound, not a guaranteed wait: the confirmation window is
+    /// internally clamped below the leader lease (`election_timeout_max`). The reply carries a
+    /// single `read_log_id` captured when the call starts, which is only linearizable while the
+    /// granting quorum is still suppressing competing elections — a span bounded by the leader
+    /// lease. A `timeout` larger than the lease is therefore capped; spending a longer budget
+    /// safely would require re-capturing `read_log_id` under a fresh quorum, which this call
+    /// does not do.
+    ///
     /// Returns the same result as [`ensure_linearizable`](Self::ensure_linearizable).
     #[since(version = "0.10.0", change = "add timeout-bounded ReadIndex confirmation")]
     #[tracing::instrument(level = "debug", skip(self))]
@@ -1114,8 +1124,7 @@ where
         read_policy: ReadPolicy,
         timeout: Duration,
     ) -> Result<Option<LogIdOf<C>>, RaftError<C, LinearizableReadError<C>>> {
-        let linearizer =
-            self.app_api().get_read_linearizer(read_policy, Some(timeout)).await.into_raft_result()?;
+        let linearizer = self.app_api().get_read_linearizer(read_policy, Some(timeout)).await.into_raft_result()?;
 
         let state = linearizer.await_ready(self).await?;
         Ok(Some(state.read_log_id().clone()))


### PR DESCRIPTION
## Problem

When a KV calls `ensure_linearizable` (ReadIndex): the leader sends one round of heartbeats and needs a quorum to ack before it can safely serve the read. Today that confirmation runs a **single** heartbeat round with a per-peer timeout of `heartbeat_interval` (e.g. 50ms). If the one peer that would carry the quorum has a transient blip longer than `heartbeat_interval`, the whole read fails with `QuorumNotEnough` -- **even when the caller had a much larger request deadline (e.g. 500ms) still to spend.** The confirmation was throwing away most of the budget.

The question this PR answers: **how do we let `ensure_linearizable` use more of the caller's timeout budget to ride out transient blips, without (a) storming healthy replicas with retries, or (b) breaking linearizability?**

## Approach

**1. Timeout-bounded, per-peer confirmation.**
New public API `Raft::ensure_linearizable_with_timeout(read_policy, timeout)`, threading an `Option<Duration>` through `get_read_linearizer` -> `RaftMsg::GetLinearizer` -> `handle_ensure_linearizable_read`.

- `timeout = None` -> unchanged legacy behavior (single heartbeat round, one attempt per voter).
- `timeout = Some(d)` -> keep re-confirming **only the voters that have not yet acked**, one heartbeat at a time per peer, paced at ~`heartbeat_interval`, until a quorum acks or the budget runs out. A peer that already acked is never re-contacted, and the call returns the instant a quorum is reached.

This avoids the retry storm: we don't re-ping healthy peers that already answered, and a down peer is probed at normal heartbeat cadence rather than in a busy loop. A higher vote from any peer aborts immediately with `ForwardToLeader`.

**2. Clamp the budget below `leader_lease` (the linearizability fix).**
The reply carries a single `read_log_id` captured up front. That value is only linearizable while the quorum that acked is *still* the recognized leadership -- i.e. no higher-term leader could have committed past it. openraft's leader-lease invariant gives us exactly this bound: a follower that acks a heartbeat resets its election timer and **won't start an election for `leader_lease`** (`= election_timeout_max`; see `Leader::clock_progress`). So if every ack lands within one `leader_lease` of the round start, the granting quorum's election-suppression intervals overlap at the moment we answer -> no competing leader can have been elected -> the read is linearizable. This is the same property the legacy single (~50ms) round relied on implicitly.

Therefore the effective retry window is capped at **`leader_lease - heartbeat_interval`** (floored at one heartbeat), regardless of how large the caller's `timeout` is. `timeout` is an **upper bound**, not a guaranteed wait: with defaults (`election_timeout_max = 300ms`, `heartbeat_interval = 50ms`) a 500ms caller budget is clamped to ~250ms of confirmation -- still ~5x the old 50ms, enough to absorb the blips we were seeing, while staying provably safe.

Spending a budget *larger* than the leader lease would require re-capturing `read_log_id` under a fresh quorum each round (a RaftCore-integrated waiter); that is deliberately out of scope here and noted as follow-up.

## Test plan

- [x] `cargo test -p tests --test client_api t11_client_reads` (all 6 pass)
- [x] `make lint` (clean)
- [ ] Follow-up (separate PR): "Tier 2" RaftCore-integrated per-round re-capture, to safely use a budget beyond `leader_lease`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1851)
<!-- Reviewable:end -->
