### PR TITLE
ci: cap every ci job at 15 minutes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
   test-release-build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       matrix:
@@ -43,6 +44,7 @@ jobs:
 
   openraft-test-bench:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       matrix:
@@ -68,6 +70,7 @@ jobs:
   # Test crate `openraft/` and `macros/`
   test-openraft-core-crates:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -118,6 +121,7 @@ jobs:
   # Run integration test `tests/`.
   test-crate-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -169,6 +173,7 @@ jobs:
 
   stores:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -199,6 +204,7 @@ jobs:
   # benchmarks/minimal is a standalone crate for benchmarking openraft cluster.
   bench-minimal:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -222,6 +228,7 @@ jobs:
   # Test external crate.
   rt-monoio:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Setup | Checkout
@@ -238,6 +245,7 @@ jobs:
 
   rt-compio:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Setup | Checkout
@@ -254,6 +262,7 @@ jobs:
 
   metrics-otel:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Setup | Checkout
@@ -276,6 +285,7 @@ jobs:
   # This job only tests crate `openraft`.
   openraft-feature-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -341,6 +351,7 @@ jobs:
   # Integration tests with various features.
   tests-feature-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -385,6 +396,7 @@ jobs:
   detsim:
     name: Deterministic simulation test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -404,6 +416,7 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -447,6 +460,7 @@ jobs:
 
   examples:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # RocksDB-backed examples (raft-kv-rocksdb, rocksstore) were the slowest CI
     # jobs because librocksdb-sys compiles bundled RocksDB (8.10) C++ from
     # source. Link the system librocksdb instead so it is not compiled at all;

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -426,8 +426,10 @@ jobs:
       - name: Doc tests
         run: cargo test --doc --all
 
-      - shell: bash
-        run: cargo install cargo-audit
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
 
       - name: Audit dependencies
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,17 @@ name: ci
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule: [cron: '40 1 * * *']
+
+# Superseded runs keep occupying runner slots, and this workflow alone queues
+# 41 jobs against 20 concurrent runners. Cancel outdated pull-request runs, but
+# let main and scheduled runs finish so history stays complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   test-release-build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -387,7 +387,7 @@ jobs:
           cache-workspaces: tests-turmoil
 
       - name: Run deterministic simulation
-        run: cd tests-turmoil && cargo run --bin fuzz -- --iterations 5 --max-steps 10000
+        run: cd tests-turmoil && cargo run --release --bin fuzz -- --iterations 5 --max-steps 10000
         env:
           RUST_LOG: info
           RUST_BACKTRACE: full

--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -9,6 +9,10 @@ on:
   push:
     branches:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   check-commit-message:
     name: check-subject

--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/jepsen/docker/node.Dockerfile
+++ b/jepsen/docker/node.Dockerfile
@@ -1,15 +1,33 @@
-FROM rust:bookworm AS builder
+# librocksdb-sys bundles RocksDB 8.10 and compiles its C++ from source, which
+# took 7m39s of the 8m13s image build. Link the system librocksdb instead;
+# ROCKSDB_INCLUDE_DIR points bindgen at the matching headers so the generated
+# bindings match the installed lib. Both stages use Ubuntu 24.04 because its
+# librocksdb is the version already proven against this crate by the
+# `examples` job in .github/workflows/ci.yaml.
+FROM ubuntu:24.04 AS builder
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       build-essential \
+      ca-certificates \
       clang \
       cmake \
+      curl \
       libclang-dev \
+      librocksdb-dev \
       libssl-dev \
       pkg-config \
       protobuf-compiler \
  && rm -rf /var/lib/apt/lists/*
+
+# No default toolchain: cargo runs under /openraft, so the root rust-toolchain
+# pin drives which toolchain rustup installs on first use.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --profile minimal --default-toolchain none
+ENV PATH=/root/.cargo/bin:$PATH
+
+ENV ROCKSDB_LIB_DIR=/usr/lib/x86_64-linux-gnu \
+    ROCKSDB_INCLUDE_DIR=/usr/include
 
 WORKDIR /openraft
 COPY . .
@@ -17,14 +35,18 @@ COPY . .
 RUN cargo build --release \
       --manifest-path examples/raft-kv-rocksdb/Cargo.toml
 
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 
+# The binary links librocksdb dynamically, so the runtime image needs it too.
+# Use the -dev package: its name is stable across RocksDB version bumps, while
+# the versioned runtime package name is not.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       ca-certificates \
       iproute2 \
       iptables \
       libgcc-s1 \
+      librocksdb-dev \
       libstdc++6 \
       netcat-openbsd \
       openssh-server \

--- a/tests-turmoil/Cargo.toml
+++ b/tests-turmoil/Cargo.toml
@@ -30,3 +30,9 @@ turmoil = "0.6"
 
 [dev-dependencies]
 test-harness = "0.3"
+
+# The fuzzer runs release-built so the simulation is not bottlenecked by
+# unoptimized code, but its purpose is to trip openraft's invariant checks,
+# which a stock release build would compile out.
+[profile.release]
+debug-assertions = true

--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -144,15 +144,14 @@ struct FuzzConfig {
     crash_file: Option<String>,
 }
 
+/// Verbose defaults for interactive fuzzing. `RUST_LOG`, when set, replaces them
+/// entirely; previously it was merged with these, so a caller asking for `info`
+/// still got every `openraft` trace event.
+const DEFAULT_LOG_FILTER: &str = "info,openraft=trace,tests_turmoil=debug";
+
 fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("openraft=trace".parse().unwrap())
-                .add_directive("tests_turmoil=debug".parse().unwrap())
-                .add_directive("info".parse().unwrap()),
-        )
-        .init();
+    let log_filter = std::env::var("RUST_LOG").unwrap_or_else(|_| DEFAULT_LOG_FILTER.to_string());
+    tracing_subscriber::fmt().with_env_filter(tracing_subscriber::EnvFilter::new(log_filter)).init();
 
     let config = FuzzConfig::parse();
 


### PR DESCRIPTION

## Changelog

##### ci: cap every ci job at 15 minutes
# Summary

Every job in the ci workflow now has a timeout. Previously none did, so
a stuck job was bounded only by the GitHub default of 6 hours.

# Details

In scheduled run 30188722185 the examples job for raft-kv-memstore hung
for 45 minutes and then failed, which by itself set that run's 46-minute
duration; every other job in the same run finished within 3.6m. A hang
there also holds a runner slot that the remaining jobs are queuing for.

15 minutes is roughly four times the slowest legitimate job observed and
leaves room for a cold cache, so it should only ever fire on a genuine
hang. GitHub has no workflow-level default for this, so it is set per
job.


##### ci: stop running superseded and duplicate workflow runs
# Summary

Pull-request workflows now cancel their own outdated runs, and ci no
longer fires twice for the same commit. Both changes free runner slots
rather than making any single job faster.

# Details

A ci run queues 41 jobs against 20 concurrent runners, so it already
takes two waves: one sampled run spent 27.1 queue-minutes against 48.8
run-minutes, with the worst job waiting 2.2m to start. Runs left behind
by a new push kept competing for those slots. The concurrency group
cancels outdated pull-request runs while letting main and scheduled runs
finish, so nightly history stays complete.

ci listened to every push on every branch in addition to pull_request,
so a branch with an open pull request built the same commit twice. It
now matches jepsen.yml and builds pushes only on main; pull requests
still get a full run.

The examples matrix was also considered as a way to shed 9 of the 41
jobs, on the reading that its nightly leg only adds fmt and clippy. It
does not: the test step has no toolchain condition, so nightly runs the
example test suites too. Dropping that leg would remove real coverage,
so the matrix is left alone.


##### chore: ci: install cargo-audit from a prebuilt binary
# Summary

The lint job built cargo-audit from source. It now comes from
taiki-e/install-action, which the coverage workflow already uses for
cargo-llvm-cov.

# Details

The source build is normally hidden by the toolchain action's cache of
$CARGO_HOME/bin, costing about a second. On a cache miss it costs a
minute or more, so this removes a tail-latency spike rather than a
steady cost.

cargo-expand, installed the same way in this workflow and in
coverage.yml, is deliberately left alone: it ships no release assets, so
there is no prebuilt binary for install-action or cargo-binstall to
fetch, and routing it through them would still compile from source.


##### perf: ci: run the turmoil fuzzer optimized and quiet
# Summary

The deterministic simulation job built the fuzzer unoptimized and logged
every openraft trace event regardless of RUST_LOG. Both are fixed, which
takes the simulation from the slowest job in the ci workflow to a
rounding error.

# Details

The job was the ci workflow's critical path at 4.22m, of which 3.72m was
this step. Measured locally at the same 5 iterations and 10000 steps,
the simulation itself drops from 27.2s to 3.5s once optimized.

RUST_LOG was effectively ignored. The subscriber merged the hardcoded
`openraft=trace` directive into whatever the environment asked for, and
a target-specific directive outranks a global one, so the job's
`RUST_LOG: info` still produced 609469 debug lines out of 613585. The
hardcoded directives are now a default that RUST_LOG replaces outright.

The fuzzer exists to trip openraft's debug assertions, which a stock
release profile compiles out, so tests-turmoil pins debug-assertions on
for its release profile. Without that pin the 78 debug_assert sites in
openraft would silently vanish from the simulation.

The first run after this lands pays a cold release build; the workspace
is already cached by cache-workspaces, so later runs reuse it.


##### perf: jepsen: link system RocksDB in the node image
# Summary

The Jepsen node image no longer compiles RocksDB's C++ from source. It
links the distro's librocksdb instead, which removes the dominant cost
of the Jepsen CI job.

# Details

Building the image took 8m13s of the job's 9.9m, and 7m39s of that was
librocksdb-sys compiling its bundled RocksDB 8.10. The `examples` job in
ci.yaml already avoids this by pointing the crate at the system library,
so the node image now does the same.

Both stages move to Ubuntu 24.04. The crate is known to build against
noble's librocksdb 8.9.1 because ci.yaml's `examples` job does exactly
that on ubuntu-latest. The runtime stage has to match the builder:
setting ROCKSDB_LIB_DIR makes librocksdb-sys link dynamically, so the
node image needs a compatible librocksdb and glibc at run time. It
installs librocksdb-dev rather than the versioned runtime package
because the -dev name survives RocksDB version bumps.

Leaving the rust base image means installing rustup. It installs no
default toolchain: cargo runs under /openraft, where the repository's
rust-toolchain pin selects the compiler, so the stable toolchain that
rust:bookworm shipped was downloaded and never used.

---

- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1881)
<!-- Reviewable:end -->
