### PR TITLE
docs: tests-turmoil: sync README with the new oracle and invariant checks

### DIFF
--- a/tests-turmoil/README.md
+++ b/tests-turmoil/README.md
@@ -18,12 +18,15 @@ A cluster that cannot heal without faults has a liveness bug (stuck replication,
 
 ### Client oracle
 
-`src/oracle.rs` tracks every write attempt by unique serial. Acked writes record the returned `LogId`; failed or timed-out writes are *unknown* (they may still commit later) and are never assumed absent. Each observed value embeds `(serial, writing LogId)`, giving four checks:
+`src/oracle.rs` tracks every write attempt by unique serial. Acked writes record the returned `LogId`; failed or timed-out writes are *unknown* (they may still commit later) and are never assumed absent. Each observed value embeds `(serial, writing LogId)`, and every piece of evidence — acks (including the previous value each apply returns), linearizable reads, and final-state scans — feeds these checks:
 
 - **Phantom value**: an observed value must map back to a known write attempt.
+- **One serial, one log id**: all sightings of a serial must agree on its log id, and one log id must never carry two different serials.
 - **Monotonic reads**: per key, a sequential reader must never observe an older `LogId` than it already saw.
 - **Read-your-writes**: a linearizable read must observe at least the acked floor captured before the read started.
-- **Durability**: after final convergence, no acked write may be lost.
+- **Predecessor chain**: the previous value an ack's apply returns must be the newest known-committed write to the key below the new entry — committed data cannot vanish between two acks even if no read touches the window.
+- **Absence floor**: an apply seeing the key absent, or a read observing it absent at its `ReadIndex` barrier, forbids any write to the key from ever resolving below that point.
+- **Durability** (final): after final convergence, no acked write — and no write any read observed — may be lost.
 
 ### Chaos and operations
 
@@ -50,6 +53,7 @@ The checker lives in `src/invariants/`, with one file per property. Each propert
 | Monotonic Commit Index  | §3.4     | `MonotonicCommitIndex`          | A node's `committed.index` never decreases across ticks                              |
 | Monotonic Applied Index | derived  | —                               | A node's `last_applied.index` never decreases across ticks                           |
 | Monotonic Vote          | §3.3     | `MonotonicVote`                 | A node's persisted vote (ordered by `(term, leader_id, committed)`) never regresses  |
+| Monotonic SM Keys       | derived  | —                               | Per node and key, the writing log id never decreases and keys never vanish          |
 
 All identity comparisons use `CommittedLeaderId` (not just `term`), so the same checks are correct under both openraft modes:
 - `leader_id_std`: `CommittedLeaderId == term`, so Election Safety reduces to "one leader per term".

--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -1106,12 +1106,16 @@ async fn read_client_loop(
         )
         .await
         {
-            Ok(Ok(_)) => {
+            Ok(Ok(barrier)) => {
                 let observed = sm.get_key(&key);
                 if dbg_ops() {
-                    println!("DBG read key={key} observed={:?}", observed.as_ref().map(|m| m.log_id));
+                    println!(
+                        "DBG read key={key} observed={:?} barrier={:?}",
+                        observed.as_ref().map(|m| m.log_id),
+                        barrier
+                    );
                 }
-                history.lock().unwrap().record_read(&key, observed.as_ref(), floor);
+                history.lock().unwrap().record_read(&key, observed.as_ref(), floor, barrier);
             }
             _ => {
                 if dbg_ops() {

--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -1024,7 +1024,7 @@ async fn driver_loop(queue: DriverQueue, history: Arc<Mutex<ClientHistory>>) -> 
                                 if dbg_ops() {
                                     println!("DBG ack serial={serial} log={}", resp.log_id);
                                 }
-                                history.lock().unwrap().record_write_acked(serial, resp.log_id)
+                                history.lock().unwrap().record_write_acked(serial, resp.log_id, resp.data.prev)
                             }
                             _ => {
                                 if dbg_ops() {

--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -1091,7 +1091,7 @@ async fn read_client_loop(
 
         let leader = cluster_state.lock().unwrap().find_leader_entry();
         let Some((leader_id, raft)) = leader else {
-            history.lock().unwrap().record_read_failed();
+            history.lock().unwrap().record_read_no_leader();
             continue;
         };
         let sm = cluster_state.lock().unwrap().get_state_machine(leader_id).expect("sm must be registered");

--- a/tests-turmoil/src/invariants/mod.rs
+++ b/tests-turmoil/src/invariants/mod.rs
@@ -23,6 +23,7 @@
 //! | Monotonic CommitIndex   | §3.4        | `MonotonicCommitIndex`           | [`monotonic`]            |
 //! | Monotonic AppliedIndex  | derived     | (follows `applied ≤ committed`)  | [`monotonic`]            |
 //! | Monotonic Vote          | §3.3        | `MonotonicVote`                  | [`monotonic`]            |
+//! | Monotonic SM Keys       | derived     | —                                | [`sm_monotonic`]         |
 //!
 //! Leader Append-Only (Paper §3.6.3) is not checked directly: its safety
 //! content for committed entries is already covered by Log Matching +
@@ -50,6 +51,7 @@ pub mod election_safety;
 pub mod leader_completeness;
 pub mod log_matching;
 pub mod monotonic;
+pub mod sm_monotonic;
 pub mod state_machine_safety;
 pub mod state_ordering;
 pub mod violation;
@@ -92,6 +94,7 @@ pub struct InvariantCheckResult {
 pub struct InvariantChecker {
     witnesses: committed_immutable::Witness,
     monotonic: monotonic::MonotonicHistory,
+    sm_monotonic: sm_monotonic::SmMonotonicHistory,
 }
 
 impl InvariantChecker {
@@ -130,6 +133,7 @@ impl InvariantChecker {
         // --- Cross-tick checks (must update internal state) ---
         self.witnesses.check_and_record(snapshots, &mut violations);
         self.monotonic.check_and_record(snapshots, &mut violations);
+        self.sm_monotonic.check_and_record(snapshots, &mut violations);
 
         InvariantCheckResult { violations }
     }

--- a/tests-turmoil/src/invariants/sm_monotonic.rs
+++ b/tests-turmoil/src/invariants/sm_monotonic.rs
@@ -1,0 +1,62 @@
+//! Per-node, per-key state-machine monotonicity (derived).
+//!
+//! A node applies only committed entries, in log order, and an installed
+//! snapshot must be at or ahead of the node's applied state — so on any
+//! single node, the log id that last wrote a key can only move forward, and
+//! a key can never disappear. Checking this per tick makes *every* node's
+//! state machine content observable to the checker: a follower's key-level
+//! rollback (apply-before-commit, bad snapshot handling) no longer hides
+//! until the node happens to share an applied log id with another node
+//! (State Machine Safety) or until the final durability scan.
+//!
+//! No reset-on-restart is needed: storage in this harness is durable across
+//! crashes (a bounced node keeps its log store and state machine), and a
+//! crashed node drops out of the snapshot list while down, so it resumes
+//! at-or-ahead of its last observed state.
+
+use std::collections::BTreeMap;
+
+use super::violation::InvariantViolation;
+use crate::cluster::FullNodeSnapshot;
+use crate::typ::LogId;
+use crate::typ::NodeId;
+
+/// Cross-tick per-key state-machine monotonicity checker. One key map per
+/// node, updated on every invocation.
+#[derive(Default)]
+pub struct SmMonotonicHistory {
+    /// Per node: last seen (key -> log id of the entry that wrote it).
+    seen: BTreeMap<NodeId, BTreeMap<String, LogId>>,
+}
+
+impl SmMonotonicHistory {
+    pub fn check_and_record(
+        &mut self,
+        snapshots: &[(NodeId, FullNodeSnapshot)],
+        violations: &mut Vec<InvariantViolation>,
+    ) {
+        for (node_id, s) in snapshots {
+            let current: BTreeMap<String, LogId> = s.sm.data.iter().map(|(k, m)| (k.clone(), m.log_id)).collect();
+
+            if let Some(prev) = self.seen.get(node_id) {
+                for (key, prev_log_id) in prev {
+                    let now = current.get(key);
+                    let regressed = match now {
+                        Some(log_id) => log_id < prev_log_id,
+                        None => true,
+                    };
+                    if regressed {
+                        violations.push(InvariantViolation::SmKeyRegressed {
+                            node: *node_id,
+                            key: key.clone(),
+                            previous: *prev_log_id,
+                            current: now.copied(),
+                        });
+                    }
+                }
+            }
+
+            self.seen.insert(*node_id, current);
+        }
+    }
+}

--- a/tests-turmoil/src/invariants/tests.rs
+++ b/tests-turmoil/src/invariants/tests.rs
@@ -141,6 +141,15 @@ impl SnapshotBuilder {
         self
     }
 
+    fn sm_key_at(mut self, k: &str, lid: LogId) -> Self {
+        self.sm_data.insert(k.into(), crate::store::ValueMeta {
+            value: format!("v-{k}"),
+            serial: 0,
+            log_id: lid,
+        });
+        self
+    }
+
     fn build(self) -> (NodeId, FullNodeSnapshot) {
         let mut raft = RaftMetrics::<TypeConfig>::new_initial(self.node_id);
         raft.current_term = self.term;
@@ -659,6 +668,71 @@ fn monotonic_applied_index_regression() {
         current: 4,
         ..
     });
+}
+
+#[test]
+fn sm_key_regression_detected() {
+    let mut checker = InvariantChecker::default();
+
+    let tick1 = vec![SnapshotBuilder::new(1).sm_key_at("k", log_id(1, 1, 5)).build()];
+    assert_no_violations!(checker.check(&tick1).violations);
+
+    // The key rolled back to an older writing log id.
+    let tick2 = vec![SnapshotBuilder::new(1).sm_key_at("k", log_id(1, 1, 3)).build()];
+    let r = checker.check(&tick2);
+    assert_variant!(r.violations, InvariantViolation::SmKeyRegressed {
+        node: 1,
+        current: Some(_),
+        ..
+    });
+}
+
+#[test]
+fn sm_key_vanished_detected() {
+    let mut checker = InvariantChecker::default();
+
+    let tick1 = vec![SnapshotBuilder::new(1).sm_key_at("k", log_id(1, 1, 5)).build()];
+    assert_no_violations!(checker.check(&tick1).violations);
+
+    // Keys are never deleted: disappearing is a rollback.
+    let tick2 = vec![SnapshotBuilder::new(1).build()];
+    let r = checker.check(&tick2);
+    assert_variant!(r.violations, InvariantViolation::SmKeyRegressed {
+        node: 1,
+        current: None,
+        ..
+    });
+}
+
+#[test]
+fn sm_key_progress_is_clean() {
+    let mut checker = InvariantChecker::default();
+
+    let tick1 = vec![SnapshotBuilder::new(1).sm_key_at("k", log_id(1, 1, 5)).build()];
+    assert_no_violations!(checker.check(&tick1).violations);
+
+    // Same position, advanced position, new keys, and a new node: all fine.
+    let tick2 = vec![
+        SnapshotBuilder::new(1).sm_key_at("k", log_id(2, 2, 8)).sm_key_at("k2", log_id(2, 2, 9)).build(),
+        SnapshotBuilder::new(2).sm_key_at("k", log_id(1, 1, 5)).build(),
+    ];
+    assert_no_violations!(checker.check(&tick2).violations);
+}
+
+#[test]
+fn sm_key_checked_across_node_downtime() {
+    let mut checker = InvariantChecker::default();
+
+    let tick1 = vec![SnapshotBuilder::new(1).sm_key_at("k", log_id(1, 1, 5)).build()];
+    assert_no_violations!(checker.check(&tick1).violations);
+
+    // Node 1 is down: it drops out of the snapshot list entirely.
+    assert_no_violations!(checker.check(&[]).violations);
+
+    // Storage is durable, so it must come back at-or-ahead of where it was.
+    let tick3 = vec![SnapshotBuilder::new(1).sm_key_at("k", log_id(1, 1, 3)).build()];
+    let r = checker.check(&tick3);
+    assert_variant!(r.violations, InvariantViolation::SmKeyRegressed { node: 1, .. });
 }
 
 #[test]

--- a/tests-turmoil/src/invariants/violation.rs
+++ b/tests-turmoil/src/invariants/violation.rs
@@ -96,6 +96,17 @@ pub enum InvariantViolation {
         previous: String,
         current: String,
     },
+
+    /// Monotonic SM Keys (derived — a node applies committed entries in log
+    /// order and installs only at-or-ahead snapshots): on one node, the log
+    /// id that last wrote a key must never decrease across ticks, and a key
+    /// must never disappear (`current: None`).
+    SmKeyRegressed {
+        node: NodeId,
+        key: String,
+        previous: crate::typ::LogId,
+        current: Option<crate::typ::LogId>,
+    },
 }
 
 impl std::fmt::Display for InvariantViolation {
@@ -191,6 +202,17 @@ impl std::fmt::Display for InvariantViolation {
                 current,
             } => {
                 write!(f, "MonotonicVote: n{node} vote {previous} -> {current}")
+            }
+            Self::SmKeyRegressed {
+                node,
+                key,
+                previous,
+                current,
+            } => {
+                write!(
+                    f,
+                    "MonotonicSmKeys: n{node} key={key} written at {previous} -> {current:?}"
+                )
             }
         }
     }

--- a/tests-turmoil/src/oracle.rs
+++ b/tests-turmoil/src/oracle.rs
@@ -23,6 +23,12 @@
 //! - **Lost observed write** (final): likewise for the highest log id any linearizable read
 //!   observed per key — an observation of committed state is a durability commitment even when the
 //!   write that produced it was never acked.
+//! - **Predecessor chain**: an ack carries the key's previous versioned value, read by the apply at
+//!   the state directly below the new entry. It must be the newest known-committed write to the key
+//!   below that position — a committed write cannot vanish between two acks, even if no read ever
+//!   touches the window.
+//! - **Absence floor**: a write applied onto an absent key asserts the key had no committed write
+//!   below that log id, so no write to the key may ever resolve below it.
 //!
 //! A failed or timed-out write is recorded as [`WriteOutcome::Unknown`], never
 //! as "guaranteed absent": openraft may fail a `client_write` call (e.g. on
@@ -107,6 +113,27 @@ pub enum OracleViolation {
         first_serial: u64,
         second_serial: u64,
     },
+    /// An ack's previous-value evidence contradicts the known committed
+    /// writes to the key: the apply at `log_id` returned `prev` (`None` =
+    /// key absent), but the newest known-committed write to the key below
+    /// `log_id` is `newest_below`. Fires when `prev` is not below `log_id`,
+    /// when it is older than `newest_below`, or when the key was reported
+    /// absent over a committed write.
+    BrokenPredecessor {
+        key: String,
+        log_id: LogId,
+        prev: Option<LogId>,
+        newest_below: Option<LogId>,
+    },
+    /// A write resolved to a position below an absence floor: an earlier
+    /// apply at `absent_at` had observed the key absent, so no write to the
+    /// key may exist below `absent_at`.
+    WriteBelowAbsence {
+        key: String,
+        serial: u64,
+        log_id: LogId,
+        absent_at: LogId,
+    },
 }
 
 impl std::fmt::Display for OracleViolation {
@@ -165,6 +192,30 @@ impl std::fmt::Display for OracleViolation {
                     "DivergentEntry: log id {log_id} seen with serial {first_serial} and again with {second_serial}"
                 )
             }
+            Self::BrokenPredecessor {
+                key,
+                log_id,
+                prev,
+                newest_below,
+            } => {
+                write!(
+                    f,
+                    "BrokenPredecessor: key={key} apply at {log_id} returned prev {prev:?}, \
+                     newest known-committed write below is {newest_below:?}"
+                )
+            }
+            Self::WriteBelowAbsence {
+                key,
+                serial,
+                log_id,
+                absent_at,
+            } => {
+                write!(
+                    f,
+                    "WriteBelowAbsence: key={key} serial={serial} resolved at {log_id}, \
+                     but the apply at {absent_at} observed the key absent"
+                )
+            }
         }
     }
 }
@@ -202,6 +253,12 @@ pub struct ClientHistory {
     resolved_log: BTreeMap<u64, LogId>,
     /// log id -> serial: the reverse direction of [`Self::resolved_log`].
     resolved_serial: BTreeMap<LogId, u64>,
+    /// Per key: every exactly-positioned committed write (log id -> serial),
+    /// accumulated from all evidence via [`Self::resolve`].
+    committed_by_key: BTreeMap<String, BTreeMap<LogId, u64>>,
+    /// Per key: the highest log id whose apply observed the key absent.
+    /// No write to the key may ever resolve below this floor.
+    absent_below: BTreeMap<String, LogId>,
     /// Per key: highest acked (log_id, serial).
     max_acked: BTreeMap<String, (LogId, u64)>,
     /// Per key: log id observed by the latest completed read.
@@ -222,19 +279,25 @@ impl ClientHistory {
     }
 
     /// Record a successful `client_write` response.
-    pub fn record_write_acked(&mut self, serial: u64, log_id: LogId) {
+    ///
+    /// `prev` is the key's previous versioned value returned by the apply
+    /// ([`crate::typ::Response::prev`]): an exact observation of the key at
+    /// the state directly below `log_id`, checked against the predecessor
+    /// chain.
+    pub fn record_write_acked(&mut self, serial: u64, log_id: LogId, prev: Option<ValueMeta>) {
         self.stats.writes_acked += 1;
-        self.resolve(serial, log_id);
         let Some(attempt) = self.attempts.get_mut(&serial) else {
             return;
         };
         attempt.outcome = WriteOutcome::Acked(log_id);
 
         let key = attempt.key.clone();
+        self.resolve(&key, serial, log_id);
         let is_newer = self.max_acked.get(&key).is_none_or(|(acked, _)| log_id > *acked);
         if is_newer {
-            self.max_acked.insert(key, (log_id, serial));
+            self.max_acked.insert(key.clone(), (log_id, serial));
         }
+        self.check_prev_chain(&key, log_id, prev.as_ref());
     }
 
     /// Record a failed or timed-out `client_write` call.
@@ -266,7 +329,7 @@ impl ClientHistory {
 
         if let Some(meta) = observed {
             self.check_value_is_attempted(key, meta);
-            self.resolve(meta.serial, meta.log_id);
+            self.resolve(key, meta.serial, meta.log_id);
         }
 
         // Monotonic reads: this client reads sequentially, so per key the
@@ -346,19 +409,24 @@ impl ClientHistory {
             }
             for (key, meta) in &sm.data {
                 self.check_value_is_attempted(key, meta);
-                self.resolve(meta.serial, meta.log_id);
+                self.resolve(key, meta.serial, meta.log_id);
             }
         }
     }
 
-    /// Pin `serial` to `log_id` and check the serial <-> log id bijection.
+    /// Pin `serial` to `log_id` on `key` and check the serial <-> log id
+    /// bijection.
     ///
-    /// Every evidence source feeds this: write acks, read observations and
-    /// final-scan observations. A request is proposed exactly once and a log
-    /// entry has exactly one log id, so the mapping must be one-to-one in
-    /// both directions; any disagreement means an entry was applied twice or
-    /// an ack pointed at the wrong entry.
-    fn resolve(&mut self, serial: u64, log_id: LogId) {
+    /// Every evidence source feeds this: write acks, read observations,
+    /// previous-value observations and final-scan observations. A request is
+    /// proposed exactly once and a log entry has exactly one log id, so the
+    /// mapping must be one-to-one in both directions; any disagreement means
+    /// an entry was applied twice or an ack pointed at the wrong entry.
+    ///
+    /// `key` is the key the value was observed under. The position also
+    /// feeds the per-key committed-write chain and is checked against the
+    /// key's absence floor.
+    fn resolve(&mut self, key: &str, serial: u64, log_id: LogId) {
         match self.resolved_log.get(&serial) {
             None => {
                 self.resolved_log.insert(serial, log_id);
@@ -384,6 +452,60 @@ impl ClientHistory {
                 });
             }
             Some(_) => {}
+        }
+        self.committed_by_key.entry(key.to_string()).or_default().insert(log_id, serial);
+        if let Some(absent_at) = self.absent_below.get(key)
+            && log_id < *absent_at
+        {
+            self.violations.push(OracleViolation::WriteBelowAbsence {
+                key: key.to_string(),
+                serial,
+                log_id,
+                absent_at: *absent_at,
+            });
+        }
+    }
+
+    /// Check an ack's previous-value evidence against the predecessor chain.
+    ///
+    /// The apply of the entry at `log_id` read the key's state directly
+    /// below its own position, so `prev` must be the newest committed write
+    /// to the key below `log_id`. Any known-committed write above `prev`
+    /// (or any at all, when `prev` is `None`) vanished from the key without
+    /// being overwritten. A `None` also establishes the key's absence floor.
+    fn check_prev_chain(&mut self, key: &str, log_id: LogId, prev: Option<&ValueMeta>) {
+        if let Some(meta) = prev {
+            self.check_value_is_attempted(key, meta);
+            self.resolve(key, meta.serial, meta.log_id);
+        }
+
+        let newest_below = self
+            .committed_by_key
+            .get(key)
+            .and_then(|writes| writes.range(..log_id).next_back())
+            .map(|(l, _)| *l);
+        let prev_pos = prev.map(|m| m.log_id);
+        let broken = match (prev_pos, newest_below) {
+            (Some(p), _) if p >= log_id => true,
+            (Some(p), Some(newest)) => p < newest,
+            (Some(_), None) => false,
+            (None, Some(_)) => true,
+            (None, None) => false,
+        };
+        if broken {
+            self.violations.push(OracleViolation::BrokenPredecessor {
+                key: key.to_string(),
+                log_id,
+                prev: prev_pos,
+                newest_below,
+            });
+        }
+
+        if prev.is_none() {
+            let floor = self.absent_below.entry(key.to_string()).or_insert(log_id);
+            if *floor < log_id {
+                *floor = log_id;
+            }
         }
     }
 
@@ -486,7 +608,7 @@ mod tests {
     #[test]
     fn stale_read_detected() {
         let mut h = history_with_write(1, "k", "v1");
-        h.record_write_acked(1, log_id(2, 1, 9));
+        h.record_write_acked(1, log_id(2, 1, 9), None);
 
         let floor = h.acked_floor("k");
         assert_eq!(floor, Some(log_id(2, 1, 9)));
@@ -502,7 +624,7 @@ mod tests {
     fn read_at_or_above_floor_is_clean() {
         let mut h = history_with_write(1, "k", "v1");
         h.record_write_attempt(2, "k".to_string(), "v2".to_string());
-        h.record_write_acked(1, log_id(2, 1, 9));
+        h.record_write_acked(1, log_id(2, 1, 9), None);
 
         let floor = h.acked_floor("k");
         // Exactly the acked write.
@@ -525,7 +647,7 @@ mod tests {
     #[test]
     fn lost_acked_write_detected_in_final_state() {
         let mut h = history_with_write(1, "k", "v1");
-        h.record_write_acked(1, log_id(2, 1, 9));
+        h.record_write_acked(1, log_id(2, 1, 9), None);
 
         // Node 1 lost the key entirely; node 2 has an older log id.
         let mut sm1 = StateMachineData::default();
@@ -592,7 +714,7 @@ mod tests {
     #[test]
     fn duplicate_apply_detected_across_ack_and_read() {
         let mut h = history_with_write(1, "k", "v1");
-        h.record_write_acked(1, log_id(2, 1, 9));
+        h.record_write_acked(1, log_id(2, 1, 9), None);
 
         // The same serial shows up at a different log position.
         h.record_read("k", Some(&meta(1, "v1", log_id(3, 1, 20))), None);
@@ -608,7 +730,7 @@ mod tests {
     #[test]
     fn duplicate_apply_detected_in_final_scan() {
         let mut h = history_with_write(1, "k", "v1");
-        h.record_write_acked(1, log_id(2, 1, 9));
+        h.record_write_acked(1, log_id(2, 1, 9), None);
 
         // Final state holds the acked serial at a higher position: not a
         // lost write, but the same entry applied twice.
@@ -641,7 +763,7 @@ mod tests {
     #[test]
     fn consistent_evidence_is_clean() {
         let mut h = history_with_write(1, "k", "v1");
-        h.record_write_acked(1, log_id(2, 1, 9));
+        h.record_write_acked(1, log_id(2, 1, 9), None);
         h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), None);
 
         let mut sm = StateMachineData::default();
@@ -652,10 +774,129 @@ mod tests {
     }
 
     #[test]
+    fn prev_chain_consistent_is_clean() {
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_attempt(2, "k".to_string(), "v2".to_string());
+
+        h.record_write_acked(1, log_id(1, 1, 5), None);
+        h.record_write_acked(2, log_id(1, 1, 9), Some(meta(1, "v1", log_id(1, 1, 5))));
+        assert!(h.drain_violations().is_empty());
+    }
+
+    #[test]
+    fn broken_predecessor_missed_committed_write() {
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_attempt(2, "k".to_string(), "v2".to_string());
+        h.record_write_attempt(3, "k".to_string(), "v3".to_string());
+
+        h.record_write_acked(1, log_id(1, 1, 5), None);
+        h.record_write_acked(2, log_id(1, 1, 9), Some(meta(1, "v1", log_id(1, 1, 5))));
+        // W3's apply skipped the committed W2@9: it saw W1@5 as predecessor.
+        h.record_write_acked(3, log_id(1, 1, 12), Some(meta(1, "v1", log_id(1, 1, 5))));
+
+        let violations = h.drain_violations();
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert!(matches!(&violations[0], OracleViolation::BrokenPredecessor { .. }));
+    }
+
+    #[test]
+    fn broken_predecessor_absent_over_committed_write() {
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_attempt(2, "k".to_string(), "v2".to_string());
+
+        h.record_write_acked(1, log_id(1, 1, 5), None);
+        // W2's apply saw the key absent although W1 committed below it.
+        h.record_write_acked(2, log_id(1, 1, 9), None);
+
+        let violations = h.drain_violations();
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert!(matches!(&violations[0], OracleViolation::BrokenPredecessor {
+            prev: None,
+            newest_below: Some(_),
+            ..
+        }));
+    }
+
+    #[test]
+    fn prev_at_or_above_own_position_detected() {
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_attempt(2, "k".to_string(), "v2".to_string());
+
+        // The apply at 9 returned a predecessor from position 10.
+        h.record_write_acked(2, log_id(1, 1, 9), Some(meta(1, "v1", log_id(1, 1, 10))));
+
+        let violations = h.drain_violations();
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert!(matches!(&violations[0], OracleViolation::BrokenPredecessor { .. }));
+    }
+
+    #[test]
+    fn write_below_absence_detected() {
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_attempt(2, "k".to_string(), "v2".to_string());
+
+        // W2's apply at 9 observed the key absent: nothing committed below 9.
+        h.record_write_acked(2, log_id(1, 1, 9), None);
+        // Yet a read finds W1 committed at 5.
+        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 5))), None);
+
+        let violations = h.drain_violations();
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert!(matches!(&violations[0], OracleViolation::WriteBelowAbsence {
+            serial: 1,
+            ..
+        }));
+    }
+
+    #[test]
+    fn prev_of_unacked_write_is_clean() {
+        // W2's prev names the never-acked W1: committed evidence, not a
+        // violation; W1's late ack at exactly that position stays consistent.
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_attempt(2, "k".to_string(), "v2".to_string());
+
+        h.record_write_acked(2, log_id(1, 1, 9), Some(meta(1, "v1", log_id(1, 1, 5))));
+        h.record_write_acked(1, log_id(1, 1, 5), None);
+        assert!(h.drain_violations().is_empty());
+    }
+
+    #[test]
+    fn duplicate_apply_detected_via_prev_value() {
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_attempt(2, "k".to_string(), "v2".to_string());
+
+        h.record_write_acked(1, log_id(1, 1, 5), None);
+        // W2's prev carries W1 at position 7, but W1 was acked at 5.
+        h.record_write_acked(2, log_id(1, 1, 9), Some(meta(1, "v1", log_id(1, 1, 7))));
+
+        let violations = h.drain_violations();
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert!(matches!(&violations[0], OracleViolation::DuplicateApply {
+            serial: 1,
+            ..
+        }));
+    }
+
+    #[test]
+    fn phantom_prev_value_detected() {
+        let mut h = history_with_write(2, "k", "v2");
+
+        // The apply returned a predecessor no tracked write produced.
+        h.record_write_acked(2, log_id(1, 1, 9), Some(meta(99, "vx", log_id(1, 1, 5))));
+
+        let violations = h.drain_violations();
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert!(matches!(&violations[0], OracleViolation::PhantomValue {
+            serial: 99,
+            ..
+        }));
+    }
+
+    #[test]
     fn final_durability_clean_when_overwritten_by_later_write() {
         let mut h = history_with_write(1, "k", "v1");
         h.record_write_attempt(2, "k".to_string(), "v2".to_string());
-        h.record_write_acked(1, log_id(2, 1, 9));
+        h.record_write_acked(1, log_id(2, 1, 9), None);
 
         // The acked write was overwritten by a later, never-acked write:
         // that is a legal linearizable history.

--- a/tests-turmoil/src/oracle.rs
+++ b/tests-turmoil/src/oracle.rs
@@ -28,7 +28,8 @@
 //!   below that position — a committed write cannot vanish between two acks, even if no read ever
 //!   touches the window.
 //! - **Absence floor**: a write applied onto an absent key asserts the key had no committed write
-//!   below that log id, so no write to the key may ever resolve below it.
+//!   below that log id; a linearizable read observing the key absent asserts none at or below its
+//!   `ReadIndex` barrier. No write to the key may ever resolve below such a floor.
 //!
 //! A failed or timed-out write is recorded as [`WriteOutcome::Unknown`], never
 //! as "guaranteed absent": openraft may fail a `client_write` call (e.g. on
@@ -125,9 +126,9 @@ pub enum OracleViolation {
         prev: Option<LogId>,
         newest_below: Option<LogId>,
     },
-    /// A write resolved to a position below an absence floor: an earlier
-    /// apply at `absent_at` had observed the key absent, so no write to the
-    /// key may exist below `absent_at`.
+    /// A write was found at a position below an absence floor: an apply's
+    /// previous value or an absent read at a `ReadIndex` barrier asserted
+    /// that the key holds no committed write below `absent_at` (exclusive).
     WriteBelowAbsence {
         key: String,
         serial: u64,
@@ -212,8 +213,8 @@ impl std::fmt::Display for OracleViolation {
             } => {
                 write!(
                     f,
-                    "WriteBelowAbsence: key={key} serial={serial} resolved at {log_id}, \
-                     but the apply at {absent_at} observed the key absent"
+                    "WriteBelowAbsence: key={key} serial={serial} found at {log_id}, \
+                     but the key was asserted absent below {absent_at}"
                 )
             }
         }
@@ -323,8 +324,20 @@ impl ClientHistory {
     /// Record and check one completed linearizable read.
     ///
     /// `floor` is the value of [`Self::acked_floor`] captured before the read
-    /// started.
-    pub fn record_read(&mut self, key: &str, observed: Option<&ValueMeta>, floor: Option<LogId>) {
+    /// started. `barrier` is the `ReadIndex` log id returned by
+    /// `ensure_linearizable`: the observed state contains at least every
+    /// entry at or below it. The state may legitimately have advanced
+    /// *beyond* the barrier by the time the value is read, so a present
+    /// value asserts nothing extra; but keys are never deleted, so observing
+    /// the key *absent* asserts it has no committed write at or below the
+    /// barrier.
+    pub fn record_read(
+        &mut self,
+        key: &str,
+        observed: Option<&ValueMeta>,
+        floor: Option<LogId>,
+        barrier: Option<LogId>,
+    ) {
         self.stats.reads_ok += 1;
 
         if let Some(meta) = observed {
@@ -365,6 +378,26 @@ impl ClientHistory {
 
         if let Some(meta) = observed {
             self.last_read.insert(key.to_string(), meta.log_id);
+        }
+
+        // An absent key at a ReadIndex barrier proves the key had no
+        // committed write at or below the barrier: check the known committed
+        // writes now and raise the key's absence floor for future evidence.
+        if observed.is_none()
+            && let Some(b) = barrier
+        {
+            let bound = after(b);
+            if let Some((log_id, serial)) =
+                self.committed_by_key.get(key).and_then(|writes| writes.range(..bound).next_back())
+            {
+                self.violations.push(OracleViolation::WriteBelowAbsence {
+                    key: key.to_string(),
+                    serial: *serial,
+                    log_id: *log_id,
+                    absent_at: bound,
+                });
+            }
+            self.raise_absence_floor(key, bound);
         }
     }
 
@@ -502,10 +535,16 @@ impl ClientHistory {
         }
 
         if prev.is_none() {
-            let floor = self.absent_below.entry(key.to_string()).or_insert(log_id);
-            if *floor < log_id {
-                *floor = log_id;
-            }
+            self.raise_absence_floor(key, log_id);
+        }
+    }
+
+    /// Raise `key`'s absence floor to `bound`: the key is asserted to hold
+    /// no committed write below `bound` (exclusive). Floors only go up.
+    fn raise_absence_floor(&mut self, key: &str, bound: LogId) {
+        let floor = self.absent_below.entry(key.to_string()).or_insert(bound);
+        if *floor < bound {
+            *floor = bound;
         }
     }
 
@@ -528,6 +567,14 @@ impl ClientHistory {
             });
         }
     }
+}
+
+/// The exclusive-bound equivalent of an inclusive one: `x <= b` iff
+/// `x < after(b)`. Log indexes are consecutive integers per leader and the
+/// leader id orders before the index, so no log id sorts strictly between
+/// `(leader, index)` and `(leader, index + 1)`.
+fn after(b: LogId) -> LogId {
+    LogId::new(b.leader_id, b.index + 1)
 }
 
 #[cfg(test)]
@@ -557,7 +604,7 @@ mod tests {
     #[test]
     fn read_of_attempted_value_is_clean() {
         let mut h = history_with_write(1, "k", "v1");
-        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 5))), None);
+        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 5))), None, None);
         assert!(h.drain_violations().is_empty());
     }
 
@@ -566,12 +613,12 @@ mod tests {
         let mut h = history_with_write(1, "k", "v1");
 
         // Unknown serial.
-        h.record_read("k", Some(&meta(99, "v1", log_id(1, 1, 5))), None);
+        h.record_read("k", Some(&meta(99, "v1", log_id(1, 1, 5))), None, None);
         // Right serial, wrong value. (Same log id in both serial-1 reads so
         // only the phantom check fires, not the bijection check.)
-        h.record_read("k", Some(&meta(1, "other", log_id(1, 1, 6))), None);
+        h.record_read("k", Some(&meta(1, "other", log_id(1, 1, 6))), None, None);
         // Right serial and value, wrong key.
-        h.record_read("x", Some(&meta(1, "v1", log_id(1, 1, 6))), None);
+        h.record_read("x", Some(&meta(1, "v1", log_id(1, 1, 6))), None, None);
 
         let violations = h.drain_violations();
         assert_eq!(violations.len(), 3);
@@ -583,11 +630,11 @@ mod tests {
         let mut h = history_with_write(1, "k", "v1");
         h.record_write_attempt(2, "k".to_string(), "v2".to_string());
 
-        h.record_read("k", Some(&meta(2, "v2", log_id(2, 1, 9))), None);
+        h.record_read("k", Some(&meta(2, "v2", log_id(2, 1, 9))), None, None);
         // Older log id observed after a newer one.
-        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 5))), None);
+        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 5))), None, None);
         // Key vanished after being present.
-        h.record_read("k", None, None);
+        h.record_read("k", None, None, None);
 
         let violations = h.drain_violations();
         assert_eq!(violations.len(), 2);
@@ -599,9 +646,9 @@ mod tests {
         let mut h = history_with_write(1, "k", "v1");
         h.record_write_attempt(2, "k".to_string(), "v2".to_string());
 
-        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 5))), None);
-        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 5))), None);
-        h.record_read("k", Some(&meta(2, "v2", log_id(2, 2, 9))), None);
+        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 5))), None, None);
+        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 5))), None, None);
+        h.record_read("k", Some(&meta(2, "v2", log_id(2, 2, 9))), None, None);
         assert!(h.drain_violations().is_empty());
     }
 
@@ -614,7 +661,7 @@ mod tests {
         assert_eq!(floor, Some(log_id(2, 1, 9)));
 
         // Read started after the ack but observes nothing.
-        h.record_read("k", None, floor);
+        h.record_read("k", None, floor, None);
         let violations = h.drain_violations();
         assert_eq!(violations.len(), 1);
         assert!(matches!(&violations[0], OracleViolation::StaleRead { .. }));
@@ -628,9 +675,9 @@ mod tests {
 
         let floor = h.acked_floor("k");
         // Exactly the acked write.
-        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), floor);
+        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), floor, None);
         // A later (unacked) write is also fine.
-        h.record_read("k", Some(&meta(2, "v2", log_id(2, 1, 12))), floor);
+        h.record_read("k", Some(&meta(2, "v2", log_id(2, 1, 12))), floor, None);
         assert!(h.drain_violations().is_empty());
     }
 
@@ -640,7 +687,7 @@ mod tests {
         h.record_write_failed(1);
 
         // A failed write may still commit and be observed later: not a violation.
-        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 3))), None);
+        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 3))), None, None);
         assert!(h.drain_violations().is_empty());
     }
 
@@ -683,7 +730,7 @@ mod tests {
         // observed it: it committed, so it must survive to the final state.
         let mut h = history_with_write(1, "k", "v1");
         h.record_write_failed(1);
-        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), None);
+        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), None, None);
 
         let sm = StateMachineData::default();
         h.check_final_durability(&[(1, sm)]);
@@ -701,7 +748,7 @@ mod tests {
     fn final_at_or_above_observed_is_clean() {
         let mut h = history_with_write(1, "k", "v1");
         h.record_write_attempt(2, "k".to_string(), "v2".to_string());
-        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), None);
+        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), None, None);
 
         // Overwritten by a later (never-acked, never-read) write: fine.
         let mut sm = StateMachineData::default();
@@ -717,7 +764,7 @@ mod tests {
         h.record_write_acked(1, log_id(2, 1, 9), None);
 
         // The same serial shows up at a different log position.
-        h.record_read("k", Some(&meta(1, "v1", log_id(3, 1, 20))), None);
+        h.record_read("k", Some(&meta(1, "v1", log_id(3, 1, 20))), None, None);
 
         let violations = h.drain_violations();
         assert_eq!(violations.len(), 1, "{violations:?}");
@@ -752,8 +799,8 @@ mod tests {
         h.record_write_attempt(2, "x".to_string(), "v2".to_string());
 
         // Two different serials observed at the same log id.
-        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), None);
-        h.record_read("x", Some(&meta(2, "v2", log_id(2, 1, 9))), None);
+        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), None, None);
+        h.record_read("x", Some(&meta(2, "v2", log_id(2, 1, 9))), None, None);
 
         let violations = h.drain_violations();
         assert_eq!(violations.len(), 1, "{violations:?}");
@@ -764,7 +811,7 @@ mod tests {
     fn consistent_evidence_is_clean() {
         let mut h = history_with_write(1, "k", "v1");
         h.record_write_acked(1, log_id(2, 1, 9), None);
-        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), None);
+        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), None, None);
 
         let mut sm = StateMachineData::default();
         sm.data.insert("k".to_string(), meta(1, "v1", log_id(2, 1, 9)));
@@ -838,7 +885,7 @@ mod tests {
         // W2's apply at 9 observed the key absent: nothing committed below 9.
         h.record_write_acked(2, log_id(1, 1, 9), None);
         // Yet a read finds W1 committed at 5.
-        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 5))), None);
+        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 5))), None, None);
 
         let violations = h.drain_violations();
         assert_eq!(violations.len(), 1, "{violations:?}");
@@ -846,6 +893,57 @@ mod tests {
             serial: 1,
             ..
         }));
+    }
+
+    #[test]
+    fn absent_read_at_barrier_forbids_later_resolution_below() {
+        let mut h = history_with_write(1, "k", "v1");
+
+        // The key is absent at barrier 9: no committed write may exist <= 9.
+        h.record_read("k", None, None, Some(log_id(1, 1, 9)));
+        // Yet W1 turns up committed at 5.
+        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 5))), None, None);
+
+        let violations = h.drain_violations();
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert!(matches!(&violations[0], OracleViolation::WriteBelowAbsence {
+            serial: 1,
+            ..
+        }));
+    }
+
+    #[test]
+    fn absent_read_at_barrier_detects_known_write_at_boundary() {
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_acked(1, log_id(1, 1, 9), None);
+
+        // The barrier covers the acked position itself: <= is violated.
+        h.record_read("k", None, None, Some(log_id(1, 1, 9)));
+
+        let violations = h.drain_violations();
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert!(matches!(&violations[0], OracleViolation::WriteBelowAbsence {
+            serial: 1,
+            ..
+        }));
+    }
+
+    #[test]
+    fn absent_read_without_barrier_is_uninformative() {
+        let mut h = history_with_write(1, "k", "v1");
+
+        h.record_read("k", None, None, None);
+        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 5))), None, None);
+        assert!(h.drain_violations().is_empty());
+    }
+
+    #[test]
+    fn present_read_beyond_barrier_is_clean() {
+        let mut h = history_with_write(1, "k", "v1");
+
+        // The state may have advanced past the barrier by read time.
+        h.record_read("k", Some(&meta(1, "v1", log_id(1, 1, 12))), None, Some(log_id(1, 1, 9)));
+        assert!(h.drain_violations().is_empty());
     }
 
     #[test]

--- a/tests-turmoil/src/oracle.rs
+++ b/tests-turmoil/src/oracle.rs
@@ -20,6 +20,9 @@
 //!   that write or a later one.
 //! - **Lost acked write** (final): after the cluster heals, every key's value must sit at or above
 //!   the highest acked log id for that key.
+//! - **Lost observed write** (final): likewise for the highest log id any linearizable read
+//!   observed per key — an observation of committed state is a durability commitment even when the
+//!   write that produced it was never acked.
 //!
 //! A failed or timed-out write is recorded as [`WriteOutcome::Unknown`], never
 //! as "guaranteed absent": openraft may fail a `client_write` call (e.g. on
@@ -77,6 +80,14 @@ pub enum OracleViolation {
         acked: LogId,
         found: Option<LogId>,
     },
+    /// After healing, a key ended below a log id that a linearizable read
+    /// had already observed (the write itself may never have been acked).
+    LostObservedWrite {
+        node: NodeId,
+        key: String,
+        observed: LogId,
+        found: Option<LogId>,
+    },
     /// One serial was seen at two different log ids: the same request was
     /// applied at two log positions, or an ack pointed at a different entry
     /// than the one later observed.
@@ -117,6 +128,17 @@ impl std::fmt::Display for OracleViolation {
                 write!(
                     f,
                     "LostAckedWrite: n{node} key={key} acked at {acked}, final state has {found:?}"
+                )
+            }
+            Self::LostObservedWrite {
+                node,
+                key,
+                observed,
+                found,
+            } => {
+                write!(
+                    f,
+                    "LostObservedWrite: n{node} key={key} read-observed at {observed}, final state has {found:?}"
                 )
             }
             Self::DuplicateApply { serial, first, second } => {
@@ -278,7 +300,10 @@ impl ClientHistory {
     /// Check every acked write against the final, healed state machines.
     ///
     /// Call only after convergence: each member must hold, for every key with
-    /// an acked write, a value at or above the acked log id.
+    /// an acked write, a value at or above the acked log id, and for every
+    /// key a read observed, a value at or above the observed log id — a
+    /// linearizable observation of committed state is a durability commitment
+    /// exactly like an ack, even when the write itself was never acked.
     pub fn check_final_durability(&mut self, members: &[(NodeId, StateMachineData)]) {
         for (node, sm) in members {
             for (key, (acked, _serial)) in &self.max_acked {
@@ -292,6 +317,21 @@ impl ClientHistory {
                         node: *node,
                         key: key.clone(),
                         acked: *acked,
+                        found: found.map(|m| m.log_id),
+                    });
+                }
+            }
+            for (key, observed) in &self.last_read {
+                let found = sm.data.get(key);
+                let lost = match found {
+                    Some(meta) => meta.log_id < *observed,
+                    None => true,
+                };
+                if lost {
+                    self.violations.push(OracleViolation::LostObservedWrite {
+                        node: *node,
+                        key: key.clone(),
+                        observed: *observed,
                         found: found.map(|m| m.log_id),
                     });
                 }
@@ -505,6 +545,40 @@ mod tests {
             })),
             "{violations:?}"
         );
+    }
+
+    #[test]
+    fn lost_observed_write_detected_in_final_state() {
+        // The write was never acked (Unknown), but a linearizable read
+        // observed it: it committed, so it must survive to the final state.
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_failed(1);
+        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), None);
+
+        let sm = StateMachineData::default();
+        h.check_final_durability(&[(1, sm)]);
+
+        let violations = h.drain_violations();
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert!(matches!(&violations[0], OracleViolation::LostObservedWrite {
+            node: 1,
+            found: None,
+            ..
+        }));
+    }
+
+    #[test]
+    fn final_at_or_above_observed_is_clean() {
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_attempt(2, "k".to_string(), "v2".to_string());
+        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), None);
+
+        // Overwritten by a later (never-acked, never-read) write: fine.
+        let mut sm = StateMachineData::default();
+        sm.data.insert("k".to_string(), meta(2, "v2", log_id(3, 1, 12)));
+        h.check_final_durability(&[(1, sm)]);
+
+        assert!(h.drain_violations().is_empty());
     }
 
     #[test]

--- a/tests-turmoil/src/oracle.rs
+++ b/tests-turmoil/src/oracle.rs
@@ -10,6 +10,9 @@
 //!
 //! - **Phantom value**: an observed value must correspond to a tracked write attempt (same serial,
 //!   key and value). Anything else is corruption.
+//! - **One serial, one log id**: every request is proposed exactly once, so all sightings of a
+//!   serial (ack, read, final scan) must agree on its log id, and one log id must never be seen
+//!   carrying two different serials.
 //! - **Monotonic reads**: sequential linearizable reads of one key must observe non-decreasing log
 //!   ids. Keys are never deleted, so a key can never be observed absent after being observed
 //!   present.
@@ -74,6 +77,17 @@ pub enum OracleViolation {
         acked: LogId,
         found: Option<LogId>,
     },
+    /// One serial was seen at two different log ids: the same request was
+    /// applied at two log positions, or an ack pointed at a different entry
+    /// than the one later observed.
+    DuplicateApply { serial: u64, first: LogId, second: LogId },
+    /// One log id was seen carrying two different serials: a single log
+    /// position held two different contents.
+    DivergentEntry {
+        log_id: LogId,
+        first_serial: u64,
+        second_serial: u64,
+    },
 }
 
 impl std::fmt::Display for OracleViolation {
@@ -103,6 +117,22 @@ impl std::fmt::Display for OracleViolation {
                 write!(
                     f,
                     "LostAckedWrite: n{node} key={key} acked at {acked}, final state has {found:?}"
+                )
+            }
+            Self::DuplicateApply { serial, first, second } => {
+                write!(
+                    f,
+                    "DuplicateApply: serial={serial} seen at log id {first} and again at {second}"
+                )
+            }
+            Self::DivergentEntry {
+                log_id,
+                first_serial,
+                second_serial,
+            } => {
+                write!(
+                    f,
+                    "DivergentEntry: log id {log_id} seen with serial {first_serial} and again with {second_serial}"
                 )
             }
         }
@@ -138,6 +168,10 @@ impl std::fmt::Display for WorkloadStats {
 pub struct ClientHistory {
     /// serial -> attempt. Serials are unique across one simulation.
     attempts: BTreeMap<u64, WriteAttempt>,
+    /// serial -> log id, pinned by the first evidence (ack or observation).
+    resolved_log: BTreeMap<u64, LogId>,
+    /// log id -> serial: the reverse direction of [`Self::resolved_log`].
+    resolved_serial: BTreeMap<LogId, u64>,
     /// Per key: highest acked (log_id, serial).
     max_acked: BTreeMap<String, (LogId, u64)>,
     /// Per key: log id observed by the latest completed read.
@@ -160,6 +194,7 @@ impl ClientHistory {
     /// Record a successful `client_write` response.
     pub fn record_write_acked(&mut self, serial: u64, log_id: LogId) {
         self.stats.writes_acked += 1;
+        self.resolve(serial, log_id);
         let Some(attempt) = self.attempts.get_mut(&serial) else {
             return;
         };
@@ -201,6 +236,7 @@ impl ClientHistory {
 
         if let Some(meta) = observed {
             self.check_value_is_attempted(key, meta);
+            self.resolve(meta.serial, meta.log_id);
         }
 
         // Monotonic reads: this client reads sequentially, so per key the
@@ -262,7 +298,44 @@ impl ClientHistory {
             }
             for (key, meta) in &sm.data {
                 self.check_value_is_attempted(key, meta);
+                self.resolve(meta.serial, meta.log_id);
             }
+        }
+    }
+
+    /// Pin `serial` to `log_id` and check the serial <-> log id bijection.
+    ///
+    /// Every evidence source feeds this: write acks, read observations and
+    /// final-scan observations. A request is proposed exactly once and a log
+    /// entry has exactly one log id, so the mapping must be one-to-one in
+    /// both directions; any disagreement means an entry was applied twice or
+    /// an ack pointed at the wrong entry.
+    fn resolve(&mut self, serial: u64, log_id: LogId) {
+        match self.resolved_log.get(&serial) {
+            None => {
+                self.resolved_log.insert(serial, log_id);
+            }
+            Some(first) if *first != log_id => {
+                self.violations.push(OracleViolation::DuplicateApply {
+                    serial,
+                    first: *first,
+                    second: log_id,
+                });
+            }
+            Some(_) => {}
+        }
+        match self.resolved_serial.get(&log_id) {
+            None => {
+                self.resolved_serial.insert(log_id, serial);
+            }
+            Some(first) if *first != serial => {
+                self.violations.push(OracleViolation::DivergentEntry {
+                    log_id,
+                    first_serial: *first,
+                    second_serial: serial,
+                });
+            }
+            Some(_) => {}
         }
     }
 
@@ -324,10 +397,11 @@ mod tests {
 
         // Unknown serial.
         h.record_read("k", Some(&meta(99, "v1", log_id(1, 1, 5))), None);
-        // Right serial, wrong value.
+        // Right serial, wrong value. (Same log id in both serial-1 reads so
+        // only the phantom check fires, not the bijection check.)
         h.record_read("k", Some(&meta(1, "other", log_id(1, 1, 6))), None);
         // Right serial and value, wrong key.
-        h.record_read("x", Some(&meta(1, "v1", log_id(1, 1, 7))), None);
+        h.record_read("x", Some(&meta(1, "v1", log_id(1, 1, 6))), None);
 
         let violations = h.drain_violations();
         assert_eq!(violations.len(), 3);
@@ -431,6 +505,68 @@ mod tests {
             })),
             "{violations:?}"
         );
+    }
+
+    #[test]
+    fn duplicate_apply_detected_across_ack_and_read() {
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_acked(1, log_id(2, 1, 9));
+
+        // The same serial shows up at a different log position.
+        h.record_read("k", Some(&meta(1, "v1", log_id(3, 1, 20))), None);
+
+        let violations = h.drain_violations();
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert!(matches!(&violations[0], OracleViolation::DuplicateApply {
+            serial: 1,
+            ..
+        }));
+    }
+
+    #[test]
+    fn duplicate_apply_detected_in_final_scan() {
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_acked(1, log_id(2, 1, 9));
+
+        // Final state holds the acked serial at a higher position: not a
+        // lost write, but the same entry applied twice.
+        let mut sm = StateMachineData::default();
+        sm.data.insert("k".to_string(), meta(1, "v1", log_id(3, 1, 12)));
+        h.check_final_durability(&[(1, sm)]);
+
+        let violations = h.drain_violations();
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert!(matches!(&violations[0], OracleViolation::DuplicateApply {
+            serial: 1,
+            ..
+        }));
+    }
+
+    #[test]
+    fn divergent_entry_detected() {
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_attempt(2, "x".to_string(), "v2".to_string());
+
+        // Two different serials observed at the same log id.
+        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), None);
+        h.record_read("x", Some(&meta(2, "v2", log_id(2, 1, 9))), None);
+
+        let violations = h.drain_violations();
+        assert_eq!(violations.len(), 1, "{violations:?}");
+        assert!(matches!(&violations[0], OracleViolation::DivergentEntry { .. }));
+    }
+
+    #[test]
+    fn consistent_evidence_is_clean() {
+        let mut h = history_with_write(1, "k", "v1");
+        h.record_write_acked(1, log_id(2, 1, 9));
+        h.record_read("k", Some(&meta(1, "v1", log_id(2, 1, 9))), None);
+
+        let mut sm = StateMachineData::default();
+        sm.data.insert("k".to_string(), meta(1, "v1", log_id(2, 1, 9)));
+        h.check_final_durability(&[(1, sm)]);
+
+        assert!(h.drain_violations().is_empty());
     }
 
     #[test]

--- a/tests-turmoil/src/oracle.rs
+++ b/tests-turmoil/src/oracle.rs
@@ -228,6 +228,9 @@ pub struct WorkloadStats {
     pub writes_acked: u64,
     pub writes_failed: u64,
     pub reads_ok: u64,
+    /// Reads abandoned because no leader was visible to send them to.
+    pub reads_no_leader: u64,
+    /// Reads whose `ReadIndex` barrier failed or timed out.
     pub reads_failed: u64,
 }
 
@@ -235,8 +238,13 @@ impl std::fmt::Display for WorkloadStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "writes attempted/acked/failed={}/{}/{}, reads ok/failed={}/{}",
-            self.writes_attempted, self.writes_acked, self.writes_failed, self.reads_ok, self.reads_failed
+            "writes attempted/acked/failed={}/{}/{}, reads ok/no-leader/failed={}/{}/{}",
+            self.writes_attempted,
+            self.writes_acked,
+            self.writes_failed,
+            self.reads_ok,
+            self.reads_no_leader,
+            self.reads_failed
         )
     }
 }
@@ -317,6 +325,12 @@ impl ClientHistory {
         self.max_acked.get(key).map(|(log_id, _)| *log_id)
     }
 
+    /// Record a read abandoned before it started: no leader was visible.
+    pub fn record_read_no_leader(&mut self) {
+        self.stats.reads_no_leader += 1;
+    }
+
+    /// Record a read whose `ReadIndex` barrier failed or timed out.
     pub fn record_read_failed(&mut self) {
         self.stats.reads_failed += 1;
     }

--- a/tests-turmoil/src/oracle.rs
+++ b/tests-turmoil/src/oracle.rs
@@ -44,6 +44,14 @@ pub enum WriteOutcome {
     /// Acked as committed and applied at this log id.
     Acked(LogId),
     /// The call failed or timed out. The write may still commit later.
+    ///
+    /// This is the only failure outcome on purpose: no `client_write` error
+    /// variant proves the entry was never proposed. Even `ForwardToLeader`
+    /// is delivered to responders of already-appended entries when their log
+    /// is truncated or purged (`RaftCore::run_truncate_log` /
+    /// `run_purge_log`), and a purged entry may even have committed — it can
+    /// be superseded by a snapshot that contains it. Refining any error into
+    /// "definitely absent" would therefore be unsound.
     Unknown,
 }
 

--- a/tests-turmoil/src/store.rs
+++ b/tests-turmoil/src/store.rs
@@ -29,7 +29,7 @@ use crate::typ::*;
 /// `log_id` is the id of the log entry that last wrote the key. It exposes the
 /// key's position in the total log order, which is what the client oracle
 /// compares to detect stale or non-monotonic reads.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ValueMeta {
     pub value: String,
     /// Serial of the client write that produced this value.
@@ -247,20 +247,18 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachine> {
             data.last_applied = Some(entry.log_id);
 
             let response = match entry.payload {
-                EntryPayload::Blank => Response { value: None },
+                EntryPayload::Blank => Response { prev: None },
                 EntryPayload::Normal(ref req) => {
                     let prev = data.data.insert(req.key.clone(), ValueMeta {
                         value: req.value.clone(),
                         serial: req.serial,
                         log_id: entry.log_id,
                     });
-                    Response {
-                        value: prev.map(|v| v.value),
-                    }
+                    Response { prev }
                 }
                 EntryPayload::Membership(ref mem) => {
                     data.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
-                    Response { value: None }
+                    Response { prev: None }
                 }
             };
 

--- a/tests-turmoil/src/typ.rs
+++ b/tests-turmoil/src/typ.rs
@@ -39,9 +39,14 @@ impl std::fmt::Display for Request {
 }
 
 /// Client response.
+///
+/// `prev` is the key's previous versioned value, read by the apply at state
+/// `log_id - 1`: an exact, linearizable observation of the key immediately
+/// below the write's own log position, which the oracle uses to verify the
+/// per-key predecessor chain.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Response {
-    pub value: Option<String>,
+    pub prev: Option<crate::store::ValueMeta>,
 }
 
 openraft::declare_raft_types!(


### PR DESCRIPTION

## Changelog

##### docs: tests-turmoil: sync README with the new oracle and invariant checks
# Summary

The README's oracle section still described the original four checks;
it now lists all eight, including the serial<->log-id bijection, the
predecessor chain from write responses, the absence floors, and the
observed-write durability extension. The invariants table gains the
Monotonic SM Keys row.


##### test: turmoil: split read failures by cause in workload stats
# Summary

The read-failure counter merged two very different situations: a read
abandoned because no leader was visible, and a read whose `ReadIndex`
barrier failed or timed out on a live leader. The final summary now
reports them separately, so a run with heavy leader churn is
distinguishable from one where the barrier itself misbehaves.

Example:

    Final summary: ... reads ok/no-leader/failed=311/2/11, ...


##### test: turmoil: check per-node per-key state machine monotonicity
# Summary

A new cross-tick invariant makes every node's state machine content
observable to the checker on every tick: per node and per key, the log
id that last wrote the key must never decrease, and a key must never
disappear. Previously a follower's key-level rollback
(apply-before-commit, bad snapshot handling) was invisible until the
follower happened to share an applied log id with another node (State
Machine Safety) or until the final durability scan.

# Details

The check is sound because a node applies only committed entries in
log order and an installed snapshot must be at or ahead of the node's
applied state, so per-node per-key positions only move forward; a
snapshot install that regresses a key is exactly the bug class to
catch. No reset-on-restart handling is needed: storage in this harness
is durable across crashes (a bounced node keeps its log store and
state machine object), and a crashed node drops out of the snapshot
list while down, so it resumes at-or-ahead of its last observed state.

`SmMonotonicHistory` joins the temporal checkers in
`InvariantChecker`, feeding on the full-node snapshots the tick loop
already collects; memory is O(nodes x key space), trivial at fuzz
key-space sizes. Violations surface as `SmKeyRegressed` with the
previous and current writing log id (`None` = key vanished).

Verified with invariant unit tests (regression, disappearance,
progress, downtime gap) and clean fuzz sweeps (3 x 20k and 6 x 30k
steps including crash/bounce and snapshot chaos, no false positives).


##### test: turmoil: turn absent reads into checks via ReadIndex barrier
# Summary

The read client now captures the barrier log id that
`ensure_linearizable` returns and hands it to the oracle. With it, a
linearizable read that observes a key *absent* finally carries
information: the key can have no committed write at or below the
barrier. Previously absence was only checked against the
acked-before-start floor, so a never-acked-but-committed write below
the barrier slipped through.

# Details

Keys are never deleted and the observed state may legitimately run
ahead of the barrier, so a present value asserts nothing extra, while
absence at any state at-or-after the barrier is also absence at the
barrier itself — that asymmetry makes the check sound.

An absent read at barrier B checks the already-known committed writes
to the key immediately and raises the key's absence floor (shared with
the predecessor-chain check) so any write later resolving at or below
B fires `WriteBelowAbsence`. The inclusive bound converts exactly to
the existing exclusive floor as `(B.leader_id, B.index + 1)`: log
indexes are consecutive per leader and the leader id orders before the
index, so no log id sorts strictly between.

Verified with the oracle unit tests (including the at-boundary case)
and clean fuzz sweeps (3 x 20k and 5 x 30k steps, no false positives).


##### test: turmoil: check the per-key predecessor chain from acks
# Summary

Every acked write's response now carries the key's previous versioned
value, giving the oracle an exact, linearizable observation of the key
directly below the new entry's log position. This closes the window
the durability scan is blind to: a committed write overwritten between
two acks with no interleaved read used to vanish undetected, because
only the per-key maximum was checked.

# Details

`Response` carries the full previous `ValueMeta` (value, serial, log
id) instead of just the value string, so prev evidence needs no
parsing of the `value-{serial}-{rand}` format and pins an exact log
position. The apply reads the key at state `log_id - 1` exactly, and
blank and membership entries never touch the data map, which makes the
evidence sound.

The oracle accumulates every exactly-positioned committed write per
key (fed from acks, reads, prev values and final scans through the
serial<->log-id resolution) and checks each ack's prev against it:

- `BrokenPredecessor`: the prev must be the newest known-committed
  write to the key below the ack's position — it may not sit at or
  above the ack, be older than a known-committed write in between, or
  be absent while a committed write exists below.
- `WriteBelowAbsence`: a `None` prev asserts the key had no committed
  write below that position; any write to the key later resolving
  under that floor is a violation.

Prev values feed the existing phantom and bijection checks too, so a
double-applied entry surfaces as `DuplicateApply` even when only its
prev sighting disagrees. A prev naming a never-acked write is
committed evidence, not a violation: unknown writes may commit.

Verified with the oracle unit tests plus clean fuzz sweeps (3 x 20k
and 6 x 30k steps, no false positives).


##### docs: tests-turmoil: record why write errors cannot refine Unknown
# Summary

Document on `WriteOutcome::Unknown` that no `client_write` error
variant can be classified as a definite rejection, closing an oracle
review finding that proposed exactly that refinement.

# Details

The review suggested treating `ForwardToLeader` as proof of
non-proposal, so a later sighting of that serial would be a violation.
Reading RaftCore shows the variant is ambiguous: besides the pre-append
not-a-leader rejection, `run_truncate_log` and `run_purge_log` deliver
`ForwardToLeader` to responders of already-appended entries, and a
purged entry can even have committed elsewhere when a snapshot
supersedes a former leader's log. A "rejected, hence absent" outcome
would raise false violations in precisely the snapshot-catch-up chaos
this fuzzer generates, so Unknown-never-absent stays the only failure
outcome, now with the soundness argument attached.


##### test: turmoil: read observations create durability obligations
# Summary

The final durability scan now also requires every key to sit at or
above the highest log id any linearizable read observed for it, not
just the highest acked one. A read of committed state is a durability
commitment exactly like an ack, even when the write that produced the
value was never acked.

# Details

Previously a write that timed out (outcome Unknown) but was then seen
by a `ReadIndex` read — proof that it committed — created no
obligation: `check_final_durability` iterated `max_acked` only, so if
the cluster later rolled the key back and no further read happened to
hit it, nothing fired. The scan now walks `last_read` as well and
reports `LostObservedWrite` when the final state is below an observed
log id.

Soundness: `last_read` only ever holds log ids returned by
post-barrier reads of committed state, and keys are never deleted, so
the final state falling below an observed id is always real data loss.


##### test: turmoil: pin each write serial to one log id in the oracle
# Summary

The oracle now cross-checks every sighting of a write — ack, read
observation, final-state scan — against a serial <-> log id bijection,
so a request applied at two log positions, or one log position observed
with two different contents, becomes a violation instead of passing the
order-only checks.

# Details

Previously the ack's log id was stored but never compared with later
observations: a duplicate apply (e.g. a replay around snapshot
handling) that re-executes an acked request at a higher index passes
the phantom check (serial, key and value all match) and every ordering
check (the log id only ever goes up). The new `resolve()` pins the
first-seen log id per serial and the first-seen serial per log id;
any later disagreement raises `DuplicateApply` or `DivergentEntry`.

Soundness: the workload proposes every serial exactly once and a log
entry has exactly one log id, so the mapping is one-to-one in a
correct run. Snapshot installation carries entry log ids unchanged, so
snapshot-based catch-up cannot produce a false positive.

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1890)
<!-- Reviewable:end -->
