### PR TITLE
feat: add process nemesis

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -11,16 +11,23 @@ permissions:
 
 jobs:
   jepsen:
-    name: Jepsen
+    name: Jepsen (${{ matrix.nemesis }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        nemesis:
+          - partition
+          - process
 
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v4
 
       - name: Test | Jepsen
-        run: make -C jepsen jepsen
+        run: make -C jepsen jepsen NEMESIS=${{ matrix.nemesis }}
 
       - name: Debug | Docker logs
         if: failure()
@@ -32,7 +39,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: jepsen-results
+          name: jepsen-results-${{ matrix.nemesis }}
           path: |
             jepsen/store/
             jepsen/docker-compose.log

--- a/jepsen/Makefile
+++ b/jepsen/Makefile
@@ -1,8 +1,9 @@
 COMPOSE := docker compose -f docker/docker-compose.yml
 NODES ?= n1,n2,n3
 CONCURRENCY ?= 3
+NEMESIS ?= partition
 SSH_KEY ?= /root/.ssh/openraft-jepsen
-ARGS ?= --nodes $(NODES) --concurrency $(CONCURRENCY) --ssh-private-key $(SSH_KEY)
+ARGS ?= --nodes $(NODES) --concurrency $(CONCURRENCY) --nemesis $(NEMESIS) --ssh-private-key $(SSH_KEY)
 
 jepsen: build
 	@echo "[jepsen] starting containers"

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -53,6 +53,7 @@ jepsen/
     cluster.clj
     nemesis/
       partition.clj
+      process.clj
     workload.clj
 ```
 
@@ -63,6 +64,7 @@ The `jepsen.openraft` namespace contains the OpenRaft-specific Jepsen code:
 - `db.clj`: Jepsen DB lifecycle for starting and stopping OpenRaft nodes.
 - `cluster.clj`: cluster bootstrap helpers.
 - `nemesis/partition.clj`: leader-aware network partition faults and recovery.
+- `nemesis/process.clj`: quorum-safe process crashes and restarts.
 - `workload.clj`: generators and checkers for client operations.
 
 ## Running
@@ -88,6 +90,9 @@ $ make -C jepsen up
 # Run the linearizability test against the running containers.
 $ make -C jepsen test
 
+# Run the process crash/restart test instead of the default partition test.
+$ make -C jepsen test NEMESIS=process
+
 # Stop and remove the Jepsen containers.
 $ make -C jepsen down
 ```
@@ -101,6 +106,11 @@ lasts 10 seconds. A run is valid only if both modes occur, every node agrees on
 a leader after the final heal, client operations continue during recovery, and
 the final recovery write and read succeed.
 
+The process nemesis reads the effective voter configs from OpenRaft metrics and
+randomly stops a non-empty voter subset whose survivors still form a quorum. It
+supports both stable and joint membership, covers leader and follower-only
+crashes, and waits for every stopped node to rejoin after restart.
+
 ## TODO
 
 - [x] Add the Leiningen project definition and CLI skeleton.
@@ -111,7 +121,7 @@ the final recovery write and read succeed.
 - [x] Bootstrap a three-node OpenRaft cluster.
 - [ ] Record acknowledged write, read, and info operation counts in each run.
 - [x] Add a network partition nemesis.
-- [ ] Add nemeses for process kill/restart.
+- [x] Add nemeses for process kill/restart.
 - [x] Add a read, write, and compare-and-set workload.
 - [x] Add linearizability checking with Knossos.
 - [ ] Add snapshot pressure and membership churn workloads.

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -6,7 +6,11 @@
                     [tests :as tests]]
             [jepsen.openraft [db :as openraft-db]
                              [workload :as workload]]
-            [jepsen.openraft.nemesis [partition :as partition]]))
+            [jepsen.openraft.nemesis [partition :as partition]
+                                     [process :as process]]))
+
+(def nemesis-types
+  #{:partition :process})
 
 (def cli-opts
   [[nil "--api-port PORT" "OpenRaft application HTTP port."
@@ -15,15 +19,25 @@
 
    [nil "--raft-port PORT" "OpenRaft internal Raft RPC port."
     :default 22001
-    :parse-fn parse-long]])
+    :parse-fn parse-long]
+
+   [nil "--nemesis TYPE" "Fault type: partition or process."
+    :default :partition
+    :parse-fn keyword
+    :validate [nemesis-types (cli/one-of nemesis-types)]]])
 
 (defn openraft-test [opts]
-  (let [workload (workload/workload opts)
-        nemesis-package (partition/partition-package)]
+  (let [database (openraft-db/db opts)
+        workload (workload/workload opts)
+        nemesis-type (:nemesis opts :partition)
+        nemesis-package (case nemesis-type
+                          :partition (partition/partition-package)
+                          :process (process/process-package database))]
     (merge tests/noop-test
            opts
-           {:name "openraft linearizable register"
-            :db (openraft-db/db opts)
+           {:name (str "openraft linearizable register "
+                       (name nemesis-type))
+            :db database
             :client (:client workload)
             :nemesis (:nemesis nemesis-package)
             :generator (gen/phases

--- a/jepsen/src/jepsen/openraft/cluster.clj
+++ b/jepsen/src/jepsen/openraft/cluster.clj
@@ -4,6 +4,8 @@
             [jepsen.openraft.client :as client]
             [jepsen.util :as util]))
 
+;; TODO: Use an explicit node-name to OpenRaft ID mapping before introducing
+;; membership change nemeses.
 (defn node-id [test node]
   (let [index (.indexOf (:nodes test) node)]
     (when (neg? index)
@@ -45,6 +47,32 @@
          (throw (ex-info "OpenRaft cluster is not ready yet" {})))
     {:log-message "Waiting for every OpenRaft node to agree on a leader"
      :timeout 60000}))
+
+(defn voter-configs
+  "Maps the effective OpenRaft voter configs to Jepsen node names."
+  [test {:keys [leader metrics]}]
+  (let [configs (get-in metrics
+                        [leader
+                         :membership_config
+                         :membership
+                         :configs])
+        voter-ids (set (mapcat identity configs))]
+    (when-not (seq configs)
+      (throw (ex-info "OpenRaft metrics contain no voter configs"
+                      {:leader leader
+                       :metrics (get metrics leader)})))
+    (let [nodes-by-id (into {}
+                            (map (fn [node]
+                                   [(node-id test node) node])
+                                 (:nodes test)))
+          unknown-ids (remove #(contains? nodes-by-id %) voter-ids)]
+      (when (seq unknown-ids)
+        (throw (ex-info "OpenRaft voter is not a Jepsen test node"
+                        {:voter-ids voter-ids
+                         :unknown-ids (vec unknown-ids)})))
+      (mapv (fn [config]
+              (set (map nodes-by-id config)))
+            configs))))
 
 (defn bootstrap! [test]
   (let [leader (jepsen/primary test)

--- a/jepsen/src/jepsen/openraft/nemesis/partition.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/partition.clj
@@ -4,35 +4,41 @@
                     [generator :as gen]
                     [nemesis :as nemesis]
                     [random :as random]]
-            [jepsen.openraft.cluster :as cluster]))
+            [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.quorum :as quorum]))
 
 (def partition-seconds 10)
 (def recovery-seconds 5)
 (def required-partition-modes
   #{:leader-in-majority :leader-in-minority})
 
-(defn- partition-components [nodes leader mode]
-  (let [nodes (vec nodes)
-        node-count (count nodes)
-        majority-size (inc (quot node-count 2))
-        minority-size (- node-count majority-size)]
-    (when (< node-count 3)
-      (throw (ex-info "A partition test requires at least three nodes"
-                      {:nodes nodes})))
-    (when-not (some #{leader} nodes)
-      (throw (ex-info "The current leader is not a test node"
+(defn- partition-components [nodes configs leader mode]
+  (let [voters (quorum/voter-set configs)]
+    (when-not (contains? voters leader)
+      (throw (ex-info "The current leader is not a voter"
                       {:leader leader
-                       :nodes nodes})))
-    (let [leader-component-size (case mode
-                                  :leader-in-majority majority-size
-                                  :leader-in-minority minority-size
-                                  (throw (ex-info "Unknown partition mode"
-                                                  {:mode mode})))
-          followers (random/shuffle (remove #{leader} nodes))
-          leader-component (into [leader]
-                                 (take (dec leader-component-size) followers))
-          other-component (vec (remove (set leader-component) nodes))]
-      [leader-component other-component])))
+                       :configs configs})))
+    (let [quorums (remove #(= voters %)
+                          (quorum/quorum-sets configs))
+          candidates (case mode
+                       :leader-in-majority
+                       (filter #(contains? % leader) quorums)
+
+                       :leader-in-minority
+                       (remove #(contains? % leader) quorums)
+
+                       (throw (ex-info "Unknown partition mode"
+                                       {:mode mode})))
+          quorum-side (first (random/shuffle candidates))]
+      (when-not quorum-side
+        (throw (ex-info "Membership has no partition for the requested mode"
+                        {:leader leader
+                         :mode mode
+                         :configs configs})))
+      (let [other-side (remove quorum-side nodes)]
+        (if (contains? quorum-side leader)
+          [(vec (filter quorum-side nodes)) (vec other-side)]
+          [(vec other-side) (vec (filter quorum-side nodes))])))))
 
 (defrecord PartitionNemesis [partitioner]
   nemesis/Nemesis
@@ -42,9 +48,13 @@
   (invoke! [_ test op]
     (case (:f op)
       :start-partition
-      (let [{:keys [leader]} (cluster/await-ready! test)
+      (let [{:keys [leader] :as status} (cluster/await-ready! test)
+            configs (cluster/voter-configs test status)
             mode (:value op)
-            components (partition-components (:nodes test) leader mode)
+            components (partition-components (:nodes test)
+                                             configs
+                                             leader
+                                             mode)
             grudge (nemesis/complete-grudge components)]
         (info "Partitioning OpenRaft nodes"
               {:mode mode
@@ -57,6 +67,7 @@
         (assoc op
                :value {:mode mode
                        :leader leader
+                       :voter-configs configs
                        :components components}))
 
       :stop-partition

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -1,0 +1,185 @@
+(ns jepsen.openraft.nemesis.process
+  (:require [clojure.tools.logging :refer [info]]
+            [jepsen [checker :as checker]
+                    [generator :as gen]
+                    [nemesis :as nemesis]
+                    [random :as random]]
+            [jepsen.nemesis.combined :as combined]
+            [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.quorum :as quorum]))
+
+(def downtime-seconds 10)
+(def healthy-seconds 5)
+(def required-process-modes
+  #{:leader-killed :leader-survives})
+
+(defn- process-targets [nodes configs leader mode]
+  (let [voters (quorum/voter-set configs)]
+    (when-not (contains? voters leader)
+      (throw (ex-info "The current leader is not a voter"
+                      {:leader leader
+                       :configs configs})))
+    (let [candidates (case mode
+                       :leader-killed
+                       (filter #(contains? % leader)
+                               (quorum/fault-sets configs))
+
+                       :leader-survives
+                       (remove #(contains? % leader)
+                               (quorum/fault-sets configs))
+
+                       (throw (ex-info "Unknown process nemesis mode"
+                                       {:mode mode})))
+          target-set (first (random/shuffle candidates))]
+      (when-not target-set
+        (throw (ex-info "Membership has no quorum-safe process targets"
+                        {:leader leader
+                         :mode mode
+                         :configs configs})))
+      (->> nodes
+           (filter target-set)
+           vec))))
+
+(defrecord ProcessNemesis [delegate killed]
+  nemesis/Nemesis
+  (setup! [_ test]
+    (ProcessNemesis. (nemesis/setup! delegate test) (atom nil)))
+
+  (invoke! [_ test op]
+    (case (:f op)
+      :kill-process
+      (do
+        (when @killed
+          (throw (ex-info "Processes are already stopped"
+                          {:killed @killed})))
+        (let [status (cluster/await-ready! test)
+              leader (:leader status)
+              configs (cluster/voter-configs test status)
+              mode (:value op)
+              targets (process-targets (:nodes test)
+                                       configs
+                                       leader
+                                       mode)
+              voters (quorum/voter-set configs)
+              target-set (set targets)
+              survivors (->> (:nodes test)
+                             (filter voters)
+                             (remove target-set)
+                             vec)
+              disruption {:mode mode
+                          :leader leader
+                          :nodes targets
+                          :voter-configs configs
+                          :survivors survivors}]
+          (info "Killing OpenRaft processes" disruption)
+          (nemesis/invoke! delegate test
+                           (assoc op
+                                  :f :kill
+                                  :value targets))
+          (reset! killed disruption)
+          (assoc op :value disruption)))
+
+      :restart-process
+      (if-let [{:keys [nodes] :as disruption} @killed]
+        (do
+          (info "Restarting OpenRaft processes" {:nodes nodes})
+          (nemesis/invoke! delegate test
+                           (assoc op
+                                  :f :start
+                                  :value nodes))
+          (reset! killed nil)
+          (assoc op :value disruption))
+        (assoc op :value :no-processes-killed))
+
+      :await-recovery
+      (let [status (cluster/await-ready! test)]
+        (info "OpenRaft cluster recovered with leader" (:leader status))
+        (assoc op :value {:leader (:leader status)}))))
+
+  (teardown! [_ test]
+    (nemesis/teardown! delegate test)))
+
+(defn process-nemesis [db]
+  (nemesis/validate
+    (ProcessNemesis. (combined/db-nemesis db) (atom nil))))
+
+(defn- process-generator []
+  (gen/cycle
+    (gen/phases
+      (gen/sleep healthy-seconds)
+      {:type :info
+       :f :kill-process
+       :value :leader-survives}
+      (gen/sleep downtime-seconds)
+      {:type :info
+       :f :restart-process}
+      {:type :info
+       :f :await-recovery}
+      (gen/sleep healthy-seconds)
+      {:type :info
+       :f :kill-process
+       :value :leader-killed}
+      (gen/sleep downtime-seconds)
+      {:type :info
+       :f :restart-process}
+      {:type :info
+       :f :await-recovery})))
+
+(defn- coverage-checker []
+  (reify checker/Checker
+    (check [_ _test history _opts]
+      (let [observed-modes (->> history
+                                (filter #(= :kill-process (:f %)))
+                                (keep #(get-in % [:value :mode]))
+                                set)
+            missing-modes (remove observed-modes required-process-modes)
+            cluster-state (reduce
+                            (fn [state op]
+                              (let [operation-error? (boolean
+                                                      (or (:error op)
+                                                          (:exception op)))]
+                                (cond
+                                  (and (= :kill-process (:f op))
+                                       operation-error?)
+                                  :unknown
+
+                                  (and (= :kill-process (:f op))
+                                       (get-in op [:value :mode]))
+                                  :degraded
+
+                                  (and (= :restart-process (:f op))
+                                       operation-error?)
+                                  :unknown
+
+                                  (and (= :await-recovery (:f op))
+                                       (get-in op [:value :leader]))
+                                  :intact
+
+                                  (and (= :await-recovery (:f op))
+                                       operation-error?)
+                                  (if (= :degraded state)
+                                    :degraded
+                                    :unknown)
+
+                                  :else state)))
+                            :intact
+                            history)
+            valid? (cond
+                     (seq missing-modes) false
+                     (= :intact cluster-state) true
+                     (= :degraded cluster-state) false
+                     :else :unknown)]
+        {:valid? valid?
+         :observed-modes (vec (sort observed-modes))
+         :missing-modes (vec (sort missing-modes))
+         :cluster-state cluster-state}))))
+
+(defn process-package [db]
+  {:nemesis (process-nemesis db)
+   :generator (process-generator)
+   :final-generator (gen/phases
+                      (gen/once {:type :info
+                                 :f :restart-process})
+                      (gen/once {:type :info
+                                 :f :await-recovery}))
+   :checker (coverage-checker)})

--- a/jepsen/src/jepsen/openraft/quorum.clj
+++ b/jepsen/src/jepsen/openraft/quorum.clj
@@ -1,0 +1,46 @@
+(ns jepsen.openraft.quorum
+  (:require [clojure.set :as set]))
+
+(defn voter-set [configs]
+  (reduce set/union #{} (map set configs)))
+
+(defn quorum?
+  "True when nodes contain a majority of every voter config."
+  [configs nodes]
+  (let [nodes (set nodes)]
+    (every? (fn [config]
+              (let [config (set config)
+                    required (inc (quot (count config) 2))]
+                (>= (count (set/intersection config nodes))
+                    required)))
+            configs)))
+
+;; Jepsen clusters are small, so explicit enumeration keeps joint quorum
+;; selection simple and directly testable.
+(defn- subsets [items]
+  (reduce (fn [sets item]
+            (into sets (map #(conj % item) sets)))
+          [#{}]
+          items))
+
+(defn quorum-sets
+  "Enumerates every quorum of a stable or joint membership."
+  [configs]
+  (let [configs (mapv set configs)]
+    (when (or (empty? configs)
+              (some empty? configs))
+      (throw (ex-info "Membership must contain non-empty voter configs"
+                      {:configs configs})))
+    (->> (voter-set configs)
+         subsets
+         (filter #(quorum? configs %))
+         vec)))
+
+(defn fault-sets
+  "Enumerates non-empty voter subsets whose removal leaves a quorum."
+  [configs]
+  (let [voters (voter-set configs)]
+    (->> (quorum-sets configs)
+         (map #(set/difference voters %))
+         (remove empty?)
+         vec)))

--- a/jepsen/test/jepsen/openraft/cluster_test.clj
+++ b/jepsen/test/jepsen/openraft/cluster_test.clj
@@ -38,3 +38,22 @@
                               :current_leader nil}}]
     (with-redefs [client/metrics! metrics]
       (is (nil? (#'cluster/cluster-status test-config))))))
+
+(defn- membership [configs]
+  {:membership_config
+   {:membership
+    {:configs configs}}})
+
+(deftest maps-voter-configs-to-jepsen-nodes
+  (let [status {:leader "n2"
+                :metrics {"n2" (membership [[1 2 3]])}}]
+    (is (= [#{"n1" "n2" "n3"}]
+           (cluster/voter-configs test-config status)))))
+
+(deftest maps-joint-voter-configs
+  (let [test (assoc test-config :nodes ["n1" "n2" "n3" "n4"])
+        status {:leader "n2"
+                :metrics {"n2" (membership [[1 2 3] [1 2 4]])}}]
+    (is (= [#{"n1" "n2" "n3"}
+            #{"n1" "n2" "n4"}]
+           (cluster/voter-configs test status)))))

--- a/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
@@ -1,31 +1,35 @@
 (ns jepsen.openraft.nemesis.partition-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.set :as set]
+            [clojure.test :refer [deftest is testing]]
             [jepsen [checker :as checker]
                     [nemesis :as nemesis]]
             [jepsen.openraft.cluster :as cluster]
-            [jepsen.openraft.nemesis.partition :as partition]))
+            [jepsen.openraft.nemesis.partition :as partition]
+            [jepsen.openraft.quorum :as quorum]))
 
 (def nodes ["n1" "n2" "n3"])
 
 (deftest places-leader-in-requested-component
-  (testing "leader remains in the majority"
-    (let [[leader-side other-side]
-          (#'partition/partition-components
-            nodes
-            "n1"
-            :leader-in-majority)]
-      (is (contains? (set leader-side) "n1"))
-      (is (= 2 (count leader-side)))
-      (is (= 1 (count other-side)))))
-
-  (testing "leader is isolated in the minority"
-    (let [[leader-side other-side]
-          (#'partition/partition-components
-            nodes
-            "n1"
-            :leader-in-minority)]
-      (is (= ["n1"] leader-side))
-      (is (= #{"n2" "n3"} (set other-side))))))
+  (let [configs [(set nodes)]
+        quorums (set (quorum/quorum-sets configs))]
+    (doseq [mode [:leader-in-majority :leader-in-minority]]
+      (testing (name mode)
+        (let [[leader-side other-side]
+              (#'partition/partition-components
+                nodes
+                configs
+                "n1"
+                mode)
+              quorum-side (if (= mode :leader-in-majority)
+                            leader-side
+                            other-side)]
+          (is (contains? (set leader-side) "n1"))
+          (is (contains? quorums (set quorum-side)))
+          (is (= (set nodes)
+                 (set (concat leader-side other-side))))
+          (is (empty? (set/intersection (set leader-side)
+                                        (set other-side))))
+          (is (seq other-side)))))))
 
 (deftest resolves-leader-when-partition-starts
   (let [invocations (atom [])
@@ -43,7 +47,9 @@
             :f :start-partition
             :value :leader-in-minority}]
     (with-redefs [cluster/await-ready! (fn [_test]
-                                         {:leader "n2"})]
+                                         {:leader "n2"})
+                  cluster/voter-configs (fn [_test _status]
+                                          [(set nodes)])]
       (let [result (nemesis/invoke! subject {:nodes nodes} op)
             delegated (first @invocations)]
         (is (= :start (:f delegated)))

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -1,0 +1,112 @@
+(ns jepsen.openraft.nemesis.process-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen [checker :as checker]
+                    [nemesis :as nemesis]]
+            [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.nemesis.process :as process]
+            [jepsen.openraft.quorum :as quorum]))
+
+(def voters ["n1" "n2" "n3" "n4" "n5"])
+
+(deftest selects-fault-set-for-leader-mode
+  (let [configs [(set voters)]
+        fault-sets (set (quorum/fault-sets configs))]
+    (doseq [mode [:leader-killed :leader-survives]]
+      (testing (name mode)
+        (let [targets (#'process/process-targets
+                        voters
+                        configs
+                        "n1"
+                        mode)]
+          (is (contains? fault-sets (set targets)))
+          (is (= (= mode :leader-killed)
+                 (contains? (set targets) "n1"))))))))
+
+(deftest restarts-the-processes-that-were-killed
+  (let [invocations (atom [])
+        delegate (reify nemesis/Nemesis
+                   (setup! [this _test]
+                     this)
+                   (invoke! [_ _test op]
+                     (swap! invocations conj op)
+                     op)
+                   (teardown! [this _test]
+                     this))
+        subject (process/->ProcessNemesis delegate (atom nil))
+        test {:nodes ["n1" "n2" "n3"]}
+        status {:leader "n1"}]
+    (with-redefs [cluster/await-ready! (fn [_test] status)
+                  cluster/voter-configs
+                  (fn [_test _status] [(set (:nodes test))])]
+      (let [killed (nemesis/invoke!
+                     subject
+                     test
+                     {:type :info
+                      :f :kill-process
+                      :value :leader-killed})
+            restarted (nemesis/invoke!
+                        subject
+                        test
+                        {:type :info
+                         :f :restart-process})]
+        (is (= ["n1"] (get-in killed [:value :nodes])))
+        (is (= ["n1"] (get-in restarted [:value :nodes])))
+        (is (= [[:kill ["n1"]]
+                [:start ["n1"]]]
+               (mapv (juxt :f :value) @invocations)))))))
+
+(deftest requires-both-process-modes-and-an-intact-cluster
+  (let [subject (#'process/coverage-checker)
+        complete-history [{:f :kill-process
+                           :value {:mode :leader-survives}}
+                          {:f :await-recovery
+                           :value {:leader "n1"}}
+                          {:f :kill-process
+                           :value {:mode :leader-killed}}
+                          {:f :await-recovery
+                           :value {:leader "n2"}}]
+        missing-mode-history [{:f :kill-process
+                               :value {:mode :leader-survives}}]
+        unrecovered-history [{:f :kill-process
+                              :value {:mode :leader-survives}}
+                             {:f :await-recovery
+                              :value {:leader "n1"}}
+                             {:f :kill-process
+                              :value {:mode :leader-killed}}
+                             {:f :await-recovery
+                              :error :timeout}]]
+    (let [result (checker/check subject {} complete-history {})]
+      (is (:valid? result))
+      (is (= :intact (:cluster-state result))))
+    (let [result (checker/check subject {} missing-mode-history {})]
+      (is (false? (:valid? result)))
+      (is (= [:leader-killed] (:missing-modes result)))
+      (is (= :degraded (:cluster-state result))))
+    (let [result (checker/check subject {} unrecovered-history {})]
+      (is (false? (:valid? result)))
+      (is (empty? (:missing-modes result)))
+      (is (= :degraded (:cluster-state result))))))
+
+(deftest reports-an-indeterminate-process-state
+  (let [subject (#'process/coverage-checker)
+        covered-history [{:f :kill-process
+                          :value {:mode :leader-survives}}
+                         {:f :await-recovery
+                          :value {:leader "n1"}}
+                         {:f :kill-process
+                          :value {:mode :leader-killed}}
+                         {:f :await-recovery
+                          :value {:leader "n2"}}]
+        indeterminate-history (conj covered-history
+                                    {:f :kill-process
+                                     :value :leader-killed
+                                     :error :kill-failed})
+        recovered-history (conj indeterminate-history
+                                {:f :await-recovery
+                                 :value {:leader "n2"}})]
+    (let [result (checker/check subject {} indeterminate-history {})]
+      (is (= :unknown (:valid? result)))
+      (is (= :unknown (:cluster-state result))))
+    (let [result (checker/check subject {} recovered-history {})]
+      (is (:valid? result))
+      (is (= :intact (:cluster-state result))))))

--- a/jepsen/test/jepsen/openraft/quorum_test.clj
+++ b/jepsen/test/jepsen/openraft/quorum_test.clj
@@ -1,0 +1,38 @@
+(ns jepsen.openraft.quorum-test
+  (:require [clojure.set :as set]
+            [clojure.test :refer [deftest is]]
+            [jepsen.openraft.quorum :as quorum]))
+
+(deftest enumerates-stable-membership-quorums
+  (let [configs [#{"a" "b" "c"}]]
+    (is (= #{#{"a" "b"}
+             #{"a" "c"}
+             #{"b" "c"}
+             #{"a" "b" "c"}}
+           (set (quorum/quorum-sets configs))))))
+
+(deftest enumerates-joint-membership-quorums
+  (let [configs [#{"a" "b" "c"}
+                 #{"a" "b" "d"}]]
+    (is (= #{#{"a" "b"}
+             #{"a" "b" "c"}
+             #{"a" "b" "d"}
+             #{"a" "c" "d"}
+             #{"b" "c" "d"}
+             #{"a" "b" "c" "d"}}
+           (set (quorum/quorum-sets configs))))))
+
+(deftest fault-sets-leave-a-quorum-alive
+  (let [configs [#{"a" "b" "c"}
+                 #{"a" "b" "d"}]
+        voters (quorum/voter-set configs)
+        faults (quorum/fault-sets configs)]
+    (is (= #{#{"a"}
+             #{"b"}
+             #{"c"}
+             #{"d"}
+             #{"c" "d"}}
+           (set faults)))
+    (doseq [fault faults]
+      (is (quorum/quorum? configs
+                          (set/difference voters fault))))))


### PR DESCRIPTION

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

Part of #1597.

## Summary

This PR adds a quorum-aware process nemesis to the OpenRaft Jepsen test suite.

The nemesis exercises two process failure scenarios:

- `leader-survives`: stop one or more followers while keeping the current leader alive.
- `leader-killed`: stop a quorum-safe set of voters containing the current leader and require the surviving voters to elect a new leader.

Normal read, write, and CAS traffic continues while processes are stopped, restarted, and the cluster is recovering. The existing Knossos checker continues to verify linearizability throughout these failures.

## Quorum-aware fault selection

The process nemesis does not derive fault limits from the number of configured Jepsen nodes. Instead, it reads OpenRaft’s effective voter configurations from metrics.

OpenRaft node IDs are mapped to Jepsen node names, and a shared quorum helper enumerates the sets that contain a majority of every voter configuration.

A fault set is eligible only when:

- it is non-empty;
- removing it leaves a valid quorum;
- it satisfies the requested leader mode.

This means:

- a three-voter cluster may lose one voter;
- a five-voter cluster may lose one or two voters;
- a joint membership must retain a majority of every voter configuration.

The same quorum helper is now also used by the partition nemesis, replacing its previous node-count-based majority calculation.

## Process nemesis lifecycle

Before injecting a process failure, the nemesis waits for the cluster to agree on a leader and reads the current voter configuration.

It then runs the following cycle:

1. Keep the cluster healthy for 5 seconds.
2. Stop a quorum-safe voter set that excludes the leader.
3. Keep those processes unavailable for 10 seconds.
4. Restart the exact same processes.
5. Wait for the cluster to recover.
6. Keep the cluster healthy for another 5 seconds.
7. Stop a quorum-safe voter set containing the leader.
8. Keep those processes unavailable for 10 seconds.
9. Restart the exact same processes.
10. Wait for the cluster to recover.

The selected disruption is stored by the nemesis so that the restart operation always targets the processes stopped by the preceding kill operation. Overlapping process failures are rejected.

The final generator also restarts any remaining stopped processes and waits until every node agrees on a leader.

## Validation

A dedicated checker verifies that:

- the `leader-survives` scenario occurred;
- the `leader-killed` scenario occurred;
- the cluster successfully recovered.

The existing workload checker independently verifies that the read, write, and CAS history remains linearizable.

Unit tests cover:

- stable-membership quorum enumeration;
- joint-membership quorum enumeration;
- fault sets whose survivors retain a quorum;
- mapping OpenRaft voter IDs to Jepsen node names;
- selecting process targets for both leader modes;
- restarting the exact process set previously stopped;
- process nemesis coverage and recovery requirements;
- the partition nemesis using the shared quorum definition.

## CLI and CI

The Jepsen CLI now accepts:

```text
--nemesis partition
--nemesis process
```

The partition nemesis remains the default.

The process nemesis can be run locally with:

```bash
make -C jepsen jepsen NEMESIS=process
```

The Jepsen GitHub Actions workflow now runs `partition` and `process` as separate matrix jobs. Matrix fail-fast is disabled so that one nemesis failure does not prevent the other from completing, and failure artifacts are named by nemesis type.

## Documentation

The Jepsen README now documents:

- the new process nemesis;
- how to run it locally;
- its quorum-aware target selection;
- its leader and follower failure coverage.

## Current scope

This PR intentionally does not cover:

- removing enough voters to lose quorum;
- combining process failures with network partitions;
- concurrent membership changes;
- clock manipulation;
- disk corruption or persistent data loss.

The current node-name-to-OpenRaft-ID conversion still relies on the configured node order. An explicit mapping should be introduced before adding membership-change nemeses.



**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1870)
<!-- Reviewable:end -->
