### PR TITLE
test: reproduce `unreachable!("no data to send")` after installing a higher-term snapshot

### DIFF
--- a/tests/tests/no_data_to_send.rs
+++ b/tests/tests/no_data_to_send.rs
@@ -1,0 +1,132 @@
+//! Reproduce `unreachable!("no data to send")` in `ReplicationHandler::send_to_target`.
+//!
+//! A log id orders by leader id before index, so a snapshot whose `last_log_id` is at a
+//! higher term than the local log tail sorts above that tail.
+//!
+//! 1. A single-voter group commits a term-1 log tail.
+//! 2. `install_full_snapshot` installs a snapshot at term 3 and a lower index, carrying a term-1
+//!    vote. Openraft does not check the snapshot's `last_log_id` against that vote, and the
+//!    snapshot's log id is greater than the local one, so the conflicting tail is not truncated,
+//!    only purged up to the snapshot's index.
+//! 3. On restart, `StorageHelper::get_initial_state` sees `last_log_id < last_applied` and takes
+//!    its "clean the hole" branch: `last_log_id` becomes the term-3 purge point while the term-1
+//!    entries above it stay in the log store.
+//! 4. The node elects itself at term 2 and appends above the purge point, so `RaftState::log_ids`
+//!    is no longer monotonic in leader id.
+//! 5. Replicating to a new learner starts at `prev` = the term-3 purge point and `last` = a term-2
+//!    log id above it. `prev > last`, so `Inflight::logs` yields `Inflight::None` and
+//!    `send_to_target` hits `unreachable!`.
+//!
+//! Run with debug assertions off:
+//!
+//! ```shell
+//! RUSTFLAGS="-C debug-assertions=off" cargo test -p tests --test no_data_to_send
+//! ```
+//!
+//! With debug assertions on, the `validit` check `local_committed() <= last_log_id()` in
+//! `RaftState` fires at step 2 on the same inconsistency.
+
+#![cfg_attr(feature = "bt", feature(error_generic_member_access))]
+
+#[macro_use]
+#[path = "fixtures/mod.rs"]
+mod fixtures;
+
+use std::io::Cursor;
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::Config;
+use openraft::Membership;
+use openraft::ServerState;
+use openraft::Vote;
+use openraft::alias::SnapshotOf;
+use openraft::entry::RaftEntry;
+use openraft::raft::AppendEntriesRequest;
+use openraft_memstore::MemNodeId;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::log_id;
+use crate::fixtures::ut_harness;
+
+/// The term of the installed snapshot: above the term-1 log tail, and above term 2, the term
+/// the node reaches when it elects itself after the install.
+const SNAPSHOT_TERM: u64 = 3;
+
+const NODE: MemNodeId = 0;
+const HELPER: MemNodeId = 1;
+const LEARNER: MemNodeId = 2;
+
+const TIMEOUT: Option<Duration> = Some(Duration::from_millis(1000));
+
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn add_learner_after_installing_higher_term_snapshot() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_elect: false,
+            // A leader does not install a snapshot, and the election has to follow the install.
+            enable_leader_restore: Some(false),
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config);
+    router.new_cluster(btreeset! {NODE}, btreeset! {}).await?;
+
+    let snapshot = higher_term_snapshot(&mut router).await?;
+
+    tracing::info!("--- restart, then install the higher term snapshot");
+    restart(&mut router, NODE).await?;
+    let n0 = router.get_raft_handle(&NODE)?;
+    n0.install_full_snapshot(Vote::new_committed(1, HELPER), snapshot).await?;
+
+    tracing::info!("--- restart again, so `get_initial_state` cleans the hole, then elect");
+    restart(&mut router, NODE).await?;
+    let n0 = router.get_raft_handle(&NODE)?;
+    n0.trigger().elect(false).await?;
+    router.wait(&NODE, TIMEOUT).state(ServerState::Leader, "leader at term 2").await?;
+
+    let log_ids = n0.with_raft_state(|st| st.log_ids.clone()).await?;
+    tracing::info!(?log_ids, "--- log ids are not monotonic in leader id");
+    n0.add_learner(LEARNER, (), false).await?;
+    Ok(())
+}
+
+/// Builds a snapshot at term [`SNAPSHOT_TERM`], index 0, on a node outside the cluster under
+/// test, standing in for the snapshot an out-of-band restore hands to a node.
+///
+/// Index 0 is the lowest index that still leaves a term-1 entry above the purge point the
+/// install creates. The membership has to keep [`NODE`] a voter, or installing the snapshot
+/// would remove the receiving node from its own config.
+async fn higher_term_snapshot(router: &mut RaftRouter) -> anyhow::Result<SnapshotOf<TypeConfig, Cursor<Vec<u8>>>> {
+    router.new_raft_node(HELPER).await;
+    let helper = router.get_raft_handle(&HELPER)?;
+
+    let snapshot_log_id = log_id(SNAPSHOT_TERM, NODE, 0);
+    let membership = Membership::new_with_defaults(vec![btreeset! {NODE}], []);
+    helper
+        .append_entries(AppendEntriesRequest {
+            vote: Vote::new_committed(SNAPSHOT_TERM, NODE),
+            prev_log_id: None,
+            entries: vec![RaftEntry::new_membership(snapshot_log_id, membership)],
+            leader_commit: Some(snapshot_log_id),
+        })
+        .await?;
+    router.wait(&HELPER, TIMEOUT).applied_index(Some(0), "helper applied").await?;
+
+    helper.trigger().snapshot().await?;
+    router.wait(&HELPER, TIMEOUT).snapshot(snapshot_log_id, "snapshot built").await?;
+
+    Ok(helper.get_snapshot().await?.unwrap())
+}
+
+async fn restart(router: &mut RaftRouter, id: MemNodeId) -> anyhow::Result<()> {
+    let (node, log_store, sm) = router.remove_node(id).unwrap();
+    node.shutdown().await?;
+    router.new_raft_node_with_sto(id, log_store, sm).await;
+    Ok(())
+}


### PR DESCRIPTION
This is a draft: it adds a failing test, not a fix. I would like your view on which fix you prefer before writing one.

## What breaks

`ReplicationHandler::send_to_target` aborts the process:

```
panicked at openraft/src/engine/handler/replication_handler/mod.rs:422:31:
internal error: entered unreachable code: no data to send
```

We hit this in production, in a Raft group that had just been re-created and had a learner added to it. The added test reproduces it through the public API in about 100 lines.

## How the state comes about

A log id orders by leader id before index, so a snapshot whose `last_log_id` is at a higher term than the local log tail compares greater than that tail even when its index is lower. Four steps follow from that:

1. A single-voter group commits a term-1 log tail.
2. `install_full_snapshot` receives a snapshot at term 3 with a lower index, carrying a term-1 vote. The snapshot's `last_log_id` is never checked against that vote, and since it compares greater than the local last log id, the conflicting tail is not truncated. The log is only purged up to the snapshot's index, so the term-1 entries above it survive.
3. On restart, `StorageHelper::get_initial_state` sees `last_log_id < last_applied`, takes its "Clean the hole between last_log_id and last_applied" branch, and adopts the snapshot's log id as `last_log_id`. The purge removes entries below that index; the lower-term entries above it stay in the store.
4. The node elects itself at term 2 and appends above the purge point, so `RaftState::log_ids` is no longer monotonic in leader id. The first replication probe to a new learner is then built with `prev` at term 3 and `last` at term 2, so `prev > last`, `Inflight::logs` returns `Inflight::None`, and `send_to_target` treats that as unreachable.

## Reproducing

```shell
RUSTFLAGS="-C debug-assertions=off" cargo test -p tests --test no_data_to_send
```

Debug assertions have to be off, which is how our release builds run. With them on, the `validit` check `local_committed() <= last_log_id()` in `RaftState` fires earlier, at step 2, on the same inconsistency. That check suggests openraft already considers this state invalid.

## Versions affected

Same panic on all of these, with the test file unchanged:

| Version | Commit | Panic site |
| --- | --- | --- |
| v0.10.0-alpha.30 | 19be0c27 | `replication_handler/mod.rs:408` |
| v0.10.0-alpha.31 | b87c830b | `replication_handler/mod.rs:408` |
| main | 72f5ecb0 | `replication_handler/mod.rs:422` |

## Two possible fixes

1. Validate at install time: reject a snapshot whose `last_log_id` is inconsistent with the log it replaces, or with the vote accompanying it. This addresses the cause, but it changes public API behaviour, so it seems like your call rather than ours.
2. Be defensive in replication: treat a collapsed range as "send a snapshot" instead of reaching `unreachable!`. Small and local, but it leaves the inconsistent log in place.

There is a third option worth mentioning: make `get_initial_state` fully repair the log rather than only purging below the applied index, since that branch exists precisely to clean up a partially applied install.

Happy to implement whichever you prefer, or to adjust the test if you would rather shape it differently.

## Notes on the test

- It uses `openraft-memstore` and the existing `RaftRouter` fixtures, and adds no storage, state machine or network implementation.
- The higher-term snapshot is built by a spare node in the router, fed one membership entry through `append_entries` with a committed term-3 vote, then `trigger().snapshot()`. Its membership keeps the receiving node a voter so the install does not evict it.
- Term 3 is the minimum that reproduces: the chain is tail term 1 < election term 2 < snapshot term. At term 2 the test passes.
- CI will fail on this branch by design, since the test documents current behaviour.

**Checklist**

- [x] Updated guide with pertinent info (may not always apply).
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

Per your contributing guide's note on AI-assisted contributions: this was drafted with Claude Code, and the reproduction was verified by running it on all three versions listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1892)
<!-- Reviewable:end -->
