### PR TITLE
refactor: examples: add dir-transfer crate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -488,6 +488,7 @@ jobs:
           - 'stable'
           - 'nightly'
         example:
+          - 'dir-transfer'
           - 'log-mem'
           - 'log-rocks'
           - 'sm-rocks'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ exclude = [
     "examples/network-v1-http",
     "examples/network-v2-http",
 
+    "examples/dir-transfer",
     "examples/log-mem",
     "examples/log-rocks",
     "examples/mem-log",

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ check-parallel:
 
 
 test-examples:
+	cargo test --manifest-path examples/dir-transfer/Cargo.toml
 	cargo test --manifest-path examples/log-mem/Cargo.toml
 	cargo test --manifest-path examples/log-rocks/Cargo.toml
 	cargo test --manifest-path examples/raft-kv-memstore/Cargo.toml
@@ -104,6 +105,7 @@ lint:
 	cargo fmt --manifest-path examples/app-http/Cargo.toml
 	cargo fmt --manifest-path examples/network-v1-http/Cargo.toml
 	cargo fmt --manifest-path examples/network-v2-http/Cargo.toml
+	cargo fmt --manifest-path examples/dir-transfer/Cargo.toml
 	cargo fmt --manifest-path examples/log-mem/Cargo.toml
 	cargo fmt --manifest-path examples/log-rocks/Cargo.toml
 	cargo fmt --manifest-path examples/sm-mem/Cargo.toml
@@ -127,6 +129,7 @@ lint:
 	cargo clippy --no-deps --manifest-path examples/app-http/Cargo.toml                               --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/network-v1-http/Cargo.toml                         --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/network-v2-http/Cargo.toml                         --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path examples/dir-transfer/Cargo.toml                           --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/log-mem/Cargo.toml                                --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/log-rocks/Cargo.toml                              --all-targets -- -D warnings
 	cargo clippy --no-deps --manifest-path examples/sm-mem/Cargo.toml                                --all-targets -- -D warnings

--- a/examples/dir-transfer/Cargo.toml
+++ b/examples/dir-transfer/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "dir-transfer"
+description = "Transfer a flat directory of immutable files as an ordered stream of frames."
+readme = "README.md"
+
+version = "0.1.0"
+edition = "2024"
+authors = [
+    "drdr xp <drdr.xp@gmail.com>",
+]
+categories = ["algorithms", "asynchronous", "data-structures"]
+homepage = "https://github.com/databendlabs/openraft"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/databendlabs/openraft"
+
+[dependencies]
+crc   = { version = "3.2" }
+serde = { version = "1.0.114", features = ["derive"] }
+tokio = { version = "1.0", features = ["fs", "io-util"] }
+
+[dev-dependencies]
+tempfile = { version = "3.4.0" }
+tokio    = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/dir-transfer/README.md
+++ b/examples/dir-transfer/README.md
@@ -1,0 +1,42 @@
+# dir-transfer
+
+Transfer a flat directory of immutable files to a remote peer as an ordered stream of frames,
+without fixing a concrete transport.
+
+This crate defines the file-level protocol: the frame types, a sender that turns a directory into
+a frame stream, and a receiver that rebuilds and validates the directory. The carrier is anything
+that moves opaque frames reliably and in order: TCP, gRPC streaming, an HTTP body, a message
+queue.
+
+Built for shipping RocksDB checkpoint directories as OpenRaft snapshots (see
+`examples/sm-rocks`), but generic over any checkpoint-style directory of immutable files.
+
+## Protocol
+
+A transfer is one ordered frame stream:
+
+```text
+Manifest, { FileStart, Chunk*, FileEnd }, End
+```
+
+with one `FileStart`/`Chunk`/`FileEnd` group per manifest entry, in manifest order.
+
+- `Manifest` carries the format version and every file's name and size.
+- File names are flat: no path separators, no `.` or `..`.
+- `FileEnd` carries a CRC-64/XZ checksum of the complete file contents.
+- Every violation fails with `io::ErrorKind::InvalidData`; a failed session is discarded and
+  restarted from scratch.
+
+## Transport contract
+
+A transport implements `FrameSink` on the sending node and `FrameSource` on the receiving node,
+choosing its own frame encoding; `send_dir()` and `recv_dir()` drive one complete session over
+them. A conforming transport must:
+
+1. Deliver the frames of one session to exactly one receiver, in order, without loss or
+   duplication.
+2. Propagate receiver errors back to the sender; on any error both sides drop the session.
+3. Report success only after the receiver's `finish()` succeeds.
+
+Retry, authentication, compression, and rate limiting are transport concerns, outside this
+protocol.

--- a/examples/dir-transfer/src/frame.rs
+++ b/examples/dir-transfer/src/frame.rs
@@ -1,0 +1,151 @@
+//! Wire frame types of the directory transfer protocol.
+
+use std::io;
+
+use crc::CRC_64_XZ;
+use crc::Crc;
+use serde::Deserialize;
+use serde::Serialize;
+
+/// The protocol version this crate emits and accepts.
+///
+/// Version 1 fixes the per-file checksum to CRC-64/XZ.
+pub const FORMAT_VERSION: u32 = 1;
+
+/// Longest accepted manifest file name, in bytes.
+pub const MAX_NAME_LEN: usize = 255;
+
+/// Largest accepted [`DirFrame::Chunk`] payload, in bytes.
+pub const MAX_CHUNK_SIZE: usize = 8 * 1024 * 1024;
+
+static CRC64: Crc<u64> = Crc::<u64>::new(&CRC_64_XZ);
+
+/// Name and size of one file in a [`DirManifest`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize)]
+pub struct FileMeta {
+    /// Flat file name; no path separators.
+    pub name: String,
+
+    /// File size in bytes.
+    pub size: u64,
+}
+
+/// Description of the complete transfer, sent before any file data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize)]
+pub struct DirManifest {
+    /// Protocol version; see [`FORMAT_VERSION`].
+    pub format_version: u32,
+
+    /// Every file of the directory, in transfer order.
+    pub files: Vec<FileMeta>,
+}
+
+/// One frame of the transfer stream.
+///
+/// A valid stream is `Manifest`, then for each manifest entry in manifest order `FileStart`,
+/// zero or more `Chunk`s, `FileEnd`, and finally `End`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize)]
+pub enum DirFrame {
+    /// Names and sizes of every file about to be transferred.
+    Manifest(DirManifest),
+
+    /// Begin the next manifest file.
+    FileStart {
+        /// Name of the file; must equal the next manifest entry.
+        name: String,
+    },
+
+    /// A run of file bytes, at most [`MAX_CHUNK_SIZE`] long.
+    Chunk {
+        /// The bytes.
+        data: Vec<u8>,
+    },
+
+    /// End of the current file.
+    FileEnd {
+        /// CRC-64/XZ checksum of the complete file contents.
+        checksum: u64,
+    },
+
+    /// End of the stream; every manifest file has been transferred.
+    End,
+}
+
+/// Return a streaming hasher for the per-file checksum of [`FORMAT_VERSION`] 1.
+pub(crate) fn checksum_digest() -> crc::Digest<'static, u64> {
+    CRC64.digest()
+}
+
+/// Validate a manifest file name before any filesystem access.
+///
+/// Names must be non-empty, at most [`MAX_NAME_LEN`] bytes, free of path separators and NUL, and
+/// not `.` or `..`.
+pub(crate) fn validate_name(name: &str) -> io::Result<()> {
+    if name.is_empty() {
+        return Err(invalid_data("empty file name"));
+    }
+    if name.len() > MAX_NAME_LEN {
+        return Err(invalid_data(format!("file name longer than {MAX_NAME_LEN} bytes")));
+    }
+    if name == "." || name == ".." {
+        return Err(invalid_data(format!("file name {name:?} is not allowed")));
+    }
+    if name.contains(['/', '\\', '\0']) {
+        return Err(invalid_data(format!(
+            "file name {name:?} contains a path separator or NUL"
+        )));
+    }
+    Ok(())
+}
+
+/// Build an `InvalidData` error; the protocol maps every violation to this kind.
+pub(crate) fn invalid_data(msg: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, msg)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::checksum_digest;
+    use super::validate_name;
+
+    #[test]
+    fn test_checksum_is_crc64_xz() {
+        // CRC-64/XZ standard check value for "123456789".
+        let mut digest = checksum_digest();
+        digest.update(b"123456789");
+        assert_eq!(0x995dc9bbdf1939fa, digest.finalize());
+
+        // Streaming in parts equals hashing at once.
+        let mut digest = checksum_digest();
+        digest.update(b"1234");
+        digest.update(b"56789");
+        assert_eq!(0x995dc9bbdf1939fa, digest.finalize());
+    }
+
+    #[test]
+    fn test_validate_name() {
+        validate_name("CURRENT").unwrap();
+        validate_name("000012.sst").unwrap();
+        validate_name(&"x".repeat(super::MAX_NAME_LEN)).unwrap();
+
+        let invalid = [
+            "",
+            ".",
+            "..",
+            "a/b",
+            "/abs",
+            "a\\b",
+            "a\0b",
+            &"x".repeat(super::MAX_NAME_LEN + 1),
+        ];
+        for name in invalid {
+            let err = validate_name(name).unwrap_err();
+            assert_eq!(io::ErrorKind::InvalidData, err.kind(), "name: {name:?}");
+        }
+    }
+}

--- a/examples/dir-transfer/src/lib.rs
+++ b/examples/dir-transfer/src/lib.rs
@@ -1,0 +1,45 @@
+//! Transfer a flat directory of immutable files as an ordered stream of frames.
+//!
+//! The protocol is transport-agnostic: this crate defines the frame types and the sender and
+//! receiver state machines; the application supplies the carrier — anything that moves opaque
+//! frames reliably and in order (TCP, gRPC streaming, an HTTP body, a message queue).
+//!
+//! A valid stream is:
+//!
+//! ```text
+//! Manifest, { FileStart, Chunk*, FileEnd }, End
+//! ```
+//!
+//! with one `FileStart`/`Chunk`/`FileEnd` group per manifest entry, in manifest order.
+//!
+//! # Transport contract
+//!
+//! A transport implements [`FrameSink`] on the sending node and [`FrameSource`] on the receiving
+//! node, choosing its own frame encoding; [`send_dir`] and [`recv_dir`] drive one complete
+//! session over them. A conforming transport must:
+//!
+//! 1. Deliver the frames of one session to exactly one receiver, in order, without loss or
+//!    duplication.
+//! 2. Propagate receiver errors back to the sender; on any error both sides drop the session.
+//! 3. Report success only after the receiver's `finish()` succeeds.
+//!
+//! Retry, authentication, compression, and rate limiting are transport concerns, outside this
+//! protocol. A failed or cancelled session is discarded; a new attempt starts from scratch.
+
+mod frame;
+mod receiver;
+mod sender;
+mod transport;
+
+pub use frame::DirFrame;
+pub use frame::DirManifest;
+pub use frame::FORMAT_VERSION;
+pub use frame::FileMeta;
+pub use frame::MAX_CHUNK_SIZE;
+pub use frame::MAX_NAME_LEN;
+pub use receiver::DirReceiver;
+pub use sender::DirSender;
+pub use transport::FrameSink;
+pub use transport::FrameSource;
+pub use transport::recv_dir;
+pub use transport::send_dir;

--- a/examples/dir-transfer/src/receiver.rs
+++ b/examples/dir-transfer/src/receiver.rs
@@ -1,0 +1,205 @@
+//! Rebuild a directory from an ordered stream of frames and validate it.
+
+use std::collections::BTreeSet;
+use std::io;
+use std::path::PathBuf;
+
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
+
+use crate::frame::DirFrame;
+use crate::frame::DirManifest;
+use crate::frame::FORMAT_VERSION;
+use crate::frame::MAX_CHUNK_SIZE;
+use crate::frame::checksum_digest;
+use crate::frame::invalid_data;
+use crate::frame::validate_name;
+
+/// A receiver that writes the frame stream of one session into a target directory.
+///
+/// Feed every frame in order with [`DirReceiver::feed`], then call [`DirReceiver::finish`]. Every
+/// protocol violation fails with [`io::ErrorKind::InvalidData`]; a failed session's directory is
+/// discarded by the caller, never reused.
+pub struct DirReceiver {
+    target_dir: PathBuf,
+    manifest: DirManifest,
+    state: State,
+}
+
+enum State {
+    ExpectManifest,
+    ExpectFileStart { index: usize },
+    InFile(FileWrite),
+    ExpectEnd,
+    Done,
+}
+
+struct FileWrite {
+    index: usize,
+    file: File,
+    digest: crc::Digest<'static, u64>,
+    written: u64,
+}
+
+impl State {
+    fn name(&self) -> &'static str {
+        match self {
+            State::ExpectManifest => "expecting Manifest",
+            State::ExpectFileStart { .. } => "expecting FileStart",
+            State::InFile(_) => "receiving file data",
+            State::ExpectEnd => "expecting End",
+            State::Done => "completed",
+        }
+    }
+}
+
+fn frame_name(frame: &DirFrame) -> &'static str {
+    match frame {
+        DirFrame::Manifest(_) => "Manifest",
+        DirFrame::FileStart { .. } => "FileStart",
+        DirFrame::Chunk { .. } => "Chunk",
+        DirFrame::FileEnd { .. } => "FileEnd",
+        DirFrame::End => "End",
+    }
+}
+
+impl DirReceiver {
+    /// Create a receiver that writes into the existing, empty directory `target_dir`.
+    pub fn new(target_dir: PathBuf) -> Self {
+        Self {
+            target_dir,
+            manifest: DirManifest {
+                format_version: FORMAT_VERSION,
+                files: vec![],
+            },
+            state: State::ExpectManifest,
+        }
+    }
+
+    /// Consume the next frame of the stream, validating grammar and contents.
+    pub async fn feed(&mut self, frame: DirFrame) -> io::Result<()> {
+        let state = std::mem::replace(&mut self.state, State::Done);
+        self.state = match (state, frame) {
+            (State::ExpectManifest, DirFrame::Manifest(manifest)) => self.recv_manifest(manifest)?,
+            (State::ExpectFileStart { index }, DirFrame::FileStart { name }) => self.start_file(index, &name).await?,
+            (State::InFile(write), DirFrame::Chunk { data }) => self.recv_chunk(write, &data).await?,
+            (State::InFile(write), DirFrame::FileEnd { checksum }) => self.end_file(write, checksum).await?,
+            (State::ExpectEnd, DirFrame::End) => State::Done,
+            (state, frame) => {
+                return Err(invalid_data(format!(
+                    "unexpected {} frame while {}",
+                    frame_name(&frame),
+                    state.name()
+                )));
+            }
+        };
+        Ok(())
+    }
+
+    /// Validate completeness after [`DirFrame::End`] and synchronize the directory.
+    pub async fn finish(self) -> io::Result<()> {
+        if !matches!(self.state, State::Done) {
+            return Err(invalid_data(format!("stream truncated while {}", self.state.name())));
+        }
+        std::fs::File::open(&self.target_dir)?.sync_all()
+    }
+
+    /// Validate the manifest: version, and every file name before any filesystem write.
+    fn recv_manifest(&mut self, manifest: DirManifest) -> io::Result<State> {
+        if manifest.format_version != FORMAT_VERSION {
+            return Err(invalid_data(format!(
+                "unsupported format version {}, expect {FORMAT_VERSION}",
+                manifest.format_version
+            )));
+        }
+
+        let mut names = BTreeSet::new();
+        for meta in &manifest.files {
+            validate_name(&meta.name)?;
+            if !names.insert(&meta.name) {
+                return Err(invalid_data(format!("duplicate file name {:?}", meta.name)));
+            }
+        }
+
+        self.manifest = manifest;
+        Ok(self.next_file_state(0))
+    }
+
+    /// The state that follows the completion of file `index - 1`.
+    fn next_file_state(&self, index: usize) -> State {
+        if index < self.manifest.files.len() {
+            State::ExpectFileStart { index }
+        } else {
+            State::ExpectEnd
+        }
+    }
+
+    /// Open the target file after checking the name against the manifest order.
+    async fn start_file(&mut self, index: usize, name: &str) -> io::Result<State> {
+        let expected = &self.manifest.files[index].name;
+        if name != expected {
+            return Err(invalid_data(format!(
+                "FileStart {name:?} but manifest expects {expected:?}"
+            )));
+        }
+
+        let file = File::create(self.target_dir.join(name)).await?;
+        Ok(State::InFile(FileWrite {
+            index,
+            file,
+            digest: checksum_digest(),
+            written: 0,
+        }))
+    }
+
+    /// Append a bounded, size-checked chunk to the current file.
+    async fn recv_chunk(&mut self, mut write: FileWrite, data: &[u8]) -> io::Result<State> {
+        if data.is_empty() {
+            return Err(invalid_data("empty Chunk frame"));
+        }
+        if data.len() > MAX_CHUNK_SIZE {
+            return Err(invalid_data(format!(
+                "Chunk of {} bytes exceeds {MAX_CHUNK_SIZE}",
+                data.len()
+            )));
+        }
+
+        let size = self.manifest.files[write.index].size;
+        let written = write.written + data.len() as u64;
+        if written > size {
+            return Err(invalid_data(format!(
+                "file data {written} bytes exceeds manifest size {size}"
+            )));
+        }
+
+        write.file.write_all(data).await?;
+        write.digest.update(data);
+        write.written = written;
+        Ok(State::InFile(write))
+    }
+
+    /// Verify size and checksum, then make the completed file durable.
+    async fn end_file(&mut self, write: FileWrite, checksum: u64) -> io::Result<State> {
+        let meta = &self.manifest.files[write.index];
+        if write.written != meta.size {
+            return Err(invalid_data(format!(
+                "file {:?} ended at {} bytes, manifest size is {}",
+                meta.name, write.written, meta.size
+            )));
+        }
+
+        let actual = write.digest.finalize();
+        if actual != checksum {
+            return Err(invalid_data(format!(
+                "file {:?} checksum {actual:#018x} does not match {checksum:#018x}",
+                meta.name
+            )));
+        }
+
+        write.file.sync_all().await?;
+        Ok(self.next_file_state(write.index + 1))
+    }
+}
+
+#[cfg(test)]
+mod receiver_test;

--- a/examples/dir-transfer/src/receiver/receiver_test.rs
+++ b/examples/dir-transfer/src/receiver/receiver_test.rs
@@ -1,0 +1,245 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use crate::frame::DirFrame;
+use crate::frame::DirManifest;
+use crate::frame::FORMAT_VERSION;
+use crate::frame::FileMeta;
+use crate::frame::MAX_CHUNK_SIZE;
+use crate::receiver::DirReceiver;
+use crate::sender::DirSender;
+
+/// Read a directory into `name -> contents`, asserting it is flat.
+fn dir_contents(dir: &Path) -> BTreeMap<String, Vec<u8>> {
+    let mut contents = BTreeMap::new();
+    for entry in fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        assert!(entry.file_type().unwrap().is_file());
+        let name = entry.file_name().into_string().unwrap();
+        contents.insert(name, fs::read(entry.path()).unwrap());
+    }
+    contents
+}
+
+/// Build a source directory and its complete valid frame stream.
+async fn source_frames() -> (TempDir, Vec<DirFrame>) {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("a.txt"), b"").unwrap();
+    fs::write(dir.path().join("b.txt"), b"1234567").unwrap();
+    fs::write(dir.path().join("c.bin"), b"abcdefgh").unwrap();
+
+    let mut sender = DirSender::new(dir.path(), 4).unwrap();
+    let mut frames = Vec::new();
+    while let Some(frame) = sender.next_frame().await.unwrap() {
+        frames.push(frame);
+    }
+    (dir, frames)
+}
+
+/// Feed all frames; on success call `finish()`.
+async fn receive_all(target: &Path, frames: Vec<DirFrame>) -> io::Result<()> {
+    let mut receiver = DirReceiver::new(target.to_path_buf());
+    for frame in frames {
+        receiver.feed(frame).await?;
+    }
+    receiver.finish().await
+}
+
+/// Assert that receiving `frames` fails with `InvalidData`.
+async fn assert_rejected(frames: Vec<DirFrame>) {
+    let target = tempfile::tempdir().unwrap();
+    let err = receive_all(target.path(), frames).await.unwrap_err();
+    assert_eq!(io::ErrorKind::InvalidData, err.kind());
+}
+
+fn manifest_frame(files: Vec<FileMeta>) -> DirFrame {
+    DirFrame::Manifest(DirManifest {
+        format_version: FORMAT_VERSION,
+        files,
+    })
+}
+
+#[tokio::test]
+async fn test_round_trip() {
+    let (source, frames) = source_frames().await;
+    let target = tempfile::tempdir().unwrap();
+
+    receive_all(target.path(), frames).await.unwrap();
+
+    assert_eq!(dir_contents(source.path()), dir_contents(target.path()));
+}
+
+#[tokio::test]
+async fn test_round_trip_empty_dir() {
+    let source = tempfile::tempdir().unwrap();
+    let target = tempfile::tempdir().unwrap();
+
+    let mut sender = DirSender::new(source.path(), 4).unwrap();
+    let mut frames = Vec::new();
+    while let Some(frame) = sender.next_frame().await.unwrap() {
+        frames.push(frame);
+    }
+
+    receive_all(target.path(), frames).await.unwrap();
+    assert_eq!(BTreeMap::new(), dir_contents(target.path()));
+}
+
+#[tokio::test]
+async fn test_wrong_first_frame() {
+    assert_rejected(vec![DirFrame::FileStart {
+        name: "a.txt".to_string(),
+    }])
+    .await;
+    assert_rejected(vec![DirFrame::End]).await;
+}
+
+#[tokio::test]
+async fn test_unsupported_version() {
+    assert_rejected(vec![DirFrame::Manifest(DirManifest {
+        format_version: FORMAT_VERSION + 1,
+        files: vec![],
+    })])
+    .await;
+}
+
+#[tokio::test]
+async fn test_manifest_name_validation_precedes_writes() {
+    for name in ["../evil", "a/b", "", ".."] {
+        let target = tempfile::tempdir().unwrap();
+        let mut receiver = DirReceiver::new(target.path().to_path_buf());
+
+        let frame = manifest_frame(vec![FileMeta {
+            name: name.to_string(),
+            size: 1,
+        }]);
+        let err = receiver.feed(frame).await.unwrap_err();
+
+        assert_eq!(io::ErrorKind::InvalidData, err.kind(), "name: {name:?}");
+        assert_eq!(BTreeMap::new(), dir_contents(target.path()), "no file may be created");
+    }
+}
+
+#[tokio::test]
+async fn test_duplicate_manifest_name() {
+    let meta = FileMeta {
+        name: "dup".to_string(),
+        size: 0,
+    };
+    assert_rejected(vec![manifest_frame(vec![meta.clone(), meta])]).await;
+}
+
+#[tokio::test]
+async fn test_file_start_must_follow_manifest_order() {
+    let (_source, mut frames) = source_frames().await;
+    // Start with the second manifest file instead of the first.
+    frames[1] = DirFrame::FileStart {
+        name: "b.txt".to_string(),
+    };
+    assert_rejected(frames).await;
+}
+
+#[tokio::test]
+async fn test_duplicate_file_start() {
+    let (_source, mut frames) = source_frames().await;
+    // Frames: [Manifest, Start a, End a, Start b, ...]. Repeat "a.txt" where "b.txt" must start.
+    frames[3] = DirFrame::FileStart {
+        name: "a.txt".to_string(),
+    };
+    assert_rejected(frames).await;
+}
+
+#[tokio::test]
+async fn test_missing_file_end() {
+    let (_source, mut frames) = source_frames().await;
+    // Remove "a.txt"'s FileEnd so its FileStart is followed by another FileStart.
+    frames.remove(2);
+    assert_rejected(frames).await;
+}
+
+#[tokio::test]
+async fn test_end_before_all_manifest_files() {
+    let (_source, frames) = source_frames().await;
+    // Keep [Manifest, FileStart a, FileEnd a], then End: two manifest files were never sent.
+    let mut frames = frames[..3].to_vec();
+    frames.push(DirFrame::End);
+    assert_rejected(frames).await;
+}
+
+#[tokio::test]
+async fn test_frames_after_end() {
+    let (_source, mut frames) = source_frames().await;
+    frames.push(DirFrame::End);
+    assert_rejected(frames).await;
+}
+
+#[tokio::test]
+async fn test_truncated_stream_fails_finish() {
+    let (_source, mut frames) = source_frames().await;
+    frames.pop();
+    assert_rejected(frames).await;
+}
+
+#[tokio::test]
+async fn test_tampered_chunk() {
+    let (_source, mut frames) = source_frames().await;
+    let DirFrame::Chunk { data } = &mut frames[4] else {
+        panic!("frame 4 must be the first Chunk of b.txt");
+    };
+    data[0] ^= 0xff;
+    assert_rejected(frames).await;
+}
+
+#[tokio::test]
+async fn test_wrong_checksum() {
+    let (_source, mut frames) = source_frames().await;
+    let DirFrame::FileEnd { checksum } = &mut frames[2] else {
+        panic!("frame 2 must be a.txt's FileEnd");
+    };
+    *checksum ^= 1;
+    assert_rejected(frames).await;
+}
+
+#[tokio::test]
+async fn test_chunk_beyond_manifest_size() {
+    let (_source, mut frames) = source_frames().await;
+    frames.insert(6, DirFrame::Chunk {
+        data: b"extra".to_vec(),
+    });
+    assert_rejected(frames).await;
+}
+
+#[tokio::test]
+async fn test_file_shorter_than_manifest_size() {
+    let (_source, mut frames) = source_frames().await;
+    // Drop one Chunk of b.txt; its FileEnd then arrives before enough data.
+    frames.remove(4);
+    assert_rejected(frames).await;
+}
+
+#[tokio::test]
+async fn test_empty_chunk() {
+    let (_source, mut frames) = source_frames().await;
+    frames.insert(4, DirFrame::Chunk { data: vec![] });
+    assert_rejected(frames).await;
+}
+
+#[tokio::test]
+async fn test_oversized_chunk() {
+    let frames = vec![
+        manifest_frame(vec![FileMeta {
+            name: "big".to_string(),
+            size: (MAX_CHUNK_SIZE + 1) as u64,
+        }]),
+        DirFrame::FileStart {
+            name: "big".to_string(),
+        },
+        DirFrame::Chunk {
+            data: vec![0u8; MAX_CHUNK_SIZE + 1],
+        },
+    ];
+    assert_rejected(frames).await;
+}

--- a/examples/dir-transfer/src/sender.rs
+++ b/examples/dir-transfer/src/sender.rs
@@ -1,0 +1,323 @@
+//! Turn a flat directory of immutable files into an ordered stream of frames.
+
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
+
+use crate::frame::DirFrame;
+use crate::frame::DirManifest;
+use crate::frame::FORMAT_VERSION;
+use crate::frame::FileMeta;
+use crate::frame::MAX_CHUNK_SIZE;
+use crate::frame::checksum_digest;
+use crate::frame::invalid_data;
+use crate::frame::validate_name;
+
+/// A pull-based sender that emits the frame stream of one directory.
+///
+/// The transport drives pacing by awaiting [`DirSender::next_frame`], which yields natural
+/// backpressure. The directory must stay immutable while the sender runs; a file whose size
+/// changes mid-transfer fails the session.
+pub struct DirSender {
+    dir: PathBuf,
+    chunk_size: usize,
+    manifest: DirManifest,
+    state: State,
+}
+
+enum State {
+    SendManifest,
+    StartFile { index: usize },
+    SendFile(FileProgress),
+    SendEnd,
+    Done,
+}
+
+struct FileProgress {
+    index: usize,
+    file: File,
+    digest: crc::Digest<'static, u64>,
+    sent: u64,
+}
+
+impl DirSender {
+    /// Enumerate `dir` and build the manifest.
+    ///
+    /// The directory must be flat: every entry a regular file with a valid name. Files are
+    /// transferred in name order. `chunk_size` must be in `1..=MAX_CHUNK_SIZE`.
+    pub fn new(dir: &Path, chunk_size: usize) -> io::Result<Self> {
+        if chunk_size == 0 || chunk_size > MAX_CHUNK_SIZE {
+            return Err(invalid_data(format!(
+                "chunk_size {chunk_size} not in 1..={MAX_CHUNK_SIZE}"
+            )));
+        }
+
+        let mut files = Vec::new();
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_file() {
+                return Err(invalid_data(format!("{:?} is not a regular file", entry.path())));
+            }
+
+            let name = entry
+                .file_name()
+                .into_string()
+                .map_err(|name| invalid_data(format!("file name {name:?} is not UTF-8")))?;
+            validate_name(&name)?;
+
+            files.push(FileMeta {
+                name,
+                size: entry.metadata()?.len(),
+            });
+        }
+        files.sort_by(|a, b| a.name.cmp(&b.name));
+
+        Ok(Self {
+            dir: dir.to_path_buf(),
+            chunk_size,
+            manifest: DirManifest {
+                format_version: FORMAT_VERSION,
+                files,
+            },
+            state: State::SendManifest,
+        })
+    }
+
+    /// Return the next frame of the stream, or `None` after [`DirFrame::End`] has been emitted.
+    pub async fn next_frame(&mut self) -> io::Result<Option<DirFrame>> {
+        match std::mem::replace(&mut self.state, State::Done) {
+            State::SendManifest => {
+                self.state = self.next_file_state(0);
+                Ok(Some(DirFrame::Manifest(self.manifest.clone())))
+            }
+            State::StartFile { index } => {
+                let meta = &self.manifest.files[index];
+                let file = File::open(self.dir.join(&meta.name)).await?;
+                self.state = State::SendFile(FileProgress {
+                    index,
+                    file,
+                    digest: checksum_digest(),
+                    sent: 0,
+                });
+                Ok(Some(DirFrame::FileStart {
+                    name: meta.name.clone(),
+                }))
+            }
+            State::SendFile(progress) => self.send_file(progress).await.map(Some),
+            State::SendEnd => Ok(Some(DirFrame::End)),
+            State::Done => Ok(None),
+        }
+    }
+
+    /// The state that follows the completion of file `index - 1`.
+    fn next_file_state(&self, index: usize) -> State {
+        if index < self.manifest.files.len() {
+            State::StartFile { index }
+        } else {
+            State::SendEnd
+        }
+    }
+
+    /// Emit the next `Chunk` of the current file, or its `FileEnd` at end of file.
+    async fn send_file(&mut self, mut progress: FileProgress) -> io::Result<DirFrame> {
+        let data = read_chunk(&mut progress.file, self.chunk_size).await?;
+        let size = self.manifest.files[progress.index].size;
+
+        if data.is_empty() {
+            if progress.sent != size {
+                return Err(invalid_data(format!(
+                    "file shrank during transfer: {} < {size}",
+                    progress.sent
+                )));
+            }
+            self.state = self.next_file_state(progress.index + 1);
+            return Ok(DirFrame::FileEnd {
+                checksum: progress.digest.finalize(),
+            });
+        }
+
+        progress.digest.update(&data);
+        progress.sent += data.len() as u64;
+        if progress.sent > size {
+            return Err(invalid_data(format!(
+                "file grew during transfer: {} > {size}",
+                progress.sent
+            )));
+        }
+
+        self.state = State::SendFile(progress);
+        Ok(DirFrame::Chunk { data })
+    }
+}
+
+/// Read up to `chunk_size` bytes; a short result means end of file.
+async fn read_chunk(file: &mut File, chunk_size: usize) -> io::Result<Vec<u8>> {
+    let mut data = vec![0u8; chunk_size];
+    let mut filled = 0;
+    while filled < chunk_size {
+        let n = file.read(&mut data[filled..]).await?;
+        if n == 0 {
+            break;
+        }
+        filled += n;
+    }
+    data.truncate(filled);
+    Ok(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::io;
+
+    use super::DirSender;
+    use crate::frame::DirFrame;
+    use crate::frame::DirManifest;
+    use crate::frame::FORMAT_VERSION;
+    use crate::frame::FileMeta;
+    use crate::frame::MAX_CHUNK_SIZE;
+    use crate::frame::checksum_digest;
+
+    fn crc64(data: &[u8]) -> u64 {
+        let mut digest = checksum_digest();
+        digest.update(data);
+        digest.finalize()
+    }
+
+    async fn collect_frames(sender: &mut DirSender) -> io::Result<Vec<DirFrame>> {
+        let mut frames = Vec::new();
+        while let Some(frame) = sender.next_frame().await? {
+            frames.push(frame);
+        }
+        Ok(frames)
+    }
+
+    #[tokio::test]
+    async fn test_frame_sequence() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("b.txt"), b"1234567").unwrap();
+        fs::write(dir.path().join("a.txt"), b"").unwrap();
+        fs::write(dir.path().join("c.bin"), b"abcdefgh").unwrap();
+
+        let mut sender = DirSender::new(dir.path(), 4).unwrap();
+        let frames = collect_frames(&mut sender).await.unwrap();
+
+        let expected = vec![
+            DirFrame::Manifest(DirManifest {
+                format_version: FORMAT_VERSION,
+                files: vec![
+                    FileMeta {
+                        name: "a.txt".to_string(),
+                        size: 0,
+                    },
+                    FileMeta {
+                        name: "b.txt".to_string(),
+                        size: 7,
+                    },
+                    FileMeta {
+                        name: "c.bin".to_string(),
+                        size: 8,
+                    },
+                ],
+            }),
+            // Zero-byte file: no Chunk at all.
+            DirFrame::FileStart {
+                name: "a.txt".to_string(),
+            },
+            DirFrame::FileEnd { checksum: crc64(b"") },
+            DirFrame::FileStart {
+                name: "b.txt".to_string(),
+            },
+            DirFrame::Chunk { data: b"1234".to_vec() },
+            DirFrame::Chunk { data: b"567".to_vec() },
+            DirFrame::FileEnd {
+                checksum: crc64(b"1234567"),
+            },
+            // Size is an exact multiple of the chunk size.
+            DirFrame::FileStart {
+                name: "c.bin".to_string(),
+            },
+            DirFrame::Chunk { data: b"abcd".to_vec() },
+            DirFrame::Chunk { data: b"efgh".to_vec() },
+            DirFrame::FileEnd {
+                checksum: crc64(b"abcdefgh"),
+            },
+            DirFrame::End,
+        ];
+        assert_eq!(expected, frames);
+
+        // The stream stays exhausted.
+        assert!(sender.next_frame().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut sender = DirSender::new(dir.path(), 4).unwrap();
+        let frames = collect_frames(&mut sender).await.unwrap();
+
+        let expected = vec![
+            DirFrame::Manifest(DirManifest {
+                format_version: FORMAT_VERSION,
+                files: vec![],
+            }),
+            DirFrame::End,
+        ];
+        assert_eq!(expected, frames);
+    }
+
+    #[test]
+    fn test_invalid_chunk_size() {
+        let dir = tempfile::tempdir().unwrap();
+
+        for chunk_size in [0, MAX_CHUNK_SIZE + 1] {
+            let err = DirSender::new(dir.path(), chunk_size).err().unwrap();
+            assert_eq!(io::ErrorKind::InvalidData, err.kind());
+        }
+    }
+
+    #[test]
+    fn test_rejects_subdirectory() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("sub")).unwrap();
+
+        let err = DirSender::new(dir.path(), 4).err().unwrap();
+        assert_eq!(io::ErrorKind::InvalidData, err.kind());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_rejects_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("real"), b"x").unwrap();
+        std::os::unix::fs::symlink(dir.path().join("real"), dir.path().join("link")).unwrap();
+
+        let err = DirSender::new(dir.path(), 4).err().unwrap();
+        assert_eq!(io::ErrorKind::InvalidData, err.kind());
+    }
+
+    #[tokio::test]
+    async fn test_file_size_drift_fails() {
+        // The file shrinks after the manifest is built.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("f"), b"12345678").unwrap();
+        let mut sender = DirSender::new(dir.path(), 4).unwrap();
+        fs::write(dir.path().join("f"), b"12").unwrap();
+
+        let err = collect_frames(&mut sender).await.unwrap_err();
+        assert_eq!(io::ErrorKind::InvalidData, err.kind());
+
+        // The file grows after the manifest is built.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("f"), b"12").unwrap();
+        let mut sender = DirSender::new(dir.path(), 4).unwrap();
+        fs::write(dir.path().join("f"), b"12345678").unwrap();
+
+        let err = collect_frames(&mut sender).await.unwrap_err();
+        assert_eq!(io::ErrorKind::InvalidData, err.kind());
+    }
+}

--- a/examples/dir-transfer/src/transport.rs
+++ b/examples/dir-transfer/src/transport.rs
@@ -1,0 +1,176 @@
+//! Transport abstraction: how the frames of one session reach the remote peer.
+
+use std::future::Future;
+use std::io;
+
+use crate::frame::DirFrame;
+use crate::receiver::DirReceiver;
+use crate::sender::DirSender;
+
+/// Transmit the frames of one session to the remote peer.
+///
+/// Implementations choose their own encoding ([`DirFrame`] derives the serde traits) and must
+/// deliver frames reliably, in order, without loss or duplication. A transmission failure is
+/// reported as an [`io::Error`]; both sides then drop the session.
+pub trait FrameSink {
+    /// Transmit one frame.
+    fn send_frame(&mut self, frame: DirFrame) -> impl Future<Output = io::Result<()>> + Send;
+}
+
+/// Receive the frames of one session from the remote peer.
+pub trait FrameSource {
+    /// Return the next frame of the session.
+    ///
+    /// A session ends with [`DirFrame::End`]; a transport that runs out of frames before then
+    /// reports an error such as [`io::ErrorKind::UnexpectedEof`].
+    fn recv_frame(&mut self) -> impl Future<Output = io::Result<DirFrame>> + Send;
+}
+
+/// Send one complete session: every frame of `sender` into `sink`.
+pub async fn send_dir<S>(mut sender: DirSender, sink: &mut S) -> io::Result<()>
+where S: FrameSink {
+    while let Some(frame) = sender.next_frame().await? {
+        sink.send_frame(frame).await?;
+    }
+    Ok(())
+}
+
+/// Receive one complete session: feed every frame from `source` into `receiver` and call its
+/// `finish()` after [`DirFrame::End`].
+///
+/// No frame is read past `End`, so the transport can carry unrelated traffic afterwards.
+pub async fn recv_dir<S>(source: &mut S, mut receiver: DirReceiver) -> io::Result<()>
+where S: FrameSource {
+    loop {
+        let frame = source.recv_frame().await?;
+        let is_end = matches!(frame, DirFrame::End);
+        receiver.feed(frame).await?;
+        if is_end {
+            return receiver.finish().await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::collections::VecDeque;
+    use std::fs;
+    use std::io;
+    use std::path::Path;
+
+    use tempfile::TempDir;
+
+    use super::FrameSink;
+    use super::FrameSource;
+    use super::recv_dir;
+    use super::send_dir;
+    use crate::frame::DirFrame;
+    use crate::receiver::DirReceiver;
+    use crate::sender::DirSender;
+
+    /// An in-memory transport: sent frames queue up and are received in order.
+    #[derive(Default)]
+    struct QueueTransport {
+        frames: VecDeque<DirFrame>,
+    }
+
+    impl FrameSink for QueueTransport {
+        async fn send_frame(&mut self, frame: DirFrame) -> io::Result<()> {
+            self.frames.push_back(frame);
+            Ok(())
+        }
+    }
+
+    impl FrameSource for QueueTransport {
+        async fn recv_frame(&mut self) -> io::Result<DirFrame> {
+            self.frames
+                .pop_front()
+                .ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "transport closed"))
+        }
+    }
+
+    /// A sink that fails once `remaining` transmissions are used up.
+    struct FailingSink {
+        remaining: usize,
+    }
+
+    impl FrameSink for FailingSink {
+        async fn send_frame(&mut self, _frame: DirFrame) -> io::Result<()> {
+            if self.remaining == 0 {
+                return Err(io::Error::new(io::ErrorKind::ConnectionReset, "peer gone"));
+            }
+            self.remaining -= 1;
+            Ok(())
+        }
+    }
+
+    /// Read a directory into `name -> contents`.
+    fn dir_contents(dir: &Path) -> BTreeMap<String, Vec<u8>> {
+        let mut contents = BTreeMap::new();
+        for entry in fs::read_dir(dir).unwrap() {
+            let entry = entry.unwrap();
+            let name = entry.file_name().into_string().unwrap();
+            contents.insert(name, fs::read(entry.path()).unwrap());
+        }
+        contents
+    }
+
+    /// Send a three-file source directory into an in-memory transport.
+    async fn sent_session() -> (TempDir, QueueTransport) {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("a.txt"), b"").unwrap();
+        fs::write(dir.path().join("b.txt"), b"1234567").unwrap();
+        fs::write(dir.path().join("c.bin"), b"abcdefgh").unwrap();
+
+        let sender = DirSender::new(dir.path(), 4).unwrap();
+        let mut transport = QueueTransport::default();
+        send_dir(sender, &mut transport).await.unwrap();
+        (dir, transport)
+    }
+
+    #[tokio::test]
+    async fn test_round_trip_via_transport() {
+        let (source, mut transport) = sent_session().await;
+        let target = tempfile::tempdir().unwrap();
+
+        recv_dir(&mut transport, DirReceiver::new(target.path().to_path_buf())).await.unwrap();
+
+        assert_eq!(dir_contents(source.path()), dir_contents(target.path()));
+        assert!(transport.frames.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_recv_stops_at_end() {
+        let (_source, mut transport) = sent_session().await;
+        transport.frames.push_back(DirFrame::End);
+        let target = tempfile::tempdir().unwrap();
+
+        recv_dir(&mut transport, DirReceiver::new(target.path().to_path_buf())).await.unwrap();
+
+        // The frame after `End` is left in the transport.
+        assert_eq!(VecDeque::from([DirFrame::End]), transport.frames);
+    }
+
+    #[tokio::test]
+    async fn test_transport_closed_before_end() {
+        let (_source, mut transport) = sent_session().await;
+        transport.frames.pop_back();
+        let target = tempfile::tempdir().unwrap();
+
+        let err = recv_dir(&mut transport, DirReceiver::new(target.path().to_path_buf())).await.unwrap_err();
+
+        assert_eq!(io::ErrorKind::UnexpectedEof, err.kind());
+    }
+
+    #[tokio::test]
+    async fn test_sink_failure_propagates() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("f"), b"12345678").unwrap();
+
+        let sender = DirSender::new(dir.path(), 4).unwrap();
+        let err = send_dir(sender, &mut FailingSink { remaining: 2 }).await.unwrap_err();
+
+        assert_eq!(io::ErrorKind::ConnectionReset, err.kind());
+    }
+}


### PR DESCRIPTION

## Changelog

##### refactor: examples: add dir-transfer crate
# Summary

Add `examples/dir-transfer`, a standalone crate that transfers a flat
directory of immutable files to a remote peer as an ordered stream of
frames, without fixing a concrete transport. The target use is shipping
RocksDB checkpoint directories as OpenRaft snapshots from `sm-rocks`,
but the crate depends on neither rocksdb nor openraft and works for any
checkpoint-style directory.

# Details

A transfer is one ordered stream: `Manifest`, then per manifest entry
`FileStart`, `Chunk`s, `FileEnd`, and finally `End`. The manifest
carries every file's name and size; names are flat. Protocol version 1
fixes the per-file checksum to CRC-64/XZ. Every violation fails with
`io::ErrorKind::InvalidData`; a failed session is discarded and
restarted from scratch, never resumed.

`DirSender` enumerates the directory with `read_dir` into a manifest
(regular files only, name order, so the stream is deterministic) and
emits frames one at a time from pull-based `next_frame()`, which lets
the transport drive pacing. The directory must stay immutable while
sending; a file whose size drifts from the manifest fails the session
instead of contradicting it.

`DirReceiver` rebuilds the directory, enforcing the stream grammar as
a state machine and validating content on top: manifest names are
checked before any filesystem write (path traversal cannot touch the
disk), chunks are bounded, and `FileEnd` requires the exact size and
checksum. `End` is accepted only after every manifest file completed,
so file-list completeness is enforced by the grammar. Files are
fsynced at `FileEnd` and the directory at `finish()`, making a
successful session crash-durable.

A transport implements `FrameSink` on the sending node and
`FrameSource` on the receiving node; `send_dir()` and `recv_dir()`
drive one complete session over them. The traits are
direction-specific because the protocol is one-way, and their methods
are declared as `impl Future<...> + Send` so driver futures remain
spawnable while implementations write plain `async fn`. The crate
fixes no wire encoding: `DirFrame` derives the serde traits and each
transport picks its own serialization. `recv_dir()` reads nothing past
`End`, so the transport can carry unrelated traffic afterwards.

Tests cover exact frame sequences (including zero-byte and
chunk-multiple files), byte-identical round trips through an in-memory
transport, and rejection of reordered, duplicated, truncated,
tampered, oversized, incomplete, and traversal-carrying streams.

Register the crate like the other examples: root workspace `exclude`,
`make test-examples` and `make lint`, and the CI example matrix.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1900)
<!-- Reviewable:end -->
