### PR TITLE
Refactor Jepsen to own its test application

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,8 @@ exclude = [
     "examples/raft-kv-rocksdb",
     "examples/multi-raft-kv",
 
+    "jepsen/openraft-test-app",
+
     "rt-monoio",
     "rt-compio",
     "rt-tokio",

--- a/jepsen/Makefile
+++ b/jepsen/Makefile
@@ -7,8 +7,14 @@ SSH_KEY ?= /root/.ssh/openraft-jepsen
 ARGS ?= --nodes $(NODES) --concurrency $(CONCURRENCY) --nemesis $(NEMESIS) --ssh-private-key $(SSH_KEY)
 
 app-lint:
-	cargo fmt --manifest-path $(APP_MANIFEST)
+	cargo fmt --check --manifest-path $(APP_MANIFEST)
 	cargo clippy --no-deps --manifest-path $(APP_MANIFEST) --all-targets -- -D warnings
+
+clojure-lint:
+	clj-kondo --lint src test
+	cljfmt check src test
+
+lint: app-lint clojure-lint
 
 jepsen: build
 	@echo "[jepsen] starting containers"
@@ -38,4 +44,4 @@ down:
 	@echo "[jepsen] stopping containers"
 	@$(COMPOSE) down
 
-.PHONY: app-lint jepsen key build up test down
+.PHONY: app-lint clojure-lint lint jepsen key build up test down

--- a/jepsen/Makefile
+++ b/jepsen/Makefile
@@ -1,9 +1,14 @@
 COMPOSE := docker compose -f docker/docker-compose.yml
+APP_MANIFEST := openraft-test-app/Cargo.toml
 NODES ?= n1,n2,n3,n4,n5
 CONCURRENCY ?= 3
 NEMESIS ?= partition
 SSH_KEY ?= /root/.ssh/openraft-jepsen
 ARGS ?= --nodes $(NODES) --concurrency $(CONCURRENCY) --nemesis $(NEMESIS) --ssh-private-key $(SSH_KEY)
+
+app-lint:
+	cargo fmt --manifest-path $(APP_MANIFEST)
+	cargo clippy --no-deps --manifest-path $(APP_MANIFEST) --all-targets -- -D warnings
 
 jepsen: build
 	@echo "[jepsen] starting containers"
@@ -33,4 +38,4 @@ down:
 	@echo "[jepsen] stopping containers"
 	@$(COMPOSE) down
 
-.PHONY: jepsen key build up test down
+.PHONY: app-lint jepsen key build up test down

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -1,12 +1,19 @@
 # OpenRaft Jepsen Tests
 
-This directory contains Jepsen black-box tests for OpenRaft. The tests target the runnable OpenRaft key-value example service, rather than OpenRaft's internal Rust APIs, so they can validate externally observable behavior through real client requests, process lifecycle, and network behavior.
+This directory contains Jepsen black-box tests for OpenRaft and the dedicated
+RocksDB-backed application they exercise. The tests target the application
+through its external APIs rather than OpenRaft's internal Rust APIs, so they
+can validate externally observable behavior through real client requests,
+process lifecycle, and network behavior.
 
 These tests cover a different layer from OpenRaft's deterministic simulation tests. Simulation tests run inside a controlled Rust environment. Jepsen drives a running KV service through its external API and records a client history for later checking. Jepsen runs are not deterministic, and a Jepsen failure is not expected to replay directly in the simulation harness.
 
 ## Organization
 
-This is a standalone Clojure/Leiningen project inside the OpenRaft repository. It is not part of the Cargo workspace and should not be required for normal Rust builds or tests.
+The Clojure/Leiningen harness and its Rust test application are self-contained
+inside the OpenRaft repository. The Rust crate is excluded from the root Cargo
+workspace, so normal Rust builds and tests do not depend on Jepsen. The Jepsen
+Docker environment builds the application explicitly from its own manifest.
 
 The Docker test environment separates the Jepsen control plane from the OpenRaft data plane:
 
@@ -38,6 +45,9 @@ jepsen/
   Makefile
   project.clj
   README.md
+  openraft-test-app/
+    Cargo.toml
+    src/
   docker/
     docker-compose.yml
     control.Dockerfile
@@ -56,6 +66,11 @@ jepsen/
       process.clj
     workload.clj
 ```
+
+The `openraft-test-app` crate is derived from the RocksDB example but belongs to
+the Jepsen harness. It uses string node IDs so each Docker hostname can also be
+the corresponding OpenRaft node ID. Test-specific application changes can be
+made there without increasing the complexity of the general-purpose example.
 
 The `jepsen.openraft` namespace contains the OpenRaft-specific Jepsen code:
 
@@ -79,6 +94,9 @@ The `jepsen.openraft` namespace contains the OpenRaft-specific Jepsen code:
 From the repository root:
 
 ```bash
+# Format and lint the dedicated Rust test application.
+$ make -C jepsen app-lint
+
 # Build images, start containers, then run unit and linearizability tests.
 $ make -C jepsen jepsen
 
@@ -101,9 +119,8 @@ $ make -C jepsen test NEMESIS=membership
 $ make -C jepsen down
 ```
 
-Node names must use the form `n<ID>`, such as `n1` or `n5`, because the
-harness derives each numeric OpenRaft node ID from its Jepsen node name. IP
-addresses and `user@host` node specifications are not supported.
+The harness uses each Jepsen node's container hostname, such as `n1`, directly
+as its OpenRaft node ID.
 
 This starts the five-node Docker environment, then runs the Jepsen control
 process from the control container. Every test checks a concurrent mix of
@@ -128,7 +145,7 @@ all five nodes as voters and waits for every node to agree on a leader.
 
 - [x] Add the Leiningen project definition and CLI skeleton.
 - [x] Add Docker-based Jepsen control and node containers.
-- [x] Add a multi-stage node image for the RocksDB KV example.
+- [x] Add a multi-stage node image for the RocksDB KV test application.
 - [x] Add an HTTP client for the OpenRaft KV APIs.
 - [x] Add Jepsen process lifecycle management for OpenRaft nodes.
 - [x] Bootstrap a five-node OpenRaft cluster.

--- a/jepsen/docker/control.Dockerfile.dockerignore
+++ b/jepsen/docker/control.Dockerfile.dockerignore
@@ -1,2 +1,3 @@
+**/target
 jepsen/docker/ssh/*
 !jepsen/docker/ssh/openraft-jepsen.pub

--- a/jepsen/docker/node.Dockerfile
+++ b/jepsen/docker/node.Dockerfile
@@ -33,7 +33,7 @@ WORKDIR /openraft
 COPY . .
 
 RUN cargo build --release \
-      --manifest-path examples/raft-kv-rocksdb/Cargo.toml
+      --manifest-path jepsen/openraft-test-app/Cargo.toml
 
 FROM ubuntu:24.04
 
@@ -64,8 +64,8 @@ COPY jepsen/docker/ssh/openraft-jepsen.pub /root/.ssh/authorized_keys
 RUN chmod 600 /root/.ssh/authorized_keys
 
 COPY --from=builder \
-  /openraft/examples/raft-kv-rocksdb/target/release/raft-key-value-rocks \
-  /usr/local/bin/raft-key-value-rocks
+  /openraft/jepsen/openraft-test-app/target/release/openraft-jepsen-app \
+  /usr/local/bin/openraft-jepsen-app
 
 EXPOSE 22 21001 22001
 

--- a/jepsen/openraft-test-app/.gitignore
+++ b/jepsen/openraft-test-app/.gitignore
@@ -1,0 +1,5 @@
+target
+vendor
+.idea
+*.db
+/*.log

--- a/jepsen/openraft-test-app/Cargo.toml
+++ b/jepsen/openraft-test-app/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "openraft-jepsen-app"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "openraft-jepsen-app"
+path = "src/bin/main.rs"
+
+[dependencies]
+app-http        = { path = "../../examples/app-http" }
+log-rocks       = { path = "../../examples/log-rocks" }
+network-v2-http = { path = "../../examples/network-v2-http" }
+openraft        = { path = "../../openraft", features = ["serde", "type-alias"] }
+types-kv        = { path = "../../examples/types-kv" }
+
+clap               = { version = "4.1.11", features = ["derive", "env"] }
+futures            = { version = "0.3" }
+rocksdb            = { version = "0.22.0" }
+serde              = { version = "1.0.114", features = ["derive"] }
+serde_json         = { version = "1.0.57" }
+tokio              = { version = "1.35.1", features = ["full"] }
+tracing            = { version = "0.1.40" }
+tracing-subscriber = { version = "0.3.0", features = ["env-filter"] }

--- a/jepsen/openraft-test-app/src/app.rs
+++ b/jepsen/openraft-test-app/src/app.rs
@@ -1,0 +1,8 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use futures::lock::Mutex;
+
+pub type KeyValues = Arc<Mutex<BTreeMap<String, types_kv::VersionedValue>>>;
+
+pub type App = app_http::App<crate::TypeConfig, crate::StateMachineStore, KeyValues>;

--- a/jepsen/openraft-test-app/src/bin/main.rs
+++ b/jepsen/openraft-test-app/src/bin/main.rs
@@ -1,0 +1,39 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use openraft_jepsen_app::start_raft_node;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser, Clone, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct Opt {
+    #[clap(long)]
+    pub id: String,
+
+    #[clap(long)]
+    pub api_addr: String,
+
+    #[clap(long)]
+    pub raft_addr: String,
+
+    #[clap(long, value_name = "PATH")]
+    pub data_dir: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    // Setup the logger
+    tracing_subscriber::fmt()
+        .with_target(true)
+        .with_thread_ids(true)
+        .with_level(true)
+        .with_ansi(false)
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    // Parse the parameters passed by arguments.
+    let options = Opt::parse();
+    let data_dir = options.data_dir.unwrap_or_else(|| PathBuf::from(format!("{}.db", options.api_addr)));
+
+    start_raft_node(options.id, data_dir, options.api_addr, options.raft_addr).await
+}

--- a/jepsen/openraft-test-app/src/http_api.rs
+++ b/jepsen/openraft-test-app/src/http_api.rs
@@ -1,0 +1,20 @@
+use std::sync::Arc;
+
+use crate::app::App;
+use crate::typ::*;
+
+pub async fn read(app: Arc<App>, key: String) -> Result<types_kv::Response, Infallible> {
+    let kvs = app.data.lock().await;
+    let value = kvs.get(&key);
+
+    Ok(types_kv::Response { value: value.cloned() })
+}
+
+pub async fn linearizable_read(app: Arc<App>, key: String) -> Result<types_kv::Response, LinearizableReadError> {
+    app.ensure_linearizable().await?;
+
+    let kvs = app.data.lock().await;
+    let value = kvs.get(&key);
+
+    Ok(types_kv::Response { value: value.cloned() })
+}

--- a/jepsen/openraft-test-app/src/lib.rs
+++ b/jepsen/openraft-test-app/src/lib.rs
@@ -1,0 +1,74 @@
+#![allow(clippy::uninlined_format_args)]
+#![deny(unused_qualifications)]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use openraft::Config;
+use openraft::NodeInfo as Node;
+
+use crate::app::App;
+use crate::store::new_storage;
+
+pub mod app;
+pub mod http_api;
+pub mod store;
+
+pub type NodeId = String;
+pub type SnapshotData = std::io::Cursor<Vec<u8>>;
+
+openraft::declare_raft_types!(
+    pub TypeConfig:
+        D = types_kv::Request,
+        R = types_kv::Response,
+        NodeId = NodeId,
+        Node = Node,
+);
+
+pub type LogStore = log_rocks::RocksLogStore<TypeConfig>;
+pub type StateMachineStore = store::StateMachineStore;
+pub type Raft = openraft::Raft<TypeConfig, StateMachineStore>;
+
+#[path = "../../../examples/utils/declare_types.rs"]
+pub mod typ;
+
+pub async fn start_raft_node<P>(node_id: NodeId, dir: P, api_addr: String, raft_addr: String) -> std::io::Result<()>
+where P: AsRef<Path> {
+    // Create a configuration for the raft instance.
+    let config = Config {
+        heartbeat_interval: 50,
+        election_timeout_min: 299,
+        ..Default::default()
+    };
+
+    let config = Arc::new(config.validate().unwrap());
+
+    let (log_store, state_machine_store) = new_storage(&dir).await;
+
+    let kvs = state_machine_store.data.kvs.clone();
+
+    let network = network_v2_http::NetworkFactory::new();
+
+    // Create a local raft instance.
+    let raft = openraft::Raft::new(node_id.clone(), config.clone(), network, log_store, state_machine_store)
+        .await
+        .unwrap();
+
+    let app = Arc::new(App {
+        id: node_id,
+        api_addr: api_addr.clone(),
+        raft_addr: raft_addr.clone(),
+        raft,
+        data: kvs,
+    });
+
+    let raft_server = network_v2_http::Server::new(app.raft.clone()).run(raft_addr);
+    let app_server = app_http::Server::new(app)
+        .add_openraft_routes()
+        .post("/read", http_api::read)
+        .post("/linearizable_read", http_api::linearizable_read)
+        .run(api_addr);
+
+    tokio::try_join!(raft_server, app_server)?;
+    Ok(())
+}

--- a/jepsen/openraft-test-app/src/store.rs
+++ b/jepsen/openraft-test-app/src/store.rs
@@ -1,0 +1,250 @@
+use std::collections::BTreeMap;
+use std::io;
+use std::io::Cursor;
+use std::path::Path;
+use std::sync::Arc;
+
+use futures::Stream;
+use futures::TryStreamExt;
+use futures::lock::Mutex;
+use log_rocks::RocksLogStore;
+use openraft::EntryPayload;
+use openraft::OptionalSend;
+use openraft::RaftSnapshotBuilder;
+use openraft::storage::EntryResponder;
+use openraft::storage::RaftStateMachine;
+use rocksdb::ColumnFamily;
+use rocksdb::ColumnFamilyDescriptor;
+use rocksdb::DB;
+use rocksdb::Options;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::TypeConfig;
+use crate::typ::*;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct StoredSnapshot {
+    pub meta: SnapshotMeta,
+
+    /// The data of the state machine at the time of this snapshot.
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateMachineStore {
+    pub data: StateMachineData,
+
+    /// Snapshot index is not persisted in this test application.
+    ///
+    /// It is only used as a suffix of snapshot id, and should be globally unique.
+    /// In practice, using a timestamp in micro-second would be good enough.
+    snapshot_idx: u64,
+
+    /// State machine stores snapshot in db.
+    db: Arc<DB>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateMachineData {
+    pub last_applied_log_id: Option<LogId>,
+
+    pub last_membership: StoredMembership,
+
+    /// State built from applying the raft logs
+    pub kvs: Arc<Mutex<BTreeMap<String, types_kv::VersionedValue>>>,
+}
+
+impl RaftSnapshotBuilder<TypeConfig> for StateMachineStore {
+    type SnapshotData = Cursor<Vec<u8>>;
+
+    async fn build_snapshot(&mut self) -> Result<Snapshot, io::Error> {
+        let last_applied_log = self.data.last_applied_log_id.clone();
+        let last_membership = self.data.last_membership.clone();
+
+        let kv_json = {
+            let kvs = self.data.kvs.lock().await;
+            serde_json::to_vec(&*kvs).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+        };
+
+        let snapshot_id = if let Some(ref last) = last_applied_log {
+            format!("{}-{}-{}", last.committed_leader_id(), last.index(), self.snapshot_idx)
+        } else {
+            format!("--{}", self.snapshot_idx)
+        };
+
+        let meta = SnapshotMeta {
+            last_log_id: last_applied_log,
+            last_membership,
+            snapshot_id,
+        };
+
+        let snapshot = StoredSnapshot {
+            meta: meta.clone(),
+            data: kv_json.clone(),
+        };
+
+        self.set_current_snapshot_(snapshot)?;
+
+        Ok(Snapshot {
+            meta,
+            snapshot: Cursor::new(kv_json),
+        })
+    }
+}
+
+impl StateMachineStore {
+    async fn new(db: Arc<DB>) -> Result<StateMachineStore, io::Error> {
+        let mut sm = Self {
+            data: StateMachineData {
+                last_applied_log_id: None,
+                last_membership: Default::default(),
+                kvs: Arc::new(Mutex::new(BTreeMap::new())),
+            },
+            snapshot_idx: 0,
+            db,
+        };
+
+        let snapshot = sm.get_current_snapshot_()?;
+        if let Some(snap) = snapshot {
+            sm.update_state_machine_(snap).await?;
+        }
+
+        Ok(sm)
+    }
+
+    async fn update_state_machine_(&mut self, snapshot: StoredSnapshot) -> Result<(), io::Error> {
+        let kvs: BTreeMap<String, types_kv::VersionedValue> =
+            serde_json::from_slice(&snapshot.data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        self.data.last_applied_log_id = snapshot.meta.last_log_id;
+        self.data.last_membership = snapshot.meta.last_membership.clone();
+        let mut x = self.data.kvs.lock().await;
+        *x = kvs;
+
+        Ok(())
+    }
+
+    fn get_current_snapshot_(&self) -> Result<Option<StoredSnapshot>, io::Error> {
+        Ok(self
+            .db
+            .get_cf(self.store(), b"snapshot")
+            .map_err(io::Error::other)?
+            .and_then(|v| serde_json::from_slice(&v).ok()))
+    }
+
+    fn set_current_snapshot_(&self, snap: StoredSnapshot) -> Result<(), io::Error> {
+        self.db
+            .put_cf(self.store(), b"snapshot", serde_json::to_vec(&snap).unwrap().as_slice())
+            .map_err(io::Error::other)?;
+        self.db.flush_wal(true).map_err(io::Error::other)?;
+        Ok(())
+    }
+
+    fn store(&self) -> &ColumnFamily {
+        self.db.cf_handle("store").unwrap()
+    }
+}
+
+impl RaftStateMachine<TypeConfig> for StateMachineStore {
+    type SnapshotData = Cursor<Vec<u8>>;
+
+    type SnapshotBuilder = Self;
+
+    async fn applied_state(&mut self) -> Result<(Option<LogId>, StoredMembership), io::Error> {
+        Ok((self.data.last_applied_log_id.clone(), self.data.last_membership.clone()))
+    }
+
+    async fn apply<Strm>(&mut self, mut entries: Strm) -> Result<(), io::Error>
+    where Strm: Stream<Item = Result<EntryResponder<TypeConfig>, io::Error>> + Unpin + OptionalSend {
+        while let Some((entry, responder)) = entries.try_next().await? {
+            let version = entry.log_id.index();
+            self.data.last_applied_log_id = Some(entry.log_id.clone());
+
+            let response = match entry.payload {
+                EntryPayload::Blank => types_kv::Response::none(),
+                EntryPayload::Normal(req) => match req {
+                    types_kv::Request::Set { key, value } => {
+                        let mut st = self.data.kvs.lock().await;
+                        st.insert(key, types_kv::VersionedValue {
+                            value: value.clone(),
+                            version,
+                        });
+                        types_kv::Response::new(value, version)
+                    }
+                    types_kv::Request::CompareAndSet {
+                        key,
+                        expected_version,
+                        value,
+                    } => {
+                        let mut st = self.data.kvs.lock().await;
+                        let matches = st.get(&key).is_some_and(|current| current.version == expected_version);
+
+                        if matches {
+                            st.insert(key, types_kv::VersionedValue {
+                                value: value.clone(),
+                                version,
+                            });
+                            types_kv::Response::new(value, version)
+                        } else {
+                            types_kv::Response::none()
+                        }
+                    }
+                },
+                EntryPayload::Membership(mem) => {
+                    self.data.last_membership = StoredMembership::new(Some(entry.log_id), mem);
+                    types_kv::Response::none()
+                }
+            };
+
+            if let Some(responder) = responder {
+                responder.send(response);
+            }
+        }
+        Ok(())
+    }
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        self.snapshot_idx += 1;
+        self.clone()
+    }
+
+    async fn install_snapshot(&mut self, meta: &SnapshotMeta, snapshot: SnapshotData) -> Result<(), io::Error> {
+        let new_snapshot = StoredSnapshot {
+            meta: meta.clone(),
+            data: snapshot.into_inner(),
+        };
+
+        self.update_state_machine_(new_snapshot.clone()).await?;
+
+        self.set_current_snapshot_(new_snapshot)?;
+
+        Ok(())
+    }
+
+    async fn get_current_snapshot(&mut self) -> Result<Option<Snapshot>, io::Error> {
+        let x = self.get_current_snapshot_()?;
+        Ok(x.map(|s| Snapshot {
+            meta: s.meta.clone(),
+            snapshot: Cursor::new(s.data.clone()),
+        }))
+    }
+}
+
+pub(crate) async fn new_storage<P: AsRef<Path>>(db_path: P) -> (RocksLogStore<TypeConfig>, StateMachineStore) {
+    let mut db_opts = Options::default();
+    db_opts.create_missing_column_families(true);
+    db_opts.create_if_missing(true);
+
+    let store = ColumnFamilyDescriptor::new("store", Options::default());
+    let meta = ColumnFamilyDescriptor::new("meta", Options::default());
+    let logs = ColumnFamilyDescriptor::new("logs", Options::default());
+
+    let db = DB::open_cf_descriptors(&db_opts, db_path, vec![store, meta, logs]).unwrap();
+    let db = Arc::new(db);
+
+    let log_store = RocksLogStore::new(db.clone());
+    let sm_store = StateMachineStore::new(db).await.unwrap();
+
+    (log_store, sm_store)
+}

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -1,14 +1,14 @@
 (ns jepsen.openraft.cli
   (:gen-class)
   (:require [jepsen [checker :as checker]
-                    [cli :as cli]
-                    [generator :as gen]
-                    [tests :as tests]]
+             [cli :as cli]
+             [generator :as gen]
+             [tests :as tests]]
             [jepsen.openraft [db :as openraft-db]
-                             [workload :as workload]]
+             [workload :as workload]]
             [jepsen.openraft.nemesis [membership :as membership]
-                                     [partition :as partition]
-                                     [process :as process]]))
+             [partition :as partition]
+             [process :as process]]))
 
 (def nemesis-types
   #{:membership :partition :process})
@@ -33,8 +33,8 @@
         nemesis-type (:nemesis opts :partition)
         nemesis-package (case nemesis-type
                           :membership (membership/membership-package
-                                        database
-                                        opts)
+                                       database
+                                       opts)
                           :partition (partition/partition-package)
                           :process (process/process-package database))]
     (merge tests/noop-test
@@ -45,19 +45,19 @@
             :client (:client workload)
             :nemesis (:nemesis nemesis-package)
             :generator (gen/phases
-                         (gen/shortest-any
-                           (gen/nemesis
-                             (gen/phases
-                               (gen/time-limit
-                                 (:time-limit opts)
-                                 (:generator nemesis-package))
-                               (:final-generator nemesis-package)))
-                           (:generator workload))
-                         (:final-generator workload))
+                        (gen/shortest-any
+                         (gen/nemesis
+                          (gen/phases
+                           (gen/time-limit
+                            (:time-limit opts)
+                            (:generator nemesis-package))
+                           (:final-generator nemesis-package)))
+                         (:generator workload))
+                        (:final-generator workload))
             :checker (checker/compose
-                        {:stats (checker/stats)
-                         :nemesis (:checker nemesis-package)
-                         :workload (:checker workload)})})))
+                      {:stats (checker/stats)
+                       :nemesis (:checker nemesis-package)
+                       :workload (:checker workload)})})))
 
 (defn -main [& args]
   (cli/run! (cli/single-test-cmd {:test-fn openraft-test

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -4,8 +4,7 @@
                     [cli :as cli]
                     [generator :as gen]
                     [tests :as tests]]
-            [jepsen.openraft [cluster :as cluster]
-                             [db :as openraft-db]
+            [jepsen.openraft [db :as openraft-db]
                              [workload :as workload]]
             [jepsen.openraft.nemesis [membership :as membership]
                                      [partition :as partition]
@@ -29,8 +28,7 @@
     :validate [nemesis-types (cli/one-of nemesis-types)]]])
 
 (defn openraft-test [opts]
-  (let [opts (assoc opts :node-ids (cluster/node-id-map (:nodes opts)))
-        database (openraft-db/db opts)
+  (let [database (openraft-db/db opts)
         workload (workload/workload opts)
         nemesis-type (:nemesis opts :partition)
         nemesis-package (case nemesis-type

--- a/jepsen/src/jepsen/openraft/cluster.clj
+++ b/jepsen/src/jepsen/openraft/cluster.clj
@@ -66,14 +66,14 @@
 (defn- collect-reachable-metrics [test]
   (into {}
         (keep
-          (fn [node]
-            (try
-              [node (node-metrics! test node)]
-              (catch InterruptedException e
-                (throw e))
-              (catch Exception _
-                nil)))
-          (:nodes test))))
+         (fn [node]
+           (try
+             [node (node-metrics! test node)]
+             (catch InterruptedException e
+               (throw e))
+             (catch Exception _
+               nil)))
+         (:nodes test))))
 
 (defn- cluster-status [test]
   (let [metrics (collect-reachable-metrics test)
@@ -93,7 +93,7 @@
           {:leader leader
            :metrics metrics})))))
 
-(defn- supported-leader? [test metrics [leader leader-metrics]]
+(defn- supported-leader? [metrics [leader leader-metrics]]
   (let [leader-id (client/node-host leader)
         leader-vote (committed-leader-vote leader-metrics leader-id)
         configs (get-in leader-metrics
@@ -119,7 +119,7 @@
   "Returns the membership view of a leader supported by a voter quorum, or nil."
   [test]
   (let [metrics (collect-reachable-metrics test)
-        leaders (filter #(supported-leader? test metrics %) metrics)]
+        leaders (filter #(supported-leader? metrics %) metrics)]
     (when (= 1 (count leaders))
       (let [[leader leader-metrics] (first leaders)
             effective (get leader-metrics :membership_config)
@@ -128,8 +128,8 @@
             committed-configs (get-in committed [:membership :configs])
             voter-configs (voter-config-sets test effective-configs)
             committed-voter-configs (voter-config-sets
-                                      test
-                                      committed-configs)
+                                     test
+                                     committed-configs)
             voters (quorum/voter-set voter-configs)
             members (->> (get-in effective [:membership :nodes])
                          keys
@@ -152,15 +152,15 @@
   "Waits for a committed membership view from a quorum-supported leader."
   [test]
   (util/await-fn
-    #(let [status (membership-status test)]
-       (if (and status
-                (= (:effective-log-id status)
-                   (:committed-log-id status)))
-         status
-         (throw (ex-info "OpenRaft membership is not committed yet"
-                         {:status status}))))
-    {:log-message "Waiting for a committed OpenRaft membership"
-     :timeout 60000}))
+   #(let [status (membership-status test)]
+      (if (and status
+               (= (:effective-log-id status)
+                  (:committed-log-id status)))
+        status
+        (throw (ex-info "OpenRaft membership is not committed yet"
+                        {:status status}))))
+   {:log-message "Waiting for a committed OpenRaft membership"
+    :timeout 60000}))
 
 (defn await-stable-membership!
   "Waits for any stable membership, or for the expected voter set."
@@ -169,23 +169,23 @@
   ([test expected-voters]
    (let [expected-voters (some-> expected-voters set)]
      (util/await-fn
-       #(let [status (membership-status test)]
-          (if (and (:stable? status)
-                   (or (nil? expected-voters)
-                       (= expected-voters (:voters status))))
-            status
-            (throw (ex-info "OpenRaft membership is not stable yet"
-                            {:expected-voters expected-voters
-                             :status status}))))
-       {:log-message "Waiting for OpenRaft membership to become stable"
-        :timeout 60000}))))
+      #(let [status (membership-status test)]
+         (if (and (:stable? status)
+                  (or (nil? expected-voters)
+                      (= expected-voters (:voters status))))
+           status
+           (throw (ex-info "OpenRaft membership is not stable yet"
+                           {:expected-voters expected-voters
+                            :status status}))))
+      {:log-message "Waiting for OpenRaft membership to become stable"
+       :timeout 60000}))))
 
 (defn await-ready! [test]
   (util/await-fn
-    #(or (cluster-status test)
-         (throw (ex-info "OpenRaft cluster is not ready yet" {})))
-    {:log-message "Waiting for every OpenRaft node to agree on a leader"
-     :timeout 60000}))
+   #(or (cluster-status test)
+        (throw (ex-info "OpenRaft cluster is not ready yet" {})))
+   {:log-message "Waiting for every OpenRaft node to agree on a leader"
+    :timeout 60000}))
 
 (defn voter-configs
   "Maps the effective OpenRaft voter configs to Jepsen node names."
@@ -216,14 +216,14 @@
     ;; therefore races with the first add-learner, which fails with
     ;; `ChangeMembershipError::InProgress`.
     (util/await-fn
-      #(let [metrics (client/metrics! leader-endpoint)]
-         (if (and (= leader-id (:current_leader metrics))
-                  (membership-committed? metrics))
-           metrics
-           (throw (ex-info "Initial OpenRaft leader is not ready yet"
-                           {:metrics metrics}))))
-      {:log-message "Waiting for initial OpenRaft leader to commit its membership"
-       :timeout 60000})
+     #(let [metrics (client/metrics! leader-endpoint)]
+        (if (and (= leader-id (:current_leader metrics))
+                 (membership-committed? metrics))
+          metrics
+          (throw (ex-info "Initial OpenRaft leader is not ready yet"
+                          {:metrics metrics}))))
+     {:log-message "Waiting for initial OpenRaft leader to commit its membership"
+      :timeout 60000})
 
     (doseq [node learners
             :let [{:keys [node-id api-addr raft-addr]} (node-info test node)]]

--- a/jepsen/src/jepsen/openraft/cluster.clj
+++ b/jepsen/src/jepsen/openraft/cluster.clj
@@ -6,34 +6,8 @@
             [jepsen.openraft.quorum :as quorum]
             [jepsen.util :as util]))
 
-(defn node-id-map [nodes]
-  (let [entries (mapv
-                  (fn [node]
-                    (let [node-name (client/node-host node)
-                          [_ id] (re-matches #"n([0-9]+)" node-name)]
-                      (when-not id
-                        (throw (ex-info
-                                 "OpenRaft node names must have the form n<ID>"
-                                 {:node node})))
-                      [node-name (parse-long id)]))
-                  nodes)
-        ids (map second entries)]
-    (when-not (= (count ids) (count (set ids)))
-      (throw (ex-info "OpenRaft node IDs must be unique"
-                      {:nodes nodes
-                       :node-ids entries})))
-    (into {} entries)))
-
-(defn node-id [test node]
-  (let [node-name (client/node-host node)]
-    (if-some [id (get (:node-ids test) node-name)]
-      id
-      (throw (ex-info "Node has no OpenRaft ID"
-                      {:node node
-                       :node-ids (:node-ids test)})))))
-
 (defn node-info [test node]
-  {:node-id (node-id test node)
+  {:node-id (client/node-host node)
    :api-addr (client/api-endpoint test node)
    :raft-addr (client/raft-addr test node)})
 
@@ -56,20 +30,22 @@
   (= (get-in metrics [:committed_membership_config :log_id])
      (get-in metrics [:membership_config :log_id])))
 
-(defn- nodes-by-id [test]
-  (set/map-invert (:node-ids test)))
+(defn- test-node-ids [test]
+  (set (map client/node-host (:nodes test))))
 
-(defn- map-node-ids [test ids]
-  (let [nodes (nodes-by-id test)
-        unknown-ids (remove #(contains? nodes %) ids)]
+(defn- validate-node-ids! [test ids]
+  (let [ids (set ids)
+        unknown-ids (set/difference ids (test-node-ids test))]
     (when (seq unknown-ids)
       (throw (ex-info "OpenRaft member is not a Jepsen test node"
-                      {:member-ids (set ids)
+                      {:member-ids ids
                        :unknown-ids (vec unknown-ids)})))
-    (set (map nodes ids))))
+    ids))
 
-(defn- map-voter-configs [test configs]
-  (mapv #(map-node-ids test %) configs))
+(defn- voter-config-sets [test configs]
+  (let [configs (mapv set configs)]
+    (validate-node-ids! test (quorum/voter-set configs))
+    configs))
 
 (defn node-metrics!
   "Fetches metrics from one node while preserving thread interruption."
@@ -108,7 +84,7 @@
                (= 1 (count leaders))
                (every? (comp ready-state? :state val) metrics))
       (let [[leader leader-metrics] (first leaders)
-            leader-id (node-id test leader)
+            leader-id (client/node-host leader)
             leader-vote (committed-leader-vote leader-metrics leader-id)]
         (when (and leader-vote
                    (every? #(and (= leader-id (:current_leader %))
@@ -118,7 +94,7 @@
            :metrics metrics})))))
 
 (defn- supported-leader? [test metrics [leader leader-metrics]]
-  (let [leader-id (node-id test leader)
+  (let [leader-id (client/node-host leader)
         leader-vote (committed-leader-vote leader-metrics leader-id)
         configs (get-in leader-metrics
                         [:membership_config :membership :configs])
@@ -127,7 +103,7 @@
                                 (when (and (= leader-id
                                               (:current_leader metrics))
                                            (= leader-vote (:vote metrics)))
-                                  (node-id test node))))
+                                  (client/node-host node))))
                         set)]
     (and leader-vote
          (= "Leader" (:state leader-metrics))
@@ -135,11 +111,9 @@
          (quorum/quorum? configs supporters))))
 
 (defn- serialized-node-id [id]
-  (cond
-    (integer? id) id
-    (keyword? id) (parse-long (name id))
-    (string? id) (parse-long id)
-    :else nil))
+  (if (keyword? id)
+    (name id)
+    id))
 
 (defn membership-status
   "Returns the membership view of a leader supported by a voter quorum, or nil."
@@ -152,15 +126,15 @@
             committed (get leader-metrics :committed_membership_config)
             effective-configs (get-in effective [:membership :configs])
             committed-configs (get-in committed [:membership :configs])
-            voter-configs (map-voter-configs test effective-configs)
-            committed-voter-configs (map-voter-configs
+            voter-configs (voter-config-sets test effective-configs)
+            committed-voter-configs (voter-config-sets
                                       test
                                       committed-configs)
             voters (quorum/voter-set voter-configs)
-            member-ids (->> (get-in effective [:membership :nodes])
-                            keys
-                            (map serialized-node-id))
-            members (map-node-ids test member-ids)]
+            members (->> (get-in effective [:membership :nodes])
+                         keys
+                         (map serialized-node-id)
+                         (validate-node-ids! test))]
         {:leader leader
          :metrics metrics
          :effective-log-id (:log_id effective)
@@ -169,7 +143,7 @@
          :committed-voter-configs committed-voter-configs
          :voters voters
          :learners (set/difference members voters)
-         :non-members (set/difference (set (:nodes test)) members)
+         :non-members (set/difference (test-node-ids test) members)
          :stable? (and (= 1 (count effective-configs))
                        (= effective-configs committed-configs)
                        (membership-committed? leader-metrics))}))))
@@ -225,11 +199,11 @@
       (throw (ex-info "OpenRaft metrics contain no voter configs"
                       {:leader leader
                        :metrics (get metrics leader)})))
-    (map-voter-configs test configs)))
+    (voter-config-sets test configs)))
 
 (defn bootstrap! [test]
   (let [leader (jepsen/primary test)
-        leader-id (node-id test leader)
+        leader-id (client/node-host leader)
         leader-endpoint (client/api-endpoint test leader)
         learners (remove #{leader} (:nodes test))]
     (info "Initializing OpenRaft cluster on" leader)
@@ -258,6 +232,6 @@
 
     (info "Changing OpenRaft membership to" (:nodes test))
     (client/change-membership! leader-endpoint
-                               (mapv #(node-id test %) (:nodes test)))
+                               (mapv client/node-host (:nodes test)))
 
     (await-ready! test)))

--- a/jepsen/src/jepsen/openraft/db.clj
+++ b/jepsen/src/jepsen/openraft/db.clj
@@ -1,8 +1,8 @@
 (ns jepsen.openraft.db
   (:require [clojure.tools.logging :refer [info]]
             [jepsen [control :as c]
-                    [core :as jepsen]
-                    [db :as db]]
+             [core :as jepsen]
+             [db :as db]]
             [jepsen.control.util :as cu]
             [jepsen.openraft.client :as client]
             [jepsen.openraft.cluster :as cluster]))
@@ -16,17 +16,17 @@
 
 (defn- prepare-dirs! []
   (c/su
-    (c/exec :mkdir :-p data-dir log-dir)))
+   (c/exec :mkdir :-p data-dir log-dir)))
 
 (defn- wipe-data! []
   (c/su
-    (c/exec :rm :-rf data-dir)
-    (c/exec :mkdir :-p data-dir log-dir)))
+   (c/exec :rm :-rf data-dir)
+   (c/exec :mkdir :-p data-dir log-dir)))
 
 (defn- wipe! []
   (wipe-data!)
   (c/su
-    (c/exec :rm :-f log-file)))
+   (c/exec :rm :-f log-file)))
 
 (defn db [_opts]
   (reify
@@ -61,40 +61,40 @@
                                         :api-addr api-addr
                                         :raft-addr raft-addr})
         (c/su
-          (cu/start-daemon!
-            {:chdir data-dir
-             :env {:RUST_BACKTRACE "1"
-                   :RUST_LOG "info"}
-             :logfile log-file
-             :pidfile pid-file}
-            binary
-            :--id node-id
-            :--api-addr api-addr
-            :--raft-addr raft-addr))))
+         (cu/start-daemon!
+          {:chdir data-dir
+           :env {:RUST_BACKTRACE "1"
+                 :RUST_LOG "info"}
+           :logfile log-file
+           :pidfile pid-file}
+          binary
+          :--id node-id
+          :--api-addr api-addr
+          :--raft-addr raft-addr))))
 
-    (kill! [_ _ node]
+    (kill! [_ _ _node]
       (c/su
-        (cu/stop-daemon! process-name pid-file)))))
+       (cu/stop-daemon! process-name pid-file)))))
 
 (defn start-empty-node! [database test node]
   (c/on-nodes
-    test
-    [node]
-    (fn [test node]
-      (info node "starting an empty OpenRaft node")
-      (db/kill! database test node)
-      (wipe-data!)
-      (db/start! database test node)
-      (cu/await-tcp-port
-        (client/node-host node)
-        (:api-port test client/default-api-port)
-        {:timeout 60000}))))
+   test
+   [node]
+   (fn [test node]
+     (info node "starting an empty OpenRaft node")
+     (db/kill! database test node)
+     (wipe-data!)
+     (db/start! database test node)
+     (cu/await-tcp-port
+      (client/node-host node)
+      (:api-port test client/default-api-port)
+      {:timeout 60000}))))
 
 (defn stop-and-wipe-node! [database test node]
   (c/on-nodes
-    test
-    [node]
-    (fn [test node]
-      (info node "stopping and wiping the removed OpenRaft node")
-      (db/kill! database test node)
-      (wipe-data!))))
+   test
+   [node]
+   (fn [test node]
+     (info node "stopping and wiping the removed OpenRaft node")
+     (db/kill! database test node)
+     (wipe-data!))))

--- a/jepsen/src/jepsen/openraft/db.clj
+++ b/jepsen/src/jepsen/openraft/db.clj
@@ -7,8 +7,8 @@
             [jepsen.openraft.client :as client]
             [jepsen.openraft.cluster :as cluster]))
 
-(def binary "/usr/local/bin/raft-key-value-rocks")
-(def process-name "raft-key-value-rocks")
+(def binary "/usr/local/bin/openraft-jepsen-app")
+(def process-name "openraft-jepsen-app")
 (def data-dir "/var/lib/openraft")
 (def log-dir "/var/log/openraft")
 (def log-file (str log-dir "/openraft.log"))
@@ -54,7 +54,7 @@
     db/Kill
     (start! [_ test node]
       (prepare-dirs!)
-      (let [node-id (cluster/node-id test node)
+      (let [node-id (client/node-host node)
             api-addr (client/api-endpoint test node)
             raft-addr (client/raft-addr test node)]
         (info node "starting OpenRaft" {:id node-id

--- a/jepsen/src/jepsen/openraft/nemesis/membership.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/membership.clj
@@ -1,13 +1,13 @@
 (ns jepsen.openraft.nemesis.membership
   (:require [clojure.tools.logging :refer [info]]
             [jepsen [checker :as checker]
-                    [generator :as gen]
-                    [nemesis :as nemesis]
-                    [random :as random]
-                    [util :as util]]
+             [generator :as gen]
+             [nemesis :as nemesis]
+             [random :as random]
+             [util :as util]]
             [jepsen.openraft [client :as client]
-                             [cluster :as cluster]
-                             [db :as openraft-db]]
+             [cluster :as cluster]
+             [db :as openraft-db]]
             [jepsen.openraft.quorum :as quorum]))
 
 (def change-seconds 10)
@@ -46,9 +46,9 @@
 (defn- await-reachable-learner! [test node]
   (try
     (util/await-fn
-      #(cluster/node-metrics! test node)
-      {:log-message (str "Waiting for OpenRaft learner " node)
-       :timeout learner-wait-timeout-ms})
+     #(cluster/node-metrics! test node)
+     {:log-message (str "Waiting for OpenRaft learner " node)
+      :timeout learner-wait-timeout-ms})
     (catch InterruptedException e
       (.interrupt (Thread/currentThread))
       (throw e))
@@ -62,9 +62,9 @@
   [test leader-endpoint target-voters]
   (try
     (request-leader!
-      test
-      leader-endpoint
-      #(client/change-membership! % (voter-ids test target-voters)))
+     test
+     leader-endpoint
+     #(client/change-membership! % (voter-ids test target-voters)))
     (catch Exception e
       (when-not (ambiguous-request-error? e)
         (throw e))
@@ -102,9 +102,9 @@
       (let [status (stable-membership! test)]
         (when-not (= target-voters (:voters status))
           (request-membership-change!
-            test
-            leader-endpoint
-            target-voters)))))
+           test
+           leader-endpoint
+           target-voters)))))
   (try
     (cluster/await-stable-membership! test target-voters)
     (catch Exception e
@@ -117,24 +117,24 @@
 
 (defn- await-observed-learner! [test node]
   (util/await-fn
-    #(let [status (cluster/membership-status test)]
-       (if (and (:stable? status)
-                (contains? (:learners status) node))
-         status
-         (throw (ex-info "OpenRaft learner is not committed yet"
-                         {:node node
-                          :status status}))))
-    {:log-message (str "Waiting for OpenRaft learner " node
-                       " to appear in membership")
-     :timeout learner-wait-timeout-ms}))
+   #(let [status (cluster/membership-status test)]
+      (if (and (:stable? status)
+               (contains? (:learners status) node))
+        status
+        (throw (ex-info "OpenRaft learner is not committed yet"
+                        {:node node
+                         :status status}))))
+   {:log-message (str "Waiting for OpenRaft learner " node
+                      " to appear in membership")
+    :timeout learner-wait-timeout-ms}))
 
 (defn- add-learner-and-confirm!
   [test leader-endpoint node node-id api-addr raft-addr]
   (try
     (request-leader!
-      test
-      leader-endpoint
-      #(client/add-learner! % node-id api-addr raft-addr))
+     test
+     leader-endpoint
+     #(client/add-learner! % node-id api-addr raft-addr))
     (catch Exception e
       (when-not (ambiguous-request-error? e)
         (throw e))
@@ -168,12 +168,12 @@
                :source source
                :leader leader})
         (add-learner-and-confirm!
-          test
-          leader-endpoint
-          node
-          node-id
-          api-addr
-          raft-addr)
+         test
+         leader-endpoint
+         node
+         node-id
+         api-addr
+         raft-addr)
 
         (info "Growing OpenRaft membership"
               {:node node
@@ -182,9 +182,9 @@
 
         (let [final-status
               (change-membership-and-await!
-                test
-                leader-endpoint
-                target-voters)]
+               test
+               leader-endpoint
+               target-voters)]
           {:node node
            :source source
            :leader (:leader final-status)
@@ -194,10 +194,10 @@
 (defn- shrink-candidates [{:keys [voters metrics]}]
   (let [reachable (set (keys metrics))]
     (filter
-      (fn [node]
-        (let [target-voters (disj voters node)]
-          (quorum/quorum? [target-voters] reachable)))
-      voters)))
+     (fn [node]
+       (let [target-voters (disj voters node)]
+         (quorum/quorum? [target-voters] reachable)))
+     voters)))
 
 (defn- shrink! [database test]
   (let [{:keys [leader voters learners] :as status}
@@ -220,9 +220,9 @@
 
           (let [final-status
                 (change-membership-and-await!
-                  test
-                  leader-endpoint
-                  target-voters)]
+                 test
+                 leader-endpoint
+                 target-voters)]
             (openraft-db/stop-and-wipe-node! database test node)
             {:node node
              :leader (:leader final-status)
@@ -265,20 +265,20 @@
 
 (defn membership-nemesis [database]
   (nemesis/validate
-    (MembershipNemesis. database)))
+   (MembershipNemesis. database)))
 
 (defn- membership-generator []
   (gen/stagger
-    change-seconds
-    (gen/phases
-      {:type :info
-       :f :shrink}
-      {:type :info
-       :f :grow}
-      (gen/mix [(repeat {:type :info
-                         :f :grow})
-                (repeat {:type :info
-                         :f :shrink})]))))
+   change-seconds
+   (gen/phases
+    {:type :info
+     :f :shrink}
+    {:type :info
+     :f :grow}
+    (gen/mix [(repeat {:type :info
+                       :f :grow})
+              (repeat {:type :info
+                       :f :shrink})]))))
 
 (defn- coverage-checker []
   (reify checker/Checker
@@ -287,9 +287,9 @@
             expected-voters (set (:nodes test))
             membership-history (->> history
                                     (filter
-                                      #(#{:grow
-                                          :shrink
-                                          :restore-membership} (:f %)))
+                                     #(#{:grow
+                                         :shrink
+                                         :restore-membership} (:f %)))
                                     vec)
             errors (->> membership-history
                         (filter #(or (:error %)
@@ -297,15 +297,15 @@
                         vec)
             observed-changes (->> history
                                   (filter
-                                    #(required-changes (:f %)))
+                                   #(required-changes (:f %)))
                                   (filter
-                                    (fn [op]
-                                      (let [value (:value op)]
-                                        (and (map? value)
-                                             (contains? value :before)
-                                             (contains? value :after)
-                                             (not= (:before value)
-                                                   (:after value))))))
+                                   (fn [op]
+                                     (let [value (:value op)]
+                                       (and (map? value)
+                                            (contains? value :before)
+                                            (contains? value :after)
+                                            (not= (:before value)
+                                                  (:after value))))))
                                   (map :f)
                                   set)
             missing-changes (remove observed-changes

--- a/jepsen/src/jepsen/openraft/nemesis/membership.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/membership.clj
@@ -23,7 +23,7 @@
 (defn- voter-ids [test voters]
   (->> (:nodes test)
        (filter (set voters))
-       (mapv #(cluster/node-id test %))))
+       (mapv client/node-host)))
 
 (defn- request-leader! [test leader-endpoint request]
   (client/with-leader!

--- a/jepsen/src/jepsen/openraft/nemesis/partition.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/partition.clj
@@ -1,9 +1,9 @@
 (ns jepsen.openraft.nemesis.partition
   (:require [clojure.tools.logging :refer [info]]
             [jepsen [checker :as checker]
-                    [generator :as gen]
-                    [nemesis :as nemesis]
-                    [random :as random]]
+             [generator :as gen]
+             [nemesis :as nemesis]
+             [random :as random]]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.quorum :as quorum]))
 
@@ -89,25 +89,25 @@
 
 (defn partition-nemesis []
   (nemesis/validate
-    (PartitionNemesis. (nemesis/partitioner))))
+   (PartitionNemesis. (nemesis/partitioner))))
 
 (defn- partition-generator []
   (gen/cycle
-    (gen/phases
-      (gen/sleep recovery-seconds)
-      {:type :info
-       :f :start-partition
-       :value :leader-in-majority}
-      (gen/sleep partition-seconds)
-      {:type :info
-       :f :stop-partition}
-      (gen/sleep recovery-seconds)
-      {:type :info
-       :f :start-partition
-       :value :leader-in-minority}
-      (gen/sleep partition-seconds)
-      {:type :info
-       :f :stop-partition})))
+   (gen/phases
+    (gen/sleep recovery-seconds)
+    {:type :info
+     :f :start-partition
+     :value :leader-in-majority}
+    (gen/sleep partition-seconds)
+    {:type :info
+     :f :stop-partition}
+    (gen/sleep recovery-seconds)
+    {:type :info
+     :f :start-partition
+     :value :leader-in-minority}
+    (gen/sleep partition-seconds)
+    {:type :info
+     :f :stop-partition})))
 
 (defn- next-cluster-state
   "Applies one nemesis operation to the partition lifecycle state.
@@ -167,8 +167,8 @@
   {:nemesis (partition-nemesis)
    :generator (partition-generator)
    :final-generator (gen/phases
-                      (gen/once {:type :info
-                                 :f :stop-partition})
-                      (gen/once {:type :info
-                                 :f :await-recovery}))
+                     (gen/once {:type :info
+                                :f :stop-partition})
+                     (gen/once {:type :info
+                                :f :await-recovery}))
    :checker (coverage-checker)})

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -1,9 +1,9 @@
 (ns jepsen.openraft.nemesis.process
   (:require [clojure.tools.logging :refer [info]]
             [jepsen [checker :as checker]
-                    [generator :as gen]
-                    [nemesis :as nemesis]
-                    [random :as random]]
+             [generator :as gen]
+             [nemesis :as nemesis]
+             [random :as random]]
             [jepsen.nemesis.combined :as combined]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.quorum :as quorum]))
@@ -101,29 +101,29 @@
 
 (defn process-nemesis [db]
   (nemesis/validate
-    (ProcessNemesis. (combined/db-nemesis db) (atom nil))))
+   (ProcessNemesis. (combined/db-nemesis db) (atom nil))))
 
 (defn- process-generator []
   (gen/cycle
-    (gen/phases
-      (gen/sleep healthy-seconds)
-      {:type :info
-       :f :kill-process
-       :value :leader-survives}
-      (gen/sleep downtime-seconds)
-      {:type :info
-       :f :restart-process}
-      {:type :info
-       :f :await-recovery}
-      (gen/sleep healthy-seconds)
-      {:type :info
-       :f :kill-process
-       :value :leader-killed}
-      (gen/sleep downtime-seconds)
-      {:type :info
-       :f :restart-process}
-      {:type :info
-       :f :await-recovery})))
+   (gen/phases
+    (gen/sleep healthy-seconds)
+    {:type :info
+     :f :kill-process
+     :value :leader-survives}
+    (gen/sleep downtime-seconds)
+    {:type :info
+     :f :restart-process}
+    {:type :info
+     :f :await-recovery}
+    (gen/sleep healthy-seconds)
+    {:type :info
+     :f :kill-process
+     :value :leader-killed}
+    (gen/sleep downtime-seconds)
+    {:type :info
+     :f :restart-process}
+    {:type :info
+     :f :await-recovery})))
 
 (defn- coverage-checker []
   (reify checker/Checker
@@ -134,36 +134,36 @@
                                 set)
             missing-modes (remove observed-modes required-process-modes)
             cluster-state (reduce
-                            (fn [state op]
-                              (let [operation-error? (boolean
-                                                      (or (:error op)
-                                                          (:exception op)))]
-                                (cond
-                                  (and (= :kill-process (:f op))
-                                       operation-error?)
-                                  :unknown
+                           (fn [state op]
+                             (let [operation-error? (boolean
+                                                     (or (:error op)
+                                                         (:exception op)))]
+                               (cond
+                                 (and (= :kill-process (:f op))
+                                      operation-error?)
+                                 :unknown
 
-                                  (and (= :kill-process (:f op))
-                                       (get-in op [:value :mode]))
-                                  :degraded
+                                 (and (= :kill-process (:f op))
+                                      (get-in op [:value :mode]))
+                                 :degraded
 
-                                  (and (= :restart-process (:f op))
-                                       operation-error?)
-                                  :unknown
+                                 (and (= :restart-process (:f op))
+                                      operation-error?)
+                                 :unknown
 
-                                  (and (= :await-recovery (:f op))
-                                       (get-in op [:value :leader]))
-                                  :intact
+                                 (and (= :await-recovery (:f op))
+                                      (get-in op [:value :leader]))
+                                 :intact
 
-                                  (and (= :await-recovery (:f op))
-                                       operation-error?)
-                                  (if (= :degraded state)
-                                    :degraded
-                                    :unknown)
+                                 (and (= :await-recovery (:f op))
+                                      operation-error?)
+                                 (if (= :degraded state)
+                                   :degraded
+                                   :unknown)
 
-                                  :else state)))
-                            :intact
-                            history)
+                                 :else state)))
+                           :intact
+                           history)
             valid? (cond
                      (seq missing-modes) false
                      (= :intact cluster-state) true
@@ -178,8 +178,8 @@
   {:nemesis (process-nemesis db)
    :generator (process-generator)
    :final-generator (gen/phases
-                      (gen/once {:type :info
-                                 :f :restart-process})
-                      (gen/once {:type :info
-                                 :f :await-recovery}))
+                     (gen/once {:type :info
+                                :f :restart-process})
+                     (gen/once {:type :info
+                                :f :await-recovery}))
    :checker (coverage-checker)})

--- a/jepsen/src/jepsen/openraft/workload.clj
+++ b/jepsen/src/jepsen/openraft/workload.clj
@@ -1,8 +1,8 @@
 (ns jepsen.openraft.workload
   (:require [jepsen [checker :as checker]
-                    [client :as client]
-                    [core :as jepsen]
-                    [generator :as gen]]
+             [client :as client]
+             [core :as jepsen]
+             [generator :as gen]]
             [jepsen.openraft.client :as http]
             [knossos.model :as model]))
 
@@ -219,16 +219,16 @@
                              (cas-op latest-value value-counter)])]
     {:client (client/validate (KVClient. nil nil nil latest-value))
      :generator (gen/clients
-                  (gen/phases
-                    (gen/once {:type :invoke
-                               :f :write
-                               :value (next-value! value-counter)})
-                    (gen/stagger 0.1 operations)))
+                 (gen/phases
+                  (gen/once {:type :invoke
+                             :f :write
+                             :value (next-value! value-counter)})
+                  (gen/stagger 0.1 operations)))
      :final-generator (gen/clients
-                        (gen/phases
-                          (gen/once (final-write-op value-counter))
-                          (gen/once final-read-op)))
+                       (gen/phases
+                        (gen/once (final-write-op value-counter))
+                        (gen/once final-read-op)))
      :checker (checker/compose
-                {:linearizable (checker/linearizable
-                                 {:model (model/cas-register)})
-                 :unexpected-errors (unexpected-errors-checker)})}))
+               {:linearizable (checker/linearizable
+                               {:model (model/cas-register)})
+                :unexpected-errors (unexpected-errors-checker)})}))

--- a/jepsen/test/jepsen/openraft/cluster_test.clj
+++ b/jepsen/test/jepsen/openraft/cluster_test.clj
@@ -6,9 +6,6 @@
 
 (def test-config
   {:nodes ["n1" "n2" "n3"]
-   :node-ids {"n1" 1
-              "n2" 2
-              "n3" 3}
    :api-port 21001})
 
 (defn- vote [term leader]
@@ -16,29 +13,16 @@
                :node_id leader}
    :committed true})
 
-(deftest node-ids-do-not-depend-on-node-order
-  (let [node-ids (cluster/node-id-map ["n3" "n1" "n2"])
-        test (assoc test-config
-                    :nodes ["n2" "n3" "n1"]
-                    :node-ids node-ids)]
-    (is (= {"n1" 1
-            "n2" 2
-            "n3" 3}
-           node-ids))
-    (is (= 1 (cluster/node-id test "n1")))
-    (is (= 2 (cluster/node-id test "n2")))
-    (is (= 3 (cluster/node-id test "n3")))))
-
 (deftest finds-the-leader-agreed-on-by-all-nodes
   (let [metrics {"n1:21001" {:state "Follower"
-                              :current_leader 2
-                              :vote (vote 3 2)}
+                              :current_leader "n2"
+                              :vote (vote 3 "n2")}
                  "n2:21001" {:state "Leader"
-                              :current_leader 2
-                              :vote (vote 3 2)}
+                              :current_leader "n2"
+                              :vote (vote 3 "n2")}
                  "n3:21001" {:state "Follower"
-                              :current_leader 2
-                              :vote (vote 3 2)}}]
+                              :current_leader "n2"
+                              :vote (vote 3 "n2")}}]
     (with-redefs [client/metrics! metrics]
       (let [status (#'cluster/cluster-status test-config)]
         (is (= "n2" (:leader status)))
@@ -46,37 +30,37 @@
 
 (deftest rejects-disagreement-about-the-leader
   (let [metrics {"n1:21001" {:state "Leader"
-                              :current_leader 1
-                              :vote (vote 2 1)}
+                              :current_leader "n1"
+                              :vote (vote 2 "n1")}
                  "n2:21001" {:state "Follower"
-                              :current_leader 1
-                              :vote (vote 2 1)}
+                              :current_leader "n1"
+                              :vote (vote 2 "n1")}
                  "n3:21001" {:state "Leader"
-                              :current_leader 3
-                              :vote (vote 3 3)}}]
+                              :current_leader "n3"
+                              :vote (vote 3 "n3")}}]
     (with-redefs [client/metrics! metrics]
       (is (nil? (#'cluster/cluster-status test-config))))))
 
 (deftest rejects-a-node-without-a-known-leader
   (let [metrics {"n1:21001" {:state "Follower"
-                              :current_leader 2
-                              :vote (vote 3 2)}
+                              :current_leader "n2"
+                              :vote (vote 3 "n2")}
                  "n2:21001" {:state "Leader"
-                              :current_leader 2
-                              :vote (vote 3 2)}
+                              :current_leader "n2"
+                              :vote (vote 3 "n2")}
                  "n3:21001" {:state "Follower"
                               :current_leader nil
-                              :vote (vote 3 2)}}]
+                              :vote (vote 3 "n2")}}]
     (with-redefs [client/metrics! metrics]
       (is (nil? (#'cluster/cluster-status test-config))))))
 
 (deftest rejects-an-unreachable-test-node
   (let [metrics {"n1:21001" {:state "Follower"
-                              :current_leader 2
-                              :vote (vote 3 2)}
+                              :current_leader "n2"
+                              :vote (vote 3 "n2")}
                  "n2:21001" {:state "Leader"
-                              :current_leader 2
-                              :vote (vote 3 2)}}]
+                              :current_leader "n2"
+                              :vote (vote 3 "n2")}}]
     (with-redefs [client/metrics!
                   (fn [endpoint]
                     (or (get metrics endpoint)
@@ -129,19 +113,21 @@
 
 (def five-node-config
   {:nodes ["n1" "n2" "n3" "n4" "n5"]
-   :node-ids {"n1" 1
-              "n2" 2
-              "n3" 3
-              "n4" 4
-              "n5" 5}
    :api-port 21001})
 
 (deftest observes-a-stable-membership
-  (let [membership (stored-membership 7 [[1 2 3]] [1 2 3 4])
-        responses {"n1:21001" (metrics "Leader" 1 membership membership)
-                   "n2:21001" (metrics "Follower" 1 membership membership)
-                   "n3:21001" (metrics "Follower" 1 membership membership)
-                   "n4:21001" (metrics "Learner" 1 membership membership)}]
+  (let [membership (stored-membership
+                     7
+                     [["n1" "n2" "n3"]]
+                     ["n1" "n2" "n3" "n4"])
+        responses {"n1:21001" (metrics "Leader" "n1"
+                                       membership membership)
+                   "n2:21001" (metrics "Follower" "n1"
+                                       membership membership)
+                   "n3:21001" (metrics "Follower" "n1"
+                                       membership membership)
+                   "n4:21001" (metrics "Learner" "n1"
+                                       membership membership)}]
     (with-redefs [client/metrics!
                   (fn [endpoint]
                     (or (get responses endpoint)
@@ -157,15 +143,23 @@
         (is (= #{"n5"} (:non-members status)))))))
 
 (deftest observes-a-joint-membership
-  (let [committed (stored-membership 7 [[1 2 3]] [1 2 3 4])
+  (let [committed (stored-membership
+                    7
+                    [["n1" "n2" "n3"]]
+                    ["n1" "n2" "n3" "n4"])
         effective (stored-membership
                     8
-                    [[1 2 3] [1 2 3 4]]
-                    [1 2 3 4])
-        responses {"n1:21001" (metrics "Leader" 1 effective committed)
-                   "n2:21001" (metrics "Follower" 1 effective committed)
-                   "n3:21001" (metrics "Follower" 1 effective committed)
-                   "n4:21001" (metrics "Follower" 1 effective committed)
+                    [["n1" "n2" "n3"]
+                     ["n1" "n2" "n3" "n4"]]
+                    ["n1" "n2" "n3" "n4"])
+        responses {"n1:21001" (metrics "Leader" "n1"
+                                       effective committed)
+                   "n2:21001" (metrics "Follower" "n1"
+                                       effective committed)
+                   "n3:21001" (metrics "Follower" "n1"
+                                       effective committed)
+                   "n4:21001" (metrics "Follower" "n1"
+                                       effective committed)
                    "n5:21001" (metrics "Learner" nil effective committed)}]
     (with-redefs [client/metrics! responses]
       (let [status (cluster/membership-status five-node-config)]
@@ -202,29 +196,37 @@
       (is (= [:retry] @attempts)))))
 
 (deftest rejects-support-from-an-older-leader-term
-  (let [membership (stored-membership 7 [[1 2 3]] [1 2 3])
-        responses {"n1:21001" (metrics "Leader" 3 1
+  (let [membership (stored-membership
+                     7
+                     [["n1" "n2" "n3"]]
+                     ["n1" "n2" "n3"])
+        responses {"n1:21001" (metrics "Leader" 3 "n1"
                                        membership membership)
-                   "n2:21001" (metrics "Follower" 2 1
+                   "n2:21001" (metrics "Follower" 2 "n1"
                                        membership membership)
-                   "n3:21001" (metrics "Follower" 2 1
+                   "n3:21001" (metrics "Follower" 2 "n1"
                                        membership membership)}]
     (with-redefs [client/metrics! responses]
       (is (nil? (cluster/membership-status test-config))))))
 
 (deftest ignores-a-stale-removed-leader
-  (let [old-membership (stored-membership 7 [[1 2 3 4 5]]
-                                          [1 2 3 4 5])
-        membership (stored-membership 9 [[2 3 4]] [2 3 4])
-        responses {"n1:21001" (metrics "Leader" 1
+  (let [old-membership (stored-membership
+                         7
+                         [["n1" "n2" "n3" "n4" "n5"]]
+                         ["n1" "n2" "n3" "n4" "n5"])
+        membership (stored-membership
+                     9
+                     [["n2" "n3" "n4"]]
+                     ["n2" "n3" "n4"])
+        responses {"n1:21001" (metrics "Leader" "n1"
                                        old-membership old-membership)
-                   "n2:21001" (metrics "Leader" 2
+                   "n2:21001" (metrics "Leader" "n2"
                                        membership membership)
-                   "n3:21001" (metrics "Follower" 2
+                   "n3:21001" (metrics "Follower" "n2"
                                        membership membership)
-                   "n4:21001" (metrics "Follower" 2
+                   "n4:21001" (metrics "Follower" "n2"
                                        membership membership)
-                   "n5:21001" (metrics "Candidate" 1
+                   "n5:21001" (metrics "Candidate" "n1"
                                        old-membership old-membership)}]
     (with-redefs [client/metrics! responses]
       (let [status (cluster/membership-status five-node-config)]
@@ -234,13 +236,10 @@
 
 (deftest maps-joint-voter-configs
   (let [test (assoc test-config
-                    :nodes ["n1" "n2" "n3" "n4"]
-                    :node-ids {"n1" 1
-                               "n2" 2
-                               "n3" 3
-                               "n4" 4})
+                    :nodes ["n1" "n2" "n3" "n4"])
         status {:leader "n2"
-                :metrics {"n2" (membership [[1 2 3] [1 2 4]])}}]
+                :metrics {"n2" (membership [["n1" "n2" "n3"]
+                                            ["n1" "n2" "n4"]])}}]
     (is (= [#{"n1" "n2" "n3"}
             #{"n1" "n2" "n4"}]
            (cluster/voter-configs test status)))))

--- a/jepsen/test/jepsen/openraft/cluster_test.clj
+++ b/jepsen/test/jepsen/openraft/cluster_test.clj
@@ -15,14 +15,14 @@
 
 (deftest finds-the-leader-agreed-on-by-all-nodes
   (let [metrics {"n1:21001" {:state "Follower"
-                              :current_leader "n2"
-                              :vote (vote 3 "n2")}
+                             :current_leader "n2"
+                             :vote (vote 3 "n2")}
                  "n2:21001" {:state "Leader"
-                              :current_leader "n2"
-                              :vote (vote 3 "n2")}
+                             :current_leader "n2"
+                             :vote (vote 3 "n2")}
                  "n3:21001" {:state "Follower"
-                              :current_leader "n2"
-                              :vote (vote 3 "n2")}}]
+                             :current_leader "n2"
+                             :vote (vote 3 "n2")}}]
     (with-redefs [client/metrics! metrics]
       (let [status (#'cluster/cluster-status test-config)]
         (is (= "n2" (:leader status)))
@@ -30,37 +30,37 @@
 
 (deftest rejects-disagreement-about-the-leader
   (let [metrics {"n1:21001" {:state "Leader"
-                              :current_leader "n1"
-                              :vote (vote 2 "n1")}
+                             :current_leader "n1"
+                             :vote (vote 2 "n1")}
                  "n2:21001" {:state "Follower"
-                              :current_leader "n1"
-                              :vote (vote 2 "n1")}
+                             :current_leader "n1"
+                             :vote (vote 2 "n1")}
                  "n3:21001" {:state "Leader"
-                              :current_leader "n3"
-                              :vote (vote 3 "n3")}}]
+                             :current_leader "n3"
+                             :vote (vote 3 "n3")}}]
     (with-redefs [client/metrics! metrics]
       (is (nil? (#'cluster/cluster-status test-config))))))
 
 (deftest rejects-a-node-without-a-known-leader
   (let [metrics {"n1:21001" {:state "Follower"
-                              :current_leader "n2"
-                              :vote (vote 3 "n2")}
+                             :current_leader "n2"
+                             :vote (vote 3 "n2")}
                  "n2:21001" {:state "Leader"
-                              :current_leader "n2"
-                              :vote (vote 3 "n2")}
+                             :current_leader "n2"
+                             :vote (vote 3 "n2")}
                  "n3:21001" {:state "Follower"
-                              :current_leader nil
-                              :vote (vote 3 "n2")}}]
+                             :current_leader nil
+                             :vote (vote 3 "n2")}}]
     (with-redefs [client/metrics! metrics]
       (is (nil? (#'cluster/cluster-status test-config))))))
 
 (deftest rejects-an-unreachable-test-node
   (let [metrics {"n1:21001" {:state "Follower"
-                              :current_leader "n2"
-                              :vote (vote 3 "n2")}
+                             :current_leader "n2"
+                             :vote (vote 3 "n2")}
                  "n2:21001" {:state "Leader"
-                              :current_leader "n2"
-                              :vote (vote 3 "n2")}}]
+                             :current_leader "n2"
+                             :vote (vote 3 "n2")}}]
     (with-redefs [client/metrics!
                   (fn [endpoint]
                     (or (get metrics endpoint)
@@ -71,7 +71,7 @@
 (deftest preserves-metrics-request-interruption
   (doseq [[label error] [[:raw #(InterruptedException. "interrupted")]
                          [:wrapped #(ex-info "interrupted"
-                                            {:kind :interrupted})]]]
+                                             {:kind :interrupted})]]]
     (let [interrupted?
           @(future
              (with-redefs [client/metrics!
@@ -117,9 +117,9 @@
 
 (deftest observes-a-stable-membership
   (let [membership (stored-membership
-                     7
-                     [["n1" "n2" "n3"]]
-                     ["n1" "n2" "n3" "n4"])
+                    7
+                    [["n1" "n2" "n3"]]
+                    ["n1" "n2" "n3" "n4"])
         responses {"n1:21001" (metrics "Leader" "n1"
                                        membership membership)
                    "n2:21001" (metrics "Follower" "n1"
@@ -144,14 +144,14 @@
 
 (deftest observes-a-joint-membership
   (let [committed (stored-membership
-                    7
-                    [["n1" "n2" "n3"]]
-                    ["n1" "n2" "n3" "n4"])
+                   7
+                   [["n1" "n2" "n3"]]
+                   ["n1" "n2" "n3" "n4"])
         effective (stored-membership
-                    8
-                    [["n1" "n2" "n3"]
-                     ["n1" "n2" "n3" "n4"]]
-                    ["n1" "n2" "n3" "n4"])
+                   8
+                   [["n1" "n2" "n3"]
+                    ["n1" "n2" "n3" "n4"]]
+                   ["n1" "n2" "n3" "n4"])
         responses {"n1:21001" (metrics "Leader" "n1"
                                        effective committed)
                    "n2:21001" (metrics "Follower" "n1"
@@ -197,9 +197,9 @@
 
 (deftest rejects-support-from-an-older-leader-term
   (let [membership (stored-membership
-                     7
-                     [["n1" "n2" "n3"]]
-                     ["n1" "n2" "n3"])
+                    7
+                    [["n1" "n2" "n3"]]
+                    ["n1" "n2" "n3"])
         responses {"n1:21001" (metrics "Leader" 3 "n1"
                                        membership membership)
                    "n2:21001" (metrics "Follower" 2 "n1"
@@ -211,13 +211,13 @@
 
 (deftest ignores-a-stale-removed-leader
   (let [old-membership (stored-membership
-                         7
-                         [["n1" "n2" "n3" "n4" "n5"]]
-                         ["n1" "n2" "n3" "n4" "n5"])
+                        7
+                        [["n1" "n2" "n3" "n4" "n5"]]
+                        ["n1" "n2" "n3" "n4" "n5"])
         membership (stored-membership
-                     9
-                     [["n2" "n3" "n4"]]
-                     ["n2" "n3" "n4"])
+                    9
+                    [["n2" "n3" "n4"]]
+                    ["n2" "n3" "n4"])
         responses {"n1:21001" (metrics "Leader" "n1"
                                        old-membership old-membership)
                    "n2:21001" (metrics "Leader" "n2"

--- a/jepsen/test/jepsen/openraft/nemesis/membership_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/membership_test.clj
@@ -13,11 +13,6 @@
 
 (def test-config
   {:nodes nodes
-   :node-ids {"n1" 1
-              "n2" 2
-              "n3" 3
-              "n4" 4
-              "n5" 5}
    :api-port 21001
    :raft-port 22001})
 
@@ -25,8 +20,8 @@
   (ex-info "forward"
            {:kind :openraft-error
             :error {:ForwardToLeader
-                    {:leader_id 2
-                     :leader_node {:data endpoint}}}}))
+                     {:leader_id "n2"
+                      :leader_node {:data endpoint}}}}))
 
 (deftest shrink-confirms-membership-before-wiping
   (let [calls (atom [])
@@ -62,7 +57,8 @@
                      {:type :info
                       :f :shrink})]
         (is (= [[:await nil]
-                [:change-membership "n1:21001" [1 2 3 4]]
+                [:change-membership "n1:21001"
+                 ["n1" "n2" "n3" "n4"]]
                 [:await after]
                 [:stop-and-wipe :database "n5"]]
                @calls))
@@ -116,10 +112,11 @@
                 [:start-empty :database "n5"]
                 [:add-learner
                  "n1:21001"
-                 5
+                 "n5"
                  "n5:21001"
                  "n5:22001"]
-                [:change-membership "n1:21001" [1 2 3 4 5]]
+                [:change-membership "n1:21001"
+                 ["n1" "n2" "n3" "n4" "n5"]]
                 [:await after]]
                @calls))
         (is (= {:node "n5"
@@ -262,7 +259,9 @@
       (fn []
         (is (= stable
                (#'membership/stable-membership! test-config)))
-        (is (= [[:change-membership "n1:21001" [1 2 3 4]]
+        (is (= [[:change-membership
+                 "n1:21001"
+                 ["n1" "n2" "n3" "n4"]]
                 [:await target]]
                @calls))))))
 
@@ -383,9 +382,13 @@
                        test-config
                        {:type :info
                         :f :shrink})
-      (is (= [[:change-membership "n1:21001" [1 2 3 4]]
+      (is (= [[:change-membership
+               "n1:21001"
+               ["n1" "n2" "n3" "n4"]]
               [:await after]
-              [:change-membership "n1:21001" [1 2 3 4]]
+              [:change-membership
+               "n1:21001"
+               ["n1" "n2" "n3" "n4"]]
               [:await after]
               [:stop-and-wipe "n5"]]
              @calls)))))
@@ -422,7 +425,9 @@
                      test-config
                      {:type :info
                       :f :shrink})))
-      (is (= [[:change-membership "n1:21001" [1 2 3 4]]
+      (is (= [[:change-membership
+               "n1:21001"
+               ["n1" "n2" "n3" "n4"]]
               [:await after]]
              @calls))
       (is (false? @wiped?)))))

--- a/jepsen/test/jepsen/openraft/nemesis/membership_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/membership_test.clj
@@ -1,11 +1,11 @@
 (ns jepsen.openraft.nemesis.membership-test
   (:require [clojure.test :refer [deftest is testing]]
             [jepsen [checker :as checker]
-                    [nemesis :as nemesis]
-                    [util :as util]]
+             [nemesis :as nemesis]
+             [util :as util]]
             [jepsen.openraft [client :as client]
-                             [cluster :as cluster]
-                             [db :as openraft-db]]
+             [cluster :as cluster]
+             [db :as openraft-db]]
             [jepsen.openraft.nemesis.membership :as membership]
             [jepsen.random :as random]))
 
@@ -20,8 +20,8 @@
   (ex-info "forward"
            {:kind :openraft-error
             :error {:ForwardToLeader
-                     {:leader_id "n2"
-                      :leader_node {:data endpoint}}}}))
+                    {:leader_id "n2"
+                     :leader_node {:data endpoint}}}}))
 
 (deftest shrink-confirms-membership-before-wiping
   (let [calls (atom [])
@@ -52,10 +52,10 @@
                   (fn [database _test node]
                     (swap! calls conj [:stop-and-wipe database node]))]
       (let [result (nemesis/invoke!
-                     subject
-                     test-config
-                     {:type :info
-                      :f :shrink})]
+                    subject
+                    test-config
+                    {:type :info
+                     :f :shrink})]
         (is (= [[:await nil]
                 [:change-membership "n1:21001"
                  ["n1" "n2" "n3" "n4"]]
@@ -104,10 +104,10 @@
                     (swap! calls conj
                            [:change-membership endpoint node-ids]))]
       (let [result (nemesis/invoke!
-                     subject
-                     test-config
-                     {:type :info
-                      :f :grow})]
+                    subject
+                    test-config
+                    {:type :info
+                     :f :grow})]
         (is (= [[:await nil]
                 [:start-empty :database "n5"]
                 [:add-learner
@@ -226,10 +226,10 @@
                   (fn [_endpoint _node-ids]
                     (swap! calls conj :change-membership))]
       (let [result (nemesis/invoke!
-                     subject
-                     test-config
-                     {:type :info
-                      :f :grow})]
+                    subject
+                    test-config
+                    {:type :info
+                     :f :grow})]
         (is (= [:add-learner
                 :observe-learner
                 :change-membership
@@ -277,10 +277,10 @@
          (swap! calls conj :change-membership)
          (when (= 1 (count @calls))
            (throw (ex-info
-                    "in progress"
-                    {:kind :openraft-error
-                     :error {:ChangeMembershipError
-                             {:InProgress {}}}}))))
+                   "in progress"
+                   {:kind :openraft-error
+                    :error {:ChangeMembershipError
+                            {:InProgress {}}}}))))
        #'membership/stable-membership!
        (fn [_test]
          (swap! calls conj :complete-pending)
@@ -292,9 +292,9 @@
       (fn []
         (is (= final
                (#'membership/change-membership-and-await!
-                 test-config
-                 (atom "n1:21001")
-                 target)))
+                test-config
+                (atom "n1:21001")
+                target)))
         (is (= [:change-membership
                 :complete-pending
                 :change-membership
@@ -421,10 +421,10 @@
                     (reset! wiped? true))]
       (is (thrown? Exception
                    (nemesis/invoke!
-                     subject
-                     test-config
-                     {:type :info
-                      :f :shrink})))
+                    subject
+                    test-config
+                    {:type :info
+                     :f :shrink})))
       (is (= [[:change-membership
                "n1:21001"
                ["n1" "n2" "n3" "n4"]]
@@ -450,10 +450,10 @@
                   (fn [& _]
                     (throw (ex-info "MUST NOT wipe a voter" {})))]
       (let [result (nemesis/invoke!
-                     subject
-                     test-config
-                     {:type :info
-                      :f :shrink})]
+                    subject
+                    test-config
+                    {:type :info
+                     :f :shrink})]
         (is (= :minimum-membership (:value result)))))))
 
 (deftest restores-all-test-nodes-as-voters
@@ -480,10 +480,10 @@
          {:leader "n2"})}
       (fn []
         (let [result (nemesis/invoke!
-                       subject
-                       test-config
-                       {:type :info
-                        :f :restore-membership})]
+                      subject
+                      test-config
+                      {:type :info
+                       :f :restore-membership})]
           (is (= 2 @grow-count))
           (is (= {:leader "n2"
                   :voters (set nodes)}
@@ -499,10 +499,10 @@
       (fn []
         (let [error (try
                       (nemesis/invoke!
-                        subject
-                        test-config
-                        {:type :info
-                         :f :restore-membership})
+                       subject
+                       test-config
+                       {:type :info
+                        :f :restore-membership})
                       nil
                       (catch clojure.lang.ExceptionInfo e
                         e))]
@@ -526,8 +526,8 @@
 
 (deftest checks-membership-coverage-and-restoration
   (let [subject (:checker (membership/membership-package
-                            :database
-                            test-config))
+                           :database
+                           test-config))
         all-voters (set nodes)
         four-voters #{"n1" "n2" "n3" "n4"}
         shrink {:type :info
@@ -551,14 +551,14 @@
 
     (testing "a no-op does not count as membership change coverage"
       (let [result (checker/check
-                     subject
-                     test-config
-                     [shrink
-                      {:type :info
-                       :f :grow
-                       :value :membership-full}
-                      restore]
-                     {})]
+                    subject
+                    test-config
+                    [shrink
+                     {:type :info
+                      :f :grow
+                      :value :membership-full}
+                     restore]
+                    {})]
         (is (false? (:valid? result)))
         (is (= [:grow] (:missing-changes result)))))
 
@@ -580,13 +580,13 @@
 
     (testing "a nemesis operation error invalidates the test"
       (let [result (checker/check
-                     subject
-                     test-config
-                     (conj complete-history
-                           {:type :info
-                            :f :grow
-                            :error "learner unavailable"
-                            :exception {:kind :learner-unreachable}})
-                     {})]
+                    subject
+                    test-config
+                    (conj complete-history
+                          {:type :info
+                           :f :grow
+                           :error "learner unavailable"
+                           :exception {:kind :learner-unreachable}})
+                    {})]
         (is (false? (:valid? result)))
         (is (= 1 (:error-count result)))))))

--- a/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.set :as set]
             [clojure.test :refer [deftest is testing]]
             [jepsen [checker :as checker]
-                    [nemesis :as nemesis]]
+             [nemesis :as nemesis]]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.nemesis.partition :as partition]
             [jepsen.openraft.quorum :as quorum]))
@@ -16,10 +16,10 @@
       (testing (name mode)
         (let [[leader-side other-side]
               (#'partition/partition-components
-                nodes
-                configs
-                "n1"
-                mode)
+               nodes
+               configs
+               "n1"
+               mode)
               quorum-side (if (= mode :leader-in-majority)
                             leader-side
                             other-side)]

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -1,7 +1,7 @@
 (ns jepsen.openraft.nemesis.process-test
   (:require [clojure.test :refer [deftest is testing]]
             [jepsen [checker :as checker]
-                    [nemesis :as nemesis]]
+             [nemesis :as nemesis]]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.nemesis.process :as process]
             [jepsen.openraft.quorum :as quorum]))
@@ -14,10 +14,10 @@
     (doseq [mode [:leader-killed :leader-survives]]
       (testing (name mode)
         (let [targets (#'process/process-targets
-                        voters
-                        configs
-                        "n1"
-                        mode)]
+                       voters
+                       configs
+                       "n1"
+                       mode)]
           (is (contains? fault-sets (set targets)))
           (is (= (= mode :leader-killed)
                  (contains? (set targets) "n1"))))))))
@@ -39,16 +39,16 @@
                   cluster/voter-configs
                   (fn [_test _status] [(set (:nodes test))])]
       (let [killed (nemesis/invoke!
-                     subject
-                     test
-                     {:type :info
-                      :f :kill-process
-                      :value :leader-killed})
+                    subject
+                    test
+                    {:type :info
+                     :f :kill-process
+                     :value :leader-killed})
             restarted (nemesis/invoke!
-                        subject
-                        test
-                        {:type :info
-                         :f :restart-process})]
+                       subject
+                       test
+                       {:type :info
+                        :f :restart-process})]
         (is (= ["n1"] (get-in killed [:value :nodes])))
         (is (= ["n1"] (get-in restarted [:value :nodes])))
         (is (= [[:kill ["n1"]]

--- a/jepsen/test/jepsen/openraft/workload_test.clj
+++ b/jepsen/test/jepsen/openraft/workload_test.clj
@@ -105,11 +105,11 @@
                   :f :read
                   :value "value"}]
         result (checker/check
-                 (checker/linearizable
-                   {:model (model/cas-register)})
-                 {}
-                 history
-                 {})]
+                (checker/linearizable
+                 {:model (model/cas-register)})
+                {}
+                history
+                {})]
     (is (:valid? result)
         "an indeterminate write may have produced the value read later")))
 


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

## Summary

This PR gives the Jepsen harness its own dedicated RocksDB-backed OpenRaft
application.

The new application lives under `jepsen/openraft-test-app` and uses each
Jepsen container hostname, such as `n1`, directly as its OpenRaft node ID.

## Motivation

The existing `raft-kv-rocksdb` example uses numeric node IDs, while Jepsen
identifies nodes by container hostnames. This previously required the Jepsen
harness to:

- Restrict node names to the `n<ID>` format.
- Derive numeric OpenRaft node IDs from node names.
- Maintain explicit mappings between the two identity spaces.
- Convert membership observations back to Jepsen node names.

Changing the general-purpose example solely for Jepsen would introduce
test-specific requirements into an unrelated example. A dedicated application
keeps those requirements local to the Jepsen harness.

## Changes

- Add `jepsen/openraft-test-app`, derived from the RocksDB KV example.
- Use `String` as the application's OpenRaft node ID type.
- Use container hostnames directly for bootstrap, learner addition, and
  membership changes.
- Remove Jepsen's numeric node ID derivation and conversion logic.
- Update cluster and membership tests to use string node IDs.
- Build and run the dedicated application in the Jepsen node image.
- Exclude the application from the root Cargo workspace.
- Document the new Jepsen project structure and node identity model.
- Add `make -C jepsen lint` for Rust and Clojure checks:
  - `cargo fmt --check`
  - `cargo clippy`
  - `clj-kondo`
  - `cljfmt check`

The existing `raft-kv-rocksdb` example remains unchanged.

## Verification

- `make -C jepsen lint`
- `make -C jepsen jepsen NEMESIS=membership`

Closes #1906


**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1908)
<!-- Reviewable:end -->
