### PR TITLE
fix: track partition nemesis recovery state

### DIFF
--- a/jepsen/src/jepsen/openraft/nemesis/partition.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/partition.clj
@@ -109,6 +109,41 @@
       {:type :info
        :f :stop-partition})))
 
+(defn- next-cluster-state
+  "Applies one nemesis operation to the partition lifecycle state.
+
+  :intact means the network is healed and the cluster is ready.
+  :recovery-pending means a partition exists, or readiness after a heal has not
+  been confirmed. :unknown means a partition or heal returned an indeterminate
+  result.
+
+  A successful await-recovery does not clear :unknown: readiness only proves
+  that every node follows one leader, while leftover rules from an
+  indeterminate heal may still cut follower-to-follower links."
+  [state op]
+  (let [operation-error? (boolean (or (:error op)
+                                      (:exception op)))]
+    (case (:f op)
+      :start-partition
+      (cond
+        operation-error? :unknown
+        (get-in op [:value :mode]) :recovery-pending
+        :else state)
+
+      :stop-partition
+      (cond
+        operation-error? :unknown
+        (= :network-healed (:value op)) :recovery-pending
+        :else state)
+
+      :await-recovery
+      (cond
+        (= :unknown state) :unknown
+        (get-in op [:value :leader]) :intact
+        :else state)
+
+      state)))
+
 (defn- coverage-checker []
   (reify checker/Checker
     (check [_ _test history _opts]
@@ -117,14 +152,16 @@
                                 (keep #(get-in % [:value :mode]))
                                 set)
             missing-modes (remove observed-modes required-partition-modes)
-            recovered? (boolean
-                         (some #(and (= :await-recovery (:f %))
-                                     (get-in % [:value :leader]))
-                               history))]
-        {:valid? (and (empty? missing-modes) recovered?)
+            cluster-state (reduce next-cluster-state :intact history)
+            valid? (cond
+                     (seq missing-modes) false
+                     (= :intact cluster-state) true
+                     (= :recovery-pending cluster-state) false
+                     :else :unknown)]
+        {:valid? valid?
          :observed-modes (vec (sort observed-modes))
          :missing-modes (vec (sort missing-modes))
-         :recovered? recovered?}))))
+         :cluster-state cluster-state}))))
 
 (defn partition-package []
   {:nemesis (partition-nemesis)

--- a/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
@@ -60,18 +60,159 @@
         (is (= "n2"
                (-> result :value :leader)))))))
 
-(deftest requires-both-partitions-and-recovery
+(deftest requires-both-partitions-and-an-intact-cluster
   (let [subject (#'partition/coverage-checker)
         complete-history [{:f :start-partition
                            :value {:mode :leader-in-majority}}
+                          {:f :stop-partition
+                           :value :network-healed}
                           {:f :start-partition
                            :value {:mode :leader-in-minority}}
+                          {:f :stop-partition
+                           :value :network-healed}
                           {:f :await-recovery
                            :value {:leader "n2"}}]
-        incomplete-history [{:f :start-partition
-                             :value {:mode :leader-in-majority}}]]
-    (is (:valid? (checker/check subject {} complete-history {})))
-    (let [result (checker/check subject {} incomplete-history {})]
-      (is (false? (:valid? result)))
-      (is (= [:leader-in-minority] (:missing-modes result)))
-      (is (false? (:recovered? result))))))
+        missing-mode-history [{:f :start-partition
+                               :value {:mode :leader-in-majority}}
+                              {:f :stop-partition
+                               :value :network-healed}
+                              {:f :start-partition
+                               :value :leader-in-minority
+                               :error :partition-failed}
+                              {:f :stop-partition
+                               :value :network-healed}
+                              {:f :await-recovery
+                               :value {:leader "n2"}}]
+        unrecovered-history [{:f :start-partition
+                              :value {:mode :leader-in-majority}}
+                             {:f :stop-partition
+                              :value :network-healed}
+                             {:f :start-partition
+                              :value {:mode :leader-in-minority}}
+                             {:f :stop-partition
+                              :value :network-healed}
+                             {:f :await-recovery
+                              :error :timeout}]]
+    (testing "both modes complete and the cluster recovers"
+      (let [result (checker/check subject {} complete-history {})]
+        (is (:valid? result))
+        (is (= :intact (:cluster-state result)))))
+    (testing "a failed partition does not count toward coverage"
+      (let [result (checker/check subject {} missing-mode-history {})]
+        (is (false? (:valid? result)))
+        (is (= [:leader-in-minority] (:missing-modes result)))
+        (is (= :intact (:cluster-state result)))))
+    (testing "a confirmed heal followed by a timeout fails recovery"
+      (let [result (checker/check subject {} unrecovered-history {})]
+        (is (false? (:valid? result)))
+        (is (empty? (:missing-modes result)))
+        (is (= :recovery-pending (:cluster-state result)))))))
+
+(deftest handles-realistic-invoke-and-completion-history
+  (let [subject (#'partition/coverage-checker)
+        history [{:type :info
+                  :process :nemesis
+                  :f :start-partition
+                  :value :leader-in-majority}
+                 {:type :info
+                  :process :nemesis
+                  :f :start-partition
+                  :value {:mode :leader-in-majority
+                          :leader "n1"}}
+                 {:type :info
+                  :process :nemesis
+                  :f :stop-partition
+                  :value nil}
+                 {:type :info
+                  :process :nemesis
+                  :f :stop-partition
+                  :value :network-healed}
+                 {:type :info
+                  :process :nemesis
+                  :f :start-partition
+                  :value :leader-in-minority}
+                 {:type :info
+                  :process :nemesis
+                  :f :start-partition
+                  :value {:mode :leader-in-minority
+                          :leader "n1"}}
+                 {:type :info
+                  :process :nemesis
+                  :f :stop-partition
+                  :value nil}
+                 {:type :info
+                  :process :nemesis
+                  :f :stop-partition
+                  :value :network-healed}
+                 {:type :info
+                  :process :nemesis
+                  :f :await-recovery
+                  :value nil}
+                 {:type :info
+                  :process :nemesis
+                  :f :await-recovery
+                  :value {:leader "n2"}}
+                 {:type :info
+                  :process :nemesis
+                  :f :await-recovery
+                  :value nil}
+                 {:type :info
+                  :process :nemesis
+                  :f :await-recovery
+                  :value {:leader "n2"}}]
+        result (checker/check subject {} history {})]
+    (is (:valid? result))
+    (is (= [:leader-in-majority :leader-in-minority]
+           (:observed-modes result)))
+    (is (= :intact (:cluster-state result)))))
+
+(deftest reports-an-indeterminate-partition-state
+  (let [subject (#'partition/coverage-checker)
+        covered-history [{:f :start-partition
+                          :value {:mode :leader-in-majority}}
+                         {:f :stop-partition
+                          :value :network-healed}
+                         {:f :start-partition
+                          :value {:mode :leader-in-minority}}
+                         {:f :stop-partition
+                          :value :network-healed}
+                         {:f :await-recovery
+                          :value {:leader "n2"}}]
+        indeterminate-history
+        (conj covered-history
+              {:type :info
+               :process :nemesis
+               :f :start-partition
+               :value :leader-in-majority
+               :error "indeterminate: partition failed"
+               :exception (ex-info "partition failed" {})})
+        result (checker/check subject {} indeterminate-history {})]
+    (is (= :unknown (:valid? result)))
+    (is (= :unknown (:cluster-state result)))))
+
+(deftest reports-an-indeterminate-heal-state
+  (let [subject (#'partition/coverage-checker)
+        history-before-heal [{:f :start-partition
+                              :value {:mode :leader-in-majority}}
+                             {:f :stop-partition
+                              :value :network-healed}
+                             {:f :start-partition
+                              :value {:mode :leader-in-minority}}
+                             {:f :stop-partition
+                              :error :heal-failed}]
+        indeterminate-history (conj history-before-heal
+                                    {:f :await-recovery
+                                     :value {:leader "n2"}})
+        recovered-history (into history-before-heal
+                                [{:f :stop-partition
+                                  :value :network-healed}
+                                 {:f :await-recovery
+                                  :value {:leader "n2"}}])]
+    (testing "a successful readiness check cannot prove that a failed heal completed"
+      (let [result (checker/check subject {} indeterminate-history {})]
+        (is (= :unknown (:valid? result)))
+        (is (= :unknown (:cluster-state result)))))
+    (testing "a later confirmed heal and recovery restore the intact state"
+      (let [result (checker/check subject {} recovered-history {})]
+        (is (:valid? result))
+        (is (= :intact (:cluster-state result)))))))


### PR DESCRIPTION
Partition recovery was treated as a historical boolean, which could not distinguish a confirmed timeout from an indeterminate heal. Track the lifecycle state so the harness reports each result accurately.

Closes #1878

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1879)
<!-- Reviewable:end -->
