### PR TITLE
fix: comparing std LeaderIds panics when voted_for is None

### DIFF
--- a/openraft/src/vote/leader_id/leader_id_std.rs
+++ b/openraft/src/vote/leader_id/leader_id_std.rs
@@ -9,7 +9,6 @@ use std::ops::DerefMut;
 use display_more::DisplayOptionExt;
 
 use crate::NodeId;
-use crate::vote::LeaderIdCompare;
 use crate::vote::RaftLeaderId;
 use crate::vote::RaftTerm;
 
@@ -40,7 +39,21 @@ where
 {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        LeaderIdCompare::std(self, other)
+        match self.term.cmp(&other.term) {
+            Ordering::Equal => match (&self.voted_for, &other.voted_for) {
+                (None, None) => Some(Ordering::Equal),
+                (Some(_), None) => Some(Ordering::Greater),
+                (None, Some(_)) => Some(Ordering::Less),
+                (Some(a), Some(b)) => {
+                    if a == b {
+                        Some(Ordering::Equal)
+                    } else {
+                        None
+                    }
+                }
+            },
+            cmp => Some(cmp),
+        }
     }
 }
 
@@ -247,6 +260,15 @@ mod tests {
         assert!(!(lid(2, 2) > lid(2, 3)));
         assert!(!(lid(2, 2) < lid(2, 3)));
         assert!(!(lid(2, 2) == lid(2, 3)));
+
+        // `voted_for: None` orders below any vote in the same term
+        let none = |term| LeaderId::<u64, u64> { term, voted_for: None };
+
+        assert!(none(2) == none(2));
+        assert!(none(2) < lid(2, 2));
+        assert!(lid(2, 2) > none(2));
+        assert!(none(1) < none(2));
+        assert!(lid(1, 2) < none(2));
 
         Ok(())
     }


### PR DESCRIPTION
## Changelog

##### fix: comparing std LeaderIds panics when voted_for is None

# Summary

Comparing two std `LeaderId`s with equal terms panics when one has `voted_for: None`, because `LeaderIdCompare::std` reaches `node_id()` which unwraps `voted_for`. This makes the comparison in `PartialOrd for LeaderId` option-aware: `None` is equal to `None` and orders below any vote in the same term, same-term votes for different nodes stay incomparable. Extends `test_std_leader_id_partial_order` to cover the `None` cases.

Fixes #1872

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1873)
<!-- Reviewable:end -->
