### PR TITLE
test(jepsen): add error-aware CAS workload

### DIFF
--- a/jepsen/Makefile
+++ b/jepsen/Makefile
@@ -1,13 +1,13 @@
 COMPOSE := docker compose -f docker/docker-compose.yml
 NODES ?= n1,n2,n3
-CONCURRENCY ?= 1
+CONCURRENCY ?= 3
 SSH_KEY ?= /root/.ssh/openraft-jepsen
 ARGS ?= --nodes $(NODES) --concurrency $(CONCURRENCY) --ssh-private-key $(SSH_KEY)
 
 jepsen: build
 	@echo "[jepsen] starting containers"
 	@$(COMPOSE) up -d --force-recreate
-	@echo "[jepsen] running smoke test"
+	@echo "[jepsen] running linearizability test"
 	@$(COMPOSE) exec control lein run test $(ARGS)
 
 key:
@@ -23,7 +23,7 @@ up: key
 	@$(COMPOSE) up -d --force-recreate
 
 test:
-	@echo "[jepsen] running smoke test"
+	@echo "[jepsen] running linearizability test"
 	@$(COMPOSE) exec control lein run test $(ARGS)
 
 down:

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -25,12 +25,12 @@ The Docker test environment separates the Jepsen control plane from the OpenRaft
 +-------+-------+         +-------+-------+         +-------+-------+
         |                         |                         |
         | app_http API            | app_http API            | app_http API
-        | /init /write /read      | /metrics                | /metrics
+        | same endpoints          | same endpoints          | same endpoints
         |                         |                         |
         +----------- Raft RPC: /append /vote /snapshot -----+
 ```
 
-The control container is not an OpenRaft member. It runs the Jepsen process, controls the db nodes over SSH, and sends client operations to the KV service API. The OpenRaft cluster itself runs on `n1`, `n2`, and `n3`; those nodes communicate with each other over the Raft RPC port.
+The control container is not an OpenRaft member. It runs the Jepsen process, controls the db nodes over SSH, and sends client operations to the KV service API. Every db node exposes the same `app_http` endpoints, and the leader-aware client may contact any of them. The OpenRaft cluster itself runs on `n1`, `n2`, and `n3`; those nodes communicate with each other over the Raft RPC port.
 
 The intended layout is:
 
@@ -73,7 +73,7 @@ The `jepsen.openraft` namespace contains the OpenRaft-specific Jepsen code:
 From the repository root:
 
 ```bash
-# Build images, start containers, and run the smoke test.
+# Build images, start containers, and run the linearizability test.
 $ make -C jepsen jepsen
 
 # Generate the local Docker SSH key and build the Jepsen images.
@@ -82,14 +82,14 @@ $ make -C jepsen build
 # Start or recreate the Jepsen containers.
 $ make -C jepsen up
 
-# Run the smoke test against the running containers.
+# Run the linearizability test against the running containers.
 $ make -C jepsen test
 
 # Stop and remove the Jepsen containers.
 $ make -C jepsen down
 ```
 
-This starts three Docker node containers, then runs the Jepsen control process from the control container. The current smoke test starts the OpenRaft processes, bootstraps a three-node cluster, writes one key, reads it back, and then tears the cluster down.
+This starts three Docker node containers, then runs the Jepsen control process from the control container. The test bootstraps a three-node cluster and checks a concurrent mix of linearizable reads, writes, and compare-and-set operations with Knossos.
 
 ## TODO
 
@@ -101,5 +101,6 @@ This starts three Docker node containers, then runs the Jepsen control process f
 - [x] Bootstrap a three-node OpenRaft cluster.
 - [ ] Record acknowledged write, read, and info operation counts in each run.
 - [ ] Add nemeses for network partitions and process kill/restart.
-- [ ] Add linearizability checking.
+- [x] Add a read, write, and compare-and-set workload.
+- [x] Add linearizability checking with Knossos.
 - [ ] Add snapshot pressure and membership churn workloads.

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -21,7 +21,7 @@
     (merge tests/noop-test
            opts
            workload
-           {:name "openraft cluster smoke"
+           {:name "openraft linearizable register"
             :db (openraft-db/db opts)
             :nemesis nemesis/noop
             :checker (checker/compose

--- a/jepsen/src/jepsen/openraft/client.clj
+++ b/jepsen/src/jepsen/openraft/client.clj
@@ -1,11 +1,13 @@
 (ns jepsen.openraft.client
   (:require [cheshire.core :as json]
             [clojure.string :as str])
-  (:import (java.net URI)
+  (:import (java.net ConnectException URI)
            (java.net.http HttpClient
+                          HttpConnectTimeoutException
                           HttpRequest
                           HttpRequest$BodyPublishers
-                          HttpResponse$BodyHandlers)
+                          HttpResponse$BodyHandlers
+                          HttpTimeoutException)
            (java.time Duration)))
 
 (def default-api-port 21001)
@@ -45,6 +47,18 @@
                       :uri (str (.uri request))}
         response (try
                    (.send http-client request (HttpResponse$BodyHandlers/ofString))
+                   (catch HttpConnectTimeoutException e
+                     (throw (ex-info "HTTP connection timed out"
+                                     (assoc request-info :kind :unreachable)
+                                     e)))
+                   (catch ConnectException e
+                     (throw (ex-info "HTTP connection failed"
+                                     (assoc request-info :kind :unreachable)
+                                     e)))
+                   (catch HttpTimeoutException e
+                     (throw (ex-info "HTTP request timed out"
+                                     (assoc request-info :kind :request-timeout)
+                                     e)))
                    (catch java.io.IOException e
                      (throw (ex-info "HTTP request failed"
                                      (assoc request-info :kind :transport-error)
@@ -52,7 +66,7 @@
                    (catch InterruptedException e
                      (.interrupt (Thread/currentThread))
                      (throw (ex-info "HTTP request interrupted"
-                                     (assoc request-info :kind :transport-error)
+                                     (assoc request-info :kind :interrupted)
                                      e))))
         status (.statusCode response)
         body (.body response)
@@ -83,6 +97,48 @@
                                              :response response}))
       :else body)))
 
+(defn- forward-to-leader? [e]
+  (contains? (or (:error (ex-data e)) {}) :ForwardToLeader))
+
+(defn- forward-endpoint [e]
+  (get-in (ex-data e)
+          [:error :ForwardToLeader :leader_node :data]))
+
+(defn- unreachable? [e]
+  (= :unreachable (:kind (ex-data e))))
+
+(defn- next-endpoint [endpoints attempted e]
+  (let [forward (forward-endpoint e)
+        candidates (if forward
+                     (cons forward endpoints)
+                     endpoints)]
+    (first (remove attempted candidates))))
+
+(defn with-leader!
+  "Runs request against the cached leader and follows safe routing failures.
+
+  ForwardToLeader and connection-establishment failures prove that the request
+  was not applied, so retrying them does not duplicate a mutation. Other
+  transport failures are returned to the workload for operation-aware handling."
+  [leader-endpoint endpoints request]
+  (loop [endpoint @leader-endpoint
+         attempted #{}]
+    (let [attempted (conj attempted endpoint)
+          [result value] (try
+                           [:ok (request endpoint)]
+                           (catch Exception e
+                             [:error e]))]
+      (if (= :ok result)
+        (do
+          (reset! leader-endpoint endpoint)
+          value)
+        (if (or (forward-to-leader? value)
+                (unreachable? value))
+          (if-let [endpoint (next-endpoint endpoints attempted value)]
+            (recur endpoint attempted)
+            (throw value))
+          (throw value))))))
+
 (defn get! [endpoint path]
   (-> (request-builder endpoint path)
       (.GET)
@@ -111,10 +167,26 @@
 (defn change-membership! [endpoint node-ids]
   (ok-value (post! endpoint "/change-membership" node-ids)))
 
+;; These functions make one HTTP attempt. KVClient performs leader routing and
+;; classifies errors based on whether the operation may have taken effect.
 (defn write! [endpoint key value]
-  (ok-value (post! endpoint "/write"
-                   {:Set {:key key
-                          :value value}})))
+  (-> (post! endpoint "/write"
+             {:Set {:key key
+                    :value value}})
+      ok-value
+      :data
+      :value))
 
-(defn read! [endpoint key]
-  (ok-value (post! endpoint "/read" key)))
+(defn cas! [endpoint key expected-version value]
+  (-> (post! endpoint "/write"
+             {:CompareAndSet {:key key
+                              :expected_version expected-version
+                              :value value}})
+      ok-value
+      :data
+      :value))
+
+(defn linearizable-read! [endpoint key]
+  (-> (post! endpoint "/linearizable_read" key)
+      ok-value
+      :value))

--- a/jepsen/src/jepsen/openraft/workload.clj
+++ b/jepsen/src/jepsen/openraft/workload.clj
@@ -3,48 +3,195 @@
                     [client :as client]
                     [core :as jepsen]
                     [generator :as gen]]
-            [jepsen.openraft.client :as http]))
+            [jepsen.openraft.client :as http]
+            [knossos.model :as model]))
 
 (def key-name "jepsen-key")
-(def value-name "jepsen-value")
+
+(defn- remember-latest! [latest-value value]
+  (when value
+    (swap! latest-value
+           (fn [current]
+             (if (or (nil? current)
+                     (< (:version current) (:version value)))
+               value
+               current))))
+  value)
+
+(defn- next-value! [value-counter]
+  (str "value-" (swap! value-counter inc)))
+
+(defn- read-op [_test _process]
+  {:type :invoke
+   :f :read
+   :value nil})
+
+(defn- write-op [value-counter]
+  (fn [_test _process]
+    {:type :invoke
+     :f :write
+     :value (next-value! value-counter)}))
+
+(defn- cas-op [latest-value value-counter]
+  (fn [_test _process]
+    (let [expected @latest-value
+          new-value (next-value! value-counter)]
+      (if expected
+        {:type :invoke
+         :f :cas
+         ;; Knossos models logical values. The version is request metadata for
+         ;; OpenRaft's version-based CAS and is not part of the model value.
+         :value [(:value expected) new-value]
+         :expected-version (:version expected)}
+        {:type :invoke
+         :f :write
+         :value new-value}))))
+
+(defn- mutation? [op]
+  (#{:write :cas} (:f op)))
+
+(defn- complete-with-error [op type error unexpected?]
+  (cond-> (assoc op
+                 :type type
+                 :error error)
+    unexpected? (assoc :unexpected? true)))
+
+(defn- complete-with-ambiguous-outcome
+  "Marks an ambiguous mutation as info and a read as failed."
+  [op error unexpected?]
+  (complete-with-error op
+                       (if (mutation? op) :info :fail)
+                       error
+                       unexpected?))
+
+(defn- handle-operation-exception
+  "Classifies a client exception and returns a completed Jepsen operation.
+  Thread interruptions are rethrown."
+  [op e]
+  (let [{:keys [kind status error]} (ex-data e)]
+    (if (= :interrupted kind)
+      (throw e)
+      (let [result
+            (case kind
+              :unreachable
+              (complete-with-error op :fail :unreachable false)
+
+              :request-timeout
+              (complete-with-ambiguous-outcome op :timeout false)
+
+              :transport-error
+              (complete-with-ambiguous-outcome op :transport-error false)
+
+              :http-error
+              ;; app-http returns 4xx before invoking a handler, while a 5xx
+              ;; may occur while serializing a response after a mutation has
+              ;; completed.
+              (if (and status (<= 400 status 499))
+                (complete-with-error op :fail [:http status] true)
+                (complete-with-ambiguous-outcome op [:http status] true))
+
+              :invalid-json
+              (complete-with-ambiguous-outcome op :invalid-json true)
+
+              :openraft-error
+              (cond
+                (contains? error :ForwardToLeader)
+                (complete-with-error op :fail :not-leader false)
+
+                (contains? error :QuorumNotEnough)
+                (complete-with-error op :fail :quorum-not-enough false)
+
+                :else
+                (complete-with-ambiguous-outcome op :openraft-error true))
+
+              (complete-with-ambiguous-outcome op :client-error true))]
+        (cond-> result
+          (:unexpected? result)
+          (assoc :exception-message (ex-message e)
+                 :exception-data (ex-data e)))))))
+
+(defn- unexpected-errors-checker []
+  (reify checker/Checker
+    (check [_ _test history _opts]
+      (let [errors (filter :unexpected? history)]
+        {:valid? (empty? errors)
+         :count (count errors)
+         :errors (vec (take 10 errors))}))))
 
 ;; KVClient is the Jepsen client. Jepsen workers call invoke! with logical
 ;; operations from the generator, and this record translates them into OpenRaft
 ;; KV HTTP requests through jepsen.openraft.client.
-(defrecord KVClient [node endpoint]
+(defrecord KVClient [node leader-endpoint endpoints latest-value]
   client/Client
   (open! [this test node]
     (assoc this
            :node node
-           :endpoint (http/api-endpoint test (jepsen/primary test))))
+           :leader-endpoint (atom (http/api-endpoint test
+                                                     (jepsen/primary test)))
+           :endpoints (mapv #(http/api-endpoint test %) (:nodes test))))
 
   (setup! [this _test]
     this)
 
   (invoke! [_ _test op]
-    (case (:f op)
-      :write
-      (let [[k v] (:value op)]
-        (http/write! endpoint k v)
-        (assoc op :type :ok))
+    (try
+      (case (:f op)
+        :write
+        (let [value (http/with-leader!
+                      leader-endpoint
+                      endpoints
+                      #(http/write! % key-name (:value op)))]
+          (remember-latest! latest-value value)
+          (assoc op :type :ok))
 
-      :read
-      (assoc op
-             :type :ok
-             :value (http/read! endpoint (:value op)))))
+        :read
+        (let [value (->> (http/with-leader!
+                           leader-endpoint
+                           endpoints
+                           #(http/linearizable-read! % key-name))
+                         (remember-latest! latest-value))]
+          (assoc op
+                 :type :ok
+                 :value (:value value)))
+
+        :cas
+        (let [[_expected new-value] (:value op)
+              value (->> (http/with-leader!
+                           leader-endpoint
+                           endpoints
+                           #(http/cas! %
+                                       key-name
+                                       (:expected-version op)
+                                       new-value))
+                         (remember-latest! latest-value))]
+          (if value
+            (assoc op :type :ok)
+            (assoc op
+                   :type :fail
+                   :error :version-mismatch))))
+      (catch Exception e
+        (handle-operation-exception op e))))
 
   (teardown! [_ _test])
 
   (close! [_ _test]))
 
-(defn workload [_opts]
-  {:client (client/validate (KVClient. nil nil))
-   :generator (gen/clients
-                (gen/phases
-                  (gen/once {:type :invoke
-                             :f :write
-                             :value [key-name value-name]})
-                  (gen/once {:type :invoke
-                             :f :read
-                             :value key-name})))
-   :checker (checker/unbridled-optimism)})
+(defn workload [opts]
+  (let [latest-value (atom nil)
+        value-counter (atom 0)
+        operations (gen/mix [read-op
+                             (write-op value-counter)
+                             (cas-op latest-value value-counter)])]
+    {:client (client/validate (KVClient. nil nil nil latest-value))
+     :generator (gen/clients
+                  (gen/phases
+                    (gen/once {:type :invoke
+                               :f :write
+                               :value (next-value! value-counter)})
+                    (gen/time-limit (:time-limit opts)
+                                    (gen/stagger 0.1 operations))
+                    (gen/once read-op)))
+     :checker (checker/compose
+                {:linearizable (checker/linearizable
+                                 {:model (model/cas-register)})
+                 :unexpected-errors (unexpected-errors-checker)})}))

--- a/jepsen/test/jepsen/openraft/client_test.clj
+++ b/jepsen/test/jepsen/openraft/client_test.clj
@@ -1,0 +1,81 @@
+(ns jepsen.openraft.client-test
+  (:require [clojure.test :refer [deftest is]]
+            [jepsen.openraft.client :as client]))
+
+(defn- forward-error
+  ([]
+   (forward-error nil))
+  ([endpoint]
+   (ex-info "forward"
+            {:kind :openraft-error
+             :error {:ForwardToLeader
+                     {:leader_id (when endpoint 2)
+                      :leader_node (when endpoint
+                                     {:data endpoint})}}})))
+
+(deftest follows-leader
+  (let [leader (atom "n1:21001")
+        attempts (atom [])
+        result (client/with-leader!
+                 leader
+                 ["n1:21001" "n2:21001" "n3:21001"]
+                 (fn [endpoint]
+                   (swap! attempts conj endpoint)
+                   (if (= "n1:21001" endpoint)
+                     (throw (forward-error "n2:21001"))
+                     :ok)))]
+    (is (= :ok result))
+    (is (= ["n1:21001" "n2:21001"] @attempts))
+    (is (= "n2:21001" @leader))))
+
+(deftest searches-nodes-when-leader-is-unknown
+  (let [leader (atom "n1:21001")
+        attempts (atom [])
+        result (client/with-leader!
+                 leader
+                 ["n1:21001" "n2:21001" "n3:21001"]
+                 (fn [endpoint]
+                   (swap! attempts conj endpoint)
+                   (if (= "n3:21001" endpoint)
+                     :ok
+                     (throw (forward-error)))))]
+    (is (= :ok result))
+    (is (= ["n1:21001" "n2:21001" "n3:21001"] @attempts))
+    (is (= "n3:21001" @leader))))
+
+(deftest does-not-retry-request-timeout
+  (let [leader (atom "n1:21001")
+        attempts (atom 0)
+        error (try
+                (client/with-leader!
+                  leader
+                  ["n1:21001" "n2:21001" "n3:21001"]
+                  (fn [_]
+                    (swap! attempts inc)
+                    (throw (ex-info "timeout"
+                                    {:kind :request-timeout}))))
+                nil
+                (catch clojure.lang.ExceptionInfo e
+                  e))]
+    (is (= :request-timeout (:kind (ex-data error)))
+        "request timeouts must reach the workload error classifier")
+    (is (= 1 @attempts)
+        "request timeouts must not be retried because a mutation may have committed")))
+
+(deftest does-not-cache-an-unverified-leader
+  (let [leader (atom "n1:21001")
+        attempts (atom [])
+        error (try
+                (client/with-leader!
+                  leader
+                  ["n1:21001" "n2:21001" "n3:21001"]
+                  (fn [endpoint]
+                    (swap! attempts conj endpoint)
+                    (throw (forward-error))))
+                nil
+                (catch clojure.lang.ExceptionInfo e
+                  e))]
+    (is error)
+    (is (= ["n1:21001" "n2:21001" "n3:21001"] @attempts))
+    (is (= "n1:21001" @leader)
+        "a retry candidate becomes the cached leader only after it succeeds")))

--- a/jepsen/test/jepsen/openraft/workload_test.clj
+++ b/jepsen/test/jepsen/openraft/workload_test.clj
@@ -1,0 +1,160 @@
+(ns jepsen.openraft.workload-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen.checker :as checker]
+            [jepsen.client :as client]
+            [jepsen.openraft.client :as http]
+            [jepsen.openraft.workload :as workload]
+            [knossos.model :as model]))
+
+(defn- kv-client []
+  (workload/->KVClient nil
+                       (atom "n1:21001")
+                       ["n1:21001"]
+                       (atom nil)))
+
+(deftest classifies-timeouts-by-operation
+  (let [timeout (ex-info "timeout" {:kind :request-timeout})]
+    (with-redefs [http/write! (fn [& _] (throw timeout))
+                  http/linearizable-read! (fn [& _] (throw timeout))]
+      (testing "a write timeout is indeterminate"
+        (let [op {:type :invoke :f :write :value "value"}
+              result (client/invoke! (kv-client) {} op)]
+          (is (= :info (:type result)))
+          (is (= :timeout (:error result)))))
+
+      (testing "a read timeout has no state-machine effect"
+        (let [op {:type :invoke :f :read :value nil}
+              result (client/invoke! (kv-client) {} op)]
+          (is (= :fail (:type result)))
+          (is (= :timeout (:error result))))))))
+
+(deftest classifies-cas-outcomes
+  (let [op {:type :invoke
+            :f :cas
+            :value ["old" "new"]
+            :expected-version 1}]
+    (testing "a successful CAS keeps its logical model value"
+      (let [request (atom nil)
+            versioned {:value "new" :version 2}]
+        (with-redefs [http/cas! (fn [_endpoint _key expected-version new-value]
+                                  (reset! request [expected-version new-value])
+                                  versioned)]
+          (let [result (client/invoke! (kv-client) {} op)]
+            (is (= :ok (:type result)))
+            (is (= ["old" "new"] (:value result)))
+            (is (= [1 "new"] @request))))))
+
+    (testing "a version mismatch is a definite failure"
+      (with-redefs [http/cas! (fn [& _] nil)]
+        (let [result (client/invoke! (kv-client) {} op)]
+          (is (= :fail (:type result)))
+          (is (= :version-mismatch (:error result)))
+          (is (= (:value op) (:value result))))))
+
+    (testing "a CAS timeout is indeterminate"
+      (let [timeout (ex-info "timeout" {:kind :request-timeout})]
+        (with-redefs [http/cas! (fn [& _] (throw timeout))]
+          (let [result (client/invoke! (kv-client) {} op)]
+            (is (= :info (:type result)))
+            (is (= :timeout (:error result)))))))))
+
+(deftest keeps-versioned-values-out-of-model-history
+  (let [client (kv-client)
+        versioned {:value "value" :version 1}]
+    (testing "writes keep their logical invocation value"
+      (with-redefs [http/write! (fn [& _] versioned)]
+        (let [op {:type :invoke :f :write :value "value"}
+              result (client/invoke! client {} op)]
+          (is (= :ok (:type result)))
+          (is (= "value" (:value result))))))
+
+    (testing "reads expose only the logical value"
+      (with-redefs [http/linearizable-read! (fn [& _] versioned)]
+        (let [op {:type :invoke :f :read :value nil}
+              result (client/invoke! client {} op)]
+          (is (= :ok (:type result)))
+          (is (= "value" (:value result))))))))
+
+(deftest timed-out-write-can-explain-a-later-read
+  (let [history [{:process 0
+                  :type :invoke
+                  :f :write
+                  :value "value"}
+                 {:process 0
+                  :type :info
+                  :f :write
+                  :value "value"
+                  :error :timeout}
+                 {:process 1
+                  :type :invoke
+                  :f :read
+                  :value nil}
+                 {:process 1
+                  :type :ok
+                  :f :read
+                  :value "value"}]
+        result (checker/check
+                 (checker/linearizable
+                   {:model (model/cas-register)})
+                 {}
+                 history
+                 {})]
+    (is (:valid? result)
+        "an indeterminate write may have produced the value read later")))
+
+(deftest generates-cas-only-with-a-known-version
+  (testing "an unknown version produces a write"
+    (let [generate (#'workload/cas-op (atom nil) (atom 0))
+          op (generate nil nil)]
+      (is (= :write (:f op)))
+      (is (= "value-1" (:value op)))
+      (is (not (contains? op :expected-version)))))
+
+  (testing "a known version is captured separately from the model value"
+    (let [latest-value (atom {:value "old" :version 7})
+          generate (#'workload/cas-op latest-value (atom 0))
+          op (generate nil nil)]
+      (is (= :cas (:f op)))
+      (is (= ["old" "value-1"] (:value op)))
+      (is (= 7 (:expected-version op))))))
+
+(deftest classifies-server-errors
+  (testing "a read without quorum is a definite failure"
+    (let [quorum-error (ex-info "no quorum"
+                                {:kind :openraft-error
+                                 :error {:QuorumNotEnough {}}})]
+      (with-redefs [http/linearizable-read! (fn [& _]
+                                              (throw quorum-error))]
+        (let [op {:type :invoke :f :read :value nil}
+              result (client/invoke! (kv-client) {} op)]
+          (is (= :fail (:type result)))
+          (is (= :quorum-not-enough (:error result)))
+          (is (not (:unexpected? result)))))))
+
+  (testing "HTTP 400 is fail because app-http rejects it before handler execution"
+    (let [bad-request (ex-info "bad request"
+                               {:kind :http-error
+                                :status 400})]
+      (with-redefs [http/write! (fn [& _]
+                                  (throw bad-request))]
+        (let [op {:type :invoke :f :write :value "value"}
+              result (client/invoke! (kv-client) {} op)]
+          (is (= :fail (:type result)))
+          (is (= [:http 400] (:error result)))
+          (is (:unexpected? result))
+          (is (= "bad request" (:exception-message result)))
+          (is (= 400 (get-in result [:exception-data :status])))))))
+
+  (testing "HTTP 500 is info because response serialization follows handler execution"
+    (let [server-error (ex-info "server error"
+                                {:kind :http-error
+                                 :status 500})]
+      (with-redefs [http/write! (fn [& _]
+                                  (throw server-error))]
+        (let [op {:type :invoke :f :write :value "value"}
+              result (client/invoke! (kv-client) {} op)]
+          (is (= :info (:type result)))
+          (is (= [:http 500] (:error result)))
+          (is (:unexpected? result))
+          (is (= "server error" (:exception-message result)))
+          (is (= 500 (get-in result [:exception-data :status]))))))))


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!
-->
Part of #1597.

## Summary

This PR extends the initial OpenRaft Jepsen infrastructure with:

- A concurrent read/write/CAS workload targeting `raft-kv-rocksdb`.
- A Knossos CAS-register checker for linearizability.
- Leader-aware request routing.
- Operation-aware client error handling.
- Unit tests for leader routing and the main error classifications.

The workload operates on one versioned key. It performs an initial seed write, runs an equal mix of linearizable reads, writes, and CAS operations, and finishes with a final read.

## Error model

Jepsen distinguishes between operation outcomes:

- `:fail`: the operation definitely did not take effect. This does not by itself make the whole test invalid.
- `:info`: the operation may have taken effect, but the client could not determine its result. The checker must consider both possibilities.
- Unexpected protocol or harness errors are marked with `:unexpected?`. A separate checker makes the test invalid if any such errors occur.

Knossos history contains only logical string values. OpenRaft versions are kept as client-side `:expected-version` request metadata for CAS and are not exposed to the model.

## Leader routing

Each client maintains a cached leader endpoint.

`ForwardToLeader` and connection-establishment failures are safe to retry because the request was not applied by the contacted node. The client follows the advertised leader when available; otherwise, it searches the remaining nodes. Each endpoint is attempted at most once per logical operation.

Errors that may occur after sending a request are not retried. Retrying an indeterminate write or CAS could execute the mutation twice or turn a successful CAS into an apparent version mismatch.

## Handled outcomes

| Outcome | Retry | Jepsen result | Reason |
|---|---|---|---|
| Successful read/write/CAS | No | `:ok` | History records logical values only; versions remain client-side request metadata |
| CAS version mismatch | No | `:fail :version-mismatch` | The CAS definitely did not modify the key |
| `ForwardToLeader` | Yes | `:fail :not-leader` if routing is exhausted | A follower rejected the request before applying it |
| Connect failure or connect timeout | Yes | `:fail :unreachable` if all nodes fail | No connection was established |
| Request timeout | No | Mutation: `:info`; read: `:fail` | A mutation may have committed before its response was lost |
| Other HTTP I/O error | No | Mutation: `:info`; read: `:fail` | The point of failure is unknown |
| HTTP 4xx | No | `:fail`, unexpected | The request was rejected before application handling |
| HTTP non-4xx error | No | Mutation: `:info`; read: `:fail`; unexpected | A mutation may have completed before response generation failed |
| Invalid response JSON | No | Mutation: `:info`; read: `:fail`; unexpected | The response cannot determine the operation result |
| `QuorumNotEnough` | No | `:fail :quorum-not-enough` | The linearizable read was rejected |
| Unknown OpenRaft error | No | Mutation: `:info`; read: `:fail`; unexpected | Its application semantics are not known |
| Thread interruption | No | Rethrown | This is a Jepsen control signal, not an operation result |

## HTTP and OpenRaft errors

This PR does not change `app-http` status-code behavior.

The example API is RPC over HTTP. Transport and request-processing failures use non-200 HTTP statuses. A successfully processed RPC returns HTTP 200, and its body contains either `Ok` or `Err`.

The client therefore checks both layers:

1. HTTP status and transport failures.
2. The serialized OpenRaft `Result` in the response body.

## Errors not specifically handled yet

- `InitializeError` is only possible during cluster bootstrap. Bootstrap runs before workload history starts, so these errors are thrown and abort setup instead of being classified as `:fail` or `:info`.
- `ChangeMembershipError` variants are not classified individually because this workload keeps membership fixed. Membership grow/shrink will require its own nemesis and operation-specific policy.
- `FollowerReadError` is not used because the workload only performs linearizable reads.
- Valid JSON outside the expected `Ok`/`Err` response format is not strictly schema-validated. The selected endpoints currently have a stable Rust `Result` response contract.
- Individual handling is not provided for every possible Java HTTP exception. Unknown failures use the conservative fallback and invalidate the test.
- Network partitions, process crashes, and restarts are not introduced by this PR. Those nemeses will exercise these error paths against real faults in follow-up work.

## Verification

Verified on commit `51366e9c`:

- `lein test`: 10 tests, 47 assertions, 0 failures and 0 errors.
- Full Docker Jepsen test: valid.
- 571 operations: 562 successful, 9 expected CAS version mismatches, and 0 indeterminate operations.
- Knossos linearizability checker: valid.
- Unexpected error checker: valid, with 0 unexpected errors.

**Checklist**

- [x] Updated guide with pertinent info.
- [x] Squashed commits into logical changes.
- [x] Added and ran unit tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1855)
<!-- Reviewable:end -->