### PR TITLE
refactor: jepsen: preserve interrupts and skip empty leader forwards

### DIFF
--- a/jepsen/src/jepsen/openraft/client.clj
+++ b/jepsen/src/jepsen/openraft/client.clj
@@ -98,10 +98,11 @@
       :else body)))
 
 (defn- forward-to-leader? [e]
-  (contains? (or (:error (ex-data e)) {}) :ForwardToLeader))
+  ;; contains? returns false for a nil map, so no nil guard is needed.
+  (contains? (:error (ex-data e)) :ForwardToLeader))
 
 (defn- quorum-not-enough? [e]
-  (contains? (or (:error (ex-data e)) {}) :QuorumNotEnough))
+  (contains? (:error (ex-data e)) :QuorumNotEnough))
 
 (defn- forward-endpoint [e]
   (get-in (ex-data e)
@@ -121,8 +122,10 @@
   (retryable-read-error? e))
 
 (defn- next-endpoint [endpoints attempted e]
+  ;; A ForwardToLeader with an empty data field carries no usable address, and
+  ;; "" is truthy in Clojure, so use seq to fall back to the known endpoints.
   (let [forward (forward-endpoint e)
-        candidates (if forward
+        candidates (if (seq forward)
                      (cons forward endpoints)
                      endpoints)]
     (first (remove attempted candidates))))

--- a/jepsen/src/jepsen/openraft/workload.clj
+++ b/jepsen/src/jepsen/openraft/workload.clj
@@ -18,7 +18,10 @@
                current))))
   value)
 
-(defn- next-value! [value-counter]
+(defn- next-value!
+  "Returns a globally unique value. Uniqueness lets Knossos treat logical values
+  as a faithful stand-in for server versions; see cas-op."
+  [value-counter]
   (str "value-" (swap! value-counter inc)))
 
 (defn- read-op [_test _process]
@@ -40,7 +43,22 @@
     (fn [test process]
       (assoc (write test process) :final? true))))
 
-(defn- cas-op [latest-value value-counter]
+(defn- cas-op
+  "Generates a CAS against the latest known value, falling back to a write until
+  a version is observed.
+
+  Knossos checks linearizability over the logical string values only. This is
+  sound because logical values and server versions are in bijection:
+
+    1. next-value! never repeats a value, so every mutation is globally unique.
+    2. with-leader! retries a mutation only after a failure proving it was not
+       applied, never after an ambiguous outcome, so each unique value is
+       applied at most once.
+
+  Breaking either invariant (reusing a value, or retrying a mutation with an
+  ambiguous outcome) would map one logical value onto two versions and could
+  mask a real violation."
+  [latest-value value-counter]
   (fn [_test _process]
     (let [expected @latest-value
           new-value (next-value! value-counter)]
@@ -74,9 +92,16 @@
 
 (defn- handle-operation-exception
   "Classifies a client exception and returns a completed Jepsen operation.
-  Thread interruptions are rethrown."
+  Thread interruptions are rethrown so Jepsen's control signals survive."
   [op e]
+  ;; A raw InterruptedException (thrown outside send!, which clears the interrupt
+  ;; flag) would otherwise fall through to the :client-error default and be
+  ;; swallowed. Restore the flag and rethrow so the interrupt is not lost.
+  (when (instance? InterruptedException e)
+    (.interrupt (Thread/currentThread))
+    (throw e))
   (let [{:keys [kind status error]} (ex-data e)]
+    ;; send! already re-interrupted the thread for wrapped interruptions.
     (if (= :interrupted kind)
       (throw e)
       (let [result

--- a/jepsen/test/jepsen/openraft/client_test.clj
+++ b/jepsen/test/jepsen/openraft/client_test.clj
@@ -43,6 +43,38 @@
     (is (= ["n1:21001" "n2:21001" "n3:21001"] @attempts))
     (is (= "n3:21001" @leader))))
 
+(deftest retries-unreachable-endpoint
+  (let [leader (atom "n1:21001")
+        attempts (atom [])
+        result (client/with-leader!
+                 leader
+                 ["n1:21001" "n2:21001" "n3:21001"]
+                 (fn [endpoint]
+                   (swap! attempts conj endpoint)
+                   (if (= "n1:21001" endpoint)
+                     (throw (ex-info "unreachable" {:kind :unreachable}))
+                     :ok)))]
+    (is (= :ok result))
+    (is (= ["n1:21001" "n2:21001"] @attempts)
+        "a connection failure proves nothing was applied and is retried")
+    (is (= "n2:21001" @leader))))
+
+(deftest ignores-empty-forward-target
+  (let [leader (atom "n1:21001")
+        attempts (atom [])
+        result (client/with-leader!
+                 leader
+                 ["n1:21001" "n2:21001" "n3:21001"]
+                 (fn [endpoint]
+                   (swap! attempts conj endpoint)
+                   (if (= "n1:21001" endpoint)
+                     (throw (forward-error ""))
+                     :ok)))]
+    (is (= :ok result))
+    (is (= ["n1:21001" "n2:21001"] @attempts)
+        "an empty forward target is skipped in favor of a known endpoint")
+    (is (= "n2:21001" @leader))))
+
 (deftest does-not-retry-request-timeout
   (let [leader (atom "n1:21001")
         attempts (atom 0)

--- a/jepsen/test/jepsen/openraft/workload_test.clj
+++ b/jepsen/test/jepsen/openraft/workload_test.clj
@@ -169,3 +169,43 @@
           (is (:unexpected? result))
           (is (= "server error" (:exception-message result)))
           (is (= 500 (get-in result [:exception-data :status]))))))))
+
+(deftest rethrows-interruptions
+  (let [op {:type :invoke :f :write :value "value"}]
+    (testing "a wrapped interruption from send! propagates instead of completing"
+      (with-redefs [http/write! (fn [& _]
+                                  (throw (ex-info "interrupted"
+                                                  {:kind :interrupted})))]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (client/invoke! (kv-client) {} op)))))
+
+    (testing "a raw InterruptedException propagates and restores the interrupt flag"
+      (with-redefs [http/write! (fn [& _]
+                                  (throw (InterruptedException. "boom")))]
+        ;; Capture the exception and interrupt flag before any assertion runs:
+        ;; clojure.test's report machinery uses dosync, which clears the flag.
+        (Thread/interrupted)
+        (let [thrown (try
+                       (client/invoke! (kv-client) {} op)
+                       nil
+                       (catch InterruptedException e e))
+              interrupted (Thread/interrupted)]
+          (is (instance? InterruptedException thrown))
+          (is interrupted
+              "the interrupt flag is restored so Jepsen's control signals survive"))))))
+
+(deftest unexpected-errors-checker-flags-tagged-operations
+  (let [chk (#'workload/unexpected-errors-checker)]
+    (testing "a history without unexpected errors is valid"
+      (let [result (checker/check chk {} [{:type :ok :f :read}] {})]
+        (is (:valid? result))
+        (is (= 0 (:count result)))
+        (is (= [] (:errors result)))))
+
+    (testing "unexpected-tagged operations fail the check and are surfaced"
+      (let [tagged {:type :info :f :write :error [:http 500] :unexpected? true}
+            history [{:type :ok :f :read} tagged]
+            result (checker/check chk {} history {})]
+        (is (not (:valid? result)))
+        (is (= 1 (:count result)))
+        (is (= [tagged] (:errors result)))))))


### PR DESCRIPTION
## Changelog

##### refactor: jepsen: preserve interrupts and skip empty leader forwards
# Summary

Apply code-review follow-ups to the Jepsen CAS workload: repair two
correctness gaps in the client's error handling and leader routing,
simplify redundant routing predicates, and document the invariants that
make value-based linearizability checking sound.

# Details

A raw InterruptedException thrown outside send! (which is the only place
that re-interrupts and tags the error) fell through to the client-error
default and was swallowed, clearing the interrupt flag Jepsen relies on
for control signals. handle-operation-exception now detects a raw
interrupt, restores the flag, and rethrows.

A ForwardToLeader response with an empty data field was treated as a
usable endpoint because "" is truthy in Clojure, causing a retry against
a garbage URI. next-endpoint now uses seq so an empty forward target
falls back to the known endpoints.

Simplify the routing code the review flagged: drop the redundant nil
guard in forward-to-leader? and quorum-not-enough? (contains? already
returns false on nil).

Document the value-to-version bijection that lets Knossos verify
linearizability over logical string values alone: values are globally
unique and a mutation is retried only after a failure proving it was not
applied. The note lives on cas-op so a future workload change cannot
silently invalidate it.

Add tests for the previously uncovered paths: the unreachable retry, the
empty forward guard, interrupt rethrow (raw and wrapped), and the
unexpected-errors checker.

- Fix: #1861

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1865)
<!-- Reviewable:end -->
