### PR TITLE
Jepsen: add network partition nemesis

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -1,0 +1,44 @@
+name: jepsen
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  jepsen:
+    name: Jepsen
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v4
+
+      - name: Test | Jepsen
+        run: make -C jepsen jepsen
+
+      - name: Debug | Docker logs
+        if: failure()
+        run: |
+          docker compose -f jepsen/docker/docker-compose.yml logs --no-color \
+            | tee jepsen/docker-compose.log
+
+      - name: Debug | Upload Jepsen results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jepsen-results
+          path: |
+            jepsen/store/
+            jepsen/docker-compose.log
+          if-no-files-found: ignore
+
+      - name: Cleanup | Docker
+        if: always()
+        run: make -C jepsen down

--- a/jepsen/Makefile
+++ b/jepsen/Makefile
@@ -7,6 +7,8 @@ ARGS ?= --nodes $(NODES) --concurrency $(CONCURRENCY) --ssh-private-key $(SSH_KE
 jepsen: build
 	@echo "[jepsen] starting containers"
 	@$(COMPOSE) up -d --force-recreate
+	@echo "[jepsen] running unit tests"
+	@$(COMPOSE) exec control lein test
 	@echo "[jepsen] running linearizability test"
 	@$(COMPOSE) exec control lein run test $(ARGS)
 

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -76,7 +76,7 @@ The `jepsen.openraft` namespace contains the OpenRaft-specific Jepsen code:
 From the repository root:
 
 ```bash
-# Build images, start containers, and run the linearizability test.
+# Build images, start containers, then run unit and linearizability tests.
 $ make -C jepsen jepsen
 
 # Generate the local Docker SSH key and build the Jepsen images.

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -51,6 +51,8 @@ jepsen/
     client.clj
     db.clj
     cluster.clj
+    nemesis/
+      partition.clj
     workload.clj
 ```
 
@@ -60,6 +62,7 @@ The `jepsen.openraft` namespace contains the OpenRaft-specific Jepsen code:
 - `client.clj`: HTTP client for the OpenRaft KV example APIs.
 - `db.clj`: Jepsen DB lifecycle for starting and stopping OpenRaft nodes.
 - `cluster.clj`: cluster bootstrap helpers.
+- `nemesis/partition.clj`: leader-aware network partition faults and recovery.
 - `workload.clj`: generators and checkers for client operations.
 
 ## Running
@@ -89,7 +92,14 @@ $ make -C jepsen test
 $ make -C jepsen down
 ```
 
-This starts three Docker node containers, then runs the Jepsen control process from the control container. The test bootstraps a three-node cluster and checks a concurrent mix of linearizable reads, writes, and compare-and-set operations with Knossos.
+This starts three Docker node containers, then runs the Jepsen control process
+from the control container. The test bootstraps a three-node cluster and checks
+a concurrent mix of linearizable reads, writes, and compare-and-set operations
+with Knossos. While the workload runs, Jepsen alternates between partitions
+where the current leader is in the majority and in the minority. Each partition
+lasts 10 seconds. A run is valid only if both modes occur, every node agrees on
+a leader after the final heal, client operations continue during recovery, and
+the final recovery write and read succeed.
 
 ## TODO
 
@@ -100,7 +110,8 @@ This starts three Docker node containers, then runs the Jepsen control process f
 - [x] Add Jepsen process lifecycle management for OpenRaft nodes.
 - [x] Bootstrap a three-node OpenRaft cluster.
 - [ ] Record acknowledged write, read, and info operation counts in each run.
-- [ ] Add nemeses for network partitions and process kill/restart.
+- [x] Add a network partition nemesis.
+- [ ] Add nemeses for process kill/restart.
 - [x] Add a read, write, and compare-and-set workload.
 - [x] Add linearizability checking with Knossos.
 - [ ] Add snapshot pressure and membership churn workloads.

--- a/jepsen/docker/node.Dockerfile
+++ b/jepsen/docker/node.Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       ca-certificates \
       iproute2 \
+      iptables \
       libgcc-s1 \
       libstdc++6 \
       netcat-openbsd \

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -2,10 +2,11 @@
   (:gen-class)
   (:require [jepsen [checker :as checker]
                     [cli :as cli]
-                    [nemesis :as nemesis]
+                    [generator :as gen]
                     [tests :as tests]]
             [jepsen.openraft [db :as openraft-db]
-                             [workload :as workload]]))
+                             [workload :as workload]]
+            [jepsen.openraft.nemesis [partition :as partition]]))
 
 (def cli-opts
   [[nil "--api-port PORT" "OpenRaft application HTTP port."
@@ -17,15 +18,27 @@
     :parse-fn parse-long]])
 
 (defn openraft-test [opts]
-  (let [workload (workload/workload opts)]
+  (let [workload (workload/workload opts)
+        nemesis-package (partition/partition-package)]
     (merge tests/noop-test
            opts
-           workload
            {:name "openraft linearizable register"
             :db (openraft-db/db opts)
-            :nemesis nemesis/noop
+            :client (:client workload)
+            :nemesis (:nemesis nemesis-package)
+            :generator (gen/phases
+                         (gen/shortest-any
+                           (gen/nemesis
+                             (gen/phases
+                               (gen/time-limit
+                                 (:time-limit opts)
+                                 (:generator nemesis-package))
+                               (:final-generator nemesis-package)))
+                           (:generator workload))
+                         (:final-generator workload))
             :checker (checker/compose
                         {:stats (checker/stats)
+                         :nemesis (:checker nemesis-package)
                          :workload (:checker workload)})})))
 
 (defn -main [& args]

--- a/jepsen/src/jepsen/openraft/client.clj
+++ b/jepsen/src/jepsen/openraft/client.clj
@@ -100,12 +100,25 @@
 (defn- forward-to-leader? [e]
   (contains? (or (:error (ex-data e)) {}) :ForwardToLeader))
 
+(defn- quorum-not-enough? [e]
+  (contains? (or (:error (ex-data e)) {}) :QuorumNotEnough))
+
 (defn- forward-endpoint [e]
   (get-in (ex-data e)
           [:error :ForwardToLeader :leader_node :data]))
 
 (defn- unreachable? [e]
   (= :unreachable (:kind (ex-data e))))
+
+(defn retryable-read-error?
+  "Returns true when a read can safely try another node after this error."
+  [e]
+  (let [kind (:kind (ex-data e))]
+    (or (#{:request-timeout :transport-error} kind)
+        (quorum-not-enough? e))))
+
+(defn- reroute-next-operation? [e]
+  (retryable-read-error? e))
 
 (defn- next-endpoint [endpoints attempted e]
   (let [forward (forward-endpoint e)
@@ -118,26 +131,35 @@
   "Runs request against the cached leader and follows safe routing failures.
 
   ForwardToLeader and connection-establishment failures prove that the request
-  was not applied, so retrying them does not duplicate a mutation. Other
-  transport failures are returned to the workload for operation-aware handling."
-  [leader-endpoint endpoints request]
-  (loop [endpoint @leader-endpoint
-         attempted #{}]
-    (let [attempted (conj attempted endpoint)
-          [result value] (try
-                           [:ok (request endpoint)]
-                           (catch Exception e
-                             [:error e]))]
-      (if (= :ok result)
-        (do
-          (reset! leader-endpoint endpoint)
-          value)
-        (if (or (forward-to-leader? value)
-                (unreachable? value))
-          (if-let [endpoint (next-endpoint endpoints attempted value)]
-            (recur endpoint attempted)
-            (throw value))
-          (throw value))))))
+  was not applied, so retrying them does not duplicate a mutation. The optional
+  retryable? predicate allows side-effect-free operations to retry additional
+  failures. An ambiguous failure is returned to the workload, but the next
+  operation starts from another endpoint."
+  ([leader-endpoint endpoints request]
+   (with-leader! leader-endpoint endpoints request (constantly false)))
+  ([leader-endpoint endpoints request retryable?]
+   (loop [endpoint @leader-endpoint
+          attempted #{}]
+     (let [attempted (conj attempted endpoint)
+           [result value] (try
+                            [:ok (request endpoint)]
+                            (catch Exception e
+                              [:error e]))]
+       (if (= :ok result)
+         (do
+           (reset! leader-endpoint endpoint)
+           value)
+         (if (or (forward-to-leader? value)
+                 (unreachable? value)
+                 (retryable? value))
+           (if-let [endpoint (next-endpoint endpoints attempted value)]
+             (recur endpoint attempted)
+             (throw value))
+           (do
+             (when (reroute-next-operation? value)
+               (when-let [endpoint (next-endpoint endpoints attempted value)]
+                 (reset! leader-endpoint endpoint)))
+             (throw value))))))))
 
 (defn get! [endpoint path]
   (-> (request-builder endpoint path)

--- a/jepsen/src/jepsen/openraft/cluster.clj
+++ b/jepsen/src/jepsen/openraft/cluster.clj
@@ -20,24 +20,30 @@
 (defn- ready-state? [state]
   (#{"Leader" "Follower"} state))
 
-(defn- cluster-ready? [test]
-  (let [leader-id (node-id test (jepsen/primary test))
-        metrics (into {}
+(defn- cluster-status [test]
+  (let [metrics (into {}
                       (map (fn [node]
                              [node (client/metrics!
                                      (client/api-endpoint test node))])
-                           (:nodes test)))]
-    (when (every? (fn [[_ m]]
-                    (and (= leader-id (:current_leader m))
-                         (ready-state? (:state m))))
-                  metrics)
-      metrics)))
+                           (:nodes test)))
+        leader-ids (set (map :current_leader (vals metrics)))
+        leaders (filter (fn [[_ metrics]]
+                          (= "Leader" (:state metrics)))
+                        metrics)]
+    (when (and (= 1 (count leader-ids))
+               (= 1 (count leaders))
+               (every? (comp ready-state? :state val) metrics))
+      (let [leader-id (first leader-ids)
+            [leader _] (first leaders)]
+        (when (= leader-id (node-id test leader))
+          {:leader leader
+           :metrics metrics})))))
 
 (defn await-ready! [test]
   (util/await-fn
-    #(or (cluster-ready? test)
+    #(or (cluster-status test)
          (throw (ex-info "OpenRaft cluster is not ready yet" {})))
-    {:log-message "Waiting for OpenRaft cluster to elect a leader"
+    {:log-message "Waiting for every OpenRaft node to agree on a leader"
      :timeout 60000}))
 
 (defn bootstrap! [test]

--- a/jepsen/src/jepsen/openraft/nemesis/partition.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/partition.clj
@@ -1,0 +1,126 @@
+(ns jepsen.openraft.nemesis.partition
+  (:require [clojure.tools.logging :refer [info]]
+            [jepsen [checker :as checker]
+                    [generator :as gen]
+                    [nemesis :as nemesis]
+                    [random :as random]]
+            [jepsen.openraft.cluster :as cluster]))
+
+(def partition-seconds 10)
+(def recovery-seconds 5)
+(def required-partition-modes
+  #{:leader-in-majority :leader-in-minority})
+
+(defn- partition-components [nodes leader mode]
+  (let [nodes (vec nodes)
+        node-count (count nodes)
+        majority-size (inc (quot node-count 2))
+        minority-size (- node-count majority-size)]
+    (when (< node-count 3)
+      (throw (ex-info "A partition test requires at least three nodes"
+                      {:nodes nodes})))
+    (when-not (some #{leader} nodes)
+      (throw (ex-info "The current leader is not a test node"
+                      {:leader leader
+                       :nodes nodes})))
+    (let [leader-component-size (case mode
+                                  :leader-in-majority majority-size
+                                  :leader-in-minority minority-size
+                                  (throw (ex-info "Unknown partition mode"
+                                                  {:mode mode})))
+          followers (random/shuffle (remove #{leader} nodes))
+          leader-component (into [leader]
+                                 (take (dec leader-component-size) followers))
+          other-component (vec (remove (set leader-component) nodes))]
+      [leader-component other-component])))
+
+(defrecord PartitionNemesis [partitioner]
+  nemesis/Nemesis
+  (setup! [_ test]
+    (PartitionNemesis. (nemesis/setup! partitioner test)))
+
+  (invoke! [_ test op]
+    (case (:f op)
+      :start-partition
+      (let [{:keys [leader]} (cluster/await-ready! test)
+            mode (:value op)
+            components (partition-components (:nodes test) leader mode)
+            grudge (nemesis/complete-grudge components)]
+        (info "Partitioning OpenRaft nodes"
+              {:mode mode
+               :leader leader
+               :components components})
+        (nemesis/invoke! partitioner test
+                         (assoc op
+                                :f :start
+                                :value grudge))
+        (assoc op
+               :value {:mode mode
+                       :leader leader
+                       :components components}))
+
+      :stop-partition
+      (do
+        (info "Healing OpenRaft network partition")
+        (nemesis/invoke! partitioner test
+                         (assoc op
+                                :f :stop
+                                :value nil))
+        (assoc op :value :network-healed))
+
+      :await-recovery
+      (let [{:keys [leader]} (cluster/await-ready! test)]
+        (info "OpenRaft cluster recovered with leader" leader)
+        (assoc op :value {:leader leader}))))
+
+  (teardown! [_ test]
+    (nemesis/teardown! partitioner test)))
+
+(defn partition-nemesis []
+  (nemesis/validate
+    (PartitionNemesis. (nemesis/partitioner))))
+
+(defn- partition-generator []
+  (gen/cycle
+    (gen/phases
+      (gen/sleep recovery-seconds)
+      {:type :info
+       :f :start-partition
+       :value :leader-in-majority}
+      (gen/sleep partition-seconds)
+      {:type :info
+       :f :stop-partition}
+      (gen/sleep recovery-seconds)
+      {:type :info
+       :f :start-partition
+       :value :leader-in-minority}
+      (gen/sleep partition-seconds)
+      {:type :info
+       :f :stop-partition})))
+
+(defn- coverage-checker []
+  (reify checker/Checker
+    (check [_ _test history _opts]
+      (let [observed-modes (->> history
+                                (filter #(= :start-partition (:f %)))
+                                (keep #(get-in % [:value :mode]))
+                                set)
+            missing-modes (remove observed-modes required-partition-modes)
+            recovered? (boolean
+                         (some #(and (= :await-recovery (:f %))
+                                     (get-in % [:value :leader]))
+                               history))]
+        {:valid? (and (empty? missing-modes) recovered?)
+         :observed-modes (vec (sort observed-modes))
+         :missing-modes (vec (sort missing-modes))
+         :recovered? recovered?}))))
+
+(defn partition-package []
+  {:nemesis (partition-nemesis)
+   :generator (partition-generator)
+   :final-generator (gen/phases
+                      (gen/once {:type :info
+                                 :f :stop-partition})
+                      (gen/once {:type :info
+                                 :f :await-recovery}))
+   :checker (coverage-checker)})

--- a/jepsen/src/jepsen/openraft/workload.clj
+++ b/jepsen/src/jepsen/openraft/workload.clj
@@ -32,6 +32,14 @@
      :f :write
      :value (next-value! value-counter)}))
 
+(defn- final-read-op [test process]
+  (assoc (read-op test process) :final? true))
+
+(defn- final-write-op [value-counter]
+  (let [write (write-op value-counter)]
+    (fn [test process]
+      (assoc (write test process) :final? true))))
+
 (defn- cas-op [latest-value value-counter]
   (fn [_test _process]
     (let [expected @latest-value
@@ -106,9 +114,10 @@
 
               (complete-with-ambiguous-outcome op :client-error true))]
         (cond-> result
-          (:unexpected? result)
+          (or (:unexpected? result) (:final? op))
           (assoc :exception-message (ex-message e)
-                 :exception-data (ex-data e)))))))
+                 :exception-data (ex-data e)
+                 :unexpected? true))))))
 
 (defn- unexpected-errors-checker []
   (reify checker/Checker
@@ -148,7 +157,8 @@
         (let [value (->> (http/with-leader!
                            leader-endpoint
                            endpoints
-                           #(http/linearizable-read! % key-name))
+                           #(http/linearizable-read! % key-name)
+                           http/retryable-read-error?)
                          (remember-latest! latest-value))]
           (assoc op
                  :type :ok
@@ -176,7 +186,7 @@
 
   (close! [_ _test]))
 
-(defn workload [opts]
+(defn workload [_opts]
   (let [latest-value (atom nil)
         value-counter (atom 0)
         operations (gen/mix [read-op
@@ -188,9 +198,11 @@
                     (gen/once {:type :invoke
                                :f :write
                                :value (next-value! value-counter)})
-                    (gen/time-limit (:time-limit opts)
-                                    (gen/stagger 0.1 operations))
-                    (gen/once read-op)))
+                    (gen/stagger 0.1 operations)))
+     :final-generator (gen/clients
+                        (gen/phases
+                          (gen/once (final-write-op value-counter))
+                          (gen/once final-read-op)))
      :checker (checker/compose
                 {:linearizable (checker/linearizable
                                  {:model (model/cas-register)})

--- a/jepsen/test/jepsen/openraft/client_test.clj
+++ b/jepsen/test/jepsen/openraft/client_test.clj
@@ -60,7 +60,26 @@
     (is (= :request-timeout (:kind (ex-data error)))
         "request timeouts must reach the workload error classifier")
     (is (= 1 @attempts)
-        "request timeouts must not be retried because a mutation may have committed")))
+        "request timeouts must not be retried because a mutation may have committed")
+    (is (= "n2:21001" @leader)
+        "the next operation should avoid the endpoint which timed out")))
+
+(deftest retries-read-timeout-on-another-node
+  (let [leader (atom "n1:21001")
+        attempts (atom [])
+        result (client/with-leader!
+                 leader
+                 ["n1:21001" "n2:21001" "n3:21001"]
+                 (fn [endpoint]
+                   (swap! attempts conj endpoint)
+                   (if (= "n1:21001" endpoint)
+                     (throw (ex-info "timeout"
+                                     {:kind :request-timeout}))
+                     :ok))
+                 client/retryable-read-error?)]
+    (is (= :ok result))
+    (is (= ["n1:21001" "n2:21001"] @attempts))
+    (is (= "n2:21001" @leader))))
 
 (deftest does-not-cache-an-unverified-leader
   (let [leader (atom "n1:21001")

--- a/jepsen/test/jepsen/openraft/cluster_test.clj
+++ b/jepsen/test/jepsen/openraft/cluster_test.clj
@@ -1,0 +1,40 @@
+(ns jepsen.openraft.cluster-test
+  (:require [clojure.test :refer [deftest is]]
+            [jepsen.openraft.client :as client]
+            [jepsen.openraft.cluster :as cluster]))
+
+(def test-config
+  {:nodes ["n1" "n2" "n3"]
+   :api-port 21001})
+
+(deftest finds-the-leader-agreed-on-by-all-nodes
+  (let [metrics {"n1:21001" {:state "Follower"
+                              :current_leader 2}
+                 "n2:21001" {:state "Leader"
+                              :current_leader 2}
+                 "n3:21001" {:state "Follower"
+                              :current_leader 2}}]
+    (with-redefs [client/metrics! metrics]
+      (let [status (#'cluster/cluster-status test-config)]
+        (is (= "n2" (:leader status)))
+        (is (= 3 (count (:metrics status))))))))
+
+(deftest rejects-disagreement-about-the-leader
+  (let [metrics {"n1:21001" {:state "Leader"
+                              :current_leader 1}
+                 "n2:21001" {:state "Follower"
+                              :current_leader 1}
+                 "n3:21001" {:state "Leader"
+                              :current_leader 3}}]
+    (with-redefs [client/metrics! metrics]
+      (is (nil? (#'cluster/cluster-status test-config))))))
+
+(deftest rejects-a-node-without-a-known-leader
+  (let [metrics {"n1:21001" {:state "Follower"
+                              :current_leader 2}
+                 "n2:21001" {:state "Leader"
+                              :current_leader 2}
+                 "n3:21001" {:state "Follower"
+                              :current_leader nil}}]
+    (with-redefs [client/metrics! metrics]
+      (is (nil? (#'cluster/cluster-status test-config))))))

--- a/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
@@ -1,0 +1,71 @@
+(ns jepsen.openraft.nemesis.partition-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen [checker :as checker]
+                    [nemesis :as nemesis]]
+            [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.nemesis.partition :as partition]))
+
+(def nodes ["n1" "n2" "n3"])
+
+(deftest places-leader-in-requested-component
+  (testing "leader remains in the majority"
+    (let [[leader-side other-side]
+          (#'partition/partition-components
+            nodes
+            "n1"
+            :leader-in-majority)]
+      (is (contains? (set leader-side) "n1"))
+      (is (= 2 (count leader-side)))
+      (is (= 1 (count other-side)))))
+
+  (testing "leader is isolated in the minority"
+    (let [[leader-side other-side]
+          (#'partition/partition-components
+            nodes
+            "n1"
+            :leader-in-minority)]
+      (is (= ["n1"] leader-side))
+      (is (= #{"n2" "n3"} (set other-side))))))
+
+(deftest resolves-leader-when-partition-starts
+  (let [invocations (atom [])
+        partitioner (reify nemesis/Nemesis
+                      (setup! [this _test]
+                        this)
+                      (invoke! [_ _test op]
+                        (swap! invocations conj op)
+                        op)
+                      (teardown! [this _test]
+                        this))
+        subject (partition/->PartitionNemesis partitioner)
+        op {:type :info
+            :process :nemesis
+            :f :start-partition
+            :value :leader-in-minority}]
+    (with-redefs [cluster/await-ready! (fn [_test]
+                                         {:leader "n2"})]
+      (let [result (nemesis/invoke! subject {:nodes nodes} op)
+            delegated (first @invocations)]
+        (is (= :start (:f delegated)))
+        (is (= #{"n2"}
+               (-> result :value :components first set)))
+        (is (= :leader-in-minority
+               (-> result :value :mode)))
+        (is (= "n2"
+               (-> result :value :leader)))))))
+
+(deftest requires-both-partitions-and-recovery
+  (let [subject (#'partition/coverage-checker)
+        complete-history [{:f :start-partition
+                           :value {:mode :leader-in-majority}}
+                          {:f :start-partition
+                           :value {:mode :leader-in-minority}}
+                          {:f :await-recovery
+                           :value {:leader "n2"}}]
+        incomplete-history [{:f :start-partition
+                             :value {:mode :leader-in-majority}}]]
+    (is (:valid? (checker/check subject {} complete-history {})))
+    (let [result (checker/check subject {} incomplete-history {})]
+      (is (false? (:valid? result)))
+      (is (= [:leader-in-minority] (:missing-modes result)))
+      (is (false? (:recovered? result))))))

--- a/jepsen/test/jepsen/openraft/workload_test.clj
+++ b/jepsen/test/jepsen/openraft/workload_test.clj
@@ -26,7 +26,18 @@
         (let [op {:type :invoke :f :read :value nil}
               result (client/invoke! (kv-client) {} op)]
           (is (= :fail (:type result)))
-          (is (= :timeout (:error result))))))))
+          (is (= :timeout (:error result)))))
+
+      (testing "a final recovery write must complete"
+        (let [op {:type :invoke
+                  :f :write
+                  :value "recovery-value"
+                  :final? true}
+              result (client/invoke! (kv-client) {} op)]
+          (is (= :info (:type result)))
+          (is (:unexpected? result))
+          (is (= :request-timeout
+                 (-> result :exception-data :kind))))))))
 
 (deftest classifies-cas-outcomes
   (let [op {:type :invoke


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

Part of #1597, based on #1855

## Summary

This PR adds a Jepsen network partition nemesis on top of the
error-aware CAS workload introduced by #1855.

It exercises two partition scenarios:

- The current leader remains in the majority component.
- The current leader is isolated in the minority component.

Ordinary read, write, and CAS traffic continues while the partition is
active and while the network is healing. After the final heal, the test
waits for every node to agree on a leader and performs a final write and
read to verify recovery.

## Design

The partition layout is calculated from the current test nodes rather
than assuming a fixed three-node topology. A partition test requires at
least three nodes.

Before each partition, the nemesis reads metrics from every node and
requires:

- Every node to report the same leader ID.
- Exactly one node to report the `Leader` state.
- All other nodes to be in a ready state.
- The reported leader ID to match the node in the `Leader` state.

The partition schedule alternates between:

1. Leader in the majority for 10 seconds.
2. Heal the network.
3. Leader in the minority for 10 seconds.
4. Heal the network.

Jepsen's partitioner applies the network rules. Docker nodes receive the
`NET_ADMIN` capability required to manage those rules.

## Client behavior during partitions

A leader isolated in the minority may remain reachable through its HTTP
endpoint while being unable to commit through Raft.

The client therefore:

- Safely retries `ForwardToLeader` and connection-establishment
  failures on another node.
- Allows side-effect-free reads to retry request timeouts, transport
  errors, and `QuorumNotEnough`.
- Does not retry writes or CAS operations after ambiguous failures,
  because the mutation may already have committed.
- Moves the next operation to another endpoint after an ambiguous
  leader-related failure, preventing workers from remaining pinned to
  an obsolete leader.

## Checking

The existing Knossos CAS-register checker continues to validate
linearizability.

An additional checker verifies that:

- Both partition modes occurred.
- The final healed cluster elected and agreed on a leader.

The final write/read phase also verifies that the recovered cluster can
serve client operations.

## Scope

This PR covers one network partition at a time. It does not yet combine
partitions with process crashes, restarts, membership changes, or clock
faults.

## Verification

- `lein test`: 17 tests, 71 assertions, 0 failures.
- Full Docker Jepsen test: valid.
- Both partition modes observed.
- Cluster recovery confirmed.
- Knossos linearizability checker: valid.
- Unexpected error checker: valid with 0 unexpected errors.


**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1858)
<!-- Reviewable:end -->
