### PR TITLE
chore: vendor protoc via protoc-bin-vendored

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -481,12 +481,6 @@ jobs:
         if: matrix.example == 'raft-kv-rocksdb' || matrix.example == 'rocksstore'
         run: sudo apt-get update && sudo apt-get install -y librocksdb-dev
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: '23.x'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       # Run the following steps in the exmple dir in order to reuse the `./target` dir.
 
       - name: Test examples/${{ matrix.example }}

--- a/examples/raft-kv-memstore-grpc/Cargo.toml
+++ b/examples/raft-kv-memstore-grpc/Cargo.toml
@@ -39,6 +39,7 @@ maplit = { version = "1.0.2" }
 [build-dependencies]
 prost-build = { version = "0.14.3" }
 tonic-prost-build = { version = "0.14.6" }
+protoc-bin-vendored = { version = "3.2.0" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/raft-kv-memstore-grpc/build.rs
+++ b/examples/raft-kv-memstore-grpc/build.rs
@@ -1,5 +1,12 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=src/*");
+
+    // Use the vendored protoc binary so builds need no system protoc install.
+    let protoc = protoc_bin_vendored::protoc_bin_path()?;
+    unsafe {
+        std::env::set_var("PROTOC", protoc);
+    }
+
     let mut config = prost_build::Config::new();
     config.protoc_arg("--experimental_allow_proto3_optional");
     let proto_files = ["proto/raft.proto", "proto/app_types.proto", "proto/app.proto"];


### PR DESCRIPTION

## Changelog

##### chore: vendor protoc via protoc-bin-vendored
# Summary

raft-kv-memstore-grpc, the only example needing protoc, now gets it from
the protoc-bin-vendored crate, and the CI Protoc install step is gone.

# Details

The examples workflow installed protoc with arduino/setup-protoc, which
pulls a release binary from GitHub and intermittently 504s. The build
script now points PROTOC at the vendored binary, so protoc comes from
crates.io on every platform — no download or system package, in CI or
locally — and the install step is removed from all example jobs.

set_var runs in an unsafe block, as edition 2024 requires.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1864)
<!-- Reviewable:end -->
