### PR TITLE
change: fail fast on inconsistent snapshot and corrupted store

### DIFF
--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -123,6 +123,14 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
     // Snapshot will be installed and there are no conflicting logs.
     let mut eng = eng();
 
+    // The vote must cover the snapshot's last log id, as `accept_vote()` guarantees on the real
+    // path.
+    eng.state.vote.update(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(4, 1),
+    );
+
     let cond = eng.following_handler().install_full_snapshot(SnapshotOf::<UTConfig, ()> {
         meta: SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(4, 1, 6)),
@@ -166,7 +174,7 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
                     },
                     snapshot: (),
                 },
-                LogIOId::new(Vote::new(2, 1).to_committed(), Some(log_id(4, 1, 6))),
+                LogIOId::new(Vote::new(4, 1).to_committed(), Some(log_id(4, 1, 6))),
             )),
             Command::PurgeLog { upto: log_id(4, 1, 6) },
         ],
@@ -183,6 +191,11 @@ fn test_install_snapshot_resets_purged_effective_membership() -> anyhow::Result<
     let mut eng = eng();
     let snapshot_membership = StoredMembershipOf::<UTConfig>::new(Some(log_id(5, 1, 4)), m12());
 
+    eng.state.vote.update(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(5, 1),
+    );
     eng.state.membership_state = MembershipState::new(
         Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12())),
         Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(4, 1, 8)), m1234())),
@@ -219,6 +232,11 @@ fn test_install_snapshot_resets_purged_effective_without_truncating() -> anyhow:
     let mut eng = eng();
     let snapshot_membership = StoredMembershipOf::<UTConfig>::new(Some(log_id(5, 1, 4)), m12());
 
+    eng.state.vote.update(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(5, 1),
+    );
     eng.state.log_ids = LogIdList::new(None, vec![
         //
         log_id(2, 1, 4),
@@ -264,7 +282,7 @@ fn test_install_snapshot_resets_purged_effective_without_truncating() -> anyhow:
                     },
                     snapshot: (),
                 },
-                LogIOId::new(Vote::new(2, 1).to_committed(), Some(log_id(5, 1, 9)))
+                LogIOId::new(Vote::new(5, 1).to_committed(), Some(log_id(5, 1, 9)))
             )),
             Command::PurgeLog { upto: log_id(5, 1, 9) },
         ],
@@ -285,7 +303,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
         eng.state.vote.update(
             UTConfig::<()>::now(),
             Duration::from_millis(500),
-            Vote::new_committed(2, 1),
+            Vote::new_committed(5, 1),
         );
         eng.state.apply_progress_mut().accept(log_id(2, 1, 3));
         eng.state.log_ids = LogIdList::new(None, vec![
@@ -353,7 +371,7 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
                     },
                     snapshot: (),
                 },
-                LogIOId::new(Vote::new(2, 1).to_committed(), Some(log_id(5, 1, 6)))
+                LogIOId::new(Vote::new(5, 1).to_committed(), Some(log_id(5, 1, 6)))
             )),
             Command::PurgeLog { upto: log_id(5, 1, 6) },
         ],
@@ -367,6 +385,12 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
 fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
     // Snapshot will be installed and there are no conflicting logs.
     let mut eng = eng();
+
+    eng.state.vote.update(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(100, 1),
+    );
 
     let cond = eng.following_handler().install_full_snapshot(SnapshotOf::<UTConfig, ()> {
         meta: SnapshotMetaOf::<UTConfig> {
@@ -415,7 +439,7 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
                     },
                     snapshot: (),
                 },
-                LogIOId::new(Vote::new(2, 1).to_committed(), Some(log_id(100, 1, 100)))
+                LogIOId::new(Vote::new(100, 1).to_committed(), Some(log_id(100, 1, 100)))
             )),
             Command::PurgeLog {
                 upto: log_id(100, 1, 100)
@@ -431,6 +455,12 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
 fn test_install_snapshot_update_accepted() -> anyhow::Result<()> {
     // Snapshot will be installed and `accepted` should be updated.
     let mut eng = eng();
+
+    eng.state.vote.update(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(100, 1),
+    );
 
     let cond = eng.following_handler().install_full_snapshot(SnapshotOf::<UTConfig, ()> {
         meta: SnapshotMetaOf::<UTConfig> {
@@ -450,11 +480,50 @@ fn test_install_snapshot_update_accepted() -> anyhow::Result<()> {
 
     assert_eq!(
         Some(&IOId::new_log_io(
-            Vote::new(2, 1).to_committed(),
+            Vote::new(100, 1).to_committed(),
             Some(log_id(100, 1, 100))
         )),
         eng.state.accepted_log_io()
     );
 
     Ok(())
+}
+
+#[test]
+#[should_panic(expected = "can not be owned by the installing leader")]
+fn test_install_snapshot_beyond_leader_vote() {
+    // The vote is (2,1): no leader owns a snapshot with a term-4 last log id.
+    let mut eng = eng();
+
+    let _ = eng.following_handler().install_full_snapshot(SnapshotOf::<UTConfig, ()> {
+        meta: SnapshotMetaOf::<UTConfig> {
+            last_log_id: Some(log_id(4, 1, 6)),
+            last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        snapshot: (),
+    });
+}
+
+#[test]
+#[should_panic(expected = "contradicts locally committed logs")]
+fn test_install_snapshot_conflict_with_committed() {
+    // A snapshot greater than the local committed (4,1,5) but at a smaller index contradicts
+    // locally committed logs.
+    let mut eng = eng();
+
+    eng.state.vote.update(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(5, 1),
+    );
+
+    let _ = eng.following_handler().install_full_snapshot(SnapshotOf::<UTConfig, ()> {
+        meta: SnapshotMetaOf::<UTConfig> {
+            last_log_id: Some(log_id(5, 1, 3)),
+            last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        snapshot: (),
+    });
 }

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -259,6 +259,31 @@ where
         // snapshot_last_log_id cannot be None
         let snap_last_log_id = snap_last_log_id.unwrap();
 
+        // A snapshot never contains a log id beyond its leader's vote: such a pair cannot be
+        // produced by a protocol-following cluster and would corrupt the log id order.
+        assert!(
+            snap_last_log_id.committed_leader_id() <= &self.leader_vote.committed_leader_id(),
+            "snapshot last log id {} can not be owned by the installing leader with vote {}: \
+             a snapshot never contains a log id beyond its leader's vote; \
+             the snapshot or the vote is corrupted, e.g., the snapshot was built by a previous incarnation of the cluster",
+            snap_last_log_id,
+            self.leader_vote,
+        );
+
+        // The snapshot is greater than local committed (checked above). If it is also at a
+        // smaller index, it claims a different history for an index range that is committed
+        // locally; installing it would leave `committed > last_log_id`.
+        if let Some(committed) = self.state.local_committed() {
+            assert!(
+                snap_last_log_id.index() >= committed.index(),
+                "snapshot last log id {} is greater than the locally committed log id {} but at a smaller index: \
+                 the snapshot contradicts locally committed logs; \
+                 the snapshot or the local store is corrupted",
+                snap_last_log_id,
+                committed,
+            );
+        }
+
         // 1. Truncate all logs if conflict.
         // 2. Install snapshot.
         // 3. Purge logs the snapshot covers.

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -36,7 +36,7 @@ fn eng() -> Engine<UTConfig> {
     eng.state.vote.update(
         UTConfig::<()>::now(),
         Duration::from_millis(500),
-        Vote::new_committed(2, 1),
+        Vote::new_committed(4, 1),
     );
     eng.state.apply_progress_mut().accept(log_id(4, 1, 5));
     eng.state.log_ids = LogIdList::new(None, vec![
@@ -148,7 +148,7 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
                     },
                     snapshot: (),
                 },
-                LogIOId::new(Vote::new(2, 1).to_committed(), Some(log_id(4, 1, 6)))
+                LogIOId::new(Vote::new(4, 1).to_committed(), Some(log_id(4, 1, 6)))
             )),
             Command::PurgeLog { upto: log_id(4, 1, 6) },
             Command::Respond {

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -1025,6 +1025,22 @@ where
     /// This method is used to implement an application defined snapshot transmission.
     /// The application receives a snapshot from the leader, in chunks or a stream, and
     /// then rebuild a snapshot, then pass the snapshot to Raft to install.
+    ///
+    /// # Panics
+    ///
+    /// If `vote` is accepted, the input must be one a protocol-following cluster can produce,
+    /// otherwise this method panics (also in release builds):
+    /// - the snapshot's last log id must not be beyond the leadership of `vote`: no leader owns a
+    ///   snapshot with a log id greater than its own vote;
+    /// - a snapshot greater than the locally committed log id must not be at a smaller index: it
+    ///   would contradict locally committed logs.
+    ///
+    /// Such input indicates a forged or corrupted snapshot, e.g., one built by a previous
+    /// incarnation of the cluster. Installing it would corrupt the log id order.
+    #[since(
+        version = "0.10.0",
+        change = "panic on a snapshot inconsistent with the vote or with locally committed logs"
+    )]
     #[since(version = "0.9.0")]
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn install_full_snapshot(

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -110,6 +110,17 @@ where
             last_log_id.display()
         );
 
+        // The stored log range is `(last_purged_log_id, last_log_id]`: an inversion means the
+        // log store is corrupted, e.g., by a snapshot inconsistent with the local logs.
+        if last_log_id < last_purged_log_id {
+            let err = C::err_from_string(format!(
+                "inverted log order in log store: last_log_id({}) < last_purged_log_id({}); the log store is corrupted",
+                last_log_id.display(),
+                last_purged_log_id.display(),
+            ));
+            return Err(StorageError::read_logs(err));
+        }
+
         // TODO: It is possible `committed < last_applied` because when installing snapshot,
         //       new committed should be saved, but not yet.
         if committed < last_applied {
@@ -151,6 +162,18 @@ where
 
         // Clean up dirty state: snapshot is installed, but logs are not cleaned.
         if last_log_id < last_applied {
+            // A genuine hole means `last_applied` is also ahead by index. If `last_applied` is
+            // greater but at a smaller index, the log contains a tail that contradicts the state
+            // machine: purging below `last_applied` would not remove it.
+            if last_log_id.next_index() > last_applied.next_index() {
+                let err = C::err_from_string(format!(
+                    "inverted log order: last_applied({}) in the state machine is greater than last_log_id({}) in the log store but at a smaller index; the store is corrupted",
+                    last_applied.display(),
+                    last_log_id.display(),
+                ));
+                return Err(StorageError::read_logs(err));
+            }
+
             tracing::info!(
                 "Clean the hole between last_log_id({}) and last_applied({}) by purging logs to {}",
                 last_log_id.display(),

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -146,6 +146,7 @@ where
         run_test(builder, Self::get_initial_state_with_state).await?;
         run_test(builder, Self::get_initial_state_last_log_gt_sm).await?;
         run_test(builder, Self::get_initial_state_last_log_lt_sm).await?;
+        run_test(builder, Self::get_initial_state_inverted_log_order).await?;
         run_test(builder, Self::get_initial_state_log_ids).await?;
         run_test(builder, Self::get_initial_state_re_apply_committed).await?;
         run_test(builder, Self::save_vote).await?;
@@ -628,19 +629,39 @@ where
 
         append(&mut store, [blank_ent_0::<C>(1, 2)]).await?;
 
-        apply(&mut sm, [blank_ent_0::<C>(3, 1)]).await?;
+        apply(&mut sm, [blank_ent_0::<C>(3, 3)]).await?;
 
         let initial = StorageHelper::new(&mut store, &mut sm).with_id(NODE_ID.into()).get_initial_state().await?;
 
         assert_eq!(
-            Some(&log_id_0::<C>(3, 1)),
+            Some(&log_id_0::<C>(3, 3)),
             initial.last_log_id(),
             "state machine has higher log"
         );
         assert_eq!(
             initial.last_purged_log_id().cloned(),
-            Some(log_id_0::<C>(3, 1)),
+            Some(log_id_0::<C>(3, 3)),
             "state machine has higher log"
+        );
+        Ok(())
+    }
+
+    pub async fn get_initial_state_inverted_log_order(mut store: LS, mut sm: SM) -> Result<(), io::Error> {
+        Self::default_vote(&mut store).await?;
+
+        // The log tail (1,0,2) is at a greater index than the applied (3,0,1) but smaller in log
+        // id order: the log store contradicts the state machine; startup must refuse it.
+        append(&mut store, [blank_ent_0::<C>(1, 2)]).await?;
+
+        apply(&mut sm, [blank_ent_0::<C>(3, 1)]).await?;
+
+        let res = StorageHelper::new(&mut store, &mut sm).with_id(NODE_ID.into()).get_initial_state().await;
+
+        let err = res.unwrap_err();
+        assert!(
+            err.to_string().contains("inverted log order"),
+            "expect inverted-log-order error, got: {}",
+            err
         );
         Ok(())
     }

--- a/tests/tests/snapshot_streaming/main.rs
+++ b/tests/tests/snapshot_streaming/main.rs
@@ -16,4 +16,5 @@ mod t50_snapshot_line_rate_to_snapshot;
 mod t50_snapshot_when_lacking_log;
 mod t51_after_snapshot_add_learner_and_request_a_log;
 mod t60_snapshot_chunk_size;
+mod t90_issue_1892_inconsistent_snapshot;
 mod t90_issue_808_snapshot_to_unreachable_node_should_not_block;

--- a/tests/tests/snapshot_streaming/t90_issue_1892_inconsistent_snapshot.rs
+++ b/tests/tests/snapshot_streaming/t90_issue_1892_inconsistent_snapshot.rs
@@ -1,0 +1,163 @@
+//! Openraft rejects protocol-impossible input early, instead of corrupting its state:
+//!
+//! - Installing a snapshot whose last log id can not be owned by the leader installing it, or that
+//!   contradicts locally committed logs, panics at install time.
+//! - A store already corrupted this way is rejected at startup by
+//!   `StorageHelper::get_initial_state` with an "inverted log order" error.
+//!
+//! Without these checks such a snapshot survived installation with the conflicting log tail
+//! retained: `RaftState::log_ids` became non-monotonic in leader id and replication to a new
+//! learner later aborted the process with `unreachable!("no data to send")`.
+//!
+//! See: <https://github.com/databendlabs/openraft/pull/1892>
+
+use std::io::Cursor;
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use openraft::Config;
+use openraft::Membership;
+use openraft::Vote;
+use openraft::alias::SnapshotOf;
+use openraft::entry::RaftEntry;
+use openraft::raft::AppendEntriesRequest;
+use openraft::storage::RaftLogStorage;
+use openraft_memstore::MemNodeId;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::MemRaft;
+use crate::fixtures::RaftRouter;
+use crate::fixtures::log_id;
+use crate::fixtures::ut_harness;
+
+/// The term of the foreign snapshot: greater than any term [`NODE`] has seen.
+const SNAPSHOT_TERM: u64 = 3;
+
+const NODE: MemNodeId = 0;
+const HELPER: MemNodeId = 1;
+
+const TIMEOUT: Option<Duration> = Some(Duration::from_millis(1000));
+
+/// A snapshot whose last log id is beyond the leadership of the vote installing it is
+/// protocol-impossible input: `install_full_snapshot` panics instead of installing it.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn install_snapshot_beyond_leader_vote_panics() -> anyhow::Result<()> {
+    let (_config, mut router) = single_node_cluster().await?;
+    let snapshot = higher_term_snapshot(&mut router).await?;
+
+    tracing::info!("--- restart, then install the term-3 snapshot with a term-1 vote");
+    restart(&mut router, NODE).await?;
+    let n0 = router.get_raft_handle(&NODE)?;
+
+    let res = n0.install_full_snapshot(Vote::new_committed(1, HELPER), snapshot).await;
+
+    let err = res.unwrap_err();
+    assert!(
+        err.to_string().contains("panicked"),
+        "installing a protocol-impossible snapshot must panic the node, got: {}",
+        err
+    );
+    Ok(())
+}
+
+/// A log store purged beyond its log tail, the state `install_full_snapshot` used to leave
+/// behind, is rejected at startup.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn startup_rejects_inverted_log_store() -> anyhow::Result<()> {
+    let (config, mut router) = single_node_cluster().await?;
+
+    tracing::info!("--- corrupt the store: purge to (3,0,0), above the term-1 tail by log id order");
+    let (node, mut log_store, sm) = router.remove_node(NODE).unwrap();
+    node.shutdown().await?;
+    log_store.purge(log_id(SNAPSHOT_TERM, NODE, 0)).await?;
+
+    let res = MemRaft::new(NODE, config, router.clone(), log_store, sm).await;
+
+    let err = res.unwrap_err();
+    assert!(
+        err.to_string().contains("inverted log order"),
+        "startup must reject a log store purged beyond its tail, got: {}",
+        err
+    );
+    Ok(())
+}
+
+/// A state machine applied at a log id greater than the log tail but at a smaller index, the
+/// state a crash between installing a snapshot and purging the log used to leave behind, is
+/// rejected at startup.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn startup_rejects_inverted_applied_state() -> anyhow::Result<()> {
+    let (config, mut router) = single_node_cluster().await?;
+    let _snapshot = higher_term_snapshot(&mut router).await?;
+
+    let (n0, log_store, _sm0) = router.remove_node(NODE).unwrap();
+    n0.shutdown().await?;
+    let (helper, _helper_log, helper_sm) = router.remove_node(HELPER).unwrap();
+    helper.shutdown().await?;
+
+    tracing::info!("--- pair the term-1 log store with the state machine applied at (3,0,0)");
+    let res = MemRaft::new(NODE, config, router.clone(), log_store, helper_sm).await;
+
+    let err = res.unwrap_err();
+    assert!(
+        err.to_string().contains("inverted log order"),
+        "startup must reject a state machine ahead of the log tail at a smaller index, got: {}",
+        err
+    );
+    Ok(())
+}
+
+/// A single-voter cluster that commits a term-1 log tail: log ids `[(0,0,0), (1,0,1)]`.
+async fn single_node_cluster() -> anyhow::Result<(Arc<Config>, RaftRouter)> {
+    let config = Arc::new(
+        Config {
+            enable_elect: false,
+            // A Leader does not install a snapshot; a restart turns the node into a Follower.
+            enable_leader_restore: Some(false),
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    router.new_cluster(btreeset! {NODE}, btreeset! {}).await?;
+    Ok((config, router))
+}
+
+/// Builds a snapshot at term [`SNAPSHOT_TERM`], index 0, on a node outside the cluster under
+/// test, standing in for the snapshot an out-of-band restore hands to a node.
+///
+/// The membership keeps [`NODE`] a voter, so installing the snapshot does not evict the
+/// receiving node from its own config.
+async fn higher_term_snapshot(router: &mut RaftRouter) -> anyhow::Result<SnapshotOf<TypeConfig, Cursor<Vec<u8>>>> {
+    router.new_raft_node(HELPER).await;
+    let helper = router.get_raft_handle(&HELPER)?;
+
+    let snapshot_log_id = log_id(SNAPSHOT_TERM, NODE, 0);
+    let membership = Membership::new_with_defaults(vec![btreeset! {NODE}], []);
+    helper
+        .append_entries(AppendEntriesRequest {
+            vote: Vote::new_committed(SNAPSHOT_TERM, NODE),
+            prev_log_id: None,
+            entries: vec![RaftEntry::new_membership(snapshot_log_id, membership)],
+            leader_commit: Some(snapshot_log_id),
+        })
+        .await?;
+    router.wait(&HELPER, TIMEOUT).applied_index(Some(0), "helper applied").await?;
+
+    helper.trigger().snapshot().await?;
+    router.wait(&HELPER, TIMEOUT).snapshot(snapshot_log_id, "snapshot built").await?;
+
+    Ok(helper.get_snapshot().await?.unwrap())
+}
+
+async fn restart(router: &mut RaftRouter, id: MemNodeId) -> anyhow::Result<()> {
+    let (node, log_store, sm) = router.remove_node(id).unwrap();
+    node.shutdown().await?;
+    router.new_raft_node_with_sto(id, log_store, sm).await;
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### change: fail fast on inconsistent snapshot and corrupted store
# Summary

Installing a snapshot inconsistent with the vote installing it, or with
locally committed logs, now panics at once instead of silently
corrupting the log id order. A store that already persisted such a
state is rejected at startup with a StorageError instead of aborting
later in replication.

# Details

A snapshot whose last log id is beyond the leadership of the vote
installing it, or greater than the locally committed log id but at a
smaller index, cannot be produced by a protocol-following cluster; it
can only come from a corrupted source, e.g. a snapshot surviving from a
previous incarnation of a re-created cluster. `install_full_snapshot()`
used to accept such input, keep the conflicting committed log tail, and
leave `RaftState::log_ids` non-monotonic in leader id; the first
replication probe to a new learner then aborted the process with
`unreachable!("no data to send")`. It now panics at install time, in
release builds too, naming the inconsistency.

`StorageHelper::get_initial_state()` now returns a StorageError for a
store that already persisted this state: a log store purged beyond its
log tail, or a state machine applied ahead of the log tail at a smaller
index. The "clean the hole" repair only runs for a genuine hole, where
the applied log id is ahead by index as well; it used to adopt the
inverted applied log id as `last_log_id` while the contradicting tail
stayed in the store. Recovery is manual: wipe the node and re-add it.

The storage test suite expected the inverted state to be repaired:
`get_initial_state_last_log_lt_sm` now covers a genuine hole, and the
new `get_initial_state_inverted_log_order` expects the error.

- Fix: #1892

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1894)
<!-- Reviewable:end -->
