### PR TITLE
refactor: unify the broadcast-to-every-voter skeleton

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -10,6 +10,7 @@ compile_error!(
 mod expand;
 mod since;
 pub(crate) mod utils;
+mod variant_name;
 
 use proc_macro::TokenStream;
 use quote::quote;
@@ -246,4 +247,51 @@ fn do_since(args: TokenStream, item: TokenStream) -> Result<TokenStream, syn::Er
 pub fn expand(item: TokenStream) -> TokenStream {
     let repeat = parse_macro_input!(item as expand::Expand);
     repeat.render().into()
+}
+
+/// Derive `COUNT`, `ALL`, `index()`, `as_str()` and `Display` for an enum that names the
+/// variants of another type.
+///
+/// Such a "name" enum is used to count events into a fixed-size array, so each variant needs a
+/// stable index and the set of indices must be dense. This derive keeps the index, the variant
+/// list and the count in agreement by generating all three from the enum definition.
+///
+/// The enum must derive `Copy`, and every variant must either be a unit variant or wrap exactly
+/// one other name enum. A wrapping variant is expanded in place: it occupies as many indices as
+/// the inner enum has variants, and delegates `as_str()` to it.
+///
+/// `#[variant_name(prefix = "...")]` prepends a string to the rendering of every unit variant.
+///
+/// # Example
+///
+/// ```
+/// use openraft_macros::VariantName;
+///
+/// #[derive(Clone, Copy, VariantName)]
+/// #[variant_name(prefix = "SM::")]
+/// enum SmName {
+///     Build,
+///     Apply,
+/// }
+///
+/// #[derive(Clone, Copy, VariantName)]
+/// enum Name {
+///     Vote,
+///     StateMachine(SmName),
+///     Respond,
+/// }
+///
+/// assert_eq!(Name::COUNT, 4);
+/// assert_eq!(Name::StateMachine(SmName::Apply).index(), 2);
+/// assert_eq!(Name::Respond.index(), 3);
+/// assert_eq!(Name::StateMachine(SmName::Apply).as_str(), "SM::Apply");
+/// assert_eq!(Name::Vote.as_str(), "Vote");
+/// ```
+#[proc_macro_derive(VariantName, attributes(variant_name))]
+pub fn variant_name(item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as syn::DeriveInput);
+    match variant_name::expand(input) {
+        Ok(tokens) => tokens.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
 }

--- a/macros/src/variant_name.rs
+++ b/macros/src/variant_name.rs
@@ -1,0 +1,168 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::Data;
+use syn::DeriveInput;
+use syn::Fields;
+use syn::LitStr;
+use syn::Type;
+use syn::spanned::Spanned;
+
+/// A variant of a name enum, reduced to what code generation needs.
+enum Variant {
+    /// A unit variant. It occupies one slot and renders as `<prefix><ident>`.
+    Unit { ident: syn::Ident, text: String },
+
+    /// A variant wrapping another name enum. It occupies that enum's `COUNT` slots and
+    /// delegates its rendering to the inner enum.
+    Nested { ident: syn::Ident, inner: Box<Type> },
+}
+
+/// Expand `#[derive(VariantName)]` for `input`.
+pub(crate) fn expand(input: DeriveInput) -> Result<TokenStream, syn::Error> {
+    let name = &input.ident;
+    let prefix = parse_prefix(&input)?;
+    let variants = parse_variants(&input, &prefix)?;
+
+    // Slot offsets are not always literals: a nested variant occupies `Inner::COUNT` slots, and
+    // that value is unknown here. An offset is therefore carried as a count of the unit variants
+    // seen so far plus the list of inner enums seen so far.
+    let mut units = 0usize;
+    let mut nested = Vec::new();
+
+    let mut all_writes = Vec::new();
+    let mut index_arms = Vec::new();
+    let mut as_str_arms = Vec::new();
+
+    for variant in &variants {
+        let offset = quote! { #units #( + <#nested>::COUNT )* };
+
+        match variant {
+            Variant::Unit { ident, text } => {
+                all_writes.push(quote! { all[#offset] = #name::#ident; });
+                index_arms.push(quote! { #name::#ident => #offset, });
+                as_str_arms.push(quote! { #name::#ident => #text, });
+                units += 1;
+            }
+            Variant::Nested { ident, inner } => {
+                all_writes.push(quote! {
+                    {
+                        let mut i = 0usize;
+                        while i < <#inner>::COUNT {
+                            all[#offset + i] = #name::#ident(<#inner>::ALL[i]);
+                            i += 1;
+                        }
+                    }
+                });
+                index_arms.push(quote! { #name::#ident(inner) => #offset + inner.index(), });
+                as_str_arms.push(quote! { #name::#ident(inner) => inner.as_str(), });
+                nested.push(inner.clone());
+            }
+        }
+    }
+
+    let count = quote! { #units #( + <#nested>::COUNT )* };
+
+    // `[expr; N]` needs a value to fill the array with before the real ones are written.
+    let filler = match &variants[0] {
+        Variant::Unit { ident, .. } => quote! { #name::#ident },
+        Variant::Nested { ident, inner } => quote! { #name::#ident(<#inner>::ALL[0]) },
+    };
+
+    Ok(quote! {
+        impl #name {
+            /// Total number of variants, counting a variant that wraps another name enum as
+            /// that enum's `COUNT`.
+            #[allow(dead_code)]
+            pub const COUNT: usize = #count;
+
+            /// All variants in canonical order, with wrapped name enums expanded in place.
+            #[allow(dead_code)]
+            pub const ALL: &'static [Self] = &Self::build_all();
+
+            /// Returns the index of this variant, equal to its position in [`Self::ALL`].
+            #[allow(dead_code)]
+            pub const fn index(&self) -> usize {
+                match self {
+                    #( #index_arms )*
+                }
+            }
+
+            /// Returns the string representation of this variant.
+            #[allow(dead_code)]
+            pub const fn as_str(&self) -> &'static str {
+                match self {
+                    #( #as_str_arms )*
+                }
+            }
+
+            const fn build_all() -> [Self; Self::COUNT] {
+                let mut all = [#filler; Self::COUNT];
+                #( #all_writes )*
+                all
+            }
+        }
+
+        impl std::fmt::Display for #name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+    })
+}
+
+/// Read the optional `#[variant_name(prefix = "...")]` attribute.
+fn parse_prefix(input: &DeriveInput) -> Result<String, syn::Error> {
+    let mut prefix = String::new();
+
+    for attr in &input.attrs {
+        if !attr.path().is_ident("variant_name") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("prefix") {
+                prefix = meta.value()?.parse::<LitStr>()?.value();
+                Ok(())
+            } else {
+                Err(meta.error("unsupported `variant_name` argument, expected `prefix`"))
+            }
+        })?;
+    }
+
+    Ok(prefix)
+}
+
+fn parse_variants(input: &DeriveInput, prefix: &str) -> Result<Vec<Variant>, syn::Error> {
+    let Data::Enum(data) = &input.data else {
+        return Err(syn::Error::new(input.ident.span(), "VariantName only applies to enums"));
+    };
+
+    if data.variants.is_empty() {
+        return Err(syn::Error::new(
+            input.ident.span(),
+            "VariantName needs at least one variant",
+        ));
+    }
+
+    data.variants
+        .iter()
+        .map(|variant| {
+            let ident = variant.ident.clone();
+
+            match &variant.fields {
+                Fields::Unit => Ok(Variant::Unit {
+                    text: format!("{}{}", prefix, ident),
+                    ident,
+                }),
+                Fields::Unnamed(fields) if fields.unnamed.len() == 1 => Ok(Variant::Nested {
+                    ident,
+                    inner: Box::new(fields.unnamed[0].ty.clone()),
+                }),
+                _ => Err(syn::Error::new(
+                    variant.fields.span(),
+                    "VariantName variants must be a unit variant or wrap exactly one name enum",
+                )),
+            }
+        })
+        .collect()
+}

--- a/macros/tests/test_variant_name.rs
+++ b/macros/tests/test_variant_name.rs
@@ -1,0 +1,238 @@
+//! Behavior of `#[derive(VariantName)]`.
+//!
+//! The derive emits `COUNT`, `ALL`, `index()`, `as_str()` and `Display` from one enum definition
+//! precisely so they cannot disagree. These tests pin each generated item against a full expected
+//! value and then assert the agreement between them, since that agreement — not any single item —
+//! is what callers rely on when they use `index()` to address a `[T; COUNT]` array.
+
+use openraft_macros::VariantName;
+
+/// A leaf enum whose variants render with a prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, VariantName)]
+#[variant_name(prefix = "sm::")]
+enum SmName {
+    Build,
+    Apply,
+}
+
+/// A leaf enum with no prefix, of a different length than [`SmName`] so the two cannot be
+/// confused when both are nested into the same outer enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, VariantName)]
+enum ExtName {
+    Snapshot,
+    Purge,
+    Trigger,
+}
+
+/// Two nested variants, neither first nor last, so every offset position is covered: before any
+/// nesting, between two nestings, and after both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, VariantName)]
+#[variant_name(prefix = "outer::")]
+enum Outer {
+    Vote,
+    StateMachine(SmName),
+    Respond,
+    External(ExtName),
+    Tick,
+}
+
+/// A nested variant in first position, where the array filler has to come from the inner enum
+/// rather than from a unit variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, VariantName)]
+enum NestedFirst {
+    Sm(SmName),
+    Tail,
+}
+
+/// The smallest enum the derive accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, VariantName)]
+enum Solo {
+    Only,
+}
+
+/// Nesting is transitive: the enum wrapped here already contains nested variants of its own, so
+/// its `COUNT` and `ALL` are themselves expansions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, VariantName)]
+#[variant_name(prefix = "deep::")]
+enum Deep {
+    Head,
+    Nested(Outer),
+    Tail,
+}
+
+/// `index()` addresses a fixed-size array, so the indices must be exactly `0..COUNT` in `ALL`
+/// order. Nothing in the generated code ties `COUNT`, `ALL` and `index()` together; this checks it.
+macro_rules! assert_dense_index {
+    ($($ty:ty),* $(,)?) => {$({
+        assert_eq!(
+            <$ty>::ALL.len(),
+            <$ty>::COUNT,
+            "{}: ALL must hold exactly COUNT variants",
+            stringify!($ty)
+        );
+
+        for (i, variant) in <$ty>::ALL.iter().enumerate() {
+            assert_eq!(
+                variant.index(),
+                i,
+                "{}: {:?} must report its own position in ALL",
+                stringify!($ty),
+                variant
+            );
+        }
+    })*};
+}
+
+#[test]
+fn count_counts_a_nested_variant_as_the_whole_inner_enum() {
+    assert_eq!(SmName::COUNT, 2);
+    assert_eq!(ExtName::COUNT, 3);
+    assert_eq!(Solo::COUNT, 1);
+
+    // 3 unit variants, plus SmName's 2 and ExtName's 3.
+    assert_eq!(Outer::COUNT, 8);
+    assert_eq!(NestedFirst::COUNT, 3);
+}
+
+#[test]
+fn all_expands_a_nested_variant_in_place() {
+    assert_eq!(SmName::ALL, &[SmName::Build, SmName::Apply]);
+    assert_eq!(ExtName::ALL, &[ExtName::Snapshot, ExtName::Purge, ExtName::Trigger]);
+    assert_eq!(Solo::ALL, &[Solo::Only]);
+
+    assert_eq!(Outer::ALL, &[
+        Outer::Vote,
+        Outer::StateMachine(SmName::Build),
+        Outer::StateMachine(SmName::Apply),
+        Outer::Respond,
+        Outer::External(ExtName::Snapshot),
+        Outer::External(ExtName::Purge),
+        Outer::External(ExtName::Trigger),
+        Outer::Tick,
+    ]);
+
+    assert_eq!(NestedFirst::ALL, &[
+        NestedFirst::Sm(SmName::Build),
+        NestedFirst::Sm(SmName::Apply),
+        NestedFirst::Tail,
+    ]);
+}
+
+#[test]
+fn index_equals_position_in_all() {
+    assert_dense_index!(SmName, ExtName, Solo, Outer, NestedFirst, Deep);
+}
+
+#[test]
+fn nesting_is_transitive() {
+    assert_eq!(Deep::COUNT, 2 + Outer::COUNT);
+
+    assert_eq!(Deep::Head.index(), 0);
+    assert_eq!(Deep::Nested(Outer::Vote).index(), 1);
+    assert_eq!(Deep::Nested(Outer::Tick).index(), 1 + Outer::Tick.index());
+    assert_eq!(Deep::Tail.index(), 1 + Outer::COUNT);
+
+    // The rendering of a twice-nested variant comes from the innermost enum, so neither the
+    // `deep::` nor the `outer::` prefix reaches it.
+    assert_eq!(Deep::Head.as_str(), "deep::Head");
+    assert_eq!(Deep::Nested(Outer::Vote).as_str(), "outer::Vote");
+    assert_eq!(Deep::Nested(Outer::StateMachine(SmName::Apply)).as_str(), "sm::Apply");
+    assert_eq!(Deep::Nested(Outer::External(ExtName::Purge)).as_str(), "Purge");
+
+    // `ALL` splices in the inner enum's own expansion rather than one entry per inner variant.
+    let inner = &Deep::ALL[1..1 + Outer::COUNT];
+    let expected = Outer::ALL.iter().map(|v| Deep::Nested(*v)).collect::<Vec<_>>();
+    assert_eq!(inner, expected);
+}
+
+#[test]
+fn index_after_a_nested_variant_skips_the_whole_inner_enum() {
+    // Written against the inner `COUNT`s rather than literals: these relationships are what must
+    // survive an inner enum gaining a variant.
+    assert_eq!(Outer::Vote.index(), 0);
+    assert_eq!(Outer::StateMachine(SmName::Build).index(), 1);
+    assert_eq!(Outer::StateMachine(SmName::Apply).index(), 1 + SmName::Apply.index());
+    assert_eq!(Outer::Respond.index(), 1 + SmName::COUNT);
+    assert_eq!(Outer::External(ExtName::Snapshot).index(), 2 + SmName::COUNT);
+    assert_eq!(
+        Outer::External(ExtName::Trigger).index(),
+        2 + SmName::COUNT + ExtName::Trigger.index()
+    );
+    assert_eq!(Outer::Tick.index(), 2 + SmName::COUNT + ExtName::COUNT);
+
+    assert_eq!(NestedFirst::Sm(SmName::Build).index(), 0);
+    assert_eq!(NestedFirst::Tail.index(), SmName::COUNT);
+}
+
+#[test]
+fn as_str_prefixes_unit_variants_and_delegates_nested_ones() {
+    let names = |all: &[SmName]| all.iter().map(|v| v.as_str()).collect::<Vec<_>>();
+    assert_eq!(names(SmName::ALL), ["sm::Build", "sm::Apply"]);
+
+    let names = |all: &[ExtName]| all.iter().map(|v| v.as_str()).collect::<Vec<_>>();
+    assert_eq!(names(ExtName::ALL), ["Snapshot", "Purge", "Trigger"]);
+
+    // A nested variant keeps the inner enum's rendering, so it carries the inner prefix and not
+    // the outer one.
+    let names = |all: &[Outer]| all.iter().map(|v| v.as_str()).collect::<Vec<_>>();
+    assert_eq!(names(Outer::ALL), [
+        "outer::Vote",
+        "sm::Build",
+        "sm::Apply",
+        "outer::Respond",
+        "Snapshot",
+        "Purge",
+        "Trigger",
+        "outer::Tick",
+    ]);
+
+    assert_eq!(Solo::Only.as_str(), "Only");
+}
+
+#[test]
+fn display_renders_as_str() {
+    assert_eq!(Outer::Vote.to_string(), "outer::Vote");
+    assert_eq!(Outer::StateMachine(SmName::Apply).to_string(), "sm::Apply");
+    assert_eq!(Outer::External(ExtName::Purge).to_string(), "Purge");
+    assert_eq!(Solo::Only.to_string(), "Only");
+
+    for variant in Outer::ALL {
+        assert_eq!(variant.to_string(), variant.as_str());
+    }
+}
+
+#[test]
+fn generated_items_are_const() {
+    const COUNT: usize = Outer::COUNT;
+    const ALL: &[Outer] = Outer::ALL;
+    const UNIT_INDEX: usize = Outer::Tick.index();
+    const NESTED_INDEX: usize = Outer::External(ExtName::Purge).index();
+    const UNIT_NAME: &str = Outer::Tick.as_str();
+    const NESTED_NAME: &str = Outer::StateMachine(SmName::Build).as_str();
+
+    assert_eq!(COUNT, 8);
+    assert_eq!(ALL.len(), 8);
+    assert_eq!(UNIT_INDEX, 7);
+    assert_eq!(NESTED_INDEX, 5);
+    assert_eq!(UNIT_NAME, "outer::Tick");
+    assert_eq!(NESTED_NAME, "sm::Build");
+}
+
+/// `index()` is generated to address an array of exactly `COUNT` counters, which is the reason the
+/// three items have to agree. This walks that use case end to end.
+#[test]
+fn index_addresses_a_count_sized_array() {
+    let mut counters = [0usize; Outer::COUNT];
+
+    for variant in Outer::ALL {
+        counters[variant.index()] += 1;
+    }
+
+    assert_eq!(counters, [1; Outer::COUNT]);
+}
+
+#[test]
+fn fail() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/variant_name/fail/*.rs");
+}

--- a/macros/tests/variant_name/fail/empty_enum.rs
+++ b/macros/tests/variant_name/fail/empty_enum.rs
@@ -1,0 +1,6 @@
+#![allow(dead_code)]
+
+#[derive(openraft_macros::VariantName)]
+enum NoVariants {}
+
+fn main() {}

--- a/macros/tests/variant_name/fail/empty_enum.stderr
+++ b/macros/tests/variant_name/fail/empty_enum.stderr
@@ -1,0 +1,5 @@
+error: VariantName needs at least one variant
+ --> tests/variant_name/fail/empty_enum.rs:4:6
+  |
+4 | enum NoVariants {}
+  |      ^^^^^^^^^^

--- a/macros/tests/variant_name/fail/empty_tuple_variant.rs
+++ b/macros/tests/variant_name/fail/empty_tuple_variant.rs
@@ -1,0 +1,9 @@
+#![allow(dead_code)]
+
+#[derive(openraft_macros::VariantName)]
+enum Name {
+    Unit,
+    Empty(),
+}
+
+fn main() {}

--- a/macros/tests/variant_name/fail/empty_tuple_variant.stderr
+++ b/macros/tests/variant_name/fail/empty_tuple_variant.stderr
@@ -1,0 +1,5 @@
+error: VariantName variants must be a unit variant or wrap exactly one name enum
+ --> tests/variant_name/fail/empty_tuple_variant.rs:6:10
+  |
+6 |     Empty(),
+  |          ^^

--- a/macros/tests/variant_name/fail/multi_field_variant.rs
+++ b/macros/tests/variant_name/fail/multi_field_variant.rs
@@ -1,0 +1,9 @@
+#![allow(dead_code)]
+
+#[derive(openraft_macros::VariantName)]
+enum Name {
+    Unit,
+    Pair(u32, u32),
+}
+
+fn main() {}

--- a/macros/tests/variant_name/fail/multi_field_variant.stderr
+++ b/macros/tests/variant_name/fail/multi_field_variant.stderr
@@ -1,0 +1,5 @@
+error: VariantName variants must be a unit variant or wrap exactly one name enum
+ --> tests/variant_name/fail/multi_field_variant.rs:6:9
+  |
+6 |     Pair(u32, u32),
+  |         ^^^^^^^^^^

--- a/macros/tests/variant_name/fail/named_field_variant.rs
+++ b/macros/tests/variant_name/fail/named_field_variant.rs
@@ -1,0 +1,9 @@
+#![allow(dead_code)]
+
+#[derive(openraft_macros::VariantName)]
+enum Name {
+    Unit,
+    Named { a: u32 },
+}
+
+fn main() {}

--- a/macros/tests/variant_name/fail/named_field_variant.stderr
+++ b/macros/tests/variant_name/fail/named_field_variant.stderr
@@ -1,0 +1,5 @@
+error: VariantName variants must be a unit variant or wrap exactly one name enum
+ --> tests/variant_name/fail/named_field_variant.rs:6:11
+  |
+6 |     Named { a: u32 },
+  |           ^^^^^^^^^^

--- a/macros/tests/variant_name/fail/on_struct.rs
+++ b/macros/tests/variant_name/fail/on_struct.rs
@@ -1,0 +1,8 @@
+#![allow(dead_code)]
+
+#[derive(openraft_macros::VariantName)]
+struct NotAnEnum {
+    a: u32,
+}
+
+fn main() {}

--- a/macros/tests/variant_name/fail/on_struct.stderr
+++ b/macros/tests/variant_name/fail/on_struct.stderr
@@ -1,0 +1,5 @@
+error: VariantName only applies to enums
+ --> tests/variant_name/fail/on_struct.rs:4:8
+  |
+4 | struct NotAnEnum {
+  |        ^^^^^^^^^

--- a/macros/tests/variant_name/fail/on_union.rs
+++ b/macros/tests/variant_name/fail/on_union.rs
@@ -1,0 +1,8 @@
+#![allow(dead_code)]
+
+#[derive(openraft_macros::VariantName)]
+union NotAnEnum {
+    a: u32,
+}
+
+fn main() {}

--- a/macros/tests/variant_name/fail/on_union.stderr
+++ b/macros/tests/variant_name/fail/on_union.stderr
@@ -1,0 +1,5 @@
+error: VariantName only applies to enums
+ --> tests/variant_name/fail/on_union.rs:4:7
+  |
+4 | union NotAnEnum {
+  |       ^^^^^^^^^

--- a/macros/tests/variant_name/fail/unknown_attribute_arg.rs
+++ b/macros/tests/variant_name/fail/unknown_attribute_arg.rs
@@ -1,0 +1,9 @@
+#![allow(dead_code)]
+
+#[derive(openraft_macros::VariantName)]
+#[variant_name(suffix = "::")]
+enum Name {
+    Unit,
+}
+
+fn main() {}

--- a/macros/tests/variant_name/fail/unknown_attribute_arg.stderr
+++ b/macros/tests/variant_name/fail/unknown_attribute_arg.stderr
@@ -1,0 +1,5 @@
+error: unsupported `variant_name` argument, expected `prefix`
+ --> tests/variant_name/fail/unknown_attribute_arg.rs:4:16
+  |
+4 | #[variant_name(suffix = "::")]
+  |                ^^^^^^

--- a/openraft/src/core/notification_name.rs
+++ b/openraft/src/core/notification_name.rs
@@ -1,9 +1,12 @@
+use openraft_macros::VariantName;
+
 /// Enum representing the name of each `Notification` variant.
 ///
 /// This provides an efficient way to identify notification types without
 /// string comparisons, useful for logging, metrics, and debugging.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(VariantName)]
+#[variant_name(prefix = "Notify::")]
 pub enum NotificationName {
     VoteResponse,
     PreVoteResponse,
@@ -14,63 +17,6 @@ pub enum NotificationName {
     HeartbeatProgress,
     StateMachine,
     Tick,
-}
-
-impl NotificationName {
-    /// Total number of variants.
-    #[allow(dead_code)]
-    pub const COUNT: usize = 9;
-
-    /// All variants in canonical order.
-    #[allow(dead_code)]
-    pub const ALL: &'static [NotificationName] = &[
-        NotificationName::VoteResponse,
-        NotificationName::PreVoteResponse,
-        NotificationName::HigherVote,
-        NotificationName::StorageError,
-        NotificationName::LocalIO,
-        NotificationName::ReplicationProgress,
-        NotificationName::HeartbeatProgress,
-        NotificationName::StateMachine,
-        NotificationName::Tick,
-    ];
-
-    /// Returns the index of this variant for array-based storage.
-    #[allow(dead_code)]
-    pub const fn index(&self) -> usize {
-        match self {
-            NotificationName::VoteResponse => 0,
-            NotificationName::PreVoteResponse => 1,
-            NotificationName::HigherVote => 2,
-            NotificationName::StorageError => 3,
-            NotificationName::LocalIO => 4,
-            NotificationName::ReplicationProgress => 5,
-            NotificationName::HeartbeatProgress => 6,
-            NotificationName::StateMachine => 7,
-            NotificationName::Tick => 8,
-        }
-    }
-
-    #[allow(dead_code)]
-    pub const fn as_str(&self) -> &'static str {
-        match self {
-            NotificationName::VoteResponse => "Notify::VoteResponse",
-            NotificationName::PreVoteResponse => "Notify::PreVoteResponse",
-            NotificationName::HigherVote => "Notify::HigherVote",
-            NotificationName::StorageError => "Notify::StorageError",
-            NotificationName::LocalIO => "Notify::LocalIO",
-            NotificationName::ReplicationProgress => "Notify::ReplicationProgress",
-            NotificationName::HeartbeatProgress => "Notify::HeartbeatProgress",
-            NotificationName::StateMachine => "Notify::StateMachine",
-            NotificationName::Tick => "Notify::Tick",
-        }
-    }
-}
-
-impl std::fmt::Display for NotificationName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
 }
 
 #[cfg(test)]

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -87,6 +87,7 @@ use crate::network::RPCOption;
 use crate::network::RPCTypes;
 use crate::network::RaftNetworkFactory;
 use crate::progress::VecProgressEntry;
+use crate::progress::inflight_id::InflightId;
 use crate::progress::stream_id::StreamId;
 use crate::quorum::QuorumSet;
 use crate::raft::AppendEntriesRequest;
@@ -2231,6 +2232,274 @@ where
             tracing::info!("done joining removed replication: {}", target);
         });
     }
+
+    /// Run [`Command::UpdateIOProgress`].
+    async fn run_update_io_progress(&mut self, io_id: IOId<C>) {
+        // Notify that I/O is about to be submitted.
+        self.io_accepted_tx.send_if_greater(io_id.clone());
+
+        self.engine.state.log_progress_mut().submit(io_id.clone());
+
+        let notify = Notification::LocalIO { io_id: io_id.clone() };
+
+        self.tx_notification.send(notify).await.ok();
+    }
+
+    /// Run [`Command::AppendEntries`].
+    async fn run_append_entries(
+        &mut self,
+        committed_vote: CommittedVoteOf<C>,
+        entries: BatchOf<C, C::Entry>,
+    ) -> Result<(), StorageError<C>> {
+        let last_log_id = entries.last().unwrap().log_id();
+        let last_log_index = last_log_id.index();
+        tracing::debug!("AppendEntries: {}", entries.as_ref().display_n(10));
+
+        let entry_count = entries.len() as u64;
+
+        // Record to internal histogram
+        self.runtime_stats.append_batch.record(entry_count);
+
+        // Record to external metrics recorder
+        if let Some(r) = &self.metrics_recorder {
+            r.record_append_batch(entry_count);
+        }
+
+        let io_id = IOId::new_log_io(committed_vote, Some(last_log_id));
+        let callback = IOFlushed::new(io_id.clone(), self.tx_io_completed.clone());
+
+        // Notify that I/O is about to be submitted.
+        self.io_accepted_tx.send_if_greater(io_id.clone());
+
+        // Mark this IO request as submitted,
+        // other commands relying on it can then be processed.
+        // For example,
+        // `Replicate` command cannot run until this IO request is submitted(no need to be flushed),
+        // because it needs to read the log entry from the log store.
+        //
+        // The `submit` state must be updated before calling `append()`,
+        // because `append()` may call the callback before returning.
+        self.engine.state.log_progress_mut().submit(io_id.clone());
+
+        self.runtime_stats.record_log_stage_now(Stage::Submitted, last_log_index + 1);
+
+        // Submit IO request, do not wait for the response.
+        self.log_store.append(entries, callback).await.sto_write_logs()?;
+
+        Ok(())
+    }
+
+    /// Run [`Command::SaveVote`].
+    async fn run_save_vote(&mut self, vote: VoteOf<C>) -> Result<(), StorageError<C>> {
+        let io_id = IOId::new(&vote);
+
+        // Notify that vote I/O is about to be submitted.
+        self.io_accepted_tx.send_if_greater(io_id.clone());
+
+        self.engine.state.log_progress_mut().submit(io_id.clone());
+        self.log_store.save_vote(&vote).await.sto_write_vote()?;
+
+        self.tx_notification
+            .send(Notification::LocalIO {
+                io_id: IOId::new(&vote),
+            })
+            .await
+            .ok();
+
+        // If a non-committed vote is saved,
+        // there may be a candidate waiting for the response.
+        if let VoteStatus::Pending(non_committed) = vote.clone().into_vote_status() {
+            self.tx_notification
+                .send(Notification::VoteResponse {
+                    target: self.id.clone(),
+                    // last_log_id is not used when sending VoteRequest to local node
+                    resp: VoteResponse::new(vote, None, true),
+                    candidate_vote: non_committed,
+                })
+                .await
+                .ok();
+        }
+
+        Ok(())
+    }
+
+    /// Run [`Command::PurgeLog`].
+    async fn run_purge_log(&mut self, upto: LogIdOf<C>) -> Result<(), StorageError<C>> {
+        self.log_store.purge(upto.clone()).await.sto_write_logs()?;
+
+        // A responder may still be pending for a log covered by this purge, e.g. a former
+        // leader's uncommitted log superseded by a snapshot install. That log is gone, so
+        // fail the responder with `ForwardToLeader` instead of leaving it stranded below the
+        // purge boundary (which would later panic in `apply_to_state_machine`).
+        let leader_id = self.current_leader();
+        let leader_node = self.get_leader_node(leader_id.clone());
+        for (log_index, tx) in self.client_responders.drain_upto(upto.index()) {
+            tx.on_complete(Err(ClientWriteError::ForwardToLeader(ForwardToLeader {
+                leader_id: leader_id.clone(),
+                leader_node: leader_node.clone(),
+            })));
+            tracing::debug!("sent ForwardToLeader for purged log_index: {}", log_index);
+        }
+
+        self.engine.state.io_state_mut().update_purged(Some(upto));
+
+        Ok(())
+    }
+
+    /// Run [`Command::TruncateLog`].
+    async fn run_truncate_log(&mut self, after: Option<LogIdOf<C>>) -> Result<(), StorageError<C>> {
+        self.log_store.truncate_after(after.clone()).await.sto_write_logs()?;
+
+        // Inform clients waiting for logs to be applied.
+        let leader_id = self.current_leader();
+        let leader_node = self.get_leader_node(leader_id.clone());
+
+        for (log_index, tx) in self.client_responders.drain_from(after.next_index()) {
+            tx.on_complete(Err(ClientWriteError::ForwardToLeader(ForwardToLeader {
+                leader_id: leader_id.clone(),
+                leader_node: leader_node.clone(),
+            })));
+
+            tracing::debug!("sent ForwardToLeader for log_index: {}", log_index);
+        }
+
+        Ok(())
+    }
+
+    /// Run [`Command::SaveCommittedAndApply`].
+    async fn run_save_committed_and_apply(
+        &mut self,
+        already_applied: Option<LogIdOf<C>>,
+        upto: LogIdOf<C>,
+    ) -> Result<(), StorageError<C>> {
+        self.runtime_stats.record_log_stage_now(Stage::Committed, upto.index() + 1);
+
+        self.engine.state.apply_progress_mut().submit(upto.clone());
+
+        self.log_store.save_committed(Some(upto.clone())).await.sto_write()?;
+
+        let first = self.engine.state.get_log_id(already_applied.next_index()).unwrap();
+        self.apply_to_state_machine(first, upto).await?;
+
+        Ok(())
+    }
+
+    /// Run [`Command::ReplicateSnapshot`].
+    async fn run_replicate_snapshot(
+        &mut self,
+        leader_vote: CommittedVoteOf<C>,
+        target: C::NodeId,
+        inflight_id: InflightId,
+    ) {
+        let node = self.replications.get(&target).expect("replication to target node exists");
+
+        let snapshot_reader = self.sm_handle.new_snapshot_reader();
+        let stream_id = node.stream_id;
+        let (replication_task_context, cancel_tx) =
+            self.new_replication_task_context(leader_vote, stream_id, target.clone());
+
+        let target_node = self.engine.state.membership_state.effective().get_node(&target).unwrap();
+        let snapshot_network = self.network_factory.new_snapshot_client(target.clone(), target_node).await;
+
+        let handle = SnapshotTransmitter::<C, NF, SM>::spawn(
+            replication_task_context,
+            snapshot_network,
+            snapshot_reader,
+            inflight_id,
+            cancel_tx,
+        );
+
+        let node = self.replications.get_mut(&target).expect("replication to target node exists");
+        // TODO: it is not cleaned when snapshot transmission is done.
+        node.snapshot_transmit_handle = Some(handle);
+    }
+
+    /// Run [`Command::CloseReplicationStreams`].
+    fn run_close_replication_streams(&mut self) {
+        self.heartbeat_handle.close_workers();
+
+        let left = std::mem::take(&mut self.replications);
+        for (target, s) in left {
+            Self::close_replication(&target, s);
+        }
+    }
+
+    /// Run [`Command::RebuildReplicationStreams`].
+    async fn run_rebuild_replication_streams(
+        &mut self,
+        leader_vote: CommittedVoteOf<C>,
+        targets: Vec<TargetProgress<C>>,
+        close_old_streams: bool,
+    ) {
+        self.heartbeat_handle
+            .spawn_workers::<NF>(
+                leader_vote.clone(),
+                &mut self.network_factory,
+                &self.tx_notification,
+                &targets,
+                close_old_streams,
+            )
+            .await;
+
+        let mut new_replications = BTreeMap::new();
+
+        for prog in targets.iter() {
+            let removed = self.replications.remove(&prog.target);
+
+            let handle = if let Some(removed) = removed {
+                if close_old_streams {
+                    Self::close_replication(&prog.target, removed);
+                    None
+                } else {
+                    Some(removed)
+                }
+            } else {
+                None
+            };
+
+            let handle = if let Some(handle) = handle {
+                handle
+            } else {
+                self.spawn_replication_stream(leader_vote.clone(), prog).await
+            };
+
+            new_replications.insert(prog.target.clone(), handle);
+        }
+
+        tracing::debug!("removing unused replications");
+
+        let left = std::mem::replace(&mut self.replications, new_replications);
+
+        for (target, s) in left {
+            Self::close_replication(&target, s);
+        }
+    }
+
+    /// Run [`Command::StateMachine`], forwarding the inner command to the state machine worker.
+    async fn run_state_machine(&mut self, command: sm::Command<C, SM>) -> Result<(), StorageError<C>> {
+        let io_id = command.get_log_progress();
+
+        if let Some(io_id) = io_id {
+            self.engine.state.log_progress_mut().submit(io_id);
+        }
+
+        // If this command update the last-applied log id, mark it as submitted(to state machine).
+        if let Some(log_id) = command.get_apply_progress() {
+            self.engine.state.apply_progress_mut().submit(log_id);
+        }
+
+        if let Some(log_id) = command.get_snapshot_progress() {
+            self.engine.state.snapshot_progress_mut().submit(log_id);
+        }
+
+        // Just forward a state machine command to the worker.
+        self.sm_handle
+            .send(command)
+            .await
+            .map_err(|_e| StorageError::write_state_machine(C::err_from_string("cannot send to sm::Worker")))?;
+
+        Ok(())
+    }
 }
 
 impl<C, N, LS, SM> RaftRuntime<C, SM> for RaftCore<C, N, LS, SM>
@@ -2262,120 +2531,14 @@ where
         self.runtime_stats.record_command(cmd.name());
 
         match cmd {
-            Command::UpdateIOProgress { io_id, .. } => {
-                // Notify that I/O is about to be submitted.
-                self.io_accepted_tx.send_if_greater(io_id.clone());
-
-                self.engine.state.log_progress_mut().submit(io_id.clone());
-
-                let notify = Notification::LocalIO { io_id: io_id.clone() };
-
-                self.tx_notification.send(notify).await.ok();
-            }
+            Command::UpdateIOProgress { io_id, .. } => self.run_update_io_progress(io_id).await,
             Command::AppendEntries {
-                committed_vote: vote,
+                committed_vote,
                 entries,
-            } => {
-                let last_log_id = entries.last().unwrap().log_id();
-                let last_log_index = last_log_id.index();
-                tracing::debug!("AppendEntries: {}", entries.as_ref().display_n(10));
-
-                let entry_count = entries.len() as u64;
-
-                // Record to internal histogram
-                self.runtime_stats.append_batch.record(entry_count);
-
-                // Record to external metrics recorder
-                if let Some(r) = &self.metrics_recorder {
-                    r.record_append_batch(entry_count);
-                }
-
-                let io_id = IOId::new_log_io(vote, Some(last_log_id));
-                let callback = IOFlushed::new(io_id.clone(), self.tx_io_completed.clone());
-
-                // Notify that I/O is about to be submitted.
-                self.io_accepted_tx.send_if_greater(io_id.clone());
-
-                // Mark this IO request as submitted,
-                // other commands relying on it can then be processed.
-                // For example,
-                // `Replicate` command cannot run until this IO request is submitted(no need to be flushed),
-                // because it needs to read the log entry from the log store.
-                //
-                // The `submit` state must be updated before calling `append()`,
-                // because `append()` may call the callback before returning.
-                self.engine.state.log_progress_mut().submit(io_id.clone());
-
-                self.runtime_stats.record_log_stage_now(Stage::Submitted, last_log_index + 1);
-
-                // Submit IO request, do not wait for the response.
-                self.log_store.append(entries, callback).await.sto_write_logs()?;
-            }
-            Command::SaveVote { vote } => {
-                let io_id = IOId::new(&vote);
-
-                // Notify that vote I/O is about to be submitted.
-                self.io_accepted_tx.send_if_greater(io_id.clone());
-
-                self.engine.state.log_progress_mut().submit(io_id.clone());
-                self.log_store.save_vote(&vote).await.sto_write_vote()?;
-
-                self.tx_notification
-                    .send(Notification::LocalIO {
-                        io_id: IOId::new(&vote),
-                    })
-                    .await
-                    .ok();
-
-                // If a non-committed vote is saved,
-                // there may be a candidate waiting for the response.
-                if let VoteStatus::Pending(non_committed) = vote.clone().into_vote_status() {
-                    self.tx_notification
-                        .send(Notification::VoteResponse {
-                            target: self.id.clone(),
-                            // last_log_id is not used when sending VoteRequest to local node
-                            resp: VoteResponse::new(vote, None, true),
-                            candidate_vote: non_committed,
-                        })
-                        .await
-                        .ok();
-                }
-            }
-            Command::PurgeLog { upto } => {
-                self.log_store.purge(upto.clone()).await.sto_write_logs()?;
-
-                // A responder may still be pending for a log covered by this purge, e.g. a former
-                // leader's uncommitted log superseded by a snapshot install. That log is gone, so
-                // fail the responder with `ForwardToLeader` instead of leaving it stranded below the
-                // purge boundary (which would later panic in `apply_to_state_machine`).
-                let leader_id = self.current_leader();
-                let leader_node = self.get_leader_node(leader_id.clone());
-                for (log_index, tx) in self.client_responders.drain_upto(upto.index()) {
-                    tx.on_complete(Err(ClientWriteError::ForwardToLeader(ForwardToLeader {
-                        leader_id: leader_id.clone(),
-                        leader_node: leader_node.clone(),
-                    })));
-                    tracing::debug!("sent ForwardToLeader for purged log_index: {}", log_index);
-                }
-
-                self.engine.state.io_state_mut().update_purged(Some(upto));
-            }
-            Command::TruncateLog { after } => {
-                self.log_store.truncate_after(after.clone()).await.sto_write_logs()?;
-
-                // Inform clients waiting for logs to be applied.
-                let leader_id = self.current_leader();
-                let leader_node = self.get_leader_node(leader_id.clone());
-
-                for (log_index, tx) in self.client_responders.drain_from(after.next_index()) {
-                    tx.on_complete(Err(ClientWriteError::ForwardToLeader(ForwardToLeader {
-                        leader_id: leader_id.clone(),
-                        leader_node: leader_node.clone(),
-                    })));
-
-                    tracing::debug!("sent ForwardToLeader for log_index: {}", log_index);
-                }
-            }
+            } => self.run_append_entries(committed_vote, entries).await?,
+            Command::SaveVote { vote } => self.run_save_vote(vote).await?,
+            Command::PurgeLog { upto } => self.run_purge_log(upto).await?,
+            Command::TruncateLog { after } => self.run_truncate_log(after).await?,
             Command::SendVote { vote_req } => {
                 self.spawn_parallel_vote_requests(&vote_req, VoteRequestKind::Vote).await;
             }
@@ -2385,21 +2548,9 @@ where
             Command::ReplicateCommitted { committed } => {
                 self.committed_tx.send_if_greater(committed);
             }
-            Command::BroadcastHeartbeat { session_id } => {
-                self.broadcast_heartbeat(session_id);
-            }
-            Command::SaveCommittedAndApply {
-                already_applied: already_committed,
-                upto,
-            } => {
-                self.runtime_stats.record_log_stage_now(Stage::Committed, upto.index() + 1);
-
-                self.engine.state.apply_progress_mut().submit(upto.clone());
-
-                self.log_store.save_committed(Some(upto.clone())).await.sto_write()?;
-
-                let first = self.engine.state.get_log_id(already_committed.next_index()).unwrap();
-                self.apply_to_state_machine(first, upto).await?;
+            Command::BroadcastHeartbeat { session_id } => self.broadcast_heartbeat(session_id),
+            Command::SaveCommittedAndApply { already_applied, upto } => {
+                self.run_save_committed_and_apply(already_applied, upto).await?
             }
             Command::Replicate { req, target } => {
                 let node = self.replications.get(&target).expect("replication to target node exists");
@@ -2409,112 +2560,18 @@ where
                 leader_vote,
                 target,
                 inflight_id,
-            } => {
-                let node = self.replications.get(&target).expect("replication to target node exists");
-
-                let snapshot_reader = self.sm_handle.new_snapshot_reader();
-                let stream_id = node.stream_id;
-                let (replication_task_context, cancel_tx) =
-                    self.new_replication_task_context(leader_vote, stream_id, target.clone());
-
-                let target_node = self.engine.state.membership_state.effective().get_node(&target).unwrap();
-                let snapshot_network = self.network_factory.new_snapshot_client(target.clone(), target_node).await;
-
-                let handle = SnapshotTransmitter::<C, N, SM>::spawn(
-                    replication_task_context,
-                    snapshot_network,
-                    snapshot_reader,
-                    inflight_id,
-                    cancel_tx,
-                );
-
-                let node = self.replications.get_mut(&target).expect("replication to target node exists");
-                // TODO: it is not cleaned when snapshot transmission is done.
-                node.snapshot_transmit_handle = Some(handle);
-            }
+            } => self.run_replicate_snapshot(leader_vote, target, inflight_id).await,
             Command::BroadcastTransferLeader { req } => self.broadcast_transfer_leader(req).await,
-
-            Command::CloseReplicationStreams => {
-                self.heartbeat_handle.close_workers();
-
-                let left = std::mem::take(&mut self.replications);
-                for (target, s) in left {
-                    Self::close_replication(&target, s);
-                }
-            }
+            Command::CloseReplicationStreams => self.run_close_replication_streams(),
             Command::RebuildReplicationStreams {
                 leader_vote,
                 targets,
                 close_old_streams,
             } => {
-                self.heartbeat_handle
-                    .spawn_workers::<N>(
-                        leader_vote.clone(),
-                        &mut self.network_factory,
-                        &self.tx_notification,
-                        &targets,
-                        close_old_streams,
-                    )
-                    .await;
-
-                let mut new_replications = BTreeMap::new();
-
-                for prog in targets.iter() {
-                    let removed = self.replications.remove(&prog.target);
-
-                    let handle = if let Some(removed) = removed {
-                        if close_old_streams {
-                            Self::close_replication(&prog.target, removed);
-                            None
-                        } else {
-                            Some(removed)
-                        }
-                    } else {
-                        None
-                    };
-
-                    let handle = if let Some(handle) = handle {
-                        handle
-                    } else {
-                        self.spawn_replication_stream(leader_vote.clone(), prog).await
-                    };
-
-                    new_replications.insert(prog.target.clone(), handle);
-                }
-
-                tracing::debug!("removing unused replications");
-
-                let left = std::mem::replace(&mut self.replications, new_replications);
-
-                for (target, s) in left {
-                    Self::close_replication(&target, s);
-                }
+                self.run_rebuild_replication_streams(leader_vote, targets, close_old_streams).await;
             }
-            Command::StateMachine { command } => {
-                let io_id = command.get_log_progress();
-
-                if let Some(io_id) = io_id {
-                    self.engine.state.log_progress_mut().submit(io_id);
-                }
-
-                // If this command update the last-applied log id, mark it as submitted(to state machine).
-                if let Some(log_id) = command.get_apply_progress() {
-                    self.engine.state.apply_progress_mut().submit(log_id);
-                }
-
-                if let Some(log_id) = command.get_snapshot_progress() {
-                    self.engine.state.snapshot_progress_mut().submit(log_id);
-                }
-
-                // Just forward a state machine command to the worker.
-                self.sm_handle
-                    .send(command)
-                    .await
-                    .map_err(|_e| StorageError::write_state_machine(C::err_from_string("cannot send to sm::Worker")))?;
-            }
-            Command::Respond { resp: send, .. } => {
-                send.send();
-            }
+            Command::StateMachine { command } => self.run_state_machine(command).await?,
+            Command::Respond { resp, .. } => resp.send(),
         }
 
         Ok(None)

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1739,84 +1739,7 @@ where
             RaftMsg::ExternalCommand { cmd } => {
                 tracing::info!("{}: received RaftMsg::ExternalCommand, cmd: {:?}", func_name!(), cmd);
 
-                match cmd {
-                    ExternalCommand::Elect { pre_vote } => {
-                        if self.engine.leader.is_some() {
-                            // A Leader can not win a campaign it starts: its own heartbeats keep
-                            // refreshing the voters' leader lease, and a lease that has not expired
-                            // rejects the vote request. Leave the established leadership alone.
-                            tracing::info!("ExternalCommand: already a Leader, ignore election trigger");
-                        } else {
-                            if self.engine.state.membership_state.effective().is_voter(&self.id) {
-                                if pre_vote {
-                                    self.engine.pre_elect();
-                                } else {
-                                    self.engine.elect();
-                                }
-                                tracing::debug!("ExternalCommand: triggered election, pre_vote: {}", pre_vote);
-                            } else {
-                                // Node is switched to learner.
-                            }
-                        }
-                    }
-                    ExternalCommand::Heartbeat => {
-                        self.send_heartbeat("ExternalCommand");
-                    }
-                    ExternalCommand::Snapshot => {
-                        self.trigger_snapshot();
-                    }
-                    ExternalCommand::PurgeLog { upto } => {
-                        self.engine.trigger_purge_log(upto);
-                    }
-                    ExternalCommand::TriggerTransferLeader { to } => {
-                        self.engine.trigger_transfer_leader(to);
-                    }
-                    ExternalCommand::AllowNextRevert { to, allow, tx } => {
-                        //
-                        let res = match self.engine.try_leader_handler() {
-                            Ok(mut l) => {
-                                let res = l.replication_handler().allow_next_revert(to, allow);
-                                res.map_err(AllowNextRevertError::from)
-                            }
-                            Err(e) => {
-                                tracing::warn!("AllowNextRevert: current node is not a Leader");
-                                Err(AllowNextRevertError::from(e))
-                            }
-                        };
-                        tx.send(res).ok();
-                    }
-                    ExternalCommand::SetMetricsRecorder { recorder } => {
-                        tracing::info!("setting metrics recorder");
-                        self.metrics_recorder = recorder;
-                    }
-                    ExternalCommand::RefreshServerState {
-                        vote,
-                        membership_log_id,
-                    } => {
-                        // The condition to refresh, e.g., the membership config that removes the
-                        // Leader being committed, is checked by the sender. Refresh only if the
-                        // vote and the effective membership config log id still match what the
-                        // sender observed, so that a delayed command can not cause an unexpected
-                        // server state refresh. A `None` skips the corresponding check.
-                        let st = &self.engine.state;
-                        let vote_unchanged = vote.as_ref().is_none_or(|v| st.vote_ref() == v);
-                        let membership_unchanged = membership_log_id
-                            .as_ref()
-                            .is_none_or(|log_id| st.membership_state.effective().log_id().as_ref() == Some(log_id));
-
-                        if vote_unchanged && membership_unchanged {
-                            self.engine.refresh_server_state();
-                        } else {
-                            tracing::info!(
-                                "RefreshServerState is dropped: expected vote: {}, membership log id: {}; current vote: {}, membership log id: {}",
-                                vote.display(),
-                                membership_log_id.display(),
-                                self.engine.state.vote_ref(),
-                                self.engine.state.membership_state.effective().log_id().display(),
-                            );
-                        }
-                    }
-                }
+                self.handle_external_command(cmd);
             }
             #[cfg(feature = "runtime-stats")]
             RaftMsg::GetRuntimeStats { tx } => {
@@ -1829,6 +1752,89 @@ where
                 tx.send(stats).ok();
             }
         };
+    }
+
+    /// Handle an [`ExternalCommand`], a request from the application that bypasses the Raft
+    /// protocol, such as triggering an election or a snapshot.
+    fn handle_external_command(&mut self, cmd: ExternalCommand<C>) {
+        match cmd {
+            ExternalCommand::Elect { pre_vote } => {
+                if self.engine.leader.is_some() {
+                    // A Leader can not win a campaign it starts: its own heartbeats keep
+                    // refreshing the voters' leader lease, and a lease that has not expired
+                    // rejects the vote request. Leave the established leadership alone.
+                    tracing::info!("ExternalCommand: already a Leader, ignore election trigger");
+                } else {
+                    if self.engine.state.membership_state.effective().is_voter(&self.id) {
+                        if pre_vote {
+                            self.engine.pre_elect();
+                        } else {
+                            self.engine.elect();
+                        }
+                        tracing::debug!("ExternalCommand: triggered election, pre_vote: {}", pre_vote);
+                    } else {
+                        // Node is switched to learner.
+                    }
+                }
+            }
+            ExternalCommand::Heartbeat => {
+                self.send_heartbeat("ExternalCommand");
+            }
+            ExternalCommand::Snapshot => {
+                self.trigger_snapshot();
+            }
+            ExternalCommand::PurgeLog { upto } => {
+                self.engine.trigger_purge_log(upto);
+            }
+            ExternalCommand::TriggerTransferLeader { to } => {
+                self.engine.trigger_transfer_leader(to);
+            }
+            ExternalCommand::AllowNextRevert { to, allow, tx } => {
+                //
+                let res = match self.engine.try_leader_handler() {
+                    Ok(mut l) => {
+                        let res = l.replication_handler().allow_next_revert(to, allow);
+                        res.map_err(AllowNextRevertError::from)
+                    }
+                    Err(e) => {
+                        tracing::warn!("AllowNextRevert: current node is not a Leader");
+                        Err(AllowNextRevertError::from(e))
+                    }
+                };
+                tx.send(res).ok();
+            }
+            ExternalCommand::SetMetricsRecorder { recorder } => {
+                tracing::info!("setting metrics recorder");
+                self.metrics_recorder = recorder;
+            }
+            ExternalCommand::RefreshServerState {
+                vote,
+                membership_log_id,
+            } => {
+                // The condition to refresh, e.g., the membership config that removes the
+                // Leader being committed, is checked by the sender. Refresh only if the
+                // vote and the effective membership config log id still match what the
+                // sender observed, so that a delayed command can not cause an unexpected
+                // server state refresh. A `None` skips the corresponding check.
+                let st = &self.engine.state;
+                let vote_unchanged = vote.as_ref().is_none_or(|v| st.vote_ref() == v);
+                let membership_unchanged = membership_log_id
+                    .as_ref()
+                    .is_none_or(|log_id| st.membership_state.effective().log_id().as_ref() == Some(log_id));
+
+                if vote_unchanged && membership_unchanged {
+                    self.engine.refresh_server_state();
+                } else {
+                    tracing::info!(
+                        "RefreshServerState is dropped: expected vote: {}, membership log id: {}; current vote: {}, membership log id: {}",
+                        vote.display(),
+                        membership_log_id.display(),
+                        self.engine.state.vote_ref(),
+                        self.engine.state.membership_state.effective().log_id().display(),
+                    );
+                }
+            }
+        }
     }
 
     #[tracing::instrument(level = "debug", skip_all, fields(state = debug(self.engine.state.server_state), id=display(&self.id)

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1908,68 +1908,13 @@ where
                 }
             }
 
-            Notification::Tick { i } => {
-                // check every timer
-
-                let now = C::now();
-                tracing::debug!("received tick: {}, now: {}", i, now.display());
-
-                self.handle_tick_election();
-
-                // TODO: test: fixture: make isolated_nodes a single-way isolating.
-
-                // Leader send heartbeat
-                let heartbeat_at = self.engine.leader_ref().map(|l| l.next_heartbeat);
-                if let Some(t) = heartbeat_at
-                    && now >= t
-                {
-                    if self.runtime_config.enable_heartbeat.load(Ordering::Relaxed) {
-                        self.send_heartbeat("tick");
-                    }
-
-                    // Install next heartbeat
-                    if let Some(l) = self.engine.leader_mut() {
-                        l.next_heartbeat = C::now() + Duration::from_millis(self.config.heartbeat_interval);
-                    }
-                }
-            }
-
+            Notification::Tick { i } => self.handle_tick(i),
             Notification::StorageError { error } => {
                 tracing::error!("RaftCore received Notification::StorageError: {}", error);
                 return Err(Fatal::StorageError(error));
             }
 
-            Notification::LocalIO { io_id } => {
-                self.engine.state.log_progress_mut().try_flush(io_id.clone());
-
-                match io_id {
-                    IOId::Log(log_io_id) => {
-                        if let Some(ref log_id) = log_io_id.log_id {
-                            self.runtime_stats.record_log_stage_now(Stage::Persisted, log_id.index() + 1);
-                        }
-
-                        // No need to check against membership change,
-                        // because not like removing-then-adding a remote node,
-                        // local log wont revert when membership changes.
-                        #[allow(clippy::collapsible_if)]
-                        if self.engine.leader.is_some() {
-                            let my_vote = self.engine.leader.as_ref().map(|x| &x.committed_vote);
-                            if Self::does_vote_match(
-                                "Leader",
-                                &log_io_id.committed_vote,
-                                my_vote,
-                                "LocalIO Notification",
-                            ) {
-                                self.engine.replication_handler().update_local_progress(log_io_id.log_id);
-                            }
-                        }
-                    }
-                    IOId::Vote(_vote) => {
-                        // nothing to do
-                    }
-                }
-            }
-
+            Notification::LocalIO { io_id } => self.handle_local_io(io_id),
             Notification::ReplicationProgress {
                 stream_id,
                 progress,
@@ -1992,46 +1937,106 @@ where
                 }
             }
 
-            Notification::StateMachine { command_result } => {
-                tracing::debug!("sm::StateMachine command result: {:?}", command_result);
+            Notification::StateMachine { command_result } => self.handle_state_machine_result(command_result)?,
+        };
+        Ok(())
+    }
 
-                let res = command_result.result?;
+    /// Handle [`Notification::Tick`]: check the election timer and, if leading, the heartbeat
+    /// timer.
+    fn handle_tick(&mut self, i: u64) {
+        // check every timer
 
-                match res {
-                    sm::Response::BuildSnapshotDone(meta) => {
-                        tracing::info!(
-                            "sm::StateMachine command done: BuildSnapshotDone: {}: {}",
-                            meta.display(),
-                            func_name!()
-                        );
+        let now = C::now();
+        tracing::debug!("received tick: {}, now: {}", i, now.display());
 
-                        self.engine.on_building_snapshot_done(meta);
-                    }
-                    sm::Response::InstallSnapshot((log_io_id, meta)) => {
-                        tracing::info!(
-                            "sm::StateMachine command done: InstallSnapshot: {}, log_io_id: {}: {}",
-                            meta.display(),
-                            log_io_id,
-                            func_name!()
-                        );
+        self.handle_tick_election();
 
-                        self.engine.state.log_progress_mut().try_flush(IOId::Log(log_io_id));
+        // TODO: test: fixture: make isolated_nodes a single-way isolating.
 
-                        if let Some(meta) = meta {
-                            let st = self.engine.state.io_state_mut();
-                            if let Some(last) = &meta.last_log_id {
-                                st.apply_progress.try_flush(last.clone());
-                                st.snapshot.try_flush(last.clone());
-                            }
-                        }
-                    }
-                    sm::Response::Apply(res) => {
-                        self.runtime_stats.record_log_stage_now(Stage::Applied, res.last_applied.index() + 1);
-                        self.engine.state.apply_progress_mut().try_flush(res.last_applied);
+        // Leader send heartbeat
+        let heartbeat_at = self.engine.leader_ref().map(|l| l.next_heartbeat);
+        if let Some(t) = heartbeat_at
+            && now >= t
+        {
+            if self.runtime_config.enable_heartbeat.load(Ordering::Relaxed) {
+                self.send_heartbeat("tick");
+            }
+
+            // Install next heartbeat
+            if let Some(l) = self.engine.leader_mut() {
+                l.next_heartbeat = C::now() + Duration::from_millis(self.config.heartbeat_interval);
+            }
+        }
+    }
+
+    /// Handle [`Notification::LocalIO`]: a local log or vote write reached the disk.
+    fn handle_local_io(&mut self, io_id: IOId<C>) {
+        self.engine.state.log_progress_mut().try_flush(io_id.clone());
+
+        match io_id {
+            IOId::Log(log_io_id) => {
+                if let Some(ref log_id) = log_io_id.log_id {
+                    self.runtime_stats.record_log_stage_now(Stage::Persisted, log_id.index() + 1);
+                }
+
+                // No need to check against membership change,
+                // because not like removing-then-adding a remote node,
+                // local log wont revert when membership changes.
+                #[allow(clippy::collapsible_if)]
+                if self.engine.leader.is_some() {
+                    let my_vote = self.engine.leader.as_ref().map(|x| &x.committed_vote);
+                    if Self::does_vote_match("Leader", &log_io_id.committed_vote, my_vote, "LocalIO Notification") {
+                        self.engine.replication_handler().update_local_progress(log_io_id.log_id);
                     }
                 }
             }
-        };
+            IOId::Vote(_vote) => {
+                // nothing to do
+            }
+        }
+    }
+
+    /// Handle [`Notification::StateMachine`]: the state machine worker finished a command.
+    fn handle_state_machine_result(&mut self, command_result: sm::CommandResult<C>) -> Result<(), Fatal<C>> {
+        tracing::debug!("sm::StateMachine command result: {:?}", command_result);
+
+        let res = command_result.result?;
+
+        match res {
+            sm::Response::BuildSnapshotDone(meta) => {
+                tracing::info!(
+                    "sm::StateMachine command done: BuildSnapshotDone: {}: {}",
+                    meta.display(),
+                    func_name!()
+                );
+
+                self.engine.on_building_snapshot_done(meta);
+            }
+            sm::Response::InstallSnapshot((log_io_id, meta)) => {
+                tracing::info!(
+                    "sm::StateMachine command done: InstallSnapshot: {}, log_io_id: {}: {}",
+                    meta.display(),
+                    log_io_id,
+                    func_name!()
+                );
+
+                self.engine.state.log_progress_mut().try_flush(IOId::Log(log_io_id));
+
+                if let Some(meta) = meta {
+                    let st = self.engine.state.io_state_mut();
+                    if let Some(last) = &meta.last_log_id {
+                        st.apply_progress.try_flush(last.clone());
+                        st.snapshot.try_flush(last.clone());
+                    }
+                }
+            }
+            sm::Response::Apply(res) => {
+                self.runtime_stats.record_log_stage_now(Stage::Applied, res.last_applied.index() + 1);
+                self.engine.state.apply_progress_mut().try_flush(res.last_applied);
+            }
+        }
+
         Ok(())
     }
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -752,10 +752,6 @@ where
 
         let st = &self.engine.state;
 
-        let membership_config = st.membership_state.effective().clone();
-        let committed_membership_config = st.membership_state.committed().clone();
-        let current_leader = self.current_leader();
-
         // Get the last flushed vote, or use initial vote (term=0, node_id=self.id)
         // if no IO has been flushed yet (e.g., during startup).
         let vote = st
@@ -763,38 +759,6 @@ where
             .flushed()
             .map(|io_id| io_id.to_app_vote())
             .unwrap_or_else(|| VoteOf::<C>::new_with_default_term(self.id.clone()));
-
-        #[allow(deprecated)]
-        let m = RaftMetrics {
-            running_state: Ok(()),
-            id: self.id.clone(),
-
-            // --- data ---
-            current_term: st.vote_ref().term(),
-            vote: vote.clone(),
-            last_log_index: st.last_log_id().index(),
-            local_committed: st.local_committed().cloned(),
-            committed: st.local_committed().cloned(),
-            cluster_committed: st.cluster_committed().cloned(),
-            last_applied: st.io_applied().cloned(),
-            snapshot: st.io_snapshot_last_log_id().cloned(),
-            purged: st.io_purged().cloned(),
-
-            #[cfg(feature = "metrics-logids")]
-            log_id_list: st.log_ids.clone(),
-
-            // --- cluster ---
-            state: st.server_state,
-            current_leader: current_leader.clone(),
-            millis_since_quorum_ack,
-            last_quorum_acked: last_quorum_acked.map(SerdeInstant::new),
-            membership_config: membership_config.clone(),
-            committed_membership_config: committed_membership_config.clone(),
-            heartbeat: heartbeat.clone(),
-
-            // --- replication ---
-            replication: replication.clone(),
-        };
 
         #[allow(deprecated)]
         let data_metrics = RaftDataMetrics {
@@ -815,13 +779,48 @@ where
             heartbeat,
         };
 
-        let server_metrics = RaftServerMetrics {
+        let server_metrics = RaftServerMetrics::<C> {
             id: self.id.clone(),
-            vote: vote.clone(),
+            vote,
             state: st.server_state,
-            current_leader,
-            membership_config,
-            committed_membership_config,
+            current_leader: self.current_leader(),
+            membership_config: st.membership_state.effective().clone(),
+            committed_membership_config: st.membership_state.committed().clone(),
+        };
+
+        // `RaftMetrics` is the union of the two above, plus the running state and the term.
+        // It is assembled from them rather than re-read from the state, so that every field has
+        // exactly one place where it is derived.
+        #[allow(deprecated)]
+        let m = RaftMetrics {
+            running_state: Ok(()),
+            id: server_metrics.id.clone(),
+
+            // --- data ---
+            current_term: st.vote_ref().term(),
+            vote: server_metrics.vote.clone(),
+            last_log_index: data_metrics.last_log.index(),
+            local_committed: data_metrics.local_committed.clone(),
+            committed: data_metrics.committed.clone(),
+            cluster_committed: data_metrics.cluster_committed.clone(),
+            last_applied: data_metrics.last_applied.clone(),
+            snapshot: data_metrics.snapshot.clone(),
+            purged: data_metrics.purged.clone(),
+
+            #[cfg(feature = "metrics-logids")]
+            log_id_list: data_metrics.log_id_list.clone(),
+
+            // --- cluster ---
+            state: server_metrics.state,
+            current_leader: server_metrics.current_leader.clone(),
+            millis_since_quorum_ack: data_metrics.millis_since_quorum_ack,
+            last_quorum_acked: data_metrics.last_quorum_acked,
+            membership_config: server_metrics.membership_config.clone(),
+            committed_membership_config: server_metrics.committed_membership_config.clone(),
+            heartbeat: data_metrics.heartbeat.clone(),
+
+            // --- replication ---
+            replication: data_metrics.replication.clone(),
         };
 
         // Record to external metrics recorder

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fmt;
 use std::fmt::Debug;
+use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -21,6 +22,7 @@ use tracing::Span;
 use crate::ChangeMembers;
 use crate::Instant;
 use crate::Membership;
+use crate::OptionalSend;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::async_runtime::MpscReceiver;
@@ -1476,28 +1478,16 @@ where
     /// `Ok(granted)` from the default impl, keeping Pre-Vote a no-op during a rolling upgrade.
     #[tracing::instrument(level = "trace", skip_all)]
     async fn spawn_parallel_vote_requests(&mut self, vote_req: &VoteRequest<C>, kind: VoteRequestKind) {
-        let members = self.engine.state.membership_state.effective().voter_ids();
-
         let vote = vote_req.vote.clone();
+        let id = self.id.clone();
+        let tx = self.tx_notification.clone();
+        let ttl = Duration::from_millis(self.config.election_timeout_min);
 
-        for target in members {
-            if target == self.id {
-                continue;
-            }
-
+        self.broadcast_to_voters(ttl, |target, mut client, option| {
             let req = vote_req.clone();
-
-            // Safe unwrap(): target must be in membership
-            let target_node = self.engine.state.membership_state.effective().get_node(&target).unwrap().clone();
-            let mut client = self.network_factory.new_client(target.clone(), &target_node).await;
-
-            let tx = self.tx_notification.clone();
-
-            let ttl = Duration::from_millis(self.config.election_timeout_min);
-            let id = self.id.clone();
-            let option = RPCOption::new(ttl);
-
             let vote = vote.clone();
+            let id = id.clone();
+            let tx = tx.clone();
 
             let span = match kind {
                 VoteRequestKind::Vote => {
@@ -1508,109 +1498,64 @@ where
                 }
             };
 
-            // False positive lint warning(`non-binding `let` on a future`): https://github.com/rust-lang/rust-clippy/issues/9932
-            #[allow(clippy::let_underscore_future)]
-            let _ = C::spawn(
-                {
-                    let target = target.clone();
-                    async move {
-                        let tm_res = match kind {
-                            VoteRequestKind::Vote => C::timeout(ttl, client.vote(req, option)).await,
-                            VoteRequestKind::PreVote => C::timeout(ttl, client.pre_vote(req, option)).await,
-                        };
-                        let res = match tm_res {
-                            Ok(res) => res,
+            async move {
+                let tm_res = match kind {
+                    VoteRequestKind::Vote => C::timeout(ttl, client.vote(req, option)).await,
+                    VoteRequestKind::PreVote => C::timeout(ttl, client.pre_vote(req, option)).await,
+                };
+                let res = match tm_res {
+                    Ok(res) => res,
 
-                            Err(_timeout) => {
-                                let timeout_err = Timeout::<C> {
-                                    action: RPCTypes::Vote,
-                                    id,
-                                    target: target.clone(),
-                                    timeout: ttl,
-                                };
-                                tracing::error!("timeout while requesting {}: {}", kind.as_str(), timeout_err);
-                                return;
-                            }
+                    Err(_timeout) => {
+                        let timeout_err = Timeout::<C> {
+                            action: RPCTypes::Vote,
+                            id,
+                            target: target.clone(),
+                            timeout: ttl,
                         };
+                        tracing::error!("timeout while requesting {}: {}", kind.as_str(), timeout_err);
+                        return;
+                    }
+                };
 
-                        match res {
-                            Ok(resp) => {
-                                let candidate_vote = vote.into_non_committed();
-                                let notification = match kind {
-                                    VoteRequestKind::Vote => Notification::VoteResponse {
-                                        target,
-                                        resp,
-                                        candidate_vote,
-                                    },
-                                    VoteRequestKind::PreVote => Notification::PreVoteResponse {
-                                        target,
-                                        resp,
-                                        candidate_vote,
-                                    },
-                                };
-                                tx.send(notification).await.ok();
-                            }
-                            // A transport failure is not a grant: a partitioned peer must not count
-                            // toward the (Pre-)Vote quorum. A network that has not implemented
-                            // `pre_vote` returns `Ok(granted)` from the default impl, so Pre-Vote
-                            // degrades to a no-op rather than relying on this.
-                            Err(err) => {
-                                tracing::error!(
-                                    "while requesting {}, error: {}, target: {}",
-                                    kind.as_str(),
-                                    err,
-                                    target
-                                )
-                            }
-                        }
+                match res {
+                    Ok(resp) => {
+                        let candidate_vote = vote.into_non_committed();
+                        let notification = match kind {
+                            VoteRequestKind::Vote => Notification::VoteResponse {
+                                target,
+                                resp,
+                                candidate_vote,
+                            },
+                            VoteRequestKind::PreVote => Notification::PreVoteResponse {
+                                target,
+                                resp,
+                                candidate_vote,
+                            },
+                        };
+                        tx.send(notification).await.ok();
+                    }
+                    // A transport failure is not a grant: a partitioned peer must not count
+                    // toward the (Pre-)Vote quorum. A network that has not implemented
+                    // `pre_vote` returns `Ok(granted)` from the default impl, so Pre-Vote
+                    // degrades to a no-op rather than relying on this.
+                    Err(err) => {
+                        tracing::error!("while requesting {}, error: {}, target: {}", kind.as_str(), err, target)
                     }
                 }
-                .instrument(span),
-            );
-        }
+            }
+            .instrument(span)
+        })
+        .await;
     }
 
-    /// Spawn parallel vote requests to all cluster members.
+    /// Tell every other voter to accept a new leader.
     #[tracing::instrument(level = "trace", skip_all)]
     async fn broadcast_transfer_leader(&mut self, req: TransferLeaderRequest<C>) {
-        let voter_ids = self.engine.state.membership_state.effective().voter_ids();
+        let ttl = Duration::from_millis(self.config.election_timeout_min);
 
-        for target in voter_ids {
-            if target == self.id {
-                continue;
-            }
-
+        self.broadcast_to_voters(ttl, |target, mut client, option| {
             let r = req.clone();
-
-            // Safe unwrap(): target must be in membership
-            let target_node = self.engine.state.membership_state.effective().get_node(&target).unwrap().clone();
-            let mut client = self.network_factory.new_client(target.clone(), &target_node).await;
-
-            let ttl = Duration::from_millis(self.config.election_timeout_min);
-            let option = RPCOption::new(ttl);
-
-            let fut = {
-                let target = target.clone();
-                async move {
-                    let tm_res = C::timeout(ttl, client.transfer_leader(r, option)).await;
-                    let res = match tm_res {
-                        Ok(res) => res,
-                        Err(timeout) => {
-                            tracing::error!("timeout sending transfer_leader: {}, target: {}", timeout, target);
-                            return;
-                        }
-                    };
-
-                    match res {
-                        Err(e) => {
-                            tracing::error!("error sending transfer_leader: {}, target: {}", e, target);
-                        }
-                        Ok(resp) => {
-                            tracing::info!("Done transfer_leader sent to {}, resp: {:?}", target, resp);
-                        }
-                    }
-                }
-            };
 
             let span = tracing::debug_span!(
                 parent: &Span::current(),
@@ -1618,9 +1563,56 @@ where
                 target = display(&target)
             );
 
+            async move {
+                let tm_res = C::timeout(ttl, client.transfer_leader(r, option)).await;
+                let res = match tm_res {
+                    Ok(res) => res,
+                    Err(timeout) => {
+                        tracing::error!("timeout sending transfer_leader: {}, target: {}", timeout, target);
+                        return;
+                    }
+                };
+
+                match res {
+                    Err(e) => {
+                        tracing::error!("error sending transfer_leader: {}, target: {}", e, target);
+                    }
+                    Ok(resp) => {
+                        tracing::info!("Done transfer_leader sent to {}, resp: {:?}", target, resp);
+                    }
+                }
+            }
+            .instrument(span)
+        })
+        .await;
+    }
+
+    /// Send an RPC to every voter except this node, each in its own detached task.
+    ///
+    /// `make_rpc` is handed a fresh client for one target and the shared [`RPCOption`], and returns
+    /// the future that talks to it. Nothing is joined, so each future has to report its own
+    /// outcome; `ttl` is the timeout the caller is expected to enforce inside that future.
+    async fn broadcast_to_voters<F, Fut>(&mut self, ttl: Duration, make_rpc: F)
+    where
+        F: Fn(C::NodeId, NF::Network, RPCOption) -> Fut,
+        Fut: Future<Output = ()> + OptionalSend + 'static,
+    {
+        let voter_ids = self.engine.state.membership_state.effective().voter_ids();
+
+        for target in voter_ids {
+            if target == self.id {
+                continue;
+            }
+
+            // Safe unwrap(): target must be in membership
+            let target_node = self.engine.state.membership_state.effective().get_node(&target).unwrap().clone();
+            let client = self.network_factory.new_client(target.clone(), &target_node).await;
+
+            let fut = make_rpc(target, client, RPCOption::new(ttl));
+
             // False positive lint warning(`non-binding `let` on a future`): https://github.com/rust-lang/rust-clippy/issues/9932
             #[allow(clippy::let_underscore_future)]
-            let _ = C::spawn(fut.instrument(span));
+            let _ = C::spawn(fut);
         }
     }
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -125,7 +125,6 @@ use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::MpscReceiverOf;
 use crate::type_config::alias::MpscSenderOf;
 use crate::type_config::alias::OneshotReceiverOf;
-use crate::type_config::alias::UncommittedVoteOf;
 use crate::type_config::alias::VoteOf;
 use crate::type_config::alias::WatchReceiverOf;
 use crate::type_config::alias::WatchSenderOf;
@@ -1856,7 +1855,8 @@ where
 
                 #[allow(clippy::collapsible_if)]
                 if self.engine.candidate.is_some() {
-                    if self.does_candidate_vote_match(&candidate_vote, "VoteResponse") {
+                    let my_vote = self.engine.candidate_ref().map(|x| x.vote_ref());
+                    if Self::does_vote_match("Candidate", &candidate_vote, my_vote, "VoteResponse") {
                         self.engine.handle_vote_resp(target, resp);
                     }
                 }
@@ -1875,7 +1875,8 @@ where
 
                 #[allow(clippy::collapsible_if)]
                 if self.engine.pre_candidate.is_some() {
-                    if self.does_pre_candidate_vote_match(&candidate_vote, "PreVoteResponse") {
+                    let my_vote = self.engine.pre_candidate_ref().map(|x| x.vote_ref());
+                    if Self::does_vote_match("Pre-Candidate", &candidate_vote, my_vote, "PreVoteResponse") {
                         self.engine.handle_pre_vote_resp(target, resp);
                     }
                 }
@@ -1894,7 +1895,8 @@ where
                     leader_vote
                 );
 
-                if self.does_leader_vote_match(&leader_vote, "HigherVote") {
+                let my_vote = self.engine.leader.as_ref().map(|x| &x.committed_vote);
+                if Self::does_vote_match("Leader", &leader_vote, my_vote, "HigherVote") {
                     // Rejected vote change is ok.
                     self.engine.vote_handler().update_vote(&higher).ok();
                 }
@@ -1945,7 +1947,13 @@ where
                         // local log wont revert when membership changes.
                         #[allow(clippy::collapsible_if)]
                         if self.engine.leader.is_some() {
-                            if self.does_leader_vote_match(&log_io_id.committed_vote, "LocalIO Notification") {
+                            let my_vote = self.engine.leader.as_ref().map(|x| &x.committed_vote);
+                            if Self::does_vote_match(
+                                "Leader",
+                                &log_io_id.committed_vote,
+                                my_vote,
+                                "LocalIO Notification",
+                            ) {
                                 self.engine.replication_handler().update_local_progress(log_io_id.log_id);
                             }
                         }
@@ -2101,85 +2109,45 @@ where
         }
     }
 
-    /// If a message is sent by a previous Candidate but is received by current Candidate,
-    /// it is a stale message and should be just ignored.
-    fn does_candidate_vote_match(&self, candidate_vote: &UncommittedVoteOf<C>, msg: impl fmt::Display) -> bool {
-        // If it finished voting, Candidate's vote is None.
-        let Some(my_vote) = self.engine.candidate_ref().map(|x| x.vote_ref().clone()) else {
+    /// If a message is sent under a vote that this node no longer holds, it is a stale message
+    /// and should be just ignored.
+    ///
+    /// `role` names the role the vote belongs to, for the log message, e.g. `"Candidate"`.
+    /// `my_vote` is the vote this node currently holds in that role, `None` if it left the role
+    /// (a Candidate that finished voting has no vote).
+    ///
+    /// The two votes may have different types: the vote a message was sent under is an
+    /// `UncommittedVote`/`CommittedVote`, while the vote this node holds may be the
+    /// application's `C::Vote`. They are therefore compared by leader id.
+    fn does_vote_match<V, W>(role: &str, sent_vote: &V, my_vote: Option<&W>, msg: impl fmt::Display) -> bool
+    where
+        V: RaftVote,
+        W: RaftVote<LeaderId = V::LeaderId>,
+    {
+        let Some(my_vote) = my_vote else {
             tracing::warn!(
-                "A message will be ignored because this node is no longer Candidate: \
+                "A message will be ignored because this node is no longer {}: \
                  msg sent by vote: {}; when ({})",
-                candidate_vote,
+                role,
+                sent_vote,
                 msg
             );
             return false;
         };
 
-        if candidate_vote.leader_id() != my_vote.leader_id() {
+        if sent_vote.leader_id() != my_vote.leader_id() {
             tracing::warn!(
-                "A message will be ignored because vote changed: \
+                "A message will be ignored because {} vote changed: \
                 msg sent by vote: {}; current my vote: {}; when ({})",
-                candidate_vote,
+                role,
+                sent_vote,
                 my_vote,
-                msg
-            );
-            false
-        } else {
-            true
-        }
-    }
-
-    /// If a Pre-Vote response is for a previous Pre-Vote round, it is stale and should be ignored.
-    fn does_pre_candidate_vote_match(&self, candidate_vote: &UncommittedVoteOf<C>, msg: impl fmt::Display) -> bool {
-        let Some(my_vote) = self.engine.pre_candidate_ref().map(|x| x.vote_ref().clone()) else {
-            tracing::warn!(
-                "A message will be ignored because this node is no longer a pre-candidate: \
-                 msg sent by vote: {}; when ({})",
-                candidate_vote,
                 msg
             );
             return false;
-        };
-
-        if candidate_vote.leader_id() != my_vote.leader_id() {
-            tracing::warn!(
-                "A message will be ignored because pre-candidate vote changed: \
-                msg sent by vote: {}; current my pre-vote: {}; when ({})",
-                candidate_vote,
-                my_vote,
-                msg
-            );
-            false
-        } else {
-            true
         }
-    }
 
-    /// If a message is sent by a previous Leader but is received by current Leader,
-    /// it is a stale message and should be just ignored.
-    fn does_leader_vote_match(&self, leader_vote: &CommittedVoteOf<C>, msg: impl fmt::Display) -> bool {
-        let Some(my_vote) = self.engine.leader.as_ref().map(|x| x.committed_vote.clone()) else {
-            tracing::warn!(
-                "A message will be ignored because this node is no longer Leader: \
-                msg sent by vote: {}; when ({})",
-                leader_vote,
-                msg
-            );
-            return false;
-        };
-
-        if leader_vote != &my_vote {
-            tracing::warn!(
-                "A message will be ignored because vote changed: \
-                msg sent by vote: {}; current my vote: {}; when ({})",
-                leader_vote,
-                my_vote,
-                msg
-            );
-            false
-        } else {
-            true
-        }
+        true
     }
 
     /// Broadcast heartbeat to all followers with per-follower matching log ids.

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::fmt;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -8,6 +9,7 @@ use std::time::Duration;
 use display_more::DisplayOptionExt;
 use display_more::DisplaySliceExt;
 use futures_util::FutureExt;
+use futures_util::Stream;
 use futures_util::StreamExt;
 use futures_util::TryFutureExt;
 use futures_util::stream::FuturesUnordered;
@@ -95,6 +97,7 @@ use crate::raft::ClientWriteResult;
 use crate::raft::LogSegment;
 use crate::raft::ReadPolicy;
 use crate::raft::StreamAppendError;
+use crate::raft::StreamAppendResult;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::raft::linearizable_read::Linearizer;
@@ -122,10 +125,13 @@ use crate::type_config::alias::CommittedLeaderIdOf;
 use crate::type_config::alias::CommittedVoteOf;
 use crate::type_config::alias::EntryPayloadOf;
 use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::JoinErrorOf;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::MpscReceiverOf;
 use crate::type_config::alias::MpscSenderOf;
+use crate::type_config::alias::NodeIdOf;
 use crate::type_config::alias::OneshotReceiverOf;
+use crate::type_config::alias::StoredMembershipOf;
 use crate::type_config::alias::VoteOf;
 use crate::type_config::alias::WatchReceiverOf;
 use crate::type_config::alias::WatchSenderOf;
@@ -295,6 +301,10 @@ impl VoteRequestKind {
     }
 }
 
+/// The outcome of one leadership probe sent by [`RaftCore::spawn_leadership_probes`]: the target
+/// that answered and its append result, or the target that did not and the error that stopped it.
+type ProbeResult<C> = Result<(NodeIdOf<C>, StreamAppendResult<C>), (NodeIdOf<C>, RPCError<C>)>;
+
 impl<C, NF, LS, SM> RaftCore<C, NF, LS, SM>
 where
     C: RaftTypeConfig,
@@ -383,28 +393,15 @@ where
         };
 
         if read_policy == ReadPolicy::LeaseRead {
-            let now = C::now();
-            // Check if the lease is expired.
-            if let Some(last_quorum_acked_time) = self.last_quorum_acked_time()
-                && now < last_quorum_acked_time + self.engine.config.timer_config.leader_lease
-            {
-                tx.send(Ok(resp)).ok();
-                return;
-            }
-            tracing::debug!("{}: lease expired during lease read", self.id);
-            // we may no longer leader so error out early
-            let err = ForwardToLeader::empty();
-            tx.send(Err(err.into())).ok();
+            self.respond_lease_read(resp, tx);
             return;
         }
 
-        let my_id = self.id.clone();
         let my_vote = self.engine.state.vote_ref().clone();
-        let ttl = Duration::from_millis(self.config.heartbeat_interval);
         let eff_mem = self.engine.state.membership_state.effective().clone();
         let core_tx = self.tx_notification.clone();
 
-        let mut granted = btreeset! {my_id.clone()};
+        let granted = btreeset! {self.id.clone()};
 
         // single-node quorum, fast path, return quickly.
         if eff_mem.is_quorum(granted.iter()) {
@@ -412,8 +409,50 @@ where
             return;
         }
 
+        let pending = self.spawn_leadership_probes(&my_vote, &eff_mem).await;
+
+        // TODO: do not spawn, manage read requests with a queue by RaftCore
+
+        let waiting_fu = Self::wait_for_leadership_quorum(pending, my_vote, eff_mem, granted, core_tx, resp, tx);
+
+        // False positive lint warning(`non-binding `let` on a future`): https://github.com/rust-lang/rust-clippy/issues/9932
+        #[allow(clippy::let_underscore_future)]
+        let _ = C::spawn(waiting_fu.instrument(tracing::debug_span!("spawn_is_leader_waiting")));
+    }
+
+    /// Serve a [`ReadPolicy::LeaseRead`] request without contacting any peer.
+    ///
+    /// While the last quorum acknowledgement is younger than `leader_lease`, no other node can have
+    /// become leader, so the read is safe to answer from local state alone. Once the lease lapses
+    /// this node can no longer vouch for itself and the caller has to find the leader again.
+    fn respond_lease_read(&mut self, resp: Linearizer<C>, tx: ClientReadTx<C>) {
+        let now = C::now();
+        // Check if the lease is expired.
+        if let Some(last_quorum_acked_time) = self.last_quorum_acked_time()
+            && now < last_quorum_acked_time + self.engine.config.timer_config.leader_lease
+        {
+            tx.send(Ok(resp)).ok();
+            return;
+        }
+        tracing::debug!("{}: lease expired during lease read", self.id);
+        // we may no longer leader so error out early
+        let err = ForwardToLeader::empty();
+        tx.send(Err(err.into())).ok();
+    }
+
+    /// Probe every other voter with an empty AppendEntries, to confirm this node is still leading.
+    ///
+    /// The returned probes complete in arrival order; joining one may fail if its task panicked.
+    async fn spawn_leadership_probes(
+        &mut self,
+        my_vote: &VoteOf<C>,
+        eff_mem: &StoredMembershipOf<C>,
+    ) -> impl Stream<Item = Result<ProbeResult<C>, (NodeIdOf<C>, JoinErrorOf<C>)>> + Unpin + use<C, NF, LS, SM> {
+        let my_id = self.id.clone();
+        let ttl = Duration::from_millis(self.config.heartbeat_interval);
+
         // Spawn parallel requests, all with the standard timeout for heartbeats.
-        let mut pending = FuturesUnordered::new();
+        let pending = FuturesUnordered::new();
 
         let voter_progresses = {
             let l = &self.engine.leader.as_ref().unwrap();
@@ -484,78 +523,90 @@ where
             pending.push(task);
         }
 
-        let waiting_fu = async move {
-            // Handle responses as they return.
-            while let Some(res) = pending.next().await {
-                let (target, stream_result) = match res {
-                    Ok(Ok(res)) => res,
-                    Ok(Err((target, err))) => {
-                        tracing::error!(
-                            "timeout while confirming leadership for read request, target: {}, error: {}",
-                            target,
-                            err
-                        );
-                        continue;
-                    }
-                    Err((target, err)) => {
-                        tracing::error!("failed to join task: {}, target: {}", err, target);
-                        continue;
-                    }
-                };
+        pending
+    }
 
-                // If we receive a response with a greater vote, then revert to follower and abort this
-                // request.
-                if let Err(StreamAppendError::HigherVote(vote)) = stream_result {
-                    debug_assert!(
-                        vote.as_ref_vote() > my_vote.as_ref_vote(),
-                        "committed vote({}) has total order relation with other votes({})",
-                        my_vote,
-                        vote
+    /// Answer a read request as soon as a quorum of `pending` probes confirms this node still
+    /// leads.
+    ///
+    /// A probe reporting a higher vote ends the request immediately: the vote is forwarded to
+    /// [`RaftCore`] and the caller is told to look for the new leader. Exhausting the probes
+    /// without reaching a quorum yields [`QuorumNotEnough`].
+    async fn wait_for_leadership_quorum<S>(
+        mut pending: S,
+        my_vote: VoteOf<C>,
+        eff_mem: Arc<StoredMembershipOf<C>>,
+        mut granted: BTreeSet<NodeIdOf<C>>,
+        core_tx: MpscSenderOf<C, Notification<C>>,
+        resp: Linearizer<C>,
+        tx: ClientReadTx<C>,
+    ) where
+        S: Stream<Item = Result<ProbeResult<C>, (NodeIdOf<C>, JoinErrorOf<C>)>> + Unpin,
+    {
+        // Handle responses as they return.
+        while let Some(res) = pending.next().await {
+            let (target, stream_result) = match res {
+                Ok(Ok(res)) => res,
+                Ok(Err((target, err))) => {
+                    tracing::error!(
+                        "timeout while confirming leadership for read request, target: {}, error: {}",
+                        target,
+                        err
                     );
+                    continue;
+                }
+                Err((target, err)) => {
+                    tracing::error!("failed to join task: {}, target: {}", err, target);
+                    continue;
+                }
+            };
 
-                    let send_res = core_tx
-                        .send(Notification::HigherVote {
-                            target,
-                            higher: vote,
-                            leader_vote: my_vote.into_committed(),
-                        })
-                        .await;
+            // If we receive a response with a greater vote, then revert to follower and abort this
+            // request.
+            if let Err(StreamAppendError::HigherVote(vote)) = stream_result {
+                debug_assert!(
+                    vote.as_ref_vote() > my_vote.as_ref_vote(),
+                    "committed vote({}) has total order relation with other votes({})",
+                    my_vote,
+                    vote
+                );
 
-                    if let Err(_e) = send_res {
-                        tracing::error!("failed to send HigherVote to RaftCore");
-                    }
+                let send_res = core_tx
+                    .send(Notification::HigherVote {
+                        target,
+                        higher: vote,
+                        leader_vote: my_vote.into_committed(),
+                    })
+                    .await;
 
-                    // we are no longer leader so error out early
-                    let err = ForwardToLeader::empty();
-                    tx.send(Err(err.into())).ok();
-                    return;
+                if let Err(_e) = send_res {
+                    tracing::error!("failed to send HigherVote to RaftCore");
                 }
 
-                // Success or Conflict both confirm leadership (got valid response from follower)
-                granted.insert(target);
-
-                if eff_mem.is_quorum(granted.iter()) {
-                    tx.send(Ok(resp)).ok();
-                    return;
-                }
+                // we are no longer leader so error out early
+                let err = ForwardToLeader::empty();
+                tx.send(Err(err.into())).ok();
+                return;
             }
 
-            // If we've hit this location, then we've failed to gather needed confirmations due to
-            // request failures.
+            // Success or Conflict both confirm leadership (got valid response from follower)
+            granted.insert(target);
 
-            tx.send(Err(QuorumNotEnough {
-                cluster: eff_mem.membership().to_string(),
-                got: granted,
+            if eff_mem.is_quorum(granted.iter()) {
+                tx.send(Ok(resp)).ok();
+                return;
             }
-            .into()))
-                .ok();
-        };
+        }
 
-        // TODO: do not spawn, manage read requests with a queue by RaftCore
+        // If we've hit this location, then we've failed to gather needed confirmations due to
+        // request failures.
 
-        // False positive lint warning(`non-binding `let` on a future`): https://github.com/rust-lang/rust-clippy/issues/9932
-        #[allow(clippy::let_underscore_future)]
-        let _ = C::spawn(waiting_fu.instrument(tracing::debug_span!("spawn_is_leader_waiting")));
+        tx.send(Err(QuorumNotEnough {
+            cluster: eff_mem.membership().to_string(),
+            got: granted,
+        }
+        .into()))
+            .ok();
     }
 
     /// Submit change-membership by writing a Membership log entry.

--- a/openraft/src/core/raft_msg/raft_msg_name.rs
+++ b/openraft/src/core/raft_msg/raft_msg_name.rs
@@ -1,6 +1,9 @@
+use openraft_macros::VariantName;
+
 /// Enum representing the name of each `ExternalCommand` variant.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(VariantName)]
+#[variant_name(prefix = "Ext::")]
 pub enum ExternalCommandName {
     Elect,
     Heartbeat,
@@ -12,60 +15,6 @@ pub enum ExternalCommandName {
     RefreshServerState,
 }
 
-impl ExternalCommandName {
-    /// Total number of variants.
-    #[allow(dead_code)]
-    pub const COUNT: usize = 8;
-
-    /// All variants in canonical order.
-    #[allow(dead_code)]
-    pub const ALL: &'static [ExternalCommandName] = &[
-        ExternalCommandName::Elect,
-        ExternalCommandName::Heartbeat,
-        ExternalCommandName::Snapshot,
-        ExternalCommandName::PurgeLog,
-        ExternalCommandName::TriggerTransferLeader,
-        ExternalCommandName::AllowNextRevert,
-        ExternalCommandName::SetMetricsRecorder,
-        ExternalCommandName::RefreshServerState,
-    ];
-
-    /// Returns the index of this variant for array-based storage.
-    #[allow(dead_code)]
-    pub const fn index(&self) -> usize {
-        match self {
-            ExternalCommandName::Elect => 0,
-            ExternalCommandName::Heartbeat => 1,
-            ExternalCommandName::Snapshot => 2,
-            ExternalCommandName::PurgeLog => 3,
-            ExternalCommandName::TriggerTransferLeader => 4,
-            ExternalCommandName::AllowNextRevert => 5,
-            ExternalCommandName::SetMetricsRecorder => 6,
-            ExternalCommandName::RefreshServerState => 7,
-        }
-    }
-
-    #[allow(dead_code)]
-    pub const fn as_str(&self) -> &'static str {
-        match self {
-            ExternalCommandName::Elect => "Ext::Elect",
-            ExternalCommandName::Heartbeat => "Ext::Heartbeat",
-            ExternalCommandName::Snapshot => "Ext::Snapshot",
-            ExternalCommandName::PurgeLog => "Ext::PurgeLog",
-            ExternalCommandName::TriggerTransferLeader => "Ext::TriggerTransferLeader",
-            ExternalCommandName::AllowNextRevert => "Ext::AllowNextRevert",
-            ExternalCommandName::SetMetricsRecorder => "Ext::SetMetricsRecorder",
-            ExternalCommandName::RefreshServerState => "Ext::RefreshServerState",
-        }
-    }
-}
-
-impl std::fmt::Display for ExternalCommandName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
 /// Enum naming each Raft message type tracked for logging, metrics, and debugging.
 ///
 /// Most variants correspond one-to-one with a `RaftMsg` variant. The exception is
@@ -73,8 +22,8 @@ impl std::fmt::Display for ExternalCommandName {
 /// than as a `RaftMsg` variant, but is still recorded here for runtime stats.
 ///
 /// This provides an efficient way to identify message types without string comparisons.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(VariantName)]
 pub enum RaftMsgName {
     AppendEntries,
     RequestVote,
@@ -88,80 +37,6 @@ pub enum RaftMsgName {
     WithRaftState,
     ExternalCommand(ExternalCommandName),
     GetRuntimeStats,
-}
-
-impl RaftMsgName {
-    /// Total number of variants (including expanded ExternalCommand variants).
-    pub const COUNT: usize = 19;
-
-    /// All variants in canonical order.
-    ///
-    /// ExternalCommand variants are expanded to include all ExternalCommandName variants.
-    #[allow(dead_code)]
-    pub const ALL: &'static [RaftMsgName] = &[
-        RaftMsgName::AppendEntries,
-        RaftMsgName::RequestVote,
-        RaftMsgName::RequestPreVote,
-        RaftMsgName::InstallSnapshot,
-        RaftMsgName::ClientWrite,
-        RaftMsgName::GetLinearizer,
-        RaftMsgName::Initialize,
-        RaftMsgName::ChangeMembership,
-        RaftMsgName::HandleTransferLeader,
-        RaftMsgName::WithRaftState,
-        RaftMsgName::ExternalCommand(ExternalCommandName::Elect),
-        RaftMsgName::ExternalCommand(ExternalCommandName::Heartbeat),
-        RaftMsgName::ExternalCommand(ExternalCommandName::Snapshot),
-        RaftMsgName::ExternalCommand(ExternalCommandName::PurgeLog),
-        RaftMsgName::ExternalCommand(ExternalCommandName::TriggerTransferLeader),
-        RaftMsgName::ExternalCommand(ExternalCommandName::AllowNextRevert),
-        RaftMsgName::ExternalCommand(ExternalCommandName::SetMetricsRecorder),
-        RaftMsgName::ExternalCommand(ExternalCommandName::RefreshServerState),
-        RaftMsgName::GetRuntimeStats,
-    ];
-
-    /// Returns the index of this variant for array-based storage.
-    pub const fn index(&self) -> usize {
-        match self {
-            RaftMsgName::AppendEntries => 0,
-            RaftMsgName::RequestVote => 1,
-            RaftMsgName::RequestPreVote => 2,
-            RaftMsgName::InstallSnapshot => 3,
-            RaftMsgName::ClientWrite => 4,
-            RaftMsgName::GetLinearizer => 5,
-            RaftMsgName::Initialize => 6,
-            RaftMsgName::ChangeMembership => 7,
-            RaftMsgName::HandleTransferLeader => 8,
-            RaftMsgName::WithRaftState => 9,
-            RaftMsgName::ExternalCommand(ext) => 10 + ext.index(),
-            RaftMsgName::GetRuntimeStats => 10 + ExternalCommandName::COUNT,
-        }
-    }
-
-    /// Returns the string representation of the message name.
-    #[allow(dead_code)]
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            RaftMsgName::AppendEntries => "AppendEntries",
-            RaftMsgName::RequestVote => "RequestVote",
-            RaftMsgName::RequestPreVote => "RequestPreVote",
-            RaftMsgName::InstallSnapshot => "InstallSnapshot",
-            RaftMsgName::ClientWrite => "ClientWrite",
-            RaftMsgName::GetLinearizer => "GetLinearizer",
-            RaftMsgName::Initialize => "Initialize",
-            RaftMsgName::ChangeMembership => "ChangeMembership",
-            RaftMsgName::HandleTransferLeader => "HandleTransferLeader",
-            RaftMsgName::WithRaftState => "WithRaftState",
-            RaftMsgName::ExternalCommand(ext) => ext.as_str(),
-            RaftMsgName::GetRuntimeStats => "GetRuntimeStats",
-        }
-    }
-}
-
-impl std::fmt::Display for RaftMsgName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
 }
 
 #[cfg(test)]

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -283,7 +283,28 @@ where
             (Command::StateMachine { command },                Command::StateMachine { command: b })                                 => command == b,
             (Command::CloseReplicationStreams,                 Command::CloseReplicationStreams)                                     => true,
             (Command::ReplicateSnapshot { leader_vote, target, inflight_id }, Command::ReplicateSnapshot { leader_vote: lb, target: tb, inflight_id: ib }) => leader_vote == lb && target == tb && inflight_id == ib,
-            _ => false,
+
+            // Two different commands are never equal. These arms are spelled out per variant
+            // instead of one `_ => false`, so that a newly added variant leaves the match
+            // non-exhaustive and fails to compile until it gets a comparison arm above. A
+            // catch-all would instead make the new variant silently unequal to itself.
+            (Command::UpdateIOProgress { .. },          _) => false,
+            (Command::AppendEntries { .. },             _) => false,
+            (Command::ReplicateCommitted { .. },        _) => false,
+            (Command::BroadcastHeartbeat { .. },        _) => false,
+            (Command::SaveCommittedAndApply { .. },     _) => false,
+            (Command::Replicate { .. },                 _) => false,
+            (Command::ReplicateSnapshot { .. },         _) => false,
+            (Command::BroadcastTransferLeader { .. },   _) => false,
+            (Command::CloseReplicationStreams,          _) => false,
+            (Command::RebuildReplicationStreams { .. }, _) => false,
+            (Command::SaveVote { .. },                  _) => false,
+            (Command::SendVote { .. },                  _) => false,
+            (Command::SendPreVote { .. },               _) => false,
+            (Command::PurgeLog { .. },                  _) => false,
+            (Command::TruncateLog { .. },               _) => false,
+            (Command::StateMachine { .. },              _) => false,
+            (Command::Respond { .. },                   _) => false,
         }
     }
 }

--- a/openraft/src/engine/command_name.rs
+++ b/openraft/src/engine/command_name.rs
@@ -1,63 +1,24 @@
+use openraft_macros::VariantName;
+
 /// Enum representing the name of each `sm::Command` variant.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(u8)]
+#[derive(VariantName)]
+#[variant_name(prefix = "SM::")]
 pub enum SMCommandName {
-    BuildSnapshot = 0,
-    GetSnapshot = 1,
-    BeginReceivingSnapshot = 2,
-    InstallFullSnapshot = 3,
-    Apply = 4,
-    ExternalFunc = 5,
-}
-
-impl SMCommandName {
-    /// Total number of variants.
-    #[allow(dead_code)]
-    pub const COUNT: usize = 6;
-
-    /// All variants in canonical order.
-    #[allow(dead_code)]
-    pub const ALL: &'static [SMCommandName] = &[
-        SMCommandName::BuildSnapshot,
-        SMCommandName::GetSnapshot,
-        SMCommandName::BeginReceivingSnapshot,
-        SMCommandName::InstallFullSnapshot,
-        SMCommandName::Apply,
-        SMCommandName::ExternalFunc,
-    ];
-
-    /// Returns the index of this variant for array-based storage.
-    #[allow(dead_code)]
-    pub const fn index(&self) -> usize {
-        *self as usize
-    }
-
-    #[allow(dead_code)]
-    pub const fn as_str(&self) -> &'static str {
-        match self {
-            SMCommandName::BuildSnapshot => "SM::BuildSnapshot",
-            SMCommandName::GetSnapshot => "SM::GetSnapshot",
-            SMCommandName::BeginReceivingSnapshot => "SM::BeginReceivingSnapshot",
-            SMCommandName::InstallFullSnapshot => "SM::InstallFullSnapshot",
-            SMCommandName::Apply => "SM::Apply",
-            SMCommandName::ExternalFunc => "SM::ExternalFunc",
-        }
-    }
-}
-
-impl std::fmt::Display for SMCommandName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
+    BuildSnapshot,
+    GetSnapshot,
+    BeginReceivingSnapshot,
+    InstallFullSnapshot,
+    Apply,
+    ExternalFunc,
 }
 
 /// Enum representing the name of each `Command` variant.
 ///
 /// This provides an efficient way to identify command types without
 /// string comparisons, useful for logging, metrics, and debugging.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(VariantName)]
 pub enum CommandName {
     UpdateIOProgress,
     AppendEntries,
@@ -76,93 +37,6 @@ pub enum CommandName {
     TruncateLog,
     StateMachine(SMCommandName),
     Respond,
-}
-
-impl CommandName {
-    /// Total number of variants (including expanded StateMachine variants).
-    pub const COUNT: usize = 22;
-
-    /// All variants in canonical order.
-    ///
-    /// StateMachine variants are expanded to include all SMCommandName variants.
-    #[allow(dead_code)]
-    pub const ALL: &'static [CommandName] = &[
-        CommandName::UpdateIOProgress,
-        CommandName::AppendEntries,
-        CommandName::ReplicateCommitted,
-        CommandName::BroadcastHeartbeat,
-        CommandName::SaveCommittedAndApply,
-        CommandName::Replicate,
-        CommandName::ReplicateSnapshot,
-        CommandName::BroadcastTransferLeader,
-        CommandName::CloseReplicationStreams,
-        CommandName::RebuildReplicationStreams,
-        CommandName::SaveVote,
-        CommandName::SendVote,
-        CommandName::SendPreVote,
-        CommandName::PurgeLog,
-        CommandName::TruncateLog,
-        CommandName::StateMachine(SMCommandName::BuildSnapshot),
-        CommandName::StateMachine(SMCommandName::GetSnapshot),
-        CommandName::StateMachine(SMCommandName::BeginReceivingSnapshot),
-        CommandName::StateMachine(SMCommandName::InstallFullSnapshot),
-        CommandName::StateMachine(SMCommandName::Apply),
-        CommandName::StateMachine(SMCommandName::ExternalFunc),
-        CommandName::Respond,
-    ];
-
-    /// Returns the index of this variant for array-based storage.
-    pub const fn index(&self) -> usize {
-        match self {
-            CommandName::UpdateIOProgress => 0,
-            CommandName::AppendEntries => 1,
-            CommandName::ReplicateCommitted => 2,
-            CommandName::BroadcastHeartbeat => 3,
-            CommandName::SaveCommittedAndApply => 4,
-            CommandName::Replicate => 5,
-            CommandName::ReplicateSnapshot => 6,
-            CommandName::BroadcastTransferLeader => 7,
-            CommandName::CloseReplicationStreams => 8,
-            CommandName::RebuildReplicationStreams => 9,
-            CommandName::SaveVote => 10,
-            CommandName::SendVote => 11,
-            CommandName::SendPreVote => 12,
-            CommandName::PurgeLog => 13,
-            CommandName::TruncateLog => 14,
-            CommandName::StateMachine(sm) => 15 + sm.index(),
-            CommandName::Respond => 15 + SMCommandName::COUNT,
-        }
-    }
-
-    /// Returns the string representation of the command name.
-    #[allow(dead_code)]
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            CommandName::UpdateIOProgress => "UpdateIOProgress",
-            CommandName::AppendEntries => "AppendEntries",
-            CommandName::ReplicateCommitted => "ReplicateCommitted",
-            CommandName::BroadcastHeartbeat => "BroadcastHeartbeat",
-            CommandName::SaveCommittedAndApply => "SaveCommittedAndApply",
-            CommandName::Replicate => "Replicate",
-            CommandName::ReplicateSnapshot => "ReplicateSnapshot",
-            CommandName::BroadcastTransferLeader => "BroadcastTransferLeader",
-            CommandName::CloseReplicationStreams => "CloseReplicationStreams",
-            CommandName::RebuildReplicationStreams => "RebuildReplicationStreams",
-            CommandName::SaveVote => "SaveVote",
-            CommandName::SendVote => "SendVote",
-            CommandName::SendPreVote => "SendPreVote",
-            CommandName::PurgeLog => "PurgeLog",
-            CommandName::TruncateLog => "TruncateLog",
-            CommandName::StateMachine(sm) => sm.as_str(),
-            CommandName::Respond => "Respond",
-        }
-    }
-}
-
-impl std::fmt::Display for CommandName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
 }
 
 #[cfg(test)]

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -981,18 +981,11 @@ where
     }
 
     pub(crate) fn log_handler(&mut self) -> LogHandler<'_, C, SM> {
-        LogHandler {
-            config: &mut self.config,
-            state: &mut self.state,
-            output: &mut self.output,
-        }
+        LogHandler::new(&mut self.config, &mut self.state, &mut self.output)
     }
 
     pub(crate) fn snapshot_handler(&mut self) -> SnapshotHandler<'_, '_, C, SM> {
-        SnapshotHandler {
-            state: &mut self.state,
-            output: &mut self.output,
-        }
+        SnapshotHandler::new(&mut self.state, &mut self.output)
     }
 
     pub(crate) fn try_leader_handler(&mut self) -> Result<LeaderHandler<'_, C, SM>, ForwardToLeader<C>> {
@@ -1011,24 +1004,19 @@ where
             self.state.vote_ref()
         );
 
-        Ok(LeaderHandler {
-            config: &mut self.config,
+        Ok(LeaderHandler::new(
+            &mut self.config,
             leader,
-            state: &mut self.state,
-            output: &mut self.output,
-        })
+            &mut self.state,
+            &mut self.output,
+        ))
     }
 
     /// Return ReplicationHandler if it is Leader.
     pub(crate) fn try_replication_handler(&mut self) -> Option<ReplicationHandler<'_, C, SM>> {
         let leader = self.leader.as_mut()?;
 
-        let rh = ReplicationHandler {
-            config: &mut self.config,
-            leader,
-            state: &mut self.state,
-            output: &mut self.output,
-        };
+        let rh = ReplicationHandler::new(&mut self.config, leader, &mut self.state, &mut self.output);
 
         Some(rh)
     }
@@ -1041,12 +1029,7 @@ where
             Some(x) => x,
         };
 
-        ReplicationHandler {
-            config: &mut self.config,
-            leader,
-            state: &mut self.state,
-            output: &mut self.output,
-        }
+        ReplicationHandler::new(&mut self.config, leader, &mut self.state, &mut self.output)
     }
 
     pub(crate) fn following_handler(&mut self) -> FollowingHandler<'_, C, SM> {
@@ -1068,10 +1051,7 @@ where
     }
 
     pub(crate) fn server_state_handler(&mut self) -> ServerStateHandler<'_, C> {
-        ServerStateHandler {
-            config: &self.config,
-            state: &mut self.state,
-        }
+        ServerStateHandler::new(&self.config, &mut self.state)
     }
     pub(crate) fn establish_handler(&mut self) -> EstablishHandler<'_, C> {
         EstablishHandler {

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -317,24 +317,14 @@ where
     }
 
     fn log_handler(&mut self) -> LogHandler<'_, C, SM> {
-        LogHandler {
-            config: self.config,
-            state: self.state,
-            output: self.output,
-        }
+        LogHandler::new(self.config, self.state, self.output)
     }
 
     fn snapshot_handler(&mut self) -> SnapshotHandler<'_, '_, C, SM> {
-        SnapshotHandler {
-            state: self.state,
-            output: self.output,
-        }
+        SnapshotHandler::new(self.state, self.output)
     }
 
     fn server_state_handler(&mut self) -> ServerStateHandler<'_, C> {
-        ServerStateHandler {
-            config: self.config,
-            state: self.state,
-        }
+        ServerStateHandler::new(self.config, self.state)
     }
 }

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -2,12 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
-#[allow(unused_imports)]
 use pretty_assertions::assert_eq;
-#[allow(unused_imports)]
-use pretty_assertions::assert_ne;
-#[allow(unused_imports)]
-use pretty_assertions::assert_str_eq;
 
 use crate::Membership;
 use crate::MembershipState;

--- a/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
+++ b/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
@@ -2,12 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
-#[allow(unused_imports)]
 use pretty_assertions::assert_eq;
-#[allow(unused_imports)]
-use pretty_assertions::assert_ne;
-#[allow(unused_imports)]
-use pretty_assertions::assert_str_eq;
 
 use crate::Membership;
 use crate::MembershipState;

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -43,11 +43,25 @@ where
     pub(crate) output: &'x mut EngineOutput<C, SM>,
 }
 
-impl<C, SM> LeaderHandler<'_, C, SM>
+impl<'x, C, SM> LeaderHandler<'x, C, SM>
 where
     C: RaftTypeConfig,
     SM: RaftStateMachine<C>,
 {
+    pub(crate) fn new(
+        config: &'x mut EngineConfig<C>,
+        leader: &'x mut Leader<C, LeaderQuorumSet<C>>,
+        state: &'x mut RaftState<C>,
+        output: &'x mut EngineOutput<C, SM>,
+    ) -> Self {
+        Self {
+            config,
+            leader,
+            state,
+            output,
+        }
+    }
+
     /// Append new log entries by a leader.
     ///
     /// Also Update effective membership if the payload contains
@@ -152,11 +166,6 @@ where
     }
 
     pub(crate) fn replication_handler(&mut self) -> ReplicationHandler<'_, C, SM> {
-        ReplicationHandler {
-            config: self.config,
-            leader: self.leader,
-            state: self.state,
-            output: self.output,
-        }
+        ReplicationHandler::new(self.config, self.leader, self.state, self.output)
     }
 }

--- a/openraft/src/engine/handler/leader_handler/transfer_leader_test.rs
+++ b/openraft/src/engine/handler/leader_handler/transfer_leader_test.rs
@@ -2,12 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use maplit::btreeset;
-#[allow(unused_imports)]
 use pretty_assertions::assert_eq;
-#[allow(unused_imports)]
-use pretty_assertions::assert_ne;
-#[allow(unused_imports)]
-use pretty_assertions::assert_str_eq;
 
 use crate::Membership;
 use crate::MembershipState;

--- a/openraft/src/engine/handler/log_handler/mod.rs
+++ b/openraft/src/engine/handler/log_handler/mod.rs
@@ -27,11 +27,19 @@ where
     pub(crate) output: &'x mut EngineOutput<C, SM>,
 }
 
-impl<C, SM> LogHandler<'_, C, SM>
+impl<'x, C, SM> LogHandler<'x, C, SM>
 where
     C: RaftTypeConfig,
     SM: RaftStateMachine<C>,
 {
+    pub(crate) fn new(
+        config: &'x mut EngineConfig<C>,
+        state: &'x mut RaftState<C>,
+        output: &'x mut EngineOutput<C, SM>,
+    ) -> Self {
+        Self { config, state, output }
+    }
+
     /// Purge log entries up to `RaftState.purge_upto()`, inclusive.
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn purge_log(&mut self) {

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -60,11 +60,25 @@ where
     pub(crate) output: &'x mut EngineOutput<C, SM>,
 }
 
-impl<C, SM> ReplicationHandler<'_, C, SM>
+impl<'x, C, SM> ReplicationHandler<'x, C, SM>
 where
     C: RaftTypeConfig,
     SM: RaftStateMachine<C>,
 {
+    pub(crate) fn new(
+        config: &'x mut EngineConfig<C>,
+        leader: &'x mut Leader<C, LeaderQuorumSet<C>>,
+        state: &'x mut RaftState<C>,
+        output: &'x mut EngineOutput<C, SM>,
+    ) -> Self {
+        Self {
+            config,
+            leader,
+            state,
+            output,
+        }
+    }
+
     /// Append a new membership and update related state such as replication streams.
     ///
     /// It is called by the leader when a new membership log is appended to the log store.
@@ -514,10 +528,6 @@ where
     }
 
     pub(crate) fn log_handler(&mut self) -> LogHandler<'_, C, SM> {
-        LogHandler {
-            config: self.config,
-            state: self.state,
-            output: self.output,
-        }
+        LogHandler::new(self.config, self.state, self.output)
     }
 }

--- a/openraft/src/engine/handler/server_state_handler/mod.rs
+++ b/openraft/src/engine/handler/server_state_handler/mod.rs
@@ -14,9 +14,13 @@ where C: RaftTypeConfig
     pub(crate) state: &'st mut RaftState<C>,
 }
 
-impl<C> ServerStateHandler<'_, C>
+impl<'st, C> ServerStateHandler<'st, C>
 where C: RaftTypeConfig
 {
+    pub(crate) fn new(config: &'st EngineConfig<C>, state: &'st mut RaftState<C>) -> Self {
+        Self { config, state }
+    }
+
     /// Re-calculate the server-state if it changed, update the `server_state` field and dispatch
     /// commands to inform a runtime.
     pub(crate) fn update_server_state_if_changed(&mut self) {

--- a/openraft/src/engine/handler/snapshot_handler/mod.rs
+++ b/openraft/src/engine/handler/snapshot_handler/mod.rs
@@ -26,11 +26,15 @@ where
     pub(crate) output: &'out mut EngineOutput<C, SM>,
 }
 
-impl<C, SM> SnapshotHandler<'_, '_, C, SM>
+impl<'st, 'out, C, SM> SnapshotHandler<'st, 'out, C, SM>
 where
     C: RaftTypeConfig,
     SM: RaftStateMachine<C>,
 {
+    pub(crate) fn new(state: &'st mut RaftState<C>, output: &'out mut EngineOutput<C, SM>) -> Self {
+        Self { state, output }
+    }
+
     /// Trigger building a snapshot if there is no pending building job.
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn trigger_snapshot(&mut self) -> bool {

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -254,31 +254,18 @@ where
     }
 
     pub(crate) fn server_state_handler(&mut self) -> ServerStateHandler<'_, C> {
-        ServerStateHandler {
-            config: self.config,
-            state: self.state,
-        }
+        ServerStateHandler::new(self.config, self.state)
     }
 
     pub(crate) fn replication_handler(&mut self) -> ReplicationHandler<'_, C, SM> {
         let leader = self.leader.as_mut().unwrap();
 
-        ReplicationHandler {
-            config: self.config,
-            leader,
-            state: self.state,
-            output: self.output,
-        }
+        ReplicationHandler::new(self.config, leader, self.state, self.output)
     }
 
     pub(crate) fn leader_handler(&mut self) -> LeaderHandler<'_, C, SM> {
         let leader = self.leader.as_mut().unwrap();
 
-        LeaderHandler {
-            config: self.config,
-            leader,
-            state: self.state,
-            output: self.output,
-        }
+        LeaderHandler::new(self.config, leader, self.state, self.output)
     }
 }

--- a/openraft/src/errors/into_ok.rs
+++ b/openraft/src/errors/into_ok.rs
@@ -2,28 +2,15 @@
 
 use crate::errors::Infallible;
 
-/// Trait to convert `Result<T, E>` to `T`, if `E` is a `never` type.
-pub(crate) trait UnwrapInfallible<T> {
-    fn into_ok(self) -> T;
-}
-
-impl<T, E> UnwrapInfallible<T> for Result<T, E>
-where E: Into<Infallible>
-{
-    fn into_ok(self) -> T {
-        match self {
-            Ok(t) => t,
-            Err(e) => {
-                // NOTE: `allow` required because of buggy reachability detection by rust compiler
-                #[allow(unreachable_code)]
-                match e.into() {}
-            }
-        }
-    }
-}
-
 /// Convert `Result<T, E>` to `T`, if `E` is a `never` type.
 pub(crate) fn into_ok<T, E>(result: Result<T, E>) -> T
 where E: Into<Infallible> {
-    UnwrapInfallible::into_ok(result)
+    match result {
+        Ok(t) => t,
+        Err(e) => {
+            // NOTE: `allow` required because of buggy reachability detection by rust compiler
+            #[allow(unreachable_code)]
+            match e.into() {}
+        }
+    }
 }

--- a/openraft/src/errors/mod.rs
+++ b/openraft/src/errors/mod.rs
@@ -6,7 +6,7 @@ pub mod decompose;
 mod error_source;
 mod fatal;
 pub(crate) mod higher_vote;
-pub mod into_ok;
+pub(crate) mod into_ok;
 pub(crate) mod into_raft_result;
 mod leader_changed;
 mod linearizable_read_error;

--- a/openraft/src/log_id/log_index_option_ext.rs
+++ b/openraft/src/log_id/log_index_option_ext.rs
@@ -1,6 +1,9 @@
+use openraft_macros::since;
+
 /// This helper trait extracts information from an `Option<LogIndex>`.
 ///
 /// In openraft, `LogIndex` is a `u64`.
+#[since(version = "0.10.0", change = "removed unused method `add()`")]
 pub trait LogIndexOptionExt {
     /// Return the next log index.
     ///
@@ -11,10 +14,6 @@ pub trait LogIndexOptionExt {
     ///
     /// If self is `None`, it panics.
     fn prev_index(&self) -> Self;
-
-    // TODO: unused, remove it
-    /// Performs an "add" operation.
-    fn add(&self, v: u64) -> Self;
 }
 
 impl LogIndexOptionExt for Option<u64> {
@@ -38,9 +37,5 @@ impl LogIndexOptionExt for Option<u64> {
                 }
             }
         }
-    }
-
-    fn add(&self, v: u64) -> Self {
-        Some(self.next_index() + v).prev_index()
     }
 }

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -82,13 +82,7 @@ where
                 if i > 0 {
                     write!(f, ",",)?;
                 }
-                write!(f, "{node_id}:")?;
-
-                if let Some(n) = self.get_node(node_id) {
-                    write!(f, "{n:?}")?;
-                } else {
-                    write!(f, "None")?;
-                }
+                self.fmt_node(f, node_id)?;
             }
             write!(f, "}}")?;
         }
@@ -104,12 +98,7 @@ where
                 write!(f, ",")?;
             }
 
-            write!(f, "{learner_id}:")?;
-            if let Some(n) = self.get_node(learner_id) {
-                write!(f, "{n:?}")?;
-            } else {
-                write!(f, "None")?;
-            }
+            self.fmt_node(f, learner_id)?;
         }
         write!(f, "]}}")?;
         Ok(())
@@ -200,6 +189,16 @@ where
     NID: NodeId,
     N: Node,
 {
+    /// Format one node as `<node_id>:<node>`, or `<node_id>:None` if this membership has no such
+    /// node.
+    fn fmt_node(&self, f: &mut fmt::Formatter<'_>, node_id: &NID) -> fmt::Result {
+        write!(f, "{node_id}:")?;
+        match self.get_node(node_id) {
+            Some(n) => write!(f, "{n:?}"),
+            None => write!(f, "None"),
+        }
+    }
+
     /// Return true if the given node id is either a voter or a learner.
     pub(crate) fn contains(&self, node_id: &NID) -> bool {
         self.nodes.contains_key(node_id)

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -352,60 +352,57 @@ where
     fn compute_target_membership(mut self, change: ChangeMembers<NID, N>) -> Membership<NID, N> {
         let last = self.get_joint_config().last().cloned().unwrap_or_default();
 
-        match change {
-            ChangeMembers::AddVoterIds(add_voter_ids) => {
-                let new_voter_ids = last.union(&add_voter_ids).cloned().collect::<BTreeSet<_>>();
-                self.configs = vec![new_voter_ids];
-                self
-            }
+        // `None` means the change does not touch the voter set, only `nodes`.
+        let new_voter_ids: Option<BTreeSet<NID>> = match change {
+            ChangeMembers::AddVoterIds(add_voter_ids) => Some(last.union(&add_voter_ids).cloned().collect()),
             ChangeMembers::AddVoters(add_voters) => {
                 // Add nodes without overriding existent
                 self.nodes = Self::extend_nodes(self.nodes, &add_voters);
 
                 let add_voter_ids = add_voters.keys().cloned().collect::<BTreeSet<_>>();
-                let new_voter_ids = last.union(&add_voter_ids).cloned().collect::<BTreeSet<_>>();
-                self.configs = vec![new_voter_ids];
-                self
+                Some(last.union(&add_voter_ids).cloned().collect())
             }
             ChangeMembers::RemoveVoters(remove_voter_ids) => {
-                let new_voter_ids = last.difference(&remove_voter_ids).cloned().collect::<BTreeSet<_>>();
-                self.configs = vec![new_voter_ids];
-                self
+                Some(last.difference(&remove_voter_ids).cloned().collect())
             }
-            ChangeMembers::ReplaceAllVoters(all_voter_ids) => {
-                self.configs = vec![all_voter_ids];
-                self
-            }
+            ChangeMembers::ReplaceAllVoters(all_voter_ids) => Some(all_voter_ids),
             ChangeMembers::AddNodes(add_nodes) => {
                 // When adding nodes, do not override existing node
                 for (node_id, node) in add_nodes.into_iter() {
                     self.nodes.entry(node_id).or_insert(node);
                 }
-                self
+                None
             }
             ChangeMembers::SetNodes(set_nodes) => {
                 for (node_id, node) in set_nodes.into_iter() {
                     self.nodes.insert(node_id, node);
                 }
-                self
+                None
             }
             ChangeMembers::RemoveNodes(remove_node_ids) => {
                 for node_id in remove_node_ids.iter() {
                     self.nodes.remove(node_id);
                 }
-                self
+                None
             }
             ChangeMembers::ReplaceAllNodes(all_nodes) => {
                 self.nodes = all_nodes;
-                self
+                None
             }
             ChangeMembers::Batch(batch) => {
+                // Each nested change already updated `configs` as needed.
                 for change in batch {
                     self = self.compute_target_membership(change);
                 }
-                self
+                None
             }
+        };
+
+        if let Some(voter_ids) = new_voter_ids {
+            self.configs = vec![voter_ids];
         }
+
+        self
     }
 }
 

--- a/openraft/src/network/v2/network.rs
+++ b/openraft/src/network/v2/network.rs
@@ -262,7 +262,6 @@ use crate::network::NetStreamAppend;
 use crate::network::NetTransferLeader;
 use crate::network::NetVote;
 
-#[allow(clippy::manual_async_fn)]
 impl<C, T> NetAppend<C> for T
 where
     C: RaftTypeConfig,
@@ -287,7 +286,6 @@ where
     }
 }
 
-#[allow(clippy::manual_async_fn)]
 impl<C, T> NetVote<C> for T
 where
     C: RaftTypeConfig,
@@ -302,7 +300,6 @@ where
     }
 }
 
-#[allow(clippy::manual_async_fn)]
 impl<C, T> NetSnapshot<C> for T
 where
     C: RaftTypeConfig,
@@ -321,7 +318,6 @@ where
     }
 }
 
-#[allow(clippy::manual_async_fn)]
 impl<C, T> NetTransferLeader<C> for T
 where
     C: RaftTypeConfig,

--- a/openraft/src/progress/mod.rs
+++ b/openraft/src/progress/mod.rs
@@ -18,8 +18,6 @@ pub(crate) mod stream_id;
 pub(crate) mod vec_progress;
 pub(crate) mod vec_progress_entry;
 
-// TODO: remove it
-#[allow(unused_imports)]
 pub(crate) use inflight::Inflight;
 pub(crate) use vec_progress::VecProgress;
 pub(crate) use vec_progress_entry::VecProgressEntry;

--- a/openraft/src/progress/vec_progress.rs
+++ b/openraft/src/progress/vec_progress.rs
@@ -152,13 +152,7 @@ where
     where Fmt: Fn(&mut Formatter<'_>, &Entry) -> std::fmt::Result {
         DisplayVecProgress { inner: self, f }
     }
-}
 
-impl<Entry, QS> VecProgress<Entry, QS>
-where
-    Entry: VecProgressEntry,
-    QS: QuorumSet<Id = Entry::Id>,
-{
     /// Update one of the scalar values and re-calculate the quorum-accepted value.
     ///
     /// It returns `Err(quorum_accepted)` if the `id` is not found.

--- a/openraft/src/raft/api/app.rs
+++ b/openraft/src/raft/api/app.rs
@@ -18,6 +18,7 @@ use crate::raft::message::WriteResult;
 use crate::raft::message::into_write_result;
 use crate::raft::raft_inner::RaftInner;
 use crate::raft::responder::core_responder::CoreResponder;
+#[cfg(feature = "runtime-stats")]
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::BatchOf;
 use crate::type_config::alias::EntryPayloadOf;
@@ -49,8 +50,7 @@ where C: RaftTypeConfig
         &self,
         read_policy: ReadPolicy,
     ) -> Result<Result<Linearizer<C>, LinearizableReadError<C>>, Fatal<C>> {
-        let (tx, rx) = C::oneshot();
-        self.inner.call_core(RaftMsg::GetLinearizer { read_policy, tx }, rx).await
+        self.inner.call_core_oneshot(|tx| RaftMsg::GetLinearizer { read_policy, tx }).await
     }
 
     #[since(version = "0.10.0")]

--- a/openraft/src/raft/api/management.rs
+++ b/openraft/src/raft/api/management.rs
@@ -17,7 +17,6 @@ use crate::impls::ProgressResponder;
 use crate::membership::IntoNodes;
 use crate::raft::ClientWriteResult;
 use crate::raft::raft_inner::RaftInner;
-use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::OneshotReceiverOf;
 
@@ -43,15 +42,11 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn initialize<T>(&self, members: T) -> Result<Result<(), InitializeError<C>>, Fatal<C>>
     where T: IntoNodes<C::NodeId, C::Node> + Debug {
-        let (tx, rx) = C::oneshot();
         self.inner
-            .call_core(
-                RaftMsg::Initialize {
-                    members: members.into_nodes(),
-                    tx,
-                },
-                rx,
-            )
+            .call_core_oneshot(|tx| RaftMsg::Initialize {
+                members: members.into_nodes(),
+                tx,
+            })
             .await
     }
 

--- a/openraft/src/raft/api/management.rs
+++ b/openraft/src/raft/api/management.rs
@@ -6,7 +6,6 @@ use openraft_macros::since;
 
 use crate::ChangeMembers;
 use crate::LogIdOptionExt;
-use crate::OptionalSend;
 use crate::RaftMetrics;
 use crate::RaftTypeConfig;
 use crate::core::raft_msg::RaftMsg;
@@ -18,7 +17,6 @@ use crate::membership::IntoNodes;
 use crate::raft::ClientWriteResult;
 use crate::raft::raft_inner::RaftInner;
 use crate::type_config::alias::LogIdOf;
-use crate::type_config::alias::OneshotReceiverOf;
 
 /// Provides management APIs for the Raft system.
 ///
@@ -65,7 +63,7 @@ where C: RaftTypeConfig
             retain
         );
 
-        let (tx, rx) = new_responder_pair::<C, _>();
+        let (tx, rx) = ProgressResponder::<C, _>::complete_only();
 
         tracing::debug!("change_membership: start",);
 
@@ -107,7 +105,7 @@ where C: RaftTypeConfig
         tracing::debug!("committed a joint config: {} {:?}", log_id, joint);
         tracing::debug!("the second step is to change to uniform config: {:?}", changes);
 
-        let (tx, rx) = new_responder_pair::<C, _>();
+        let (tx, rx) = ProgressResponder::<C, _>::complete_only();
 
         // The second step, send a NOOP change to flatten the joint config.
         let changes = ChangeMembers::AddVoterIds(Default::default());
@@ -133,7 +131,7 @@ where C: RaftTypeConfig
         node: C::Node,
         blocking: bool,
     ) -> Result<ClientWriteResult<C>, Fatal<C>> {
-        let (tx, rx) = new_responder_pair::<C, _>();
+        let (tx, rx) = ProgressResponder::<C, _>::complete_only();
 
         let msg = RaftMsg::ChangeMembership {
             changes: ChangeMembers::AddNodes(btreemap! {id.clone()=>node}),
@@ -228,14 +226,4 @@ where C: RaftTypeConfig
         // Not up to date, keep waiting.
         Err(())
     }
-}
-
-fn new_responder_pair<C, T>() -> (ProgressResponder<C, T>, OneshotReceiverOf<C, T>)
-where
-    C: RaftTypeConfig,
-    T: OptionalSend,
-{
-    let (tx, complete_rx) = ProgressResponder::complete_only();
-
-    (tx, complete_rx)
 }

--- a/openraft/src/raft/api/protocol.rs
+++ b/openraft/src/raft/api/protocol.rs
@@ -124,16 +124,14 @@ where
     pub(crate) async fn vote(&self, rpc: VoteRequest<C>) -> Result<VoteResponse<C>, Fatal<C>> {
         tracing::info!("Raft::vote(): rpc: {}", rpc);
 
-        let (tx, rx) = C::oneshot();
-        self.inner.call_core(RaftMsg::RequestVote { rpc, tx }, rx).await
+        self.inner.call_core_oneshot(|tx| RaftMsg::RequestVote { rpc, tx }).await
     }
 
     #[tracing::instrument(level = "debug", skip(self, rpc))]
     pub(crate) async fn pre_vote(&self, rpc: VoteRequest<C>) -> Result<VoteResponse<C>, Fatal<C>> {
         tracing::info!("Raft::pre_vote(): rpc: {}", rpc);
 
-        let (tx, rx) = C::oneshot();
-        self.inner.call_core(RaftMsg::RequestPreVote { rpc, tx }, rx).await
+        self.inner.call_core_oneshot(|tx| RaftMsg::RequestPreVote { rpc, tx }).await
     }
 
     #[since(version = "0.10.0")]
@@ -144,8 +142,8 @@ where
     ) -> Result<AppendEntriesResponse<C>, Fatal<C>> {
         tracing::debug!("Raft::append_entries: rpc: {}", rpc);
 
-        let (tx, rx) = C::oneshot();
-        let stream_result: StreamAppendResult<C> = self.inner.call_core(RaftMsg::AppendEntries { rpc, tx }, rx).await?;
+        let stream_result: StreamAppendResult<C> =
+            self.inner.call_core_oneshot(|tx| RaftMsg::AppendEntries { rpc, tx }).await?;
         Ok(AppendEntriesResponse::from(stream_result))
     }
 

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -697,8 +697,7 @@ where
     /// This returns a snapshot of the stats at the time of the call.
     #[cfg(feature = "runtime-stats")]
     pub async fn runtime_stats(&self) -> Result<RuntimeStats<C>, Fatal<C>> {
-        let (tx, rx) = C::oneshot();
-        self.inner.call_core(RaftMsg::GetRuntimeStats { tx }, rx).await
+        self.inner.call_core_oneshot(|tx| RaftMsg::GetRuntimeStats { tx }).await
     }
 
     /// Check if this node is currently the leader.

--- a/openraft/src/raft/raft_inner.rs
+++ b/openraft/src/raft/raft_inner.rs
@@ -104,6 +104,22 @@ where C: RaftTypeConfig
         })
     }
 
+    /// Invoke RaftCore with a message that carries a oneshot responder, and block waiting for the
+    /// response.
+    ///
+    /// The sender half is handed to `make_msg` and the matching receiver half is awaited here.
+    /// Prefer this over [`Self::call_core`]: `RaftMsg` does not carry the response type, so
+    /// `call_core` accepts any receiver, including one belonging to a different request.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) async fn call_core_oneshot<T, F>(&self, make_msg: F) -> Result<T, Fatal<C>>
+    where
+        T: OptionalSend,
+        F: FnOnce(OneshotSenderOf<C, T>) -> RaftMsg<C>,
+    {
+        let (tx, rx) = C::oneshot();
+        self.call_core(make_msg(tx), rx).await
+    }
+
     /// Receive a message from RaftCore, return an error if the response is not delivered.
     pub(crate) async fn recv_msg<T, E>(&self, rx: impl Future<Output = Result<T, E>>) -> Result<T, Fatal<C>>
     where

--- a/openraft/src/raft_state/io_state/io_progress.rs
+++ b/openraft/src/raft_state/io_state/io_progress.rs
@@ -95,18 +95,7 @@ where
     /// Enforces strict monotonicity - panics in debug mode if updates arrive out of order.
     pub(crate) fn accept(&mut self, new_accepted: T) {
         tracing::debug!("RAFT_io    {}; new_accepted: {}", self, new_accepted);
-
-        if cfg!(debug_assertions) {
-            assert!(
-                self.accepted.as_ref().is_none_or(|accepted| accepted <= &new_accepted),
-                "expect accepted:{} < new_accepted:{}",
-                self.accepted.display(),
-                new_accepted,
-            );
-        }
-
-        self.accepted = Some(new_accepted);
-
+        Self::advance(&mut self.accepted, "accepted", new_accepted);
         tracing::debug!("RAFT_io    {}", self);
     }
 
@@ -115,40 +104,36 @@ where
     /// Enforces strict monotonicity - panics in debug mode if updates arrive out of order.
     pub(crate) fn submit(&mut self, new_submitted: T) {
         tracing::debug!("RAFT_io    {}; new_submitted: {}", self, new_submitted);
-
-        if cfg!(debug_assertions) {
-            assert!(
-                self.submitted.as_ref().is_none_or(|submitted| submitted <= &new_submitted),
-                "expect submitted:{} < new_submitted:{}",
-                self.submitted.display(),
-                new_submitted,
-            );
-        }
-
-        self.submitted = Some(new_submitted);
-
+        Self::advance(&mut self.submitted, "submitted", new_submitted);
         tracing::debug!("RAFT_io    {}", self);
     }
 
     /// Update the `flush` cursor of the I/O progress.
     ///
-    /// Only updates if the new value is greater than the current value.
-    /// This allows the flush cursor to tolerate out-of-order I/O completion notifications.
+    /// Enforces strict monotonicity - panics in debug mode if updates arrive out of order.
+    /// Use [`Self::try_flush`] to tolerate out-of-order I/O completion notifications.
     pub(crate) fn flush(&mut self, new_flushed: T) {
         tracing::debug!("RAFT_io    {}; new_flushed: {}", self, new_flushed);
+        Self::advance(&mut self.flushed, "flushed", new_flushed);
+        tracing::debug!("RAFT_io    {}", self);
+    }
 
+    /// Move one cursor forward to `new_value`.
+    ///
+    /// `stage` names the cursor in the assertion message, e.g. `"accepted"`.
+    fn advance(cursor: &mut Option<T>, stage: &str, new_value: T) {
         if cfg!(debug_assertions) {
             assert!(
-                self.flushed.as_ref().is_none_or(|flushed| flushed <= &new_flushed),
-                "expect flushed:{} < new_flushed:{}",
-                self.flushed.display(),
-                new_flushed,
+                cursor.as_ref().is_none_or(|current| current <= &new_value),
+                "expect {}:{} < new_{}:{}",
+                stage,
+                cursor.display(),
+                stage,
+                new_value,
             );
         }
 
-        self.flushed = Some(new_flushed);
-
-        tracing::debug!("RAFT_io    {}", self);
+        *cursor = Some(new_value);
     }
 
     /// Conditionally update all three cursors (accepted, submitted, flushed) to the same value.
@@ -177,7 +162,6 @@ where
     pub(crate) fn try_accept(&mut self, new_accepted: T) {
         if self.accepted.as_ref() < Some(&new_accepted) {
             self.accept(new_accepted);
-            tracing::debug!("RAFT_io    {}", self);
         }
     }
 
@@ -186,16 +170,13 @@ where
     pub(crate) fn try_submit(&mut self, new_submitted: T) {
         if self.submitted.as_ref() < Some(&new_submitted) {
             self.submit(new_submitted);
-            tracing::debug!("RAFT_io    {}", self);
         }
     }
 
     /// Conditionally update the `flush` cursor if the new value is greater.
-    #[allow(dead_code)]
     pub(crate) fn try_flush(&mut self, new_flushed: T) {
         if self.flushed.as_ref() < Some(&new_flushed) {
             self.flush(new_flushed);
-            tracing::debug!("RAFT_io    {}", self);
         }
     }
 

--- a/openraft/src/raft_state/mod.rs
+++ b/openraft/src/raft_state/mod.rs
@@ -100,19 +100,7 @@ where
     C::NodeId: Default,
 {
     fn default() -> Self {
-        let vote = VoteOf::<C>::new_with_default_term(C::NodeId::default());
-
-        Self {
-            vote: Leased::without_last_update(vote),
-            log_ids: LogIdList::default(),
-            membership_state: MembershipState::default(),
-            snapshot_meta: SnapshotMetaOf::<C>::default(),
-            last_inflight_id: 0,
-            server_state: ServerState::default(),
-            io_state: Valid::new(IOState::default()),
-            purge_upto: None,
-            progress_id_gen: Default::default(),
-        }
+        Self::new(C::NodeId::default())
     }
 }
 
@@ -195,7 +183,6 @@ where C: RaftTypeConfig
 impl<C> RaftState<C>
 where C: RaftTypeConfig
 {
-    #[allow(dead_code)]
     pub(crate) fn new(node_id: C::NodeId) -> Self {
         let vote = VoteOf::<C>::new_with_default_term(node_id);
 


### PR DESCRIPTION

## Changelog

##### refactor: unify the broadcast-to-every-voter skeleton
# Summary

`spawn_parallel_vote_requests` and `broadcast_transfer_leader` now share
one `broadcast_to_voters` helper for iterating voters, building clients
and detaching tasks, and supply only the RPC each of them sends.

# Details

Both functions independently spelled out the same seven steps: read the
effective membership, skip self, look up the target node, open a client,
build the `RPCOption` from `election_timeout_min`, spawn, and silence
the same false-positive `let_underscore_future` lint. Changing how the
leader reaches its peers therefore meant finding both copies, and a
third caller would have made a third.

The helper takes the timeout and a closure that turns a target's client
into the future to run, so each caller keeps its own request type,
timeout handling, logging and span name. Spans in particular stay
per-RPC rather than collapsing into one shared name, because the
closure builds them and `Span::current()` still resolves to the
instrumented caller.

`broadcast_transfer_leader` also loses a doc comment claiming it sends
vote requests, which was itself a leftover of the duplication.


##### refactor: construct engine sub-handlers through new()
# Summary

Give the five sub-handlers that are built from more than one place a
`new()` constructor, so their field lists live in one location instead
of being respelled at every accessor.

# Details

`Engine` and the handlers themselves both hand out sub-handlers, so the
same borrow wiring was written out repeatedly: `ReplicationHandler` was
spelled out at four sites, `LogHandler` and `ServerStateHandler` at
three, `LeaderHandler` and `SnapshotHandler` at two. Adding a field to
any of them meant finding and updating every one, with nothing to catch
a site that was missed except the compiler.

`VoteHandler`, `FollowingHandler` and `EstablishHandler` keep their
struct literals: each has exactly one construction site, so a
constructor would add indirection without removing duplication.

The impl blocks that gained a constructor now name their lifetime
instead of eliding it, since the constructor has to tie its borrows to
the returned handler.


##### refactor: split handle_ensure_linearizable_read into three phases
# Summary

Separate the lease-read shortcut, the leadership probe fan-out, and the
quorum wait into their own methods, leaving the entry point as the
policy decision it describes.

# Details

At ~195 lines the method interleaved three unrelated concerns: an
entirely local lease check that never touches the network, a fan-out
that builds one RPC per voter, and a detached task that tallies
responses. Reading any one of them meant scrolling past the other two,
and the lease-read path in particular was easy to miss because it sat
between the `Linearizer` construction and the probe setup.

The probe fan-out returns its in-flight futures as an opaque `Stream`
rather than a boxed one, so the split costs no allocation on the read
path. `wait_for_leadership_quorum` is generic over that stream and takes
the seven values the detached task needs by value, which is what the
`async move` block already captured.

`ProbeResult` names the per-target outcome that both halves pass
between them; without it the two signatures would each repeat the same
nested `Result` of tuples.

Behavior is unchanged: same lease comparison, same single-node fast
path, same RPCs, same responses on every exit.


##### refactor: extract Tick/LocalIO/StateMachine arms from handle_notification
# Summary

Move the three multi-statement arms of `RaftCore::handle_notification`
into dedicated methods, leaving the match as a dispatch table.

# Details

`handle_notification` mixed a nine-arm dispatch with three arms that each
carried a nested match or a timer/heartbeat sequence, so the shape of the
dispatch was only visible by scrolling past the bodies. Tick, LocalIO and
StateMachine now live in `handle_tick`, `handle_local_io` and
`handle_state_machine_result`; the remaining arms were already short
enough to read inline and stay there.

`handle_state_machine_result` returns `Result<(), Fatal<C>>` so the
storage-error `?` on the command result keeps converting exactly as it
did inside the dispatch. The move is otherwise byte-for-byte: no
reordering, no changed conditions, no altered logging.


##### refactor: extract handle_external_command() from handle_api_msg
# Summary

The `ExternalCommand` arm of `handle_api_msg` held a second match over
eight external commands, eighty lines deep inside the first. That inner
match moves to `handle_external_command()`.

# Details

`handle_api_msg` dispatches on message kind, and every other arm is a
few lines that hand off to a named handler. This one arm instead
expanded inline into a whole second dispatcher, so the shape of the
outer match was only visible by scrolling past the election, snapshot
and revert-flag logic nested inside it.

The new method is not `async`: none of the external commands await, so
the arm never needed to be inline for that reason.


##### refactor: split run_command's match into per-command methods
# Summary

`RaftCore::run_command` was a 255-line match. The ten arms with real
bodies moved to `run_<command>()` methods, leaving a dispatch that fits
on one screen.

# Details

The method mixed two jobs at two different scales: deciding whether a
command's precondition is met and may run at all, and carrying out every
kind of command. The second job dominated, so the first was buried under
two hundred lines of storage calls, replication setup and channel sends,
and no single command's handling was visible without scrolling past the
others.

Arms whose body is one call -- `SendVote`, `BroadcastHeartbeat`,
`Replicate`, `BroadcastTransferLeader`, `Respond` -- stay inline. Giving
them a wrapper each would hide, rather than show, that these commands do
one thing.

The bodies are unchanged, including the `SnapshotTransmitter` and
`spawn_workers` type arguments, which now name the surrounding block's
`NF` parameter instead of the `RaftRuntime` impl's `N`.


##### refactor: make Command's PartialEq fail to compile on a new variant
# Summary

`PartialEq for Command` ended in `_ => false`. That arm is replaced by
one `(Variant { .. }, _) => false` arm per variant, which leaves the
match non-exhaustive when a variant is added.

# Details

Every other per-variant match on `Command` -- `name()`, `kind()`,
`condition()`, `Display` -- is exhaustive, so adding a variant already
forces the author to visit them. `eq()` was the exception: the catch-all
absorbed the new variant and made it unequal to itself. Nothing would
have failed at build time, and the symptom would surface later as an
engine test whose expected command list never matches.

Spelling the mismatches out per variant costs seventeen one-line arms
and buys the same compile-time prompt the sibling matches give. Checked
by adding a variant and observing E0004 point at this match.


##### feat: derive COUNT/ALL/index/as_str for the name enums
# Summary

The five "name" enums used by runtime stats hand-maintained `COUNT`,
`ALL`, `index()`, `as_str()` and `Display`. They now carry
`#[derive(VariantName)]`, a new derive in `openraft-macros` that
generates all five from the enum definition.

# Details

`CommandName`, `SMCommandName`, `NotificationName`,
`ExternalCommandName` and `RaftMsgName` each feed a fixed-size counter
array indexed by `index()`, so `COUNT`, the order of `ALL` and the
values returned by `index()` all have to agree. Nothing enforced that:
`COUNT` was a literal, `ALL` a hand-written list, and `index()` a match
with hand-written integers. Adding a variant meant editing four places,
and getting any of them wrong silently mis-attributes counters or
panics on an out-of-range index.

The derive treats a variant that wraps another name enum as occupying
that enum's whole index range, which is what `CommandName::StateMachine`
and `RaftMsgName::ExternalCommand` already did by hand with expressions
like `15 + sm.index()`. Offsets after such a variant are emitted as
`n + Inner::COUNT` rather than a literal, so the inner enum can grow
without touching the outer one.

`ALL` stays a `&'static [Self]`, built by a `const fn` that copies the
inner enum's `ALL` into place, so the existing `for name in
CommandName::ALL` loops in the stats display are unaffected.

The five enums also lose their `#[allow(dead_code)]`. The attribute was
covering the hand-written associated items, which the derive now emits
with its own targeted suppression.

The `test_*_index` tests, which pin the correspondence between `ALL`
order and `index()`, pass unchanged.


##### refactor: assign configs once in compute_target_membership()
# Summary

The match in `compute_target_membership()` now yields the new voter set
instead of writing `self.configs` and returning `self` from every arm.
The assignment and the return happen once, after the match.

# Details

Nine arms each ended with `self`, and four of them separately performed
`self.configs = vec![new_voter_ids]`. That shape hid the actual
distinction between the arms, which is simply whether a change affects
the voter set or only `nodes`. The match now returns
`Option<BTreeSet<NID>>` and makes that distinction the thing the reader
sees.

`Batch` yields `None` because its recursive calls have already applied
whatever `configs` update each nested change required; overwriting after
the loop would discard their work.


##### refactor: extract Membership::fmt_node() from the Display impl
# Summary

`Membership`'s `Display` impl formatted a node id and its node twice,
once in the voters loop and once in the learners loop. Both now call
`fmt_node()`.

# Details

The two copies rendered the same `<node_id>:<node>` shape and the same
`None` fallback for a node id with no entry in `nodes`. Keeping them
apart meant any change to how a node prints had to be made in both
loops, and a partial change would produce output where voters and
learners disagree on their own format.

`membership_test` pins the rendered string for voters, learners and
node payloads, so it covers both call sites.


##### refactor: drop stale clippy::manual_async_fn suppressions
# Summary

Four blanket impls in the v2 network module carried
`#[allow(clippy::manual_async_fn)]`. All four define their methods with
`async fn`, which is the form the lint asks for, so the attribute could
never have fired.

# Details

`manual_async_fn` fires on `fn f() -> impl Future { async { .. } }`.
These impls were presumably written that way once and converted to
`async fn` without the suppressions being revisited. Clippy is clean
without them under the default features and under `single-threaded`.


##### test: drop unused pretty_assertions imports from leader_handler tests
# Summary

Three `leader_handler` test files imported `assert_ne` and
`assert_str_eq` without ever calling them, and silenced the resulting
warnings with `#[allow(unused_imports)]`. They now import only
`assert_eq`, matching the other twenty-three engine test files.

# Details

The suppressions were what let the unused imports survive: nine
`#[allow(unused_imports)]` across three files, one of them even on the
`assert_eq` import that every one of these files does use. Removing the
imports removes the reason for the attribute, so the files need no
suppression at all.


##### change: remove the unused LogIndexOptionExt::add()
# Summary

`LogIndexOptionExt::add()` had carried a "TODO: unused, remove it" note
and has no caller anywhere in the workspace. It is removed. The stale
`unused_imports` suppression on the `progress::Inflight` re-export is
removed too.

# Details

`add()` is a method on a publicly exported trait, so dropping it is a
breaking change for any downstream implementor of
`LogIndexOptionExt`; the trait is annotated accordingly. The trait is
implemented in this crate only for `Option<u64>`, and the method is
reachable but pointless: it computes `next_index() + v` and then steps
back one.

The `Inflight` re-export was marked "TODO: remove it" and silenced with
`#[allow(unused_imports)]`, but `progress::entry::update` imports it
through that very path. Both the note and the suppression were wrong;
the re-export stays and now compiles without help.


##### refactor: call ProgressResponder::complete_only() directly
# Summary

The file-local `new_responder_pair()` in the management API was a rename
of `ProgressResponder::complete_only()`. Its three callers now name the
constructor directly and the wrapper is gone.

# Details

The wrapper's whole body was one call to `complete_only()` followed by
returning its result unchanged. It gave the same operation a second name
visible only inside this module, so a reader had to jump through it to
find out which responder kind these membership calls use.


##### refactor: drop the UnwrapInfallible trait behind into_ok()
# Summary

`errors::into_ok` held a `UnwrapInfallible` trait and a free `into_ok()`
function that did nothing but call the trait method. The function now
holds the body and the trait is gone.

# Details

The trait existed to offer `result.into_ok()` method syntax, which no
caller ever used. The one caller, `Decompose::decompose_infallible()`,
passes the free function to `Option::map`, so the trait only added a
hop.

The module also becomes `pub(crate)`, matching its siblings in
`errors`. Everything it declares was already `pub(crate)`, so it was a
public module from which nothing could be named.


##### refactor: add call_core_oneshot() to pair the responder with its message
# Summary

The six call sites that create a oneshot channel, put its sender into a
`RaftMsg` and hand the receiver to `call_core()` now go through
`RaftInner::call_core_oneshot()`, which builds the message from the
sender it created.

# Details

`call_core()` takes the message and the receiver as unrelated
arguments. `RaftMsg` is not parameterized by the response type, so
nothing checks that the receiver belongs to the sender inside the
message; passing a receiver from some other request of the same type
compiles and then waits for a reply that request will never send.
Creating both halves in one place removes the possibility.

`call_core()` stays for the `ChangeMembership` calls, which pair the
message with a `ProgressResponder` rather than a plain oneshot.

`TypeConfigExt` is no longer used in the management API, and in the app
API it is now reached only from `runtime-stats` code, so its import
takes the same feature gate the neighbouring `InstantOf` import has.


##### refactor: assemble RaftMetrics from the data and server metrics
# Summary

`report_metrics` built three metrics structs by reading the Raft state
three times over. It now derives each value once, into
`RaftDataMetrics` and `RaftServerMetrics`, and assembles `RaftMetrics`
from those two.

# Details

`RaftMetrics` is the union of the other two structs plus the running
state and the current term, so every one of its eighteen shared fields
had a second derivation next to it. Nothing tied the copies together:
changing how `last_applied` or `millis_since_quorum_ack` is obtained
required finding and editing each site, and a miss would ship two
metrics streams that disagree about the same node at the same instant.

`RaftServerMetrics` needs an explicit type argument. Its fields are all
associated types of `C`, which do not determine `C`, so the field reads
in the `RaftMetrics` literal leave it unconstrained.


##### refactor: share one cursor-advance helper across the IOProgress setters
# Summary

`IOProgress::accept()`, `submit()` and `flush()` each carried their own
copy of the debug-mode monotonicity assertion. The assertion now lives
in a single `advance()` helper that the three setters call.

# Details

The three bodies were identical apart from the cursor field and the
stage word in the panic message, so the assertion had to be kept in sync
by hand. `advance()` takes the cursor and the stage name and formats the
same message, which the two `should_panic` tests pin byte-for-byte.

`flush()`'s doc comment described `try_flush()`'s behavior, claiming it
"only updates if the new value is greater". It does not; it asserts
monotonicity like the other two. The doc now says so and points at
`try_flush()` for the tolerant variant. This is the drift the copies
were hiding.

`try_flush()` loses its `#[allow(dead_code)]`, which was stale: it has
non-test callers in `RaftCore`. `try_accept()` and `try_submit()` keep
theirs, since they are still test-only.

The `try_*` methods also each re-logged the progress line that the
setter they delegate to had just logged.


##### refactor: collapse the three stale-vote checks into does_vote_match()
# Summary

`does_candidate_vote_match`, `does_pre_candidate_vote_match` and
`does_leader_vote_match` were three copies of the same check. They are
replaced by one `does_vote_match()` that takes the role name and the
vote the node currently holds in that role.

# Details

All three answered the same question: is the vote a notification was
sent under still the vote this node holds? They differed only in which
field the current vote is read from and in the wording of the two
`warn!` lines. Three copies meant a fix to the check had to be applied
three times, and the pre-candidate copy had already drifted into its
own phrasing.

The caller now reads the current vote and passes it in, which is what
makes one implementation possible: the extraction is the only genuinely
role-specific part.

The helper is generic over two vote types rather than one. The vote a
message was sent under is an internal `UncommittedVote`/`CommittedVote`,
while the vote the node holds may be the application's `C::Vote`, so the
two sides are compared by leader id. That is what the candidate checks
already did; the leader check compared whole votes, which is equivalent
because `CommittedVote` wraps nothing but a leader id.


##### refactor: build RaftState::default() on top of RaftState::new()
# Summary

The `Default` impl for `RaftState` no longer repeats the field-by-field
construction that `new()` already performs; it delegates to
`new(C::NodeId::default())`.

# Details

Both constructors initialized the same nine fields with the same values
and differed only in where the node id came from. Two copies of a struct
literal drift the moment a field is added: the compiler forces the new
field into both, but nothing forces the two to agree on its initial
value.

`new()` also loses its `#[allow(dead_code)]`. The attribute was needed
only because every caller sat behind `#[cfg(test)]`; the `Default` impl
is now an unconditional caller.


##### refactor: merge the two identical VecProgress impl blocks
# Summary

`VecProgress` spread its inherent methods across two `impl` blocks that
declared the same generic parameters and the same bounds. They are now a
single block.

# Details

The split carried no meaning. Both blocks were `impl<Entry, QS>
VecProgress<Entry, QS>` with a byte-identical `where` clause, and no
concept separated the methods in one from the methods in the other. The
only thing it produced was ambiguity about which block a newly added
method belongs in.

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1880)
<!-- Reviewable:end -->
