### PR TITLE
feat: add heartbeat_min_interval to suppress redundant heartbeats

### DIFF
--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -33,6 +33,7 @@ pub(crate) struct Defaults {
     pub election_timeout_min: u64,
     pub election_timeout_max: u64,
     pub heartbeat_interval: u64,
+    pub heartbeat_min_interval: u64,
     pub install_snapshot_timeout: u64,
     pub send_snapshot_timeout: u64,
     pub max_payload_entries: u64,
@@ -60,6 +61,7 @@ pub(crate) const DEFAULTS: Defaults = Defaults {
     election_timeout_min: 150,
     election_timeout_max: 300,
     heartbeat_interval: 50,
+    heartbeat_min_interval: 0,
     install_snapshot_timeout: 200,
     send_snapshot_timeout: 0,
     max_payload_entries: 300,
@@ -193,6 +195,23 @@ pub struct Config {
     /// The heartbeat interval in milliseconds at which leaders will send heartbeats to followers
     #[cfg_attr(feature = "clap", clap(long, default_value_t = DEFAULTS.heartbeat_interval))]
     pub heartbeat_interval: u64,
+
+    /// The minimum interval in milliseconds between two heartbeats to the same follower.
+    ///
+    /// A successful replication response proves the same liveness facts as a heartbeat response
+    /// and also updates the leader lease clock. When a follower has acknowledged an RPC
+    /// (replication or heartbeat) that was sent within the last `heartbeat_min_interval`
+    /// milliseconds, the periodic heartbeat to this follower is suppressed, since it would be
+    /// redundant. Under sustained writes this eliminates most heartbeat RPCs; heartbeats resume
+    /// automatically once replication idles.
+    ///
+    /// It must hold that `heartbeat_interval + heartbeat_min_interval < election_timeout_min`,
+    /// so that suppression can never delay a heartbeat past a follower's election timeout.
+    ///
+    /// Defaults to 0, meaning heartbeats are always sent at `heartbeat_interval`.
+    #[since(version = "0.10.0")]
+    #[cfg_attr(feature = "clap", clap(long, default_value = "0"))]
+    pub heartbeat_min_interval: Option<u64>,
 
     /// The timeout for sending then installing the last snapshot segment,
     /// in millisecond. It is also used as the timeout for sending a non-last segment if
@@ -547,6 +566,7 @@ impl Default for Config {
             election_timeout_min: DEFAULTS.election_timeout_min,
             election_timeout_max: DEFAULTS.election_timeout_max,
             heartbeat_interval: DEFAULTS.heartbeat_interval,
+            heartbeat_min_interval: Some(DEFAULTS.heartbeat_min_interval),
             install_snapshot_timeout: DEFAULTS.install_snapshot_timeout,
             send_snapshot_timeout: DEFAULTS.send_snapshot_timeout,
             max_payload_entries: DEFAULTS.max_payload_entries,
@@ -661,6 +681,13 @@ impl Config {
         self.max_append_entries.unwrap_or(4096)
     }
 
+    /// Get the minimum interval in milliseconds between two heartbeats to the same follower.
+    ///
+    /// Defaults to 0 if not specified, meaning heartbeat suppression is disabled.
+    pub(crate) fn heartbeat_min_interval(&self) -> u64 {
+        self.heartbeat_min_interval.unwrap_or(0)
+    }
+
     /// Validate the state of this config.
     pub fn validate(self) -> Result<Config, ConfigError> {
         if self.election_timeout_min >= self.election_timeout_max {
@@ -674,6 +701,14 @@ impl Config {
             return Err(ConfigError::ElectionTimeoutLTHeartBeat {
                 election_timeout_min: self.election_timeout_min,
                 heartbeat_interval: self.heartbeat_interval,
+            });
+        }
+
+        if self.election_timeout_min <= self.heartbeat_interval + self.heartbeat_min_interval() {
+            return Err(ConfigError::HeartbeatMinIntervalTooLarge {
+                election_timeout_min: self.election_timeout_min,
+                heartbeat_interval: self.heartbeat_interval,
+                heartbeat_min_interval: self.heartbeat_min_interval(),
             });
         }
 

--- a/openraft/src/config/config_test.rs
+++ b/openraft/src/config/config_test.rs
@@ -61,3 +61,31 @@ fn test_invalid_election_timeout_config_produces_expected_error() {
         heartbeat_interval: 1500
     });
 }
+
+#[test]
+fn test_invalid_heartbeat_min_interval_produces_expected_error() {
+    let config = Config {
+        election_timeout_min: 1000,
+        election_timeout_max: 2000,
+        heartbeat_interval: 500,
+        heartbeat_min_interval: Some(500),
+        ..Default::default()
+    };
+
+    let res = config.validate();
+    let err = res.unwrap_err();
+    assert_eq!(err, ConfigError::HeartbeatMinIntervalTooLarge {
+        election_timeout_min: 1000,
+        heartbeat_interval: 500,
+        heartbeat_min_interval: 500,
+    });
+
+    let config = Config {
+        election_timeout_min: 1000,
+        election_timeout_max: 2000,
+        heartbeat_interval: 500,
+        heartbeat_min_interval: Some(499),
+        ..Default::default()
+    };
+    assert!(config.validate().is_ok());
+}

--- a/openraft/src/config/error.rs
+++ b/openraft/src/config/error.rs
@@ -38,6 +38,20 @@ pub enum ConfigError {
         heartbeat_interval: u64,
     },
 
+    /// Heartbeat suppression must not delay a heartbeat past a follower's election timeout.
+    #[since(version = "0.10.0")]
+    #[error(
+        "heartbeat_interval({heartbeat_interval}) + heartbeat_min_interval({heartbeat_min_interval}) must be < election_timeout_min({election_timeout_min})"
+    )]
+    HeartbeatMinIntervalTooLarge {
+        /// Minimum election timeout value.
+        election_timeout_min: u64,
+        /// Heartbeat interval value.
+        heartbeat_interval: u64,
+        /// Minimum interval between two heartbeats to the same follower.
+        heartbeat_min_interval: u64,
+    },
+
     /// Invalid snapshot policy string format.
     #[error("snapshot policy string is invalid: '{invalid:?}' expect: '{syntax}'")]
     InvalidSnapshotPolicy {

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -2205,18 +2205,20 @@ where
 
         let cluster_committed = lh.state.cluster_committed().cloned();
         let now = C::now();
-        let events =
-            lh.leader
-                .progress
-                .iter()
-                .filter(|progress_entry| progress_entry.id != self.id)
-                .map(|progress_entry| {
-                    (progress_entry.id.clone(), HeartbeatEvent {
-                        time: now,
-                        matching: progress_entry.matching.clone(),
-                        cluster_committed: cluster_committed.clone(),
-                    })
-                });
+        let min_interval = Duration::from_millis(self.config.heartbeat_min_interval());
+        let leader = &*lh.leader;
+        let events = leader
+            .progress
+            .iter()
+            .filter(|progress_entry| progress_entry.id != self.id)
+            .filter(|progress_entry| leader.need_heartbeat(&progress_entry.id, now, min_interval))
+            .map(|progress_entry| {
+                (progress_entry.id.clone(), HeartbeatEvent {
+                    time: now,
+                    matching: progress_entry.matching.clone(),
+                    cluster_committed: cluster_committed.clone(),
+                })
+            });
 
         self.heartbeat_handle.broadcast(events);
     }

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::time::Duration;
 
 use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
@@ -228,6 +229,22 @@ where
         }
     }
 
+    /// Decide whether a heartbeat needs to be sent to `target` at time `now`.
+    ///
+    /// A heartbeat is redundant if `target` has recently acknowledged an RPC (log replication
+    /// or heartbeat): the acknowledgment proves the follower's liveness and already extended
+    /// the leader lease via [`Self::clock_progress`], which records the *sending* time of the
+    /// last acknowledged RPC.
+    ///
+    /// `min_interval` is [`Config::heartbeat_min_interval`]; `0` disables suppression so that
+    /// a heartbeat is always sent.
+    ///
+    /// [`Config::heartbeat_min_interval`]: `crate::Config::heartbeat_min_interval`
+    pub(crate) fn need_heartbeat(&self, target: &C::NodeId, now: InstantOf<C>, min_interval: Duration) -> bool {
+        let acked = self.clock_progress.try_get(target).and_then(|entry| entry.val);
+        acked.is_none_or(|sending_time| now >= sending_time + min_interval)
+    }
+
     pub(crate) fn is_replication_stream_valid(&self, target: &C::NodeId, stream_id: StreamId) -> bool {
         if let Some(entry) = self.progress.try_get(target)
             && entry.stream_id == stream_id
@@ -249,6 +266,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::time::Duration;
 
     use maplit::btreeset;
 
@@ -441,5 +459,47 @@ mod tests {
         leading.clock_progress.increase_to(&3, Some(t3)).ok();
         let t = leading.last_quorum_acked_time();
         assert_eq!(Some(t2), t, "n2 and n3 acked");
+    }
+
+    #[test]
+    fn test_need_heartbeat() {
+        let mut leading = Leader::<UTConfig, Vec<BTreeSet<u64>>>::new(
+            Vote::new(2, 1).into_committed(),
+            vec![btreeset! {1, 2, 3}],
+            [4],
+            None,
+            SharedIdGenerator::new(),
+        );
+
+        let min_interval = Duration::from_millis(100);
+        let t0 = UTConfig::<()>::now();
+
+        assert!(
+            leading.need_heartbeat(&2, t0, min_interval),
+            "never acknowledged: must send"
+        );
+        assert!(
+            leading.need_heartbeat(&9, t0, min_interval),
+            "unknown target: must send"
+        );
+
+        leading.clock_progress.increase_to(&2, Some(t0)).ok();
+
+        assert!(
+            !leading.need_heartbeat(&2, t0 + Duration::from_millis(99), min_interval),
+            "acked RPC sent within min_interval: suppressed"
+        );
+        assert!(
+            leading.need_heartbeat(&2, t0 + Duration::from_millis(100), min_interval),
+            "acked RPC sending time is min_interval old: must send"
+        );
+        assert!(
+            leading.need_heartbeat(&2, t0, Duration::ZERO),
+            "zero min_interval disables suppression"
+        );
+        assert!(
+            leading.need_heartbeat(&3, t0 + Duration::from_millis(99), min_interval),
+            "only the acked follower is suppressed"
+        );
     }
 }


### PR DESCRIPTION

## Changelog

##### feat: add heartbeat_min_interval to suppress redundant heartbeats
# Summary

Add a `heartbeat_min_interval` config option that suppresses the
periodic heartbeat to a follower that has recently acknowledged an
RPC. A replication response proves the same liveness facts as a
heartbeat response and already updates the leader lease, so the
heartbeat is redundant. Defaults to 0, which keeps current behavior.

# Details

The heartbeat broadcast in RaftCore now skips a follower whose last
acknowledged RPC (replication or heartbeat) was sent within
`heartbeat_min_interval` milliseconds, decided by the new
`Leader::need_heartbeat()` against `clock_progress`, which records the
sending time of the last acknowledged RPC. Under sustained writes this
eliminates most heartbeat RPCs; heartbeats resume automatically once
replication idles.

Config validation enforces
`heartbeat_interval + heartbeat_min_interval < election_timeout_min`
via the new `ConfigError::HeartbeatMinIntervalTooLarge`, so
suppression can never delay a heartbeat past a follower's election
timeout.

- Part: #1853

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1857)
<!-- Reviewable:end -->
