### PR TITLE
refactor: scope runtime_stats dead_code allow to the feature

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -557,7 +557,7 @@ where
                     .send(Notification::HigherVote {
                         target,
                         higher: vote,
-                        leader_vote: my_vote.into_committed(),
+                        leader_vote: my_vote.to_committed(),
                     })
                     .await;
 
@@ -1500,7 +1500,7 @@ where
 
                 match res {
                     Ok(resp) => {
-                        let candidate_vote = vote.into_non_committed();
+                        let candidate_vote = vote.to_non_committed();
                         let notification = match kind {
                             VoteRequestKind::Vote => Notification::VoteResponse {
                                 target,

--- a/openraft/src/core/runtime_stats/log_stage/histograms.rs
+++ b/openraft/src/core/runtime_stats/log_stage/histograms.rs
@@ -45,7 +45,6 @@ impl LogStageHistograms {
     }
 
     /// Build a stacked ASCII chart of all stage-to-stage latency histograms.
-    #[allow(dead_code)]
     pub(crate) fn ascii_chart(&self) -> AsciiChart {
         AsciiChart::new()
             .add("1:proposed→received", self.proposed_to_received.clone())

--- a/openraft/src/core/runtime_stats/log_stage/lifecycle_latency.rs
+++ b/openraft/src/core/runtime_stats/log_stage/lifecycle_latency.rs
@@ -43,6 +43,9 @@ where I: Instant
 }
 
 /// Stage-specific convenience methods for [`LogStages`].
+///
+/// The per-stage wrappers round out the API rather than serving a current caller; only `new` is
+/// used today.
 #[allow(dead_code)]
 impl<I> LogStages<I>
 where I: Instant

--- a/openraft/src/core/runtime_stats/mod.rs
+++ b/openraft/src/core/runtime_stats/mod.rs
@@ -1,3 +1,11 @@
+//! Runtime statistics collection.
+//!
+//! Everything here is reachable only through `Raft::runtime_stats`, which exists only under the
+//! `runtime-stats` feature. With the feature off the whole module is legitimately unreachable, so
+//! the allow below is conditioned on that rather than applied outright: with the feature on, dead
+//! code here is real dead code and still warns.
+#![cfg_attr(not(feature = "runtime-stats"), allow(dead_code))]
+
 mod display_mode;
 #[allow(clippy::module_inception)]
 mod runtime_stats;

--- a/openraft/src/core/runtime_stats/runtime_stats.rs
+++ b/openraft/src/core/runtime_stats/runtime_stats.rs
@@ -173,7 +173,6 @@ where C: RaftTypeConfig
         }
     }
 
-    #[allow(dead_code)]
     pub fn record_log_stage(&mut self, stage: Stage, index: u64, now: InstantOf<C>) {
         #[cfg(feature = "runtime-stats")]
         self.log_stage.record_stage(stage, index, now);
@@ -184,7 +183,6 @@ where C: RaftTypeConfig
         }
     }
 
-    #[allow(dead_code)]
     pub fn build_log_stage_histograms(&mut self) {
         #[cfg(feature = "runtime-stats")]
         {
@@ -198,7 +196,6 @@ where C: RaftTypeConfig
     /// `RuntimeStatsDisplay` can be cheaply formatted multiple times.
     ///
     /// Use builder methods like `.human_readable()` to change the display mode.
-    #[allow(dead_code)]
     pub fn display(&self) -> RuntimeStatsDisplay<C> {
         RuntimeStatsDisplay {
             mode: DisplayMode::default(),

--- a/openraft/src/core/runtime_stats/runtime_stats_display.rs
+++ b/openraft/src/core/runtime_stats/runtime_stats_display.rs
@@ -23,7 +23,6 @@ use crate::type_config::alias::InstantOf;
 ///
 /// All values are computed upfront so `Display::fmt()` is cheap.
 /// Use [`DisplayMode`] to control the output format.
-#[allow(dead_code)]
 pub struct RuntimeStatsDisplay<C>
 where C: RaftTypeConfig
 {
@@ -45,7 +44,6 @@ where C: RaftTypeConfig
     pub(crate) log_stages: LogStages<InstantOf<C>>,
 }
 
-#[allow(dead_code)]
 impl<C> RuntimeStatsDisplay<C>
 where C: RaftTypeConfig
 {
@@ -86,7 +84,6 @@ where C: RaftTypeConfig
 impl<C> RuntimeStatsDisplay<C>
 where C: RaftTypeConfig
 {
-    #[allow(dead_code)]
     fn fmt_compact(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -158,7 +155,6 @@ where C: RaftTypeConfig
         write!(f, "}} }}")
     }
 
-    #[allow(dead_code)]
     fn fmt_multiline(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "RuntimeStats:")?;
         writeln!(f, "  apply_batch: {}", self.apply_batch)?;
@@ -217,7 +213,6 @@ where C: RaftTypeConfig
         Ok(())
     }
 
-    #[allow(dead_code)]
     #[cfg(feature = "runtime-stats")]
     fn fmt_human_readable(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Batch sizes table
@@ -396,7 +391,6 @@ where C: RaftTypeConfig
     }
 
     /// Fallback when tabled is not available.
-    #[allow(dead_code)]
     #[cfg(not(feature = "runtime-stats"))]
     fn fmt_human_readable(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_multiline(f)

--- a/openraft/src/engine/command_name.rs
+++ b/openraft/src/engine/command_name.rs
@@ -65,7 +65,7 @@ mod tests {
     type C = UTConfig;
 
     fn committed_vote(term: u64, node_id: u64) -> CommittedVote<UTLeaderId> {
-        Vote::<UTLeaderId>::new(term, node_id).into_committed()
+        Vote::<UTLeaderId>::new(term, node_id).to_committed()
     }
 
     #[test]

--- a/openraft/src/engine/command_scheduler.rs
+++ b/openraft/src/engine/command_scheduler.rs
@@ -102,7 +102,7 @@ mod tests {
     type C = UTConfig;
 
     fn committed_vote(term: u64, node_id: u64) -> crate::vote::committed::CommittedVote<UTLeaderId> {
-        Vote::<UTLeaderId>::new(term, node_id).into_committed()
+        Vote::<UTLeaderId>::new(term, node_id).to_committed()
     }
 
     fn config_with_max_append(max_append_entries: u64) -> Config {

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -1043,7 +1043,7 @@ where
         );
 
         FollowingHandler {
-            leader_vote: leader_vote.into_committed(),
+            leader_vote: leader_vote.to_committed(),
             config: &mut self.config,
             state: &mut self.state,
             output: &mut self.output,

--- a/openraft/src/engine/handler/following_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/append_entries_test.rs
@@ -70,16 +70,13 @@ fn test_follower_append_entries_update_accepted() -> anyhow::Result<()> {
         eng.state.log_ids.key_log_ids()
     );
     assert_eq!(
-        Some(&IOId::new_log_io(
-            Vote::new(2, 1).into_committed(),
-            Some(log_id(3, 1, 5))
-        )),
+        Some(&IOId::new_log_io(Vote::new(2, 1).to_committed(), Some(log_id(3, 1, 5)))),
         eng.state.accepted_log_io()
     );
     assert_eq!(eng.output.take_commands(), vec![
         //
         Command::AppendEntries {
-            committed_vote: Vote::new(2, 1).into_committed(),
+            committed_vote: Vote::new(2, 1).to_committed(),
             entries: Batch::of([blank_ent::<UTConfig>(3, 1, 4), blank_ent::<UTConfig>(3, 1, 5)]),
         }
     ]);
@@ -98,19 +95,16 @@ fn test_follower_append_entries_update_accepted() -> anyhow::Result<()> {
         ]);
         assert_eq!(Some(&log_id(3, 1, 5)), eng.state.last_log_id());
         assert_eq!(
-            Some(&IOId::new_log_io(
-                Vote::new(3, 1).into_committed(),
-                Some(log_id(3, 1, 4))
-            )),
+            Some(&IOId::new_log_io(Vote::new(3, 1).to_committed(), Some(log_id(3, 1, 4)))),
             eng.state.accepted_log_io()
         );
         assert_eq!(eng.output.take_commands(), vec![
             //
             Command::UpdateIOProgress {
                 when: Some(Condition::IOFlushed {
-                    io_id: IOId::new_log_io(Vote::new(2, 1).into_committed(), Some(log_id(3, 1, 5)))
+                    io_id: IOId::new_log_io(Vote::new(2, 1).to_committed(), Some(log_id(3, 1, 5)))
                 }),
-                io_id: IOId::new_log_io(Vote::new(3, 1).into_committed(), Some(log_id(3, 1, 4))),
+                io_id: IOId::new_log_io(Vote::new(3, 1).to_committed(), Some(log_id(3, 1, 4))),
             }
         ]);
     }
@@ -120,10 +114,7 @@ fn test_follower_append_entries_update_accepted() -> anyhow::Result<()> {
         eng.following_handler().append_entries(Some(log_id(2, 1, 3)), vec![]);
         assert_eq!(Some(&log_id(3, 1, 5)), eng.state.last_log_id());
         assert_eq!(
-            Some(&IOId::new_log_io(
-                Vote::new(3, 1).into_committed(),
-                Some(log_id(3, 1, 4))
-            )),
+            Some(&IOId::new_log_io(Vote::new(3, 1).to_committed(), Some(log_id(3, 1, 4)))),
             eng.state.accepted_log_io()
         );
 

--- a/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
+++ b/openraft/src/engine/handler/following_handler/do_append_entries_test.rs
@@ -88,7 +88,7 @@ fn test_follower_do_append_entries_no_membership_entries() -> anyhow::Result<()>
         vec![
             //
             Command::AppendEntries {
-                committed_vote: Vote::new(1, 1).into_committed(),
+                committed_vote: Vote::new(1, 1).to_committed(),
                 entries: Batch::of([blank_ent::<UTConfig>(3, 1, 4)])
             },
         ],
@@ -137,7 +137,7 @@ fn test_follower_do_append_entries_one_membership_entry() -> anyhow::Result<()> 
     );
     assert_eq!(
         vec![Command::AppendEntries {
-            committed_vote: Vote::new(1, 1).into_committed(),
+            committed_vote: Vote::new(1, 1).to_committed(),
             entries: Batch::of([
                 //
                 blank_ent::<UTConfig>(3, 1, 4),
@@ -196,7 +196,7 @@ fn test_follower_do_append_entries_three_membership_entries() -> anyhow::Result<
     );
     assert_eq!(
         vec![Command::AppendEntries {
-            committed_vote: Vote::new(1, 1).into_committed(),
+            committed_vote: Vote::new(1, 1).to_committed(),
             entries: Batch::of([
                 blank_ent::<UTConfig>(3, 1, 4),
                 EntryOf::<UTConfig>::new_membership(log_id(3, 1, 5), m01()),

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -166,7 +166,7 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
                     },
                     snapshot: (),
                 },
-                LogIOId::new(Vote::new(2, 1).into_committed(), Some(log_id(4, 1, 6))),
+                LogIOId::new(Vote::new(2, 1).to_committed(), Some(log_id(4, 1, 6))),
             )),
             Command::PurgeLog { upto: log_id(4, 1, 6) },
         ],
@@ -264,7 +264,7 @@ fn test_install_snapshot_resets_purged_effective_without_truncating() -> anyhow:
                     },
                     snapshot: (),
                 },
-                LogIOId::new(Vote::new(2, 1).into_committed(), Some(log_id(5, 1, 9)))
+                LogIOId::new(Vote::new(2, 1).to_committed(), Some(log_id(5, 1, 9)))
             )),
             Command::PurgeLog { upto: log_id(5, 1, 9) },
         ],
@@ -353,7 +353,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
                     },
                     snapshot: (),
                 },
-                LogIOId::new(Vote::new(2, 1).into_committed(), Some(log_id(5, 1, 6)))
+                LogIOId::new(Vote::new(2, 1).to_committed(), Some(log_id(5, 1, 6)))
             )),
             Command::PurgeLog { upto: log_id(5, 1, 6) },
         ],
@@ -415,7 +415,7 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
                     },
                     snapshot: (),
                 },
-                LogIOId::new(Vote::new(2, 1).into_committed(), Some(log_id(100, 1, 100)))
+                LogIOId::new(Vote::new(2, 1).to_committed(), Some(log_id(100, 1, 100)))
             )),
             Command::PurgeLog {
                 upto: log_id(100, 1, 100)
@@ -450,7 +450,7 @@ fn test_install_snapshot_update_accepted() -> anyhow::Result<()> {
 
     assert_eq!(
         Some(&IOId::new_log_io(
-            Vote::new(2, 1).into_committed(),
+            Vote::new(2, 1).to_committed(),
             Some(log_id(100, 1, 100))
         )),
         eng.state.accepted_log_io()

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -125,10 +125,7 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
         "should return log ids for 3 entries"
     );
     assert_eq!(
-        Some(&IOId::new_log_io(
-            Vote::new(3, 1).into_committed(),
-            Some(log_id(3, 1, 6))
-        )),
+        Some(&IOId::new_log_io(Vote::new(3, 1).to_committed(), Some(log_id(3, 1, 6)))),
         eng.state.accepted_log_io()
     );
     assert_eq!(None, eng.state.log_ids.purged());
@@ -151,7 +148,7 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             Command::AppendEntries {
-                committed_vote: Vote::new(3, 1).into_committed(),
+                committed_vote: Vote::new(3, 1).to_committed(),
                 entries: Batch::of([
                     blank_ent::<UTConfig>(3, 1, 4), //
                     blank_ent::<UTConfig>(3, 1, 5),
@@ -196,10 +193,7 @@ fn test_leader_append_entries_single_node_leader() -> anyhow::Result<()> {
         "should return log ids for 3 entries"
     );
     assert_eq!(
-        Some(&IOId::new_log_io(
-            Vote::new(3, 1).into_committed(),
-            Some(log_id(3, 1, 6))
-        )),
+        Some(&IOId::new_log_io(Vote::new(3, 1).to_committed(), Some(log_id(3, 1, 6)))),
         eng.state.accepted_log_io()
     );
     assert_eq!(None, eng.state.log_ids.purged());
@@ -223,7 +217,7 @@ fn test_leader_append_entries_single_node_leader() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![Command::AppendEntries {
-            committed_vote: Vote::new(3, 1).into_committed(),
+            committed_vote: Vote::new(3, 1).to_committed(),
             entries: Batch::of([
                 blank_ent::<UTConfig>(3, 1, 4), //
                 blank_ent::<UTConfig>(3, 1, 5),
@@ -259,10 +253,7 @@ fn test_leader_append_entries_with_membership_log() -> anyhow::Result<()> {
         "should return log ids for 3 entries"
     );
     assert_eq!(
-        Some(&IOId::new_log_io(
-            Vote::new(3, 1).into_committed(),
-            Some(log_id(3, 1, 6))
-        )),
+        Some(&IOId::new_log_io(Vote::new(3, 1).to_committed(), Some(log_id(3, 1, 6)))),
         eng.state.accepted_log_io()
     );
     assert_eq!(None, eng.state.log_ids.purged());
@@ -287,7 +278,7 @@ fn test_leader_append_entries_with_membership_log() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             Command::AppendEntries {
-                committed_vote: Vote::new(3, 1).into_committed(),
+                committed_vote: Vote::new(3, 1).to_committed(),
                 entries: Batch::of([
                     blank_ent::<UTConfig>(3, 1, 4), //
                     EntryOf::<UTConfig>::new_membership(log_id(3, 1, 5), m1_2()),
@@ -295,7 +286,7 @@ fn test_leader_append_entries_with_membership_log() -> anyhow::Result<()> {
                 ])
             },
             Command::RebuildReplicationStreams {
-                leader_vote: Vote::new(3, 1).into_committed(),
+                leader_vote: Vote::new(3, 1).to_committed(),
                 targets: vec![TargetProgress {
                     target: 2,
                     target_node: (),

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -60,7 +60,7 @@ fn test_leader_send_heartbeat() -> anyhow::Result<()> {
             vec![
                 //
                 Command::BroadcastHeartbeat {
-                    session_id: ReplicationSessionId::new(Vote::new(3, 1).into_committed(), Some(log_id(2, 1, 3))),
+                    session_id: ReplicationSessionId::new(Vote::new(3, 1).to_committed(), Some(log_id(2, 1, 3))),
                 },
             ],
             eng.output.take_commands()
@@ -75,7 +75,7 @@ fn test_leader_send_heartbeat() -> anyhow::Result<()> {
             vec![
                 //
                 Command::BroadcastHeartbeat {
-                    session_id: ReplicationSessionId::new(Vote::new(3, 1).into_committed(), Some(log_id(2, 1, 3))),
+                    session_id: ReplicationSessionId::new(Vote::new(3, 1).to_committed(), Some(log_id(2, 1, 3))),
                 },
             ],
             eng.output.take_commands()

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -87,7 +87,7 @@ fn test_leader_append_membership_for_leader() -> anyhow::Result<()> {
         vec![
             //
             Command::RebuildReplicationStreams {
-                leader_vote: Vote::new(6, 2).into_committed(),
+                leader_vote: Vote::new(6, 2).to_committed(),
                 targets: vec![
                     TargetProgress {
                         target: 3,

--- a/openraft/src/engine/handler/vote_handler/become_leader_test.rs
+++ b/openraft/src/engine/handler/vote_handler/become_leader_test.rs
@@ -58,17 +58,17 @@ fn test_become_leader() -> anyhow::Result<()> {
     let leader = eng.leader.as_ref().unwrap();
     assert_eq!(leader.noop_log_id, log_id(2, 1, 0));
     assert_eq!(leader.last_log_id(), Some(&log_id(2, 1, 0)));
-    assert_eq!(*leader.committed_vote_ref(), Vote::new(2, 1).into_committed());
+    assert_eq!(*leader.committed_vote_ref(), Vote::new(2, 1).to_committed());
 
     assert_eq!(ServerState::Leader, eng.state.server_state);
 
     assert_eq!(eng.output.take_commands(), vec![
         Command::UpdateIOProgress {
             when: None,
-            io_id: IOId::new_log_io(Vote::new(2, 1).into_committed(), None)
+            io_id: IOId::new_log_io(Vote::new(2, 1).to_committed(), None)
         },
         Command::RebuildReplicationStreams {
-            leader_vote: Vote::new(2, 1).into_committed(),
+            leader_vote: Vote::new(2, 1).to_committed(),
             targets: vec![TargetProgress {
                 target: 0,
                 target_node: (),
@@ -77,7 +77,7 @@ fn test_become_leader() -> anyhow::Result<()> {
             close_old_streams: true,
         },
         Command::AppendEntries {
-            committed_vote: Vote::new(2, 1).into_committed(),
+            committed_vote: Vote::new(2, 1).to_committed(),
             entries: Batch::of([EntryOf::<UTConfig>::new_blank(log_id(2, 1, 0))])
         },
         // Pipeline mode: ProgressEntry::empty(0) has matching.next_index()=0 == searching_end=0

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -132,9 +132,9 @@ fn test_append_entries_prev_log_id_is_applied() -> anyhow::Result<()> {
             Command::CloseReplicationStreams,
             Command::UpdateIOProgress {
                 when: Some(Condition::IOFlushed {
-                    io_id: IOId::new_log_io(Vote::new(2, 1).into_committed(), None)
+                    io_id: IOId::new_log_io(Vote::new(2, 1).to_committed(), None)
                 }),
-                io_id: IOId::new_log_io(Vote::new(2, 1).into_committed(), Some(log_id(0, 1, 0)))
+                io_id: IOId::new_log_io(Vote::new(2, 1).to_committed(), Some(log_id(0, 1, 0)))
             }
         ],
         eng.output.take_commands()
@@ -233,7 +233,7 @@ fn test_append_entries_prev_log_id_is_committed() -> anyhow::Result<()> {
                 after: Some(log_id(1, 1, 1))
             },
             Command::AppendEntries {
-                committed_vote: Vote::new(2, 1).into_committed(),
+                committed_vote: Vote::new(2, 1).to_committed(),
                 entries: Batch::of([blank_ent::<UTConfig>(2, 1, 2)])
             },
         ],
@@ -341,7 +341,7 @@ fn test_append_entries_conflict() -> anyhow::Result<()> {
                 after: Some(log_id(1, 1, 2))
             },
             Command::AppendEntries {
-                committed_vote: Vote::new(2, 1).into_committed(),
+                committed_vote: Vote::new(2, 1).to_committed(),
                 entries: Batch::of([EntryOf::<UTConfig>::new_membership(log_id(3, 1, 3), m34())])
             },
         ],

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -199,10 +199,7 @@ fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
             eng.leader.as_ref().unwrap().last_log_id().copied()
         );
         assert_eq!(
-            Some(&IOId::new_log_io(
-                Vote::new(2, 1).into_committed(),
-                Some(log_id(2, 1, 1))
-            )),
+            Some(&IOId::new_log_io(Vote::new(2, 1).to_committed(), Some(log_id(2, 1, 1)))),
             eng.state.accepted_log_io()
         );
         assert!(
@@ -215,7 +212,7 @@ fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
         assert_eq!(
             vec![
                 Command::RebuildReplicationStreams {
-                    leader_vote: Vote::new(2, 1).into_committed(),
+                    leader_vote: Vote::new(2, 1).to_committed(),
                     targets: vec![TargetProgress {
                         target: 2,
                         target_node: (),
@@ -227,7 +224,7 @@ fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
                     vote: Vote::new_committed(2, 1)
                 },
                 Command::AppendEntries {
-                    committed_vote: Vote::new(2, 1).into_committed(),
+                    committed_vote: Vote::new(2, 1).to_committed(),
                     entries: Batch::of([EntryOf::<UTConfig>::new_blank(log_id(2, 1, 1))]),
                 },
                 Command::Replicate {

--- a/openraft/src/engine/tests/initialize_test.rs
+++ b/openraft/src/engine/tests/initialize_test.rs
@@ -56,7 +56,7 @@ fn test_initialize_single_node() -> anyhow::Result<()> {
             vec![
                 //
                 Command::AppendEntries {
-                    committed_vote: Vote::new_with_default_term(1).into_committed(),
+                    committed_vote: Vote::new_with_default_term(1).to_committed(),
                     entries: Batch::of([EntryOf::<UTConfig>::new_membership(log_id(0, 1, 0), m1())]),
                 },
             ],
@@ -100,7 +100,7 @@ fn test_initialize() -> anyhow::Result<()> {
             vec![
                 //
                 Command::AppendEntries {
-                    committed_vote: Vote::new_with_default_term(1).into_committed(),
+                    committed_vote: Vote::new_with_default_term(1).to_committed(),
                     entries: Batch::of([EntryOf::<UTConfig>::new_membership(log_id(0, 1, 0), m12())]),
                 },
             ],

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -148,7 +148,7 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
                     },
                     snapshot: (),
                 },
-                LogIOId::new(Vote::new(2, 1).into_committed(), Some(log_id(4, 1, 6)))
+                LogIOId::new(Vote::new(2, 1).to_committed(), Some(log_id(4, 1, 6)))
             )),
             Command::PurgeLog { upto: log_id(4, 1, 6) },
             Command::Respond {

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -75,10 +75,10 @@ fn test_startup_as_leader_without_logs() -> anyhow::Result<()> {
         vec![
             Command::UpdateIOProgress {
                 when: None,
-                io_id: IOId::new_log_io(Vote::new(2, 2).into_committed(), Some(log_id(1, 1, 3)))
+                io_id: IOId::new_log_io(Vote::new(2, 2).to_committed(), Some(log_id(1, 1, 3)))
             },
             Command::RebuildReplicationStreams {
-                leader_vote: Vote::new(2, 2).into_committed(),
+                leader_vote: Vote::new(2, 2).to_committed(),
                 targets: vec![TargetProgress {
                     target: 3,
                     target_node: (),
@@ -87,7 +87,7 @@ fn test_startup_as_leader_without_logs() -> anyhow::Result<()> {
                 close_old_streams: true,
             },
             Command::AppendEntries {
-                committed_vote: Vote::new(2, 2).into_committed(),
+                committed_vote: Vote::new(2, 2).to_committed(),
                 entries: Batch::of([EntryOf::<UTConfig>::new_blank(log_id(2, 2, 4))]),
             },
             Command::Replicate {
@@ -129,10 +129,10 @@ fn test_startup_as_leader_with_proposed_logs() -> anyhow::Result<()> {
         vec![
             Command::UpdateIOProgress {
                 when: None,
-                io_id: IOId::new_log_io(Vote::new(1, 2).into_committed(), Some(log_id(1, 2, 6)))
+                io_id: IOId::new_log_io(Vote::new(1, 2).to_committed(), Some(log_id(1, 2, 6)))
             },
             Command::RebuildReplicationStreams {
-                leader_vote: Vote::new(1, 2).into_committed(),
+                leader_vote: Vote::new(1, 2).to_committed(),
                 targets: vec![TargetProgress {
                     target: 3,
                     target_node: (),

--- a/openraft/src/errors/membership_error.rs
+++ b/openraft/src/errors/membership_error.rs
@@ -25,6 +25,18 @@ where NID: NodeId
     NodeNotFound(#[from] NodeNotFound<NID>),
 }
 
+/// Translate a membership validation failure into a rejected change request.
+///
+/// The two enums overlap, but they describe different layers: [`MembershipError`] says a
+/// membership value is invalid, while [`ChangeMembershipError`] says a caller's request was
+/// refused. Embedding one in the other would collapse that distinction and, worse, lose the
+/// specific advice below.
+///
+/// `NodeNotFound` deliberately becomes `LearnerNotFound`. The only way membership validation
+/// reports a missing node is a voter with no `Node` entry, which means the caller tried to promote
+/// a node it never added. `LearnerNotFound` says exactly that, whereas `NodeNotFound` would only
+/// say the node is missing. The `operation` field dropped in the process is always
+/// `Operation::None` on this path, so nothing diagnostic is lost.
 impl<CLID, NID> From<MembershipError<NID>> for ChangeMembershipError<CLID, NID>
 where
     CLID: RaftCommittedLeaderId,

--- a/openraft/src/log_id/mod.rs
+++ b/openraft/src/log_id/mod.rs
@@ -94,28 +94,33 @@ where CLID: RaftCommittedLeaderId
     }
 }
 
+/// Inherent counterparts of the [`RaftLogId`] methods, so callers do not have to import the trait.
+///
+/// Each one delegates rather than reimplementing, so the trait impl stays the only definition. An
+/// inherent method shadows the trait method at every call site, so a second copy here would let the
+/// two drift apart without any call site changing.
 impl<CLID> LogId<CLID>
 where CLID: RaftCommittedLeaderId
 {
     /// Creates a log id proposed by a committed leader with `leader_id` at the given index.
     pub fn new(leader_id: CLID, index: u64) -> Self {
-        LogId { leader_id, index }
+        RaftLogId::new(leader_id, index)
     }
 
     /// Returns the leader id that proposed this log.
     pub fn committed_leader_id(&self) -> &CLID {
-        &self.leader_id
+        RaftLogId::committed_leader_id(self)
     }
 
     /// Get the established(committed) leader ID of this log entry.
     #[deprecated(since = "0.10.0", note = "Use `committed_leader_id` instead.")]
     pub fn leader_id(&self) -> &CLID {
-        &self.leader_id
+        RaftLogId::committed_leader_id(self)
     }
 
     /// Get the log index.
     pub fn index(&self) -> u64 {
-        self.index
+        RaftLogId::index(self)
     }
 }
 

--- a/openraft/src/proposer/candidate.rs
+++ b/openraft/src/proposer/candidate.rs
@@ -130,7 +130,7 @@ where
         let vote = {
             let vote = self.vote_ref().clone();
             debug_assert!(!vote.is_committed());
-            vote.into_committed()
+            vote.to_committed()
         };
 
         // TODO: tricky: the new LeaderId is different from the last log id

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -283,7 +283,7 @@ mod tests {
     fn test_leader_new_with_proposed_log_id() {
         tracing::info!("--- vote greater than last log id, create new noop_log_id");
         {
-            let vote = Vote::new(2, 2).into_committed();
+            let vote = Vote::new(2, 2).to_committed();
             let leader = Leader::<UTConfig, _>::new(
                 vote,
                 vec![btreeset! {1, 2, 3}],
@@ -298,7 +298,7 @@ mod tests {
 
         tracing::info!("--- vote equals last log id, reuse noop_log_id");
         {
-            let vote = Vote::new(1, 2).into_committed();
+            let vote = Vote::new(1, 2).to_committed();
             let leader = Leader::<UTConfig, _>::new(
                 vote,
                 vec![btreeset! {1, 2, 3}],
@@ -313,7 +313,7 @@ mod tests {
 
         tracing::info!("--- vote equals last log id, reuse noop_log_id, last_leader_log_id.len()==1");
         {
-            let vote = Vote::new(1, 2).into_committed();
+            let vote = Vote::new(1, 2).to_committed();
             let leader = Leader::<UTConfig, _>::new(
                 vote,
                 vec![btreeset! {1, 2, 3}],
@@ -328,7 +328,7 @@ mod tests {
 
         tracing::info!("--- no last log ids, create new noop_log_id, last_leader_log_id.len()==0");
         {
-            let vote = Vote::new(1, 2).into_committed();
+            let vote = Vote::new(1, 2).to_committed();
             let leader =
                 Leader::<UTConfig, _>::new(vote, vec![btreeset! {1, 2, 3}], vec![], None, SharedIdGenerator::new());
 
@@ -339,7 +339,7 @@ mod tests {
 
     #[test]
     fn test_leader_established() {
-        let vote = Vote::new(2, 2).into_committed();
+        let vote = Vote::new(2, 2).to_committed();
         let mut leader = Leader::<UTConfig, _>::new(
             vote,
             vec![btreeset! {1, 2, 3}],
@@ -360,7 +360,7 @@ mod tests {
 
     #[test]
     fn test_1_entry_none_last_log_id() {
-        let vote = Vote::new(0, 0).into_committed();
+        let vote = Vote::new(0, 0).to_committed();
         let mut leading =
             Leader::<UTConfig, _>::new(vote, vec![btreeset! {1, 2, 3}], vec![], None, SharedIdGenerator::new());
 
@@ -372,7 +372,7 @@ mod tests {
 
     #[test]
     fn test_no_entries_provided() {
-        let vote = Vote::new(2, 2).into_committed();
+        let vote = Vote::new(2, 2).to_committed();
         let mut leading = Leader::<UTConfig, _>::new(
             vote,
             vec![btreeset! {1, 2, 3}],
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     fn test_multiple_entries() {
-        let vote = Vote::new(2, 2).into_committed();
+        let vote = Vote::new(2, 2).to_committed();
         let mut leading = Leader::<UTConfig, _>::new(
             vote,
             vec![btreeset! {1, 2, 3}],
@@ -405,7 +405,7 @@ mod tests {
     #[test]
     fn test_leading_last_quorum_acked_time_leader_is_voter() {
         let mut leading = Leader::<UTConfig, Vec<BTreeSet<u64>>>::new(
-            Vote::new(2, 1).into_committed(),
+            Vote::new(2, 1).to_committed(),
             vec![btreeset! {1, 2, 3}],
             [4],
             None,
@@ -422,7 +422,7 @@ mod tests {
     #[test]
     fn test_leading_last_quorum_acked_time_leader_is_learner() {
         let mut leading = Leader::<UTConfig, Vec<BTreeSet<u64>>>::new(
-            Vote::new(2, 4).into_committed(),
+            Vote::new(2, 4).to_committed(),
             vec![btreeset! {1, 2, 3}],
             [4],
             None,
@@ -443,7 +443,7 @@ mod tests {
     #[test]
     fn test_leading_last_quorum_acked_time_leader_is_not_member() {
         let mut leading = Leader::<UTConfig, Vec<BTreeSet<u64>>>::new(
-            Vote::new(2, 5).into_committed(),
+            Vote::new(2, 5).to_committed(),
             vec![btreeset! {1, 2, 3}],
             [4],
             None,
@@ -464,7 +464,7 @@ mod tests {
     #[test]
     fn test_need_heartbeat() {
         let mut leading = Leader::<UTConfig, Vec<BTreeSet<u64>>>::new(
-            Vote::new(2, 1).into_committed(),
+            Vote::new(2, 1).to_committed(),
             vec![btreeset! {1, 2, 3}],
             [4],
             None,

--- a/openraft/src/raft_state/tests/update_committed_test.rs
+++ b/openraft/src/raft_state/tests/update_committed_test.rs
@@ -44,7 +44,7 @@ fn new_state() -> RaftState<UTConfig> {
 #[test]
 fn test_update_committed_none() -> anyhow::Result<()> {
     let mut state = new_state();
-    let committed_vote = state.vote_ref().into_committed();
+    let committed_vote = state.vote_ref().to_committed();
 
     state.update_committed(LogIOId::new(committed_vote, None));
 
@@ -65,7 +65,7 @@ fn test_update_committed_none() -> anyhow::Result<()> {
 #[test]
 fn test_update_committed_ge_accepted() -> anyhow::Result<()> {
     let mut state = new_state();
-    let committed_vote = state.vote_ref().into_committed();
+    let committed_vote = state.vote_ref().to_committed();
     state.log_progress_mut().accept(IOId::new_log_io(committed_vote.clone(), Some(log_id(1, 1, 2))));
 
     state.update_committed(LogIOId::new(committed_vote, Some(log_id(2, 1, 3))));
@@ -89,7 +89,7 @@ fn test_update_committed_ge_accepted() -> anyhow::Result<()> {
 #[test]
 fn test_update_committed_le_accepted() -> anyhow::Result<()> {
     let mut state = new_state();
-    let committed_vote = state.vote_ref().into_committed();
+    let committed_vote = state.vote_ref().to_committed();
     state.log_progress_mut().accept(IOId::new_log_io(committed_vote.clone(), Some(log_id(3, 1, 4))));
 
     state.update_committed(LogIOId::new(committed_vote, Some(log_id(2, 1, 3))));
@@ -113,10 +113,10 @@ fn test_update_committed_le_accepted() -> anyhow::Result<()> {
 #[test]
 fn test_update_committed_local_vote_lags_cluster_vote() -> anyhow::Result<()> {
     let mut state = new_state();
-    let committed_vote = state.vote_ref().into_committed();
+    let committed_vote = state.vote_ref().to_committed();
     state.log_progress_mut().accept(IOId::new_log_io(committed_vote.clone(), Some(log_id(2, 1, 3))));
 
-    let higher_vote = Vote::new_committed(3, 2).into_committed();
+    let higher_vote = Vote::new_committed(3, 2).to_committed();
     let cluster_committed = LogIOId::new(higher_vote.clone(), Some(log_id(3, 2, 4)));
 
     state.update_committed(cluster_committed.clone());
@@ -136,10 +136,10 @@ fn test_update_committed_local_vote_lags_cluster_vote() -> anyhow::Result<()> {
 #[test]
 fn test_update_committed_advances_after_local_vote_catches_up() -> anyhow::Result<()> {
     let mut state = new_state();
-    let committed_vote = state.vote_ref().into_committed();
+    let committed_vote = state.vote_ref().to_committed();
     state.log_progress_mut().accept(IOId::new_log_io(committed_vote.clone(), Some(log_id(2, 1, 3))));
 
-    let higher_vote = Vote::new_committed(3, 2).into_committed();
+    let higher_vote = Vote::new_committed(3, 2).to_committed();
     let cluster_committed = LogIOId::new(higher_vote.clone(), Some(log_id(3, 2, 4)));
 
     // Commit notification arrives before logs from the new leader; no local advancement yet.
@@ -181,7 +181,7 @@ fn test_committed_accessors() -> anyhow::Result<()> {
     // Caught-up node: the accepted log id reaches the quorum-granted commit, so the two agree.
     {
         let mut state = new_state();
-        let committed_vote = state.vote_ref().into_committed();
+        let committed_vote = state.vote_ref().to_committed();
         state.log_progress_mut().accept(IOId::new_log_io(committed_vote.clone(), Some(log_id(2, 1, 3))));
 
         state.update_committed(LogIOId::new(committed_vote, Some(log_id(2, 1, 3))));
@@ -194,10 +194,10 @@ fn test_committed_accessors() -> anyhow::Result<()> {
     // cluster-committed leads local-committed.
     {
         let mut state = new_state();
-        let committed_vote = state.vote_ref().into_committed();
+        let committed_vote = state.vote_ref().to_committed();
         state.log_progress_mut().accept(IOId::new_log_io(committed_vote, Some(log_id(2, 1, 3))));
 
-        let higher_vote = Vote::new_committed(3, 2).into_committed();
+        let higher_vote = Vote::new_committed(3, 2).to_committed();
         state.update_committed(LogIOId::new(higher_vote, Some(log_id(3, 2, 4))));
 
         assert_eq!(Some(&log_id(3, 2, 4)), state.cluster_committed());

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -1796,7 +1796,7 @@ where
     // Dummy log io id for blocking append
     let leader_id = LeaderIdOf::<C>::new(TermOf::<C>::default().next(), 0u64.into());
     let io_id = IOId::<C>::new_log_io(
-        VoteOf::<C>::from_leader_id(leader_id, true).into_committed(),
+        VoteOf::<C>::from_leader_id(leader_id, true).to_committed(),
         Some(last_log_id),
     );
 

--- a/openraft/src/vote/raft_vote.rs
+++ b/openraft/src/vote/raft_vote.rs
@@ -73,7 +73,6 @@ where Self: OptionalFeatures + Eq + Clone + Debug + Display + 'static
 }
 
 pub(crate) trait RaftVoteExt: RaftVote {
-    #[allow(dead_code)]
     fn new_with_default_term(node_id: LeaderNodeId<Self::LeaderId>) -> Self {
         let leader_id = Self::LeaderId::new_with_default_term(node_id);
         Self::from_leader_id(leader_id, false)
@@ -130,29 +129,18 @@ pub(crate) trait RaftVoteExt: RaftVote {
         UncommittedVote::new(self.to_leader_id())
     }
 
-    /// Convert this vote into a [`CommittedVote`]
-    fn into_committed(self) -> CommittedVote<Self::LeaderId> {
-        CommittedVote::new(self.to_leader_id())
-    }
-
-    /// Convert this vote into a [`UncommittedVote`]
-    fn into_non_committed(self) -> UncommittedVote<Self::LeaderId> {
-        UncommittedVote::new(self.to_leader_id())
-    }
-
     /// Converts this vote into a [`VoteStatus`] enum based on its commitment state.
     fn into_vote_status(self) -> VoteStatus<Self::LeaderId> {
         if self.is_committed() {
-            VoteStatus::Committed(self.into_committed())
+            VoteStatus::Committed(self.to_committed())
         } else {
-            VoteStatus::Pending(self.into_non_committed())
+            VoteStatus::Pending(self.to_non_committed())
         }
     }
 
     /// Converts this vote to a [`CommittedVote`] if it is committed.
     ///
     /// Returns `Some(CommittedVote)` if the vote is committed, otherwise returns `None`.
-    #[allow(dead_code)]
     fn try_to_committed(&self) -> Option<CommittedVote<Self::LeaderId>> {
         if self.is_committed() {
             Some(self.to_committed())
@@ -165,7 +153,6 @@ pub(crate) trait RaftVoteExt: RaftVote {
     ///
     /// Returns `Some(CommittedLeaderId)` if the vote is committed and has a leader ID.
     /// Returns `None` if the vote is not committed or has no leader ID.
-    #[allow(dead_code)]
     fn try_to_committed_leader_id(&self) -> Option<LeaderCommitted<Self::LeaderId>> {
         if self.is_committed() {
             Some(self.leader_id().to_committed())

--- a/openraft/src/vote/vote.rs
+++ b/openraft/src/vote/vote.rs
@@ -83,7 +83,7 @@ where LID: RaftLeaderId
     }
 
     /// Mark this vote as committed (deprecated).
-    #[deprecated(note = "use `into_committed()` instead", since = "0.10.0")]
+    #[deprecated(note = "use `to_committed()` instead", since = "0.10.0")]
     pub fn commit(&mut self) {
         self.committed = true
     }


### PR DESCRIPTION

## Changelog

##### refactor: scope runtime_stats dead_code allow to the feature
# Summary

The eleven `#[allow(dead_code)]` attributes scattered through
`core::runtime_stats` collapse into one module-level allow that applies
only when the `runtime-stats` feature is off.

# Details

Every one of those attributes was there for the same reason: the module
is reachable only via `Raft::runtime_stats`, which the `runtime-stats`
feature gates, so a default build sees the whole module as unused.
Spelling that reason once at the module root says what the per-item
copies could not — the code is unreachable by configuration, not
individually suspect.

The allow is conditional rather than blanket. With the feature enabled
the module is live, so dead code in it is real dead code and should
still warn; an unconditional allow would have silently swallowed that.

One targeted allow survives, on the per-stage `LogStages` wrappers. They
are unused in both configurations, so they need an allow of their own
and now carry a note saying they round out the API rather than serve a
caller.


##### refactor: drop RaftVoteExt into_committed/into_non_committed
# Summary

`RaftVoteExt` offered two ways to reach `CommittedVote` and
`UncommittedVote`, differing only in whether they took `self` by value.
The by-value spellings are gone; callers use the borrowing ones.

# Details

`into_committed` and `into_non_committed` had bodies byte-identical to
`to_committed` and `to_non_committed`. Taking `self` by value did not buy
the move it advertised: `RaftVote` exposes the leader id only as
`leader_id(&self) -> &Self::LeaderId`, so both spellings had to clone.
The `into_` pair was therefore strictly less capable — same cost, but
unusable from a shared reference — while reading as the cheap conversion
that Rust's naming convention reserves for ownership transfer.

The `#[allow(dead_code)]` on `new_with_default_term`,
`try_to_committed`, and `try_to_committed_leader_id` are also removed.
All three methods have callers, so the attributes were suppressing a
warning that no longer fires; keeping them would hide the day one of
these really does go unused.

`Vote::commit`'s deprecation note pointed at `into_committed` and now
names the surviving method.


##### refactor: make LogId inherent methods delegate to RaftLogId
# Summary

`LogId::new`, `committed_leader_id`, and `index` were byte-identical
copies of the `RaftLogId` impl of the same names. They now call the
trait instead of reading the fields again.

# Details

An inherent method shadows a trait method of the same name at every call
site, so the duplicated bodies were not merely redundant: had one copy
gained a check the other lacked, callers would have silently kept the
old behavior with nothing in the diff to show it.

The inherent methods are kept rather than deleted. They exist so callers
can write `log_id.index()` without importing `RaftLogId`, and removing
them would be a breaking change that forces the import on roughly 85
call sites inside this workspace alone. Delegation removes the
duplication at no cost to the public API, so no `#[since]` is needed.

The deprecated `leader_id` delegates as well, for the same reason.


##### docs: explain why MembershipError converts to a narrower variant
# Summary

Record why `ChangeMembershipError` does not embed `MembershipError`, and
why the `NodeNotFound` to `LearnerNotFound` mapping is deliberate.

# Details

The two enums look like near-duplicates joined by a hand-written `From`,
which reads as an invitation to embed one in the other. Doing so would
be a regression. Membership validation reports a missing node in exactly
one situation — a voter with no `Node` entry — which means the caller
tried to promote a node it never added. `LearnerNotFound` tells them to
add it as a learner first; `NodeNotFound` would only say it is missing.

The `operation` field the conversion drops is `Operation::None` at the
single construction site on this path, so the mapping loses a
placeholder rather than diagnostic information.

Doc only; no code change.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1884)
<!-- Reviewable:end -->
