### PR TITLE
test: jepsen: await committed membership before add-learner

### DIFF
--- a/jepsen/src/jepsen/openraft/cluster.clj
+++ b/jepsen/src/jepsen/openraft/cluster.clj
@@ -22,6 +22,10 @@
 (defn- ready-state? [state]
   (#{"Leader" "Follower"} state))
 
+(defn- membership-committed? [metrics]
+  (= (get-in metrics [:committed_membership_config :log_id])
+     (get-in metrics [:membership_config :log_id])))
+
 (defn- cluster-status [test]
   (let [metrics (into {}
                       (map (fn [node]
@@ -82,13 +86,20 @@
     (info "Initializing OpenRaft cluster on" leader)
     (client/init! leader-endpoint)
 
+    ;; OpenRaft rejects a membership change until the previous membership log
+    ;; entry is committed. `init!` only waits for the initial membership entry
+    ;; to be flushed, and `current_leader` is set as soon as the vote commits,
+    ;; which is still before that entry commits. Waiting for the leader alone
+    ;; therefore races with the first add-learner, which fails with
+    ;; `ChangeMembershipError::InProgress`.
     (util/await-fn
       #(let [metrics (client/metrics! leader-endpoint)]
-         (if (= leader-id (:current_leader metrics))
+         (if (and (= leader-id (:current_leader metrics))
+                  (membership-committed? metrics))
            metrics
            (throw (ex-info "Initial OpenRaft leader is not ready yet"
                            {:metrics metrics}))))
-      {:log-message "Waiting for initial OpenRaft leader"
+      {:log-message "Waiting for initial OpenRaft leader to commit its membership"
        :timeout 60000})
 
     (doseq [node learners


### PR DESCRIPTION

## Changelog

##### test: jepsen: await committed membership before add-learner
# Summary

Cluster bootstrap no longer races the initial membership commit, which
crashed a Jepsen run before any test operation was issued.

# Details

`init!` returns once the initial membership entry is flushed, not
committed, and `current_leader` is set as soon as the vote commits.
Bootstrap gated only on `current_leader`, so the first `add-learner`
could arrive while the index-0 membership entry was still uncommitted,
and be rejected with `ChangeMembershipError::InProgress`.

Bootstrap now also waits for `committed_membership_config` to match
`membership_config`, the same condition the server checks before
accepting a membership change. The remaining calls need no wait: a
successful `add-learner` response already implies its own membership
entry committed.

- Seen on: https://github.com/databendlabs/openraft/actions/runs/30275458744

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1885)
<!-- Reviewable:end -->
