### PR TITLE
feat: add dedicated heartbeat and snapshot network clients

### DIFF
--- a/openraft/src/core/heartbeat/handle.rs
+++ b/openraft/src/core/heartbeat/handle.rs
@@ -94,7 +94,7 @@ where C: RaftTypeConfig
             let handle = if let Some(handle) = handle {
                 handle
             } else {
-                let network = network_factory.new_client(prog.target.clone(), &prog.target_node).await;
+                let network = network_factory.new_heartbeat_client(prog.target.clone(), &prog.target_node).await;
 
                 let (tx, rx) = C::watch_channel(None);
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -437,7 +437,7 @@ where
 
             // Safe unwrap(): target is in membership
             let target_node = eff_mem.get_node(&target).unwrap().clone();
-            let mut client = self.network_factory.new_client(target.clone(), &target_node).await;
+            let mut client = self.network_factory.new_heartbeat_client(target.clone(), &target_node).await;
 
             let option = RPCOption::new(ttl);
 
@@ -2449,7 +2449,7 @@ where
                     self.new_replication_task_context(leader_vote, stream_id, target.clone());
 
                 let target_node = self.engine.state.membership_state.effective().get_node(&target).unwrap();
-                let snapshot_network = self.network_factory.new_client(target.clone(), target_node).await;
+                let snapshot_network = self.network_factory.new_snapshot_client(target.clone(), target_node).await;
 
                 let handle = SnapshotTransmitter::<C, N, SM>::spawn(
                     replication_task_context,

--- a/openraft/src/network/factory.rs
+++ b/openraft/src/network/factory.rs
@@ -1,4 +1,5 @@
 use openraft_macros::add_async_trait;
+use openraft_macros::since;
 
 use crate::OptionalSend;
 use crate::OptionalSync;
@@ -40,4 +41,33 @@ where C: RaftTypeConfig
     /// The method is intentionally async to give the implementation a chance to use asynchronous
     /// sync primitives to serialize access to the common internal object, if needed.
     async fn new_client(&mut self, target: C::NodeId, node: &C::Node) -> Self::Network;
+
+    /// Create a network client dedicated to sending heartbeat RPCs to the target node.
+    ///
+    /// This client carries the Leader's liveness probes: the periodic heartbeat that maintains the
+    /// Leader lease and the lease-confirmation probe issued for linearizable reads. These must not
+    /// be delayed by replication backpressure. On a transport that cannot multiplex a single
+    /// connection (e.g., HTTP/1.1), sharing the replication client lets a large `AppendEntries`
+    /// batch or a snapshot transfer stall heartbeats through head-of-line blocking. Override this
+    /// method to isolate these probes on an independent connection when that matters.
+    ///
+    /// The default implementation delegates to [`new_client()`](Self::new_client), so heartbeats
+    /// share the replication path unless overridden.
+    #[since(version = "0.10.0")]
+    async fn new_heartbeat_client(&mut self, target: C::NodeId, node: &C::Node) -> Self::Network {
+        self.new_client(target, node).await
+    }
+
+    /// Create a network client dedicated to transmitting snapshots to the target node.
+    ///
+    /// Snapshot transfers can be large and long-running. On a transport that cannot multiplex a
+    /// single connection, sharing the replication client lets an in-flight snapshot block ordinary
+    /// log replication. Override this method to isolate snapshot transfer on its own connection.
+    ///
+    /// The default implementation delegates to [`new_client()`](Self::new_client), so snapshot
+    /// transfer shares the replication path unless overridden.
+    #[since(version = "0.10.0")]
+    async fn new_snapshot_client(&mut self, target: C::NodeId, node: &C::Node) -> Self::Network {
+        self.new_client(target, node).await
+    }
 }


### PR DESCRIPTION

## Changelog

##### feat: add dedicated heartbeat and snapshot network clients
# Summary

`RaftNetworkFactory` can now hand out connections dedicated to Leader
liveness probes and to snapshot transfer, so transports that cannot
multiplex a single connection avoid head-of-line blocking between these
paths and ordinary log replication. Existing implementations are
unaffected: both new methods default to the current replication client.

# Details

Add `new_heartbeat_client` and `new_snapshot_client` to
`RaftNetworkFactory`, each defaulting to `new_client`. The additive,
defaulted methods keep every existing implementation compiling and
behaving as before; only implementors on non-multiplexing transports
(e.g. HTTP/1.1) need to override them to gain connection isolation. The
API also now documents that this independence is a correctness-relevant
choice rather than an implicit assumption.

Route the internal call sites accordingly: the heartbeat worker and the
linearizable-read lease-confirmation probe now use
`new_heartbeat_client`, and snapshot transmission uses
`new_snapshot_client`. The read-path probe is grouped with heartbeats
because it is the same empty-`AppendEntries` liveness check and suffers
the same blocking when it shares the replication connection.

- Part of: #1853

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1854)
<!-- Reviewable:end -->
