### PR TITLE
change: enforce leader lease for proposals and lease reads

### DIFF
--- a/examples/raft-kv-rocksdb/src/lib.rs
+++ b/examples/raft-kv-rocksdb/src/lib.rs
@@ -42,7 +42,7 @@ where
 {
     // Create a configuration for the raft instance.
     let config = Config {
-        heartbeat_interval: 250,
+        heartbeat_interval: 50,
         election_timeout_min: 299,
         ..Default::default()
     };

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -357,13 +357,19 @@ where
         // Setup sentinel values to track when we've received majority confirmation of leadership.
 
         let resp = {
-            let lh = match self.ensure_writable_leader_handler() {
+            let lh = match self.ensure_leader_handler() {
                 Ok(leading_handler) => leading_handler,
                 Err(forward) => {
                     tx.send(Err(forward.into())).ok();
                     return;
                 }
             };
+
+            if read_policy == ReadPolicy::LeaseRead && !lh.is_lease_valid() {
+                tracing::debug!("{}: lease expired during lease read", self.id);
+                tx.send(Err(ForwardToLeader::empty().into())).ok();
+                return;
+            }
 
             let read_log_id = lh.get_read_log_id();
 
@@ -375,7 +381,7 @@ where
         };
 
         if read_policy == ReadPolicy::LeaseRead {
-            self.respond_lease_read(resp, tx);
+            tx.send(Ok(resp)).ok();
             return;
         }
 
@@ -400,26 +406,6 @@ where
         // False positive lint warning(`non-binding `let` on a future`): https://github.com/rust-lang/rust-clippy/issues/9932
         #[allow(clippy::let_underscore_future)]
         let _ = C::spawn(waiting_fu.instrument(tracing::debug_span!("spawn_is_leader_waiting")));
-    }
-
-    /// Serve a [`ReadPolicy::LeaseRead`] request without contacting any peer.
-    ///
-    /// While the last quorum acknowledgement is younger than `leader_lease`, no other node can have
-    /// become leader, so the read is safe to answer from local state alone. Once the lease lapses
-    /// this node can no longer vouch for itself and the caller has to find the leader again.
-    fn respond_lease_read(&mut self, resp: Linearizer<C>, tx: ClientReadTx<C>) {
-        let now = C::now();
-        // Check if the lease is expired.
-        if let Some(last_quorum_acked_time) = self.last_quorum_acked_time()
-            && now < last_quorum_acked_time + self.engine.config.timer_config.leader_lease
-        {
-            tx.send(Ok(resp)).ok();
-            return;
-        }
-        tracing::debug!("{}: lease expired during lease read", self.id);
-        // we may no longer leader so error out early
-        let err = ForwardToLeader::empty();
-        tx.send(Err(err.into())).ok();
     }
 
     /// Probe every other voter with an empty AppendEntries, to confirm this node is still leading.
@@ -632,17 +618,28 @@ where
         );
     }
 
-    /// Ensure this node is a writable leader and return a leader handler.
+    /// Ensure this node is the leader and is not transferring leadership.
     ///
     /// Returns `Err(ForwardToLeader)` if:
     /// - This node is not the leader
     /// - The leader is transferring leadership to another node
-    fn ensure_writable_leader_handler(&mut self) -> Result<LeaderHandler<'_, C, SM>, ForwardToLeader<C>> {
+    fn ensure_leader_handler(&mut self) -> Result<LeaderHandler<'_, C, SM>, ForwardToLeader<C>> {
         let lh = self.engine.try_leader_handler()?;
 
-        // If the leader is transferring leadership, forward writes to the new leader.
+        // If the leader is transferring leadership, forward requests to the new leader.
         if let Some(to) = lh.leader.get_transfer_to() {
             return Err(lh.state.new_forward_to_leader(to.clone()));
+        }
+
+        Ok(lh)
+    }
+
+    /// Ensure this node has a valid leader lease and may accept new writes.
+    fn ensure_writable_leader_handler(&mut self) -> Result<LeaderHandler<'_, C, SM>, ForwardToLeader<C>> {
+        let lh = self.ensure_leader_handler()?;
+
+        if !lh.is_lease_valid() {
+            return Err(ForwardToLeader::empty());
         }
 
         Ok(lh)
@@ -782,7 +779,12 @@ where
         heartbeat: Option<HeartbeatMetrics<C>>,
     ) {
         let last_quorum_acked = self.last_quorum_acked_time();
-        let millis_since_quorum_ack = last_quorum_acked.map(|t| t.elapsed().as_millis() as u64);
+        let is_self_quorum = self.engine.leader.as_ref().is_some_and(|leader| leader.is_self_quorum());
+        let millis_since_quorum_ack = if is_self_quorum {
+            Some(0)
+        } else {
+            last_quorum_acked.map(|t| t.elapsed().as_millis() as u64)
+        };
 
         let st = &self.engine.state;
 
@@ -1028,8 +1030,8 @@ where
     /// This function returns the latest known time at which the leader received acknowledgment
     /// from a quorum of followers, indicating its leadership is current and recognized.
     /// If the node is not a leader or no acknowledgment has been received, `None` is returned.
-    fn last_quorum_acked_time(&mut self) -> Option<InstantOf<C>> {
-        let leading = self.engine.leader.as_mut();
+    fn last_quorum_acked_time(&self) -> Option<InstantOf<C>> {
+        let leading = self.engine.leader.as_ref();
         leading.and_then(|l| l.last_quorum_acked_time())
     }
 

--- a/openraft/src/docs/docs.md
+++ b/openraft/src/docs/docs.md
@@ -35,6 +35,7 @@ To learn about the data structures used in Openraft and the commit protocol, see
 - [`components`](`crate::docs::components`) explains the components in Openraft;
   - [`RaftStateMachine`](`crate::docs::components::state_machine`) is the core API for managing the state machine and snapshot functionalities;
 - [`protocol`](crate::docs::protocol) :
+  - [`check_quorum`](`crate::docs::protocol::check_quorum`) explains how a leader stops accepting new proposals when its quorum lease expires;
   - [`io_ordering`](`crate::docs::protocol::io_ordering`) explains why IO re-ordering is disallowed;
   - [`read`](`crate::docs::protocol::read`) explains how to do linearizable read;
   - [`replication`](`crate::docs::protocol::replication`);

--- a/openraft/src/docs/faq/06-operations/07-leader-rejects-write.md
+++ b/openraft/src/docs/faq/06-operations/07-leader-rejects-write.md
@@ -1,0 +1,20 @@
+### Why can a Leader reject a client write?
+
+A node may still report [`ServerState::Leader`][] while returning
+[`ForwardToLeader`][] with no target for a new write. This means its last quorum
+acknowledgement is older than the leader lease, so it cannot currently confirm
+that it still has authority to accept new proposals.
+
+The node does not step down. It continues heartbeat and replication traffic so
+that it can renew its lease if quorum communication recovers. Once a quorum
+acknowledges it again, new writes are accepted automatically.
+
+Writes accepted before the lease expired remain pending and may still commit.
+If an application times them out, it must treat their result as unknown.
+
+See [CheckQuorum][] for the protocol and its difference from conventional
+self-demotion.
+
+[`ServerState::Leader`]: crate::ServerState::Leader
+[`ForwardToLeader`]: crate::errors::ForwardToLeader
+[CheckQuorum]: crate::docs::protocol::check_quorum

--- a/openraft/src/docs/faq/faq-toc.md
+++ b/openraft/src/docs/faq/faq-toc.md
@@ -33,6 +33,7 @@
   * [How do I store additional information about nodes in Openraft?](#how-do-i-store-additional-information-about-nodes-in-openraft)
   * [Write returns `ForwardToLeader` but leader info is missing](#write-returns-forwardtoleader-but-leader-info-is-missing)
   * [Error logs after `raft.shutdown()` completes](#error-logs-after-raftshutdown-completes)
+  * [Why can a Leader reject a client write?](#why-can-a-leader-reject-a-client-write)
 - [Troubleshooting & Safety](#troubleshooting--safety)
   * [Panic: "assertion failed: self.internal_server_state.is_following()"](#panic-assertion-failed-selfinternal_server_stateis_following)
   * [Holding `Raft::metrics()` reference blocks the Raft node](#holding-raftmetrics-reference-blocks-the-raft-node)

--- a/openraft/src/docs/faq/faq.md
+++ b/openraft/src/docs/faq/faq.md
@@ -835,6 +835,28 @@ See: <https://github.com/databendlabs/openraft/issues/1357>
 [`Raft::shutdown`]: `crate::Raft::shutdown`
 
 
+### Why can a Leader reject a client write?
+
+A node may still report [`ServerState::Leader`][] while returning
+[`ForwardToLeader`][] with no target for a new write. This means its last quorum
+acknowledgement is older than the leader lease, so it cannot currently confirm
+that it still has authority to accept new proposals.
+
+The node does not step down. It continues heartbeat and replication traffic so
+that it can renew its lease if quorum communication recovers. Once a quorum
+acknowledges it again, new writes are accepted automatically.
+
+Writes accepted before the lease expired remain pending and may still commit.
+If an application times them out, it must treat their result as unknown.
+
+See [CheckQuorum][] for the protocol and its difference from conventional
+self-demotion.
+
+[`ServerState::Leader`]: crate::ServerState::Leader
+[`ForwardToLeader`]: crate::errors::ForwardToLeader
+[CheckQuorum]: crate::docs::protocol::check_quorum
+
+
 ## Troubleshooting & Safety
 
 ### Panic: "assertion failed: self.internal_server_state.is_following()"

--- a/openraft/src/docs/protocol/check_quorum.md
+++ b/openraft/src/docs/protocol/check_quorum.md
@@ -1,0 +1,79 @@
+# CheckQuorum
+
+CheckQuorum prevents a leader that can no longer reach a quorum from accepting
+new proposals indefinitely. It improves client behavior during a network
+partition; Raft safety does not depend on it because a leader without a quorum
+cannot commit new log entries.
+
+## Quorum lease
+
+The leader records the sending time of every acknowledged `AppendEntries` RPC.
+This includes heartbeats and normal replication. From these timestamps,
+OpenRaft calculates the latest time acknowledged by the effective quorum. Joint
+membership requires a quorum of every voter set.
+
+The leader may accept a new proposal only while:
+
+```text
+now < last_quorum_acked + leader_lease
+```
+
+If there is no quorum acknowledgement, or the acknowledgement is older than
+`leader_lease`, the proposal is rejected with an empty
+[`ForwardToLeader`][]. The empty result prevents a client from forwarding the
+request back to the same leader. The lease duration is
+`Config::election_timeout_max`.
+
+[`ForwardToLeader`]: crate::errors::ForwardToLeader
+
+## Recovery
+
+Lease expiry does not change the leader's committed vote or
+[`ServerState`][]. The leader continues sending heartbeats and replicating
+existing logs. A later quorum acknowledgement renews the lease, and the leader
+automatically resumes accepting proposals.
+
+If another leader has already been elected, quorum intersection prevents the
+old leader from renewing its lease. A voter in the new leader's quorum rejects
+the old vote, allowing the old leader to observe the higher vote and follow the
+normal leader-transition path.
+
+[`ServerState`]: crate::ServerState
+
+## Pending requests
+
+Lease expiry affects only new proposals. Requests accepted while the lease was
+valid remain pending because their log entries may still commit after quorum
+communication recovers. Applications may apply their own request timeout; such
+a timeout means that the result is unknown, not that the log entry was
+discarded.
+
+Rejecting new proposals bounds the amount of uncommitted work accumulated
+during the partition without invalidating work already accepted.
+
+## Reads
+
+[`ReadPolicy::LeaseRead`][] uses the same quorum lease and returns an error when
+the lease has expired. [`ReadPolicy::ReadIndex`][] does not rely on the lease:
+it contacts a quorum to confirm leadership and remains available as a recovery
+path.
+
+[`ReadPolicy::LeaseRead`]: crate::ReadPolicy::LeaseRead
+[`ReadPolicy::ReadIndex`]: crate::ReadPolicy::ReadIndex
+
+## Difference from conventional CheckQuorum
+
+Conventional CheckQuorum changes an isolated leader to the follower role after
+an election timeout. OpenRaft instead separates the durable leadership grant
+from the leader's current authority to accept new proposals:
+
+| Behavior | Conventional CheckQuorum | OpenRaft |
+|----------|--------------------------|----------|
+| Lease expires | Become follower | Reject new proposals |
+| Heartbeats and replication | Stop | Continue |
+| Pending requests | Usually failed | Remain pending |
+| Quorum communication recovers | Run a new election | Renew the lease |
+
+The OpenRaft behavior avoids an unnecessary election when the committed leader
+can re-establish contact with a quorum, while still giving new client requests
+an immediate routing signal.

--- a/openraft/src/docs/protocol/mod.rs
+++ b/openraft/src/docs/protocol/mod.rs
@@ -4,6 +4,11 @@ pub mod commit {
     #![doc = include_str!("commit.md")]
 }
 
+#[openraft_macros::since(version = "0.10.0")]
+pub mod check_quorum {
+    #![doc = include_str!("check_quorum.md")]
+}
+
 pub mod io_ordering {
     #![doc = include_str!("io_ordering.md")]
 }

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -62,6 +62,11 @@ where
         }
     }
 
+    /// Return whether the leader's lease is valid.
+    pub(crate) fn is_lease_valid(&self) -> bool {
+        self.leader.is_lease_valid(self.config.timer_config.leader_lease)
+    }
+
     /// Append new log entries by a leader.
     ///
     /// Also Update effective membership if the payload contains

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -165,11 +165,7 @@ where
             return;
         }
 
-        let granted = *self
-            .leader
-            .clock_progress
-            .increase_to(&target, Some(sending_time))
-            .expect("it should always update existing progress");
+        let granted = self.leader.update_clock(&target, sending_time);
 
         tracing::debug!(
             "granted leader vote clock after updating: granted: {}; clock_progress: {}",

--- a/openraft/src/metrics/wait.rs
+++ b/openraft/src/metrics/wait.rs
@@ -2,6 +2,7 @@ use core::time::Duration;
 use std::collections::BTreeSet;
 
 use futures_util::FutureExt;
+use openraft_macros::since;
 
 use crate::LogIdOptionExt;
 use crate::OptionalSend;
@@ -12,6 +13,7 @@ use crate::metrics::Condition;
 use crate::metrics::Metric;
 use crate::metrics::RaftMetrics;
 use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
 use crate::type_config::alias::WatchReceiverOf;
@@ -171,6 +173,27 @@ where C: RaftTypeConfig
         self.metrics(
             |m| m.state == want_state,
             &format!("{} .state == {:?}", msg.to_string(), want_state),
+        )
+        .await
+    }
+
+    /// Wait until this node is a leader with a quorum-acknowledged timestamp.
+    ///
+    /// If `at_least` is `Some`, the timestamp must be greater than or equal to it.
+    /// If `at_least` is `None`, any quorum-acknowledged timestamp is accepted.
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "trace", skip(self), fields(msg=msg.to_string().as_str()))]
+    pub async fn leader_with_quorum_acked(
+        &self,
+        at_least: Option<InstantOf<C>>,
+        msg: impl ToString,
+    ) -> Result<RaftMetrics<C>, WaitError> {
+        self.metrics(
+            |m| {
+                m.state == ServerState::Leader
+                    && m.last_quorum_acked.is_some_and(|acked| at_least.is_none_or(|want| acked.into_inner() >= want))
+            },
+            &format!("{} .leader_with_quorum_acked({:?})", msg.to_string(), at_least),
         )
         .await
     }

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -12,6 +12,7 @@ use crate::core::ServerState;
 use crate::engine::testing::UTConfig;
 use crate::engine::testing::log_id;
 use crate::log_id::LogIdOptionExt;
+use crate::metrics::SerdeInstant;
 use crate::metrics::Wait;
 use crate::metrics::WaitError;
 use crate::type_config::TypeConfigExt;
@@ -228,6 +229,44 @@ fn test_wait_vote() {
         h.await?;
         assert_eq!(Vote::new_committed(1, 2), got.vote);
 
+        Ok::<(), anyhow::Error>(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_wait_leader_with_quorum_acked() {
+    UTConfig::<()>::run(async {
+        let (init, w, tx) = init_wait_test::<UTConfig>();
+        let first_acked = UTConfig::<()>::now();
+        let second_acked = first_acked + Duration::from_millis(10);
+
+        let h = UTConfig::<()>::spawn(async move {
+            UTConfig::<()>::sleep(Duration::from_millis(10)).await;
+            let mut update = init.clone();
+            update.state = ServerState::Leader;
+            update.last_quorum_acked = Some(SerdeInstant::new(first_acked));
+            tx.send(update.clone())?;
+
+            UTConfig::<()>::sleep(Duration::from_millis(10)).await;
+            update.last_quorum_acked = Some(SerdeInstant::new(second_acked));
+            tx.send(update)?;
+            Ok::<(), anyhow::Error>(())
+        });
+
+        let got = w.leader_with_quorum_acked(None, "any quorum ack").await?;
+        assert_eq!(
+            (ServerState::Leader, Some(SerdeInstant::new(first_acked))),
+            (got.state, got.last_quorum_acked)
+        );
+
+        let got = w.leader_with_quorum_acked(Some(second_acked), "newer quorum ack").await?;
+        assert_eq!(
+            (ServerState::Leader, Some(SerdeInstant::new(second_acked))),
+            (got.state, got.last_quorum_acked)
+        );
+
+        h.await??;
         Ok::<(), anyhow::Error>(())
     })
     .unwrap();

--- a/openraft/src/progress/vec_progress.rs
+++ b/openraft/src/progress/vec_progress.rs
@@ -349,6 +349,11 @@ where
         Some(&self.entries[index])
     }
 
+    /// Return the number of voters.
+    pub(crate) fn voter_count(&self) -> usize {
+        self.voter_count
+    }
+
     // TODO: merge `get` and `try_get`
     /// Get the value by `id`.
     #[cfg(test)]
@@ -362,7 +367,6 @@ where
     /// In raft or other distributed consensus,
     /// To commit a value, the value has to be **accepted by a quorum** and has to be the greatest
     /// value every proposed.
-    #[cfg(test)]
     pub(crate) fn quorum_accepted(&self) -> &Entry::Progress {
         &self.quorum_accepted
     }

--- a/openraft/src/progress/vec_progress/vec_progress_test.rs
+++ b/openraft/src/progress/vec_progress/vec_progress_test.rs
@@ -202,7 +202,7 @@ fn vec_progress_new() {
         vec![(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (6, 0), (7, 0),],
         progress.entries
     );
-    assert_eq!(5, progress.voter_count);
+    assert_eq!(5, progress.voter_count());
 }
 
 #[test]

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
 use crate::base::shared_id_generator::SharedIdGenerator;
-use crate::display_ext::DisplayInstantExt;
 use crate::engine::leader_log_ids::LeaderLogIds;
 use crate::progress::VecProgress;
 use crate::progress::entry::ProgressEntry;
@@ -134,17 +133,24 @@ where
 
         let last_log_id = last_ref.map(|r| r.into_log_id());
 
+        let progress = VecProgress::new(quorum_set.clone(), learner_ids.iter().cloned(), |id| {
+            let stream_id = StreamId::new(id_gen.next_id());
+            ProgressEntry::empty(id, stream_id, last_log_id.next_index())
+        });
+
+        let now = C::now();
+        let mut clock_progress = VecProgress::new(quorum_set, learner_ids, IdVal::new_default);
+        let leader_node_id = vote.to_leader_node_id();
+        clock_progress.increase_to(&leader_node_id, Some(now)).ok();
+
         Self {
             transfer_to: None,
             committed_vote: vote,
-            next_heartbeat: C::now(),
+            next_heartbeat: now,
             last_log_id: last_log_id.clone(),
             noop_log_id,
-            progress: VecProgress::new(quorum_set.clone(), learner_ids.iter().cloned(), |id| {
-                let stream_id = StreamId::new(id_gen.next_id());
-                ProgressEntry::empty(id, stream_id, last_log_id.next_index())
-            }),
-            clock_progress: VecProgress::new(quorum_set, learner_ids, IdVal::new_default),
+            progress,
+            clock_progress,
         }
     }
 
@@ -194,39 +200,40 @@ where
         Some(LeaderLogIds::new(committed_leader_id, first, last))
     }
 
+    /// Update the clock acknowledged by `target` and return the time acknowledged by a quorum.
+    pub(crate) fn update_clock(&mut self, target: &C::NodeId, sending_time: InstantOf<C>) -> Option<InstantOf<C>> {
+        let leader_node_id = self.committed_vote.to_leader_node_id();
+        self.clock_progress.increase_to(&leader_node_id, Some(sending_time)).ok();
+
+        *self
+            .clock_progress
+            .increase_to(target, Some(sending_time))
+            .expect("the target must exist in clock progress")
+    }
+
     /// Get the last timestamp acknowledged by a quorum.
-    ///
-    /// The acknowledgement by remote nodes are updated when AppendEntries reply is received.
-    /// But if the time of the leader itself is not updated.
-    ///
-    /// Therefore, every time to retrieve the quorum acked timestamp, it should update with the
-    /// leader's time first.
-    /// It does not matter if the leader is not a voter, the QuorumSet will just ignore it.
-    ///
-    /// Note that the leader may not be in the QuorumSet at all.
-    /// In such a case, the update operation will be just ignored,
-    /// and the quorum-acked-time is totally determined by remove voters.
-    pub(crate) fn last_quorum_acked_time(&mut self) -> Option<InstantOf<C>> {
-        // For `Leading`, the vote is always the leader's vote.
-        // Thus vote.voted_for() is this node.
+    pub(crate) fn last_quorum_acked_time(&self) -> Option<InstantOf<C>> {
+        *self.clock_progress.quorum_accepted()
+    }
 
-        let node_id = self.committed_vote.to_leader_node_id();
-        let now = C::now();
-
-        tracing::debug!(
-            "{}: update with leader's local time, before retrieving quorum acked clock: leader_id: {}, now: {}",
-            func_name!(),
-            node_id,
-            now.display()
-        );
-
-        let granted = self.clock_progress.increase_to(&node_id, Some(now));
-
-        match granted {
-            Ok(x) => *x,
-            // The leader node id may not be in the quorum set.
-            Err(x) => *x,
+    /// Return whether this leader's lease is valid.
+    pub(crate) fn is_lease_valid(&self, leader_lease: Duration) -> bool {
+        if self.is_self_quorum() {
+            return true;
         }
+
+        let now = C::now();
+        self.last_quorum_acked_time().is_some_and(|acked| now < acked + leader_lease)
+    }
+
+    /// Return whether this leader alone constitutes a quorum.
+    pub(crate) fn is_self_quorum(&self) -> bool {
+        if self.clock_progress.voter_count() != 1 {
+            return false;
+        }
+
+        let leader_node_id = self.committed_vote.to_leader_node_id();
+        self.clock_progress.iter().next().unwrap().id == leader_node_id
     }
 
     /// Decide whether a heartbeat needs to be sent to `target` at time `now`.
@@ -414,7 +421,7 @@ mod tests {
 
         let now1 = UTConfig::<()>::now();
 
-        let _t2 = leading.clock_progress.increase_to(&2, Some(now1));
+        leading.update_clock(&2, now1);
         let t1 = leading.last_quorum_acked_time();
         assert_eq!(Some(now1), t1, "n1(leader) and n2 acked, t1 > t2");
     }
@@ -430,12 +437,12 @@ mod tests {
         );
 
         let t2 = UTConfig::<()>::now();
-        leading.clock_progress.increase_to(&2, Some(t2)).ok();
+        leading.update_clock(&2, t2);
         let t = leading.last_quorum_acked_time();
         assert!(t.is_none(), "n1(leader+learner) does not count in quorum");
 
         let t3 = UTConfig::<()>::now();
-        leading.clock_progress.increase_to(&3, Some(t3)).ok();
+        leading.update_clock(&3, t3);
         let t = leading.last_quorum_acked_time();
         assert_eq!(Some(t2), t, "n2 and n3 acked");
     }
@@ -451,12 +458,12 @@ mod tests {
         );
 
         let t2 = UTConfig::<()>::now();
-        leading.clock_progress.increase_to(&2, Some(t2)).ok();
+        leading.update_clock(&2, t2);
         let t = leading.last_quorum_acked_time();
         assert!(t.is_none(), "n1(leader+learner) does not count in quorum");
 
         let t3 = UTConfig::<()>::now();
-        leading.clock_progress.increase_to(&3, Some(t3)).ok();
+        leading.update_clock(&3, t3);
         let t = leading.last_quorum_acked_time();
         assert_eq!(Some(t2), t, "n2 and n3 acked");
     }

--- a/tests/tests/append_entries/t10_see_higher_vote.rs
+++ b/tests/tests/append_entries/t10_see_higher_vote.rs
@@ -32,12 +32,24 @@ async fn append_sees_higher_vote() -> Result<()> {
 
     let mut router = RaftRouter::new(config.clone());
 
-    let log_index = router.new_cluster(btreeset! {0,1}, btreeset! {}).await?;
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    router.set_unreachable(1, true);
 
     tracing::info!(log_index, "--- upgrade vote on node-1");
     {
         // Let leader lease expire
         TypeConfig::sleep(Duration::from_millis(800)).await;
+
+        // Re-establish node-0's quorum lease through node-2 while node-1 remains isolated.
+        let refresh_started = TypeConfig::now();
+        n0.trigger().heartbeat().await?;
+        n0.wait(timeout())
+            .leader_with_quorum_acked(Some(refresh_started), "node-0 quorum lease recovered through node-2")
+            .await?;
+
+        router.set_unreachable(1, false);
 
         let node = router.get_raft_handle(&1)?;
         let resp = node
@@ -58,7 +70,6 @@ async fn append_sees_higher_vote() -> Result<()> {
     {
         router.wait(&0, timeout()).state(ServerState::Leader, "node-0 is leader").await?;
 
-        let n0 = router.get_raft_handle(&0)?;
         TypeConfig::spawn(async move {
             let res = n0
                 .client_write(ClientRequest {

--- a/tests/tests/client_api/main.rs
+++ b/tests/tests/client_api/main.rs
@@ -8,6 +8,7 @@ mod fixtures;
 // See ./README.md
 
 mod t10_client_write_many;
+mod t10_client_write_quorum_lease;
 mod t10_client_writes;
 mod t11_client_reads;
 mod t12_trigger_purge_log;

--- a/tests/tests/client_api/t10_client_write_quorum_lease.rs
+++ b/tests/tests/client_api/t10_client_write_quorum_lease.rs
@@ -1,0 +1,91 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::ServerState;
+use openraft::async_runtime::WatchReceiver;
+use openraft::errors::ClientWriteError;
+use openraft::errors::ForwardToLeader;
+use openraft::errors::RaftError;
+use openraft::impls::ProgressResponder;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::ClientRequest;
+use openraft_memstore::IntoMemClientRequest;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::log_id;
+use crate::fixtures::ut_harness;
+
+/// A leader with an expired quorum lease rejects new writes without abandoning pending writes or
+/// its ability to recover the lease.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn client_write_requires_valid_quorum_lease() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            heartbeat_interval: 20,
+            election_timeout_min: 100,
+            election_timeout_max: 200,
+            enable_tick: false,
+            enable_heartbeat: false,
+            enable_elect: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+    let n0 = router.get_raft_handle(&0)?;
+
+    router.set_unreachable(1, true);
+    router.set_unreachable(2, true);
+
+    let (responder, pending_rx) = ProgressResponder::complete_only();
+    n0.client_write_ff(ClientRequest::make_request("pending", 1), Some(responder)).await?;
+    log_index += 1;
+    n0.wait(timeout()).log_index(Some(log_index), "pending write appended").await?;
+
+    TypeConfig::sleep(Duration::from_millis(config.election_timeout_max)).await;
+
+    let rejected = TypeConfig::timeout(
+        Duration::from_millis(100),
+        n0.client_write(ClientRequest::make_request("rejected", 2)),
+    )
+    .await
+    .expect("an expired leader lease rejects a new write")
+    .unwrap_err();
+
+    assert_eq!(
+        RaftError::APIError(ClientWriteError::ForwardToLeader(ForwardToLeader::empty())),
+        rejected
+    );
+
+    let metrics = n0.metrics().borrow_watched().clone();
+    assert_eq!(ServerState::Leader, metrics.state);
+    assert_eq!(Some(0), metrics.current_leader);
+    assert_eq!(Some(log_index), metrics.last_log_index);
+
+    router.set_unreachable(1, false);
+    router.set_unreachable(2, false);
+
+    let refresh_started = TypeConfig::now();
+    n0.trigger().heartbeat().await?;
+    n0.wait(timeout()).leader_with_quorum_acked(Some(refresh_started), "leader lease recovered").await?;
+
+    let recovered = n0.client_write(ClientRequest::make_request("recovered", 3)).await?;
+    log_index += 1;
+    assert_eq!(log_id(1, 0, log_index), recovered.log_id);
+
+    let pending = pending_rx.await??;
+    assert_eq!(log_id(1, 0, log_index - 1), pending.log_id);
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_secs(3))
+}

--- a/tests/tests/client_api/t11_client_reads.rs
+++ b/tests/tests/client_api/t11_client_reads.rs
@@ -330,17 +330,11 @@ async fn ensure_linearizable_with_lease_read() -> Result<()> {
         assert!(rst.is_err());
 
         // lease read should ok after new a round of heartbeat.
-        let old_quorum_acked = router.get_metrics(&leader)?.last_quorum_acked.unwrap().into_inner();
+        let refresh_started = TypeConfig::now();
         leader_handle.trigger().heartbeat().await?;
         leader_handle
             .wait(timeout())
-            .metrics(
-                |m| {
-                    let last_quorum_acked = m.last_quorum_acked;
-                    last_quorum_acked.is_some() && last_quorum_acked.unwrap().into_inner() > old_quorum_acked
-                },
-                "leader heartbeat acked",
-            )
+            .leader_with_quorum_acked(Some(refresh_started), "leader heartbeat acked")
             .await?;
 
         router

--- a/tests/tests/client_api/t14_transfer_leader.rs
+++ b/tests/tests/client_api/t14_transfer_leader.rs
@@ -258,11 +258,9 @@ async fn transfer_leader_blocks_lease_read() -> anyhow::Result<()> {
 
     let n0 = router.get_raft_handle(&0)?;
 
-    // Refresh quorum-acked time before isolating n1, so the lease is comfortably fresh
-    // and `LeaseRead` would succeed if the gate were absent.
-    n0.trigger().heartbeat().await?;
+    // Ensure the initial leader log established a quorum lease before isolating n1.
     n0.wait(Some(Duration::from_millis(500)))
-        .metrics(|m| m.last_quorum_acked.is_some(), "leader has fresh last_quorum_acked")
+        .leader_with_quorum_acked(None, "leader has last_quorum_acked")
         .await?;
 
     // Sanity: LeaseRead succeeds before the transfer.

--- a/tests/tests/membership/t21_change_membership_cases.rs
+++ b/tests/tests/membership/t21_change_membership_cases.rs
@@ -226,17 +226,13 @@ async fn change_from_to(old: BTreeSet<MemNodeId>, change_members: BTreeSet<MemNo
 
     tracing::info!(log_index, "--- write another 10 logs");
     {
-        // get new leader
-
-        // TODO(xp): leader may not be stable, other node may take leadership by a higher vote.
-        //           Then client write may receive a ForwardToLeader Error with empty leader.
-        //           Need to wait for the leader become stable.
         let m = router
             .wait(new.iter().next().unwrap(), timeout())
             .metrics(|x| x.current_leader.is_some(), format!("wait for new leader, {}", mes))
             .await?;
 
         let leader = m.current_leader.unwrap();
+        wait_for_leader_lease(&router, leader, &mes).await?;
 
         router.client_request_many(leader, "client", 10).await?;
         log_index += 10;
@@ -436,15 +432,13 @@ async fn change_by_remove(old: BTreeSet<MemNodeId>, remove: &[MemNodeId]) -> any
 
     tracing::info!(log_index, "--- write another 10 logs");
     {
-        // TODO(xp): leader may not be stable, other node may take leadership by a higher vote.
-        //           Then client write may receive a ForwardToLeader Error with empty leader.
-        //           Need to wait for the leader become stable.
         let m = router
             .wait(new.iter().next().unwrap(), timeout())
             .metrics(|x| x.current_leader.is_some(), format!("wait for new leader, {}", mes))
             .await?;
 
         let leader_id = m.current_leader.unwrap();
+        wait_for_leader_lease(&router, leader_id, &mes).await?;
 
         log_index += router.client_request_many(leader_id, "client", 10).await?;
     }
@@ -470,6 +464,15 @@ async fn change_by_remove(old: BTreeSet<MemNodeId>, remove: &[MemNodeId]) -> any
             assert!(res.is_err());
         }
     }
+
+    Ok(())
+}
+
+async fn wait_for_leader_lease(router: &RaftRouter, leader_id: MemNodeId, mes: &str) -> anyhow::Result<()> {
+    router
+        .wait(&leader_id, timeout())
+        .leader_with_quorum_acked(None, format!("leader establishes its quorum lease, {}", mes))
+        .await?;
 
     Ok(())
 }

--- a/tests/tests/membership/t31_removed_follower.rs
+++ b/tests/tests/membership/t31_removed_follower.rs
@@ -15,7 +15,7 @@ use crate::fixtures::ut_harness;
 async fn stop_replication_to_removed_follower() -> Result<()> {
     let config = Arc::new(
         Config {
-            enable_heartbeat: false,
+            enable_heartbeat: true,
             ..Default::default()
         }
         .validate()?,

--- a/tests/tests/membership/t51_hung_follower_blocks_loop.rs
+++ b/tests/tests/membership/t51_hung_follower_blocks_loop.rs
@@ -84,6 +84,18 @@ async fn remove_hung_follower_must_not_block_raft_core_loop_2() -> Result<()> {
     // HACK: wait for the leader to reach `close_membership()` to await the replication task.
     TypeConfig::sleep(Duration::from_millis(500)).await;
 
+    // Refresh the quorum lease after waiting for the core loop to reach the suspected blocking
+    // point. Heartbeats are disabled in this test, so the previous lease may have expired.
+    let refresh_started = TypeConfig::now();
+    router.get_raft_handle(&0)?.trigger().heartbeat().await?;
+    router
+        .wait(&0, timeout())
+        .leader_with_quorum_acked(
+            Some(refresh_started),
+            "leader lease recovered through the surviving quorum",
+        )
+        .await?;
+
     // The leader should still serve the surviving quorum.
     let write = router.client_request(0, "after-remove", 2);
     TypeConfig::timeout(Duration::from_secs(10), write)

--- a/tests/tests/metrics/t10_leader_last_ack.rs
+++ b/tests/tests/metrics/t10_leader_last_ack.rs
@@ -164,12 +164,7 @@ async fn leader_last_ack_3_nodes_abs_time() -> Result<()> {
         let now = TypeConfig::now();
 
         n0.trigger().heartbeat().await?;
-        n0.wait(timeout())
-            .metrics(
-                |x| x.last_quorum_acked.as_deref() >= Some(&now),
-                "last_quorum_acked refreshed",
-            )
-            .await?;
+        n0.wait(timeout()).leader_with_quorum_acked(Some(now), "last_quorum_acked refreshed").await?;
     }
 
     tracing::info!(log_index, "--- sleep and heartbeat again; last_quorum_acked refreshes");
@@ -179,12 +174,7 @@ async fn leader_last_ack_3_nodes_abs_time() -> Result<()> {
         let now = TypeConfig::now();
         n0.trigger().heartbeat().await?;
 
-        n0.wait(timeout())
-            .metrics(
-                |x| x.last_quorum_acked.as_deref() >= Some(&now),
-                "last_quorum_acked refreshed again",
-            )
-            .await?;
+        n0.wait(timeout()).leader_with_quorum_acked(Some(now), "last_quorum_acked refreshed again").await?;
     }
 
     tracing::info!(log_index, "--- remove node 1 and node 2");
@@ -203,13 +193,7 @@ async fn leader_last_ack_3_nodes_abs_time() -> Result<()> {
         let now = TypeConfig::now();
         n0.trigger().heartbeat().await?;
 
-        let got = n0
-            .wait(timeout())
-            .metrics(
-                |x| x.last_quorum_acked.as_deref() >= Some(&now),
-                "last_quorum_acked refreshed again",
-            )
-            .await;
+        let got = n0.wait(timeout()).leader_with_quorum_acked(Some(now), "last_quorum_acked refreshed again").await;
         assert!(got.is_err(), "last_quorum_acked does not refresh");
     }
 

--- a/tests/tests/metrics/t50_log_progress_api.rs
+++ b/tests/tests/metrics/t50_log_progress_api.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
-use openraft::ServerState;
 use openraft::Vote;
 use openraft::raft::FlushPoint;
 use openraft::type_config::TypeConfigExt;
@@ -148,7 +147,7 @@ async fn log_progress_with_leader_change() -> Result<()> {
     tracing::info!(log_index, "--- send client requests to new leader");
     router
         .wait(&1, Some(Duration::from_millis(2000)))
-        .state(ServerState::Leader, "wait for node 1 to become leader")
+        .leader_with_quorum_acked(None, "wait for node 1 to become leader and establish its leader lease")
         .await?;
     log_index += 1;
     log_index += router.client_request_many(1, "foo", 3).await?;

--- a/tests/tests/replication/t50_append_entries_backoff_rejoin.rs
+++ b/tests/tests/replication/t50_append_entries_backoff_rejoin.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
-use openraft::ServerState;
 use openraft::type_config::TypeConfigExt;
 use openraft_memstore::TypeConfig;
 
@@ -49,7 +48,9 @@ async fn append_entries_backoff_rejoin() -> Result<()> {
         TypeConfig::sleep(Duration::from_millis(1_000)).await;
 
         n1.trigger().elect(false).await?;
-        n1.wait(timeout()).state(ServerState::Leader, "node-1 elect").await?;
+        n1.wait(timeout())
+            .leader_with_quorum_acked(None, "node-1 elects and establishes its leader lease")
+            .await?;
     }
 
     tracing::info!(log_index, "--- write {} entries to node-1", n);


### PR DESCRIPTION

## Changelog

##### change: enforce leader lease for proposals and lease reads
# Summary

Leaders that cannot confirm a recent quorum now reject new proposals and
lease reads with ForwardToLeader while retaining leader state and
replication.

# Details

Accepted replication responses maintain quorum lease progress from request
sending timestamps. The cached quorum acknowledgment avoids redundant
runtime clock reads, while self-quorum leaders bypass expiry checks.

Heartbeats, replication, pending requests, and ReadIndex quorum probes
continue after expiry. This lets existing work finish and allows quorum
contact to restore availability without self-demotion. No configuration or
compatibility changes are introduced.

Protocol documentation and an FAQ explain this behavior and contrast it
with self-demoting CheckQuorum implementations. Tests cover lease-gated
admission and wait for quorum acknowledgment when leader readiness matters.

- Fix: #1898

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1899)
<!-- Reviewable:end -->
