### PR TITLE
ci: pin nightly jobs to the rust-toolchain version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,14 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v4
 
+      - name: Pin nightly from rust-toolchain
+        if: matrix.toolchain == 'nightly'
+        run: echo "PIN=$(cat rust-toolchain)" >> "$GITHUB_ENV"
+
       - name: Setup | Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '${{ matrix.toolchain }}'
+          toolchain: ${{ matrix.toolchain == 'nightly' && env.PIN || matrix.toolchain }}
 
       - name: Build | Release Mode
         run: cargo build --release --features "${{ matrix.features }}" --manifest-path openraft/Cargo.toml
@@ -40,10 +44,14 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v4
 
+      - name: Pin nightly from rust-toolchain
+        if: matrix.toolchain == 'nightly'
+        run: echo "PIN=$(cat rust-toolchain)" >> "$GITHUB_ENV"
+
       - name: Setup | Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '${{ matrix.toolchain }}'
+          toolchain: ${{ matrix.toolchain == 'nightly' && env.PIN || matrix.toolchain }}
 
       - name: Test build for benchmark
         run: cargo bench --features bench nothing-to-run --manifest-path openraft/Cargo.toml
@@ -66,10 +74,14 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v4
 
+      - name: Pin nightly from rust-toolchain
+        if: matrix.toolchain == 'nightly'
+        run: echo "PIN=$(cat rust-toolchain)" >> "$GITHUB_ENV"
+
       - name: Setup | Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '${{ matrix.toolchain }}'
+          toolchain: ${{ matrix.toolchain == 'nightly' && env.PIN || matrix.toolchain }}
 
       - name: Install cargo-expand
         run: cargo install cargo-expand
@@ -120,10 +132,14 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v4
 
+      - name: Pin nightly from rust-toolchain
+        if: matrix.toolchain == 'nightly'
+        run: echo "PIN=$(cat rust-toolchain)" >> "$GITHUB_ENV"
+
       - name: Setup | Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '${{ matrix.toolchain }}'
+          toolchain: ${{ matrix.toolchain == 'nightly' && env.PIN || matrix.toolchain }}
 
       - name: Test crate `tests/`
         run: cargo test --features "${{ matrix.features }}" --manifest-path tests/Cargo.toml
@@ -158,8 +174,6 @@ jobs:
 
       - name: Setup | Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: 'nightly'
 
       # - A store with defensive checks returns error when unexpected accesses are sent to RaftStore.
       # - Raft should not depend on defensive error to work correctly.
@@ -189,8 +203,6 @@ jobs:
 
       - name: Setup | Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: 'nightly'
 
       - name: Unit Tests
         run: cargo test --tests nothing --manifest-path "${{ matrix.crate }}/Cargo.toml"
@@ -208,8 +220,6 @@ jobs:
 
       - name: Setup | Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: 'nightly'
 
       - name: Unit Tests
         run: cargo test --tests --manifest-path "rt-monoio/Cargo.toml"
@@ -226,8 +236,6 @@ jobs:
 
       - name: Setup | Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: 'nightly'
 
       - name: Unit Tests
         run: cargo test --tests --manifest-path "rt-compio/Cargo.toml"
@@ -244,8 +252,6 @@ jobs:
 
       - name: Setup | Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: 'nightly'
 
       - name: Unit Tests
         run: cargo test --manifest-path "metrics-otel/Cargo.toml"
@@ -298,10 +304,14 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v4
 
+      - name: Pin nightly from rust-toolchain
+        if: matrix.toolchain == 'nightly'
+        run: echo "PIN=$(cat rust-toolchain)" >> "$GITHUB_ENV"
+
       - name: Setup | Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '${{ matrix.toolchain }}'
+          toolchain: ${{ matrix.toolchain == 'nightly' && env.PIN || matrix.toolchain }}
 
       - name: Test crate `openraft/`
         run: cargo test ${{ matrix.extra_args }} --features "${{ matrix.features }}" --manifest-path openraft/Cargo.toml
@@ -337,10 +347,14 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v4
 
+      - name: Pin nightly from rust-toolchain
+        if: matrix.toolchain == 'nightly'
+        run: echo "PIN=$(cat rust-toolchain)" >> "$GITHUB_ENV"
+
       - name: Setup | Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '${{ matrix.toolchain }}'
+          toolchain: ${{ matrix.toolchain == 'nightly' && env.PIN || matrix.toolchain }}
 
       - name: Test crate `tests/`
         run: cargo test --features "${{ matrix.features }}" --manifest-path tests/Cargo.toml
@@ -450,9 +464,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Pin nightly from rust-toolchain
+        if: matrix.toolchain == 'nightly'
+        run: echo "PIN=$(cat rust-toolchain)" >> "$GITHUB_ENV"
+
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: '${{ matrix.toolchain }}'
+          toolchain: ${{ matrix.toolchain == 'nightly' && env.PIN || matrix.toolchain }}
           components: rustfmt, clippy
           # Examples are separate workspaces; the default cache only covers the
           # repo-root target, so examples/*/target was never cached. Point the


### PR DESCRIPTION

## Changelog

##### ci: pin nightly jobs to the rust-toolchain version
# Summary

Every CI job that runs on nightly now takes its toolchain from the
./rust-toolchain file instead of floating on the latest nightly, so a
regressed newer nightly can no longer break the build.

# Details

Jobs requesting `toolchain: 'nightly'` installed whatever nightly was
newest; rustc 1.99.0-nightly (2026-07-23) ICEs in codegen while
compiling tokio and failed the Build job. Pinning removes that exposure
and makes ./rust-toolchain the single source for CI and local dev.

Single-channel jobs drop the explicit `toolchain:` input so
setup-rust-toolchain reads ./rust-toolchain directly. The
stable+nightly matrix jobs read the file into $PIN in a pre-step and
install it only on the nightly leg, leaving the stable leg and the
matrix labels unchanged.

---

- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1863)
<!-- Reviewable:end -->
