### PR TITLE
refactor: ezraft: build the kvstore example from its test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Beyond `rustfmt`, OpenRaft follows the conventions in [`CLAUDE.md`](CLAUDE.md). 
 
 ## Documentation
 
-Public documentation lives in Rustdoc comments under `openraft/src/docs/` and is published on [docs.rs](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/index.html). Update it when a public API or user-facing behavior changes.
+Public documentation lives in Rustdoc comments under `openraft/src/docs/` and is published on [docs.rs](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/index.html). Update it when a public API or user-facing behavior changes.
 
 ## Working with git
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.10.0-alpha.31"
+version = "0.10.0-alpha.32"
 edition = "2024"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Crates.io](https://img.shields.io/crates/v/openraft.svg)](https://crates.io/crates/openraft)
 [![docs.rs](https://docs.rs/openraft/badge.svg)](https://docs.rs/openraft)
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-openraft-blue.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==)](https://deepwiki.com/databendlabs/openraft)
-[![guides](https://img.shields.io/badge/guide-%E2%86%97-brightgreen)](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/index.html)
+[![guides](https://img.shields.io/badge/guide-%E2%86%97-brightgreen)](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/index.html)
 [![Discord Chat](https://img.shields.io/discord/1015845055434588200?logo=discord)](https://discord.gg/ZKw3WG7FQ9)
 <br/>
 [![CI](https://github.com/databendlabs/openraft/actions/workflows/ci.yaml/badge.svg)](https://github.com/databendlabs/openraft/actions/workflows/ci.yaml)
@@ -25,18 +25,18 @@ Currently, openraft is the consensus engine of meta-service cluster in [databend
 
 
 - 🚀 **Get started**:
-    - [OpenRaft guide](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/getting_started/index.html) is the best place to get started,
-    - [OpenRaft docs](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/index.html) for more in-depth details,
-    - [OpenRaft FAQ](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/faq/index.html) explains some common questions.
+    - [OpenRaft guide](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/getting_started/index.html) is the best place to get started,
+    - [OpenRaft docs](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/index.html) for more in-depth details,
+    - [OpenRaft FAQ](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/faq/index.html) explains some common questions.
     - [OpenRaft on DeepWiki](https://deepwiki.com/databendlabs/openraft) provides detailed architectural documentation to help understand OpenRaft internals.
 
 - 💡 **Example Applications**:
 
-    - [Examples with OpenRaft 0.10](https://github.com/databendlabs/openraft/tree/release-0.10/examples) require OpenRaft `0.10.0-alpha.31` (alpha) on [crates.io/openraft](https://crates.io/crates/openraft);
+    - [Examples with OpenRaft 0.10](https://github.com/databendlabs/openraft/tree/release-0.10/examples) require OpenRaft `0.10.0-alpha.32` (alpha) on [crates.io/openraft](https://crates.io/crates/openraft);
     - [Examples with OpenRaft 0.9](https://github.com/databendlabs/openraft/tree/release-0.9/examples) require OpenRaft 0.9 on [crates.io/openraft](https://crates.io/crates/openraft).
 
 - 🙌 **Questions**?
-    - Why not take a peek at our [FAQ](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/faq/index.html)? You might find just what you need.
+    - Why not take a peek at our [FAQ](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/faq/index.html)? You might find just what you need.
     - Wanna chat? Come hang out with us on [Discord](https://discord.gg/ZKw3WG7FQ9)!
     - Or start a new discussion over on [GitHub](https://github.com/databendlabs/openraft/discussions/new).
     - Or join our [Feishu group](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=d20l9084-6d36-4470-bac5-4bad7378d003).
@@ -69,7 +69,7 @@ Whatever your style, we're here to support you. 🚀 Let's make something awesom
 
 - **Branch main** has been under active development.
     The main branch is for the [release-0.10](https://github.com/databendlabs/openraft/tree/release-0.10).
-    Latest alpha on crates.io: [v0.10.0-alpha.31](https://crates.io/crates/openraft/0.10.0-alpha.31).
+    Latest alpha on crates.io: [v0.10.0-alpha.32](https://crates.io/crates/openraft/0.10.0-alpha.32).
     The `0.10` line is in **alpha** — the API may still change before the final `0.10.0` release.
 
 - **Branch [release-0.9](https://github.com/databendlabs/openraft/tree/release-0.9)**:
@@ -93,10 +93,10 @@ Whatever your style, we're here to support you. 🚀 Let's make something awesom
 
 # Roadmap
 
-- [x] **2022-10-31** [Extended joint membership](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/data/extended_membership/index.html)
+- [x] **2022-10-31** [Extended joint membership](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/data/extended_membership/index.html)
 - [x] **2023-02-14** Minimize confliction rate when electing;
-  See: [OpenRaft Vote design](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/data/vote/index.html);
-  Or use [standard Raft leader-ID mode](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/data/leader_id/index.html).
+  See: [OpenRaft Vote design](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/data/vote/index.html);
+  Or use [standard Raft leader-ID mode](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/data/leader_id/index.html).
 - [x] **2023-04-26** Goal performance is 1,000,000 put/sec.
 - [ ] Reduce the complexity of vote and pre-vote: [get rid of pre-vote RPC](https://github.com/databendlabs/openraft/discussions/15);
 - [ ] Support flexible quorum, e.g.: [Hierarchical Quorums](https://zookeeper.apache.org/doc/r3.5.9/zookeeperHierarchicalQuorums.html)
@@ -137,8 +137,8 @@ For benchmark detail, go to the [./benchmarks/minimal](./benchmarks/minimal) fol
 
 What sets OpenRaft apart from a standard Raft implementation:
 
-- **Generalized membership change**: [extended joint membership](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/data/extended_membership/index.html) changes an arbitrary set of nodes in a single operation; standard Raft's one-node-at-a-time change is a restricted special case.
-- **Fewer election conflicts**: the redesigned [Vote](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/data/vote/index.html) minimizes election conflict rate — a split vote does not force a new term; the [standard Raft leader-ID mode](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/data/leader_id/index.html) is also supported.
+- **Generalized membership change**: [extended joint membership](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/data/extended_membership/index.html) changes an arbitrary set of nodes in a single operation; standard Raft's one-node-at-a-time change is a restricted special case.
+- **Fewer election conflicts**: the redesigned [Vote](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/data/vote/index.html) minimizes election conflict rate — a split vote does not force a new term; the [standard Raft leader-ID mode](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/data/leader_id/index.html) is also supported.
 - **Async and event-driven**: state transitions are driven by Raft events without periodic ticks; messages are batched, reaching millions of writes/sec in the [framework benchmark](#performance).
 - **Fully pluggable**: storage (`RaftLogStorage`, `RaftStateMachine`), networking (`RaftNetworkV2`, including application-defined snapshot transport), and every core type — node ID, node, term, vote, log entry — via `RaftTypeConfig`.
 - **Runtime-agnostic**: tokio by default, [compio](./rt-compio) and [monoio](./rt-monoio) via the `AsyncRuntime` trait, and a `single-threaded` mode that removes `Send` bounds.
@@ -153,10 +153,10 @@ What sets OpenRaft apart from a standard Raft implementation:
 - ✅ **Non-voter(learner) Role**: refer to [`add_learner()`][].
 - ✅ **Log Compaction**(snapshot of state machine): by policy or manually ([`Trigger::snapshot()`][]).
 - ✅ **Snapshot replication**.
-- ✅ **Dynamic Membership**: using joint membership config change. Refer to [dynamic membership](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/cluster_control/dynamic_membership/index.html)
+- ✅ **Dynamic Membership**: using joint membership config change. Refer to [dynamic membership](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/cluster_control/dynamic_membership/index.html)
 - ✅ **Linearizable read**: [`ensure_linearizable()`][].
 - ✅ **Metrics**: [`Raft::metrics()`][], [`Raft::data_metrics()`][], and [`Raft::server_metrics()`][].
-- ⛔️ **Won't support**: Single-step config change. Single-step membership change is a restricted subset of joint consensus that only allows changing one node at a time. Openraft uses the more general [joint consensus](https://docs.rs/openraft/0.10.0-alpha.31/openraft/docs/cluster_control/dynamic_membership/index.html) approach which supports arbitrary membership changes in a single operation.
+- ⛔️ **Won't support**: Single-step config change. Single-step membership change is a restricted subset of joint consensus that only allows changing one node at a time. Openraft uses the more general [joint consensus](https://docs.rs/openraft/0.10.0-alpha.32/openraft/docs/cluster_control/dynamic_membership/index.html) approach which supports arbitrary membership changes in a single operation.
 - ✅ Toggle heartbeat / election: [`RuntimeConfigHandle::heartbeat()`][] / [`RuntimeConfigHandle::elect()`][].
 - ✅ Trigger snapshot / election manually: [`Trigger::snapshot()`][] / [`Trigger::elect()`][].
 - ✅ Purge log by policy or manually: [`Trigger::purge_log()`][].
@@ -291,18 +291,18 @@ OpenRaft is licensed under the terms of the [MIT License](https://en.wikipedia.o
 or the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0), at your choosing.
 
 
-[`change_membership()`]: https://docs.rs/openraft/0.10.0-alpha.31/openraft/raft/struct.Raft.html#method.change_membership
-[`add_learner()`]: https://docs.rs/openraft/0.10.0-alpha.31/openraft/raft/struct.Raft.html#method.add_learner
-[`Trigger::purge_log()`]: https://docs.rs/openraft/0.10.0-alpha.31/openraft/raft/trigger/struct.Trigger.html#method.purge_log
+[`change_membership()`]: https://docs.rs/openraft/0.10.0-alpha.32/openraft/raft/struct.Raft.html#method.change_membership
+[`add_learner()`]: https://docs.rs/openraft/0.10.0-alpha.32/openraft/raft/struct.Raft.html#method.add_learner
+[`Trigger::purge_log()`]: https://docs.rs/openraft/0.10.0-alpha.32/openraft/raft/trigger/struct.Trigger.html#method.purge_log
 
-[`RuntimeConfigHandle::heartbeat()`]: https://docs.rs/openraft/0.10.0-alpha.31/openraft/raft/struct.RuntimeConfigHandle.html#method.heartbeat
-[`RuntimeConfigHandle::elect()`]: https://docs.rs/openraft/0.10.0-alpha.31/openraft/raft/struct.RuntimeConfigHandle.html#method.elect
+[`RuntimeConfigHandle::heartbeat()`]: https://docs.rs/openraft/0.10.0-alpha.32/openraft/raft/struct.RuntimeConfigHandle.html#method.heartbeat
+[`RuntimeConfigHandle::elect()`]: https://docs.rs/openraft/0.10.0-alpha.32/openraft/raft/struct.RuntimeConfigHandle.html#method.elect
 
-[`Trigger::elect()`]: https://docs.rs/openraft/0.10.0-alpha.31/openraft/raft/trigger/struct.Trigger.html#method.elect
-[`Trigger::snapshot()`]: https://docs.rs/openraft/0.10.0-alpha.31/openraft/raft/trigger/struct.Trigger.html#method.snapshot
-[`Trigger::transfer_leader()`]: https://docs.rs/openraft/0.10.0-alpha.31/openraft/raft/trigger/struct.Trigger.html#method.transfer_leader
-[`Config::enable_pre_vote`]: https://docs.rs/openraft/0.10.0-alpha.31/openraft/struct.Config.html#structfield.enable_pre_vote
-[`Raft::metrics()`]: https://docs.rs/openraft/0.10.0-alpha.31/openraft/raft/struct.Raft.html#method.metrics
-[`Raft::data_metrics()`]: https://docs.rs/openraft/0.10.0-alpha.31/openraft/raft/struct.Raft.html#method.data_metrics
-[`Raft::server_metrics()`]: https://docs.rs/openraft/0.10.0-alpha.31/openraft/raft/struct.Raft.html#method.server_metrics
-[`ensure_linearizable()`]: https://docs.rs/openraft/0.10.0-alpha.31/openraft/raft/struct.Raft.html#method.ensure_linearizable
+[`Trigger::elect()`]: https://docs.rs/openraft/0.10.0-alpha.32/openraft/raft/trigger/struct.Trigger.html#method.elect
+[`Trigger::snapshot()`]: https://docs.rs/openraft/0.10.0-alpha.32/openraft/raft/trigger/struct.Trigger.html#method.snapshot
+[`Trigger::transfer_leader()`]: https://docs.rs/openraft/0.10.0-alpha.32/openraft/raft/trigger/struct.Trigger.html#method.transfer_leader
+[`Config::enable_pre_vote`]: https://docs.rs/openraft/0.10.0-alpha.32/openraft/struct.Config.html#structfield.enable_pre_vote
+[`Raft::metrics()`]: https://docs.rs/openraft/0.10.0-alpha.32/openraft/raft/struct.Raft.html#method.metrics
+[`Raft::data_metrics()`]: https://docs.rs/openraft/0.10.0-alpha.32/openraft/raft/struct.Raft.html#method.data_metrics
+[`Raft::server_metrics()`]: https://docs.rs/openraft/0.10.0-alpha.32/openraft/raft/struct.Raft.html#method.server_metrics
+[`ensure_linearizable()`]: https://docs.rs/openraft/0.10.0-alpha.32/openraft/raft/struct.Raft.html#method.ensure_linearizable

--- a/benchmarks/minimal/Cargo.toml
+++ b/benchmarks/minimal/Cargo.toml
@@ -17,8 +17,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft            = { path = "../../openraft", version = "0.10.0-alpha.31", features = ["serde", "type-alias", "runtime-stats"] }
-openraft-legacy = { path = "../../legacy", version = "0.10.0-alpha.31" }
+openraft            = { path = "../../openraft", version = "0.10.0-alpha.32", features = ["serde", "type-alias", "runtime-stats"] }
+openraft-legacy = { path = "../../legacy", version = "0.10.0-alpha.32" }
 
 anyhow     = { version = "1.0.63" }
 clap       = { version = "4.2", features = ["derive"] }

--- a/examples/log-rocks/Cargo.toml
+++ b/examples/log-rocks/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft = { path = "../../openraft", version = "0.10.0-alpha.31", features = ["serde", "type-alias"] }
+openraft = { path = "../../openraft", version = "0.10.0-alpha.32", features = ["serde", "type-alias"] }
 
 byteorder  = { version = "1.4.3" }
 rocksdb    = { version = "0.22.0" }

--- a/examples/sm-rocks/Cargo.toml
+++ b/examples/sm-rocks/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
 log-rocks = { path = "../log-rocks" }
-openraft = { path = "../../openraft", version = "0.10.0-alpha.31", features = ["serde", "type-alias"] }
+openraft = { path = "../../openraft", version = "0.10.0-alpha.32", features = ["serde", "type-alias"] }
 types-kv = { path = "../types-kv" }
 
 futures    = { version = "0.3" }

--- a/experimental/ezraft/Cargo.toml
+++ b/experimental/ezraft/Cargo.toml
@@ -14,7 +14,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-openraft = { path = "../../openraft", version = "0.10.0-alpha.31", features = ["serde", "type-alias"] }
+openraft = { path = "../../openraft", version = "0.10.0-alpha.32", features = ["serde", "type-alias"] }
 
 actix-web = "4.0"
 async-trait = "0.1"

--- a/experimental/ezraft/tests/kvstore_example.rs
+++ b/experimental/ezraft/tests/kvstore_example.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use std::process::Child;
 use std::process::Command;
 use std::process::Stdio;
+use std::sync::LazyLock;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -32,21 +33,30 @@ impl Drop for Node {
     }
 }
 
-/// The example binary, which `cargo test` builds alongside the tests.
-fn kvstore_bin() -> PathBuf {
-    // current_exe is target/debug/deps/kvstore_example-<hash>
-    let mut path = std::env::current_exe().unwrap();
-    path.pop();
-    path.pop();
-    path.push("examples");
-    path.push(format!("kvstore{}", std::env::consts::EXE_SUFFIX));
-    assert!(
-        path.is_file(),
-        "kvstore example not built at {}; run a full `cargo test -p ezraft`",
-        path.display()
-    );
-    path
-}
+/// The example binary, built by this test and located from cargo's own report.
+///
+/// The test cannot assume the example is already built: `cargo test --tests`,
+/// which `cargo llvm-cov` runs, builds test targets only. Nor can it derive the
+/// path from its own executable, because cargo has more than one target
+/// directory layout. Cargo offers no `CARGO_BIN_EXE_*` for examples, so ask it.
+static KVSTORE_BIN: LazyLock<PathBuf> = LazyLock::new(|| {
+    let cargo = std::env::var_os("CARGO").expect("cargo sets CARGO for the tests it runs");
+    let out = Command::new(cargo)
+        .args(["build", "--package", "ezraft", "--example", "kvstore"])
+        .arg("--message-format=json-render-diagnostics")
+        .stderr(Stdio::inherit())
+        .output()
+        .expect("failed to run cargo");
+    assert!(out.status.success(), "building the kvstore example failed");
+
+    String::from_utf8(out.stdout)
+        .expect("cargo emits UTF-8")
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .find(|msg| msg["reason"] == "compiler-artifact" && msg["target"]["name"] == "kvstore")
+        .and_then(|msg| msg["executable"].as_str().map(PathBuf::from))
+        .expect("cargo reported no executable for the kvstore example")
+});
 
 /// Grab a free port; the listener is dropped so the child process can bind it.
 fn free_addr() -> String {
@@ -57,7 +67,7 @@ fn free_addr() -> String {
 /// Spawn one kvstore node; its `./data/<addr>` dir and log land in `work_dir`.
 fn spawn_node(work_dir: &Path, addr: &str, seed: Option<&str>) -> io::Result<Node> {
     let log = File::create(work_dir.join(format!("node-{}.log", addr.replace(':', "-"))))?;
-    let mut cmd = Command::new(kvstore_bin());
+    let mut cmd = Command::new(&*KVSTORE_BIN);
     cmd.current_dir(work_dir)
         .args(["--addr", addr])
         .stdout(log.try_clone()?)

--- a/legacy/Cargo.toml
+++ b/legacy/Cargo.toml
@@ -14,8 +14,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-openraft = { path = "../openraft", version = "0.10.0-alpha.31", default-features = false }
-openraft-macros = { path = "../macros", version = "0.10.0-alpha.31" }
+openraft = { path = "../openraft", version = "0.10.0-alpha.32", default-features = false }
+openraft-macros = { path = "../macros", version = "0.10.0-alpha.32" }
 
 derive_more = { workspace = true }
 futures = { workspace = true }

--- a/metrics-otel/Cargo.toml
+++ b/metrics-otel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openraft-metrics-otel"
-version = "0.10.0-alpha.31"
+version = "0.10.0-alpha.32"
 edition = "2024"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",
@@ -13,5 +13,5 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft = { path = "../openraft", version = "0.10.0-alpha.31" }
+openraft = { path = "../openraft", version = "0.10.0-alpha.32" }
 opentelemetry = "0.30.0"

--- a/multiraft/Cargo.toml
+++ b/multiraft/Cargo.toml
@@ -3,7 +3,7 @@ name = "openraft-multi"
 description = "Multi-Raft adapters for connection sharing across Raft groups"
 documentation = "https://docs.rs/openraft-multiraft"
 readme = "README.md"
-version = "0.10.0-alpha.31"
+version = "0.10.0-alpha.32"
 edition = "2024"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 categories = ["network-programming", "asynchronous", "data-structures"]
@@ -13,6 +13,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft  = { path = "../openraft", version = "0.10.0-alpha.31", default-features = false }
+openraft  = { path = "../openraft", version = "0.10.0-alpha.32", default-features = false }
 anyerror  = { version = "0.1" }
 

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -15,9 +15,9 @@ repository    = { workspace = true }
 
 
 [dependencies]
-openraft-rt = { path = "../rt", version = "0.10.0-alpha.31" }
-openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.31", optional = true }
-openraft-macros = { path = "../macros", version = "0.10.0-alpha.31" }
+openraft-rt = { path = "../rt", version = "0.10.0-alpha.32" }
+openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.32", optional = true }
+openraft-macros = { path = "../macros", version = "0.10.0-alpha.32" }
 
 anyerror        = { workspace = true }
 anyhow          = { workspace = true, optional = true }
@@ -46,7 +46,7 @@ peel-off        = { workspace = true }
 anyhow            = { workspace = true }
 bincode           = { workspace = true }
 criterion         = { workspace = true }
-openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.31" }
+openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.32" }
 pretty_assertions = { workspace = true }
 serde_json        = { workspace = true }
 

--- a/rt-compio/Cargo.toml
+++ b/rt-compio/Cargo.toml
@@ -3,7 +3,7 @@ name = "openraft-rt-compio"
 description = "compio AsyncRuntime support for Openraft"
 documentation = "https://docs.rs/openraft-rt-compio"
 readme = "README.md"
-version = "0.10.0-alpha.31"
+version = "0.10.0-alpha.32"
 edition = "2024"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 categories = ["algorithms", "asynchronous", "data-structures"]
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft-rt = { path = "../rt", version = "0.10.0-alpha.31", features = ["single-threaded"] }
+openraft-rt = { path = "../rt", version = "0.10.0-alpha.32", features = ["single-threaded"] }
 
 compio           = { version = ">=0.14.0", features = ["runtime", "time"] }
 flume            = { version = "0.11.1", default-features = false, features = ["async"] }

--- a/rt-monoio/Cargo.toml
+++ b/rt-monoio/Cargo.toml
@@ -3,7 +3,7 @@ name = "openraft-rt-monoio"
 description = "monoio AsyncRuntime support for Openraft"
 documentation = "https://docs.rs/openraft-rt-monoio"
 readme = "README.md"
-version = "0.10.0-alpha.31"
+version = "0.10.0-alpha.32"
 edition = "2024"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft-rt = { path = "../rt", version = "0.10.0-alpha.31", features = ["single-threaded"] }
+openraft-rt = { path = "../rt", version = "0.10.0-alpha.32", features = ["single-threaded"] }
 
 futures-util = { version = "0.3" }
 local-sync   = { version = "0.1.1" }

--- a/rt-tokio/Cargo.toml
+++ b/rt-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.31"
+version = "0.10.0-alpha.32"
 edition = "2024"
 authors = [
     "drdrxp <drdr.xp@gmail.com>",
@@ -13,7 +13,7 @@ readme = "README.md"
 description = "Tokio runtime implementation for Openraft"
 
 [dependencies]
-openraft-rt  = { path = "../rt", version = "0.10.0-alpha.31" }
+openraft-rt  = { path = "../rt", version = "0.10.0-alpha.32" }
 tokio        = { version = "1.39", default-features = false, features = ["rt", "rt-multi-thread", "sync", "time"] }
 futures-util = { version = "0.3" }
 rand         = { version = "0.10", default-features = false, features = ["std", "std_rng", "thread_rng"] }

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -20,6 +20,6 @@ single-threaded = ["openraft-macros/single-threaded"]
 [dependencies]
 futures-channel = { workspace = true }
 futures-util    = { workspace = true }
-openraft-macros    = { version = "0.10.0-alpha.31", path = "../macros" }
+openraft-macros    = { version = "0.10.0-alpha.32", path = "../macros" }
 pin-project-lite   = { version = "0.2" }
 rand               = { workspace = true }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -27,6 +27,7 @@ CRATES=(
     multiraft
     stores/memstore
     metrics-otel
+    experimental/ezraft
 )
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/stores/memstore-custom-node-id/Cargo.toml
+++ b/stores/memstore-custom-node-id/Cargo.toml
@@ -13,7 +13,7 @@ license       = { workspace = true }
 repository    = { workspace = true }
 
 [dependencies]
-openraft  = { path = "../../openraft", version = "0.10.0-alpha.31", features = ["serde", "type-alias"] }
+openraft  = { path = "../../openraft", version = "0.10.0-alpha.32", features = ["serde", "type-alias"] }
 
 futures    = { workspace = true }
 serde      = { workspace = true }

--- a/stores/memstore/Cargo.toml
+++ b/stores/memstore/Cargo.toml
@@ -14,8 +14,8 @@ license       = { workspace = true }
 repository    = { workspace = true }
 
 [dependencies]
-openraft = { path = "../../openraft", version = "0.10.0-alpha.31", features = ["serde", "type-alias"] }
-openraft-legacy = { path = "../../legacy", version = "0.10.0-alpha.31" }
+openraft = { path = "../../openraft", version = "0.10.0-alpha.32", features = ["serde", "type-alias"] }
+openraft-legacy = { path = "../../legacy", version = "0.10.0-alpha.32" }
 
 derive_more = { workspace = true }
 futures     = { workspace = true }

--- a/tests-turmoil/Cargo.lock
+++ b/tests-turmoil/Cargo.lock
@@ -805,7 +805,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.31"
+version = "0.10.0-alpha.32"
 dependencies = [
  "anyerror",
  "backoff-series",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.31"
+version = "0.10.0-alpha.32"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.31"
+version = "0.10.0-alpha.32"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.31"
+version = "0.10.0-alpha.32"
 dependencies = [
  "futures-util",
  "openraft-rt",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -19,7 +19,7 @@ repository    = { workspace = true }
 [dependencies]
 
 [dev-dependencies]
-openraft           = { path = "../openraft", version = "0.10.0-alpha.31", features = ["type-alias"] }
+openraft           = { path = "../openraft", version = "0.10.0-alpha.32", features = ["type-alias"] }
 openraft-memstore  = { path = "../stores/memstore" }
 openraft-legacy    = { path = "../legacy" }
 


### PR DESCRIPTION

## Changelog

##### refactor: ezraft: build the kvstore example from its test
# Summary

The kvstore example test now builds the example itself and takes the
binary's path from cargo's artifact report, rather than assuming the
build already happened and guessing where it landed. Both assumptions
were wrong under `cargo llvm-cov`, which fails the coverage workflow on
main.

# Details

The test rested on two things cargo does not promise.

The first is that the example is built alongside the tests. That holds
for a bare `cargo test` but not for `cargo test --tests`, which builds
test targets only, and that is what `cargo llvm-cov` runs: the example
was never built. `make test` runs `cargo test --test '*'` and has the
same gap, so it only passed on a warm target directory.

The second is that the binary sits two directories above the test
executable. Recent nightly cargo uses a target layout where the test
executable lives under `debug/build/<pkg>/<hash>/`, so the derived path
pointed inside that unit directory instead of at `debug/examples/`.

Building the example and reading `executable` out of cargo's JSON
artifact message settles both: the binary is guaranteed to exist, and
its location comes from cargo rather than from arithmetic on an
unrelated target's path. Cargo exposes `CARGO_BIN_EXE_*` for `[[bin]]`
targets only, so an example has to be found this way; making kvstore a
binary would change the documented `cargo run --example kvstore`
workflow and ship an installable binary from a library crate.

The build runs once behind a `LazyLock` and is a no-op when the example
is already fresh. Under coverage it uses the default target directory
rather than llvm-cov's, since llvm-cov passes `--target-dir` on the
command line and not through the environment, which costs one extra
compile of the ezraft subtree in that job.


##### chore: bump version to v0.10.0-alpha.32
# Summary

Prepare the workspace for the next alpha release: move all package
versions and local dependency requirements to v0.10.0-alpha.32 and
refresh the documented release version. Since v0.10.0-alpha.31 there is
one new published crate, a leader-lease admission change, a fail-fast
rule for inconsistent snapshots, and the removal of the v1 chunk-snapshot
surface from core.

# Details

- Update workspace, crate, example, benchmark, and test manifests to
  depend on v0.10.0-alpha.32, and refresh the README and CONTRIBUTING
  alpha references so the documented version matches the manifests.

- Correct the `experimental/ezraft` entry in the publish script. It was
  spelled with a U+0142 `ł`, so the manifest path would not resolve and
  the release run would abort under `set -e` before publishing ezraft.

## Changes since v0.10.0-alpha.31

### Added

- [a12c1004] add `ezraft`, a beginner-friendly framework on top of
  openraft, published for the first time in this release. An application
  implements two traits — four methods total — and gets a replicated
  service with HTTP networking, automatic node ids, leader-forwarded
  writes, and serde-derived snapshots.

- [58b00f81] add the `bench` feature and the `#[doc(hidden)]`
  `openraft::bench_internals` module. Benchmarks now build as criterion
  targets outside the crate, and reach internals through this one module
  instead of widening the public API.

### Changed

- [cfcb067e] a Leader that cannot confirm a recent quorum now rejects
  new proposals and lease reads with `ForwardToLeader`, while keeping
  leader state and replication running so quorum contact can restore
  availability without self-demotion. This differs from self-demoting
  CheckQuorum implementations; no configuration change is needed.
  Fix: #1898

- [61586bf5] installing a snapshot inconsistent with the vote installing
  it, or with locally committed logs, now panics at install time instead
  of leaving `RaftState::log_ids` non-monotonic and aborting later in
  replication. A store that already persisted such a state is rejected
  by `StorageHelper::get_initial_state()` with a `StorageError`.
  Recovery is manual: wipe the node and re-add it. Fix: #1892

- [22d23c80] `RaftStateMachine::begin_receiving_snapshot()` is removed;
  snapshot receiver allocation is specific to the legacy v1 chunk
  protocol and now lives behind `SnapshotReceiverFactory` in
  `openraft-legacy`. Custom transports allocate their own snapshot data
  and pass the result to `Raft::install_full_snapshot()`.

- [3dc03314] the v1 chunk-snapshot types — `InstallSnapshotRequest`,
  `InstallSnapshotResponse`, `InstallSnapshotError`, `SnapshotMismatch`,
  and `SnapshotSegmentId` — move to `openraft_legacy::network_v1`. The
  core paths remain as deprecated marker types so the migration is
  guided rather than a missing-type error. The wire format is unchanged,
  so v1 peers interoperate across the move.

- [149d4355] remove `LogIndexOptionExt::add()`, a breaking change for
  downstream implementors of the trait. It had no caller and computed
  `next_index() + v` only to step back one.

- [d914c950] remove `RaftVoteExt::into_committed()` and
  `into_non_committed()`. Their bodies were identical to the borrowing
  `to_committed()` and `to_non_committed()`, which callers use instead.

- [72f5ecb0] the RocksDB example storage is split, with the log store in
  its own crate separate from the state machine.

Upgrade tip:

For legacy v1 snapshot transfer, move receiver construction out of
`RaftStateMachine`:

    use openraft_legacy::network_v1::SnapshotReceiverFactory;

    impl SnapshotReceiverFactory<TypeConfig> for StateMachine {
        type SnapshotReceiver = Cursor<Vec<u8>>;

        async fn begin_receiving_snapshot(
            &mut self,
        ) -> io::Result<Self::SnapshotReceiver> {
            Ok(Cursor::new(Vec::new()))
        }
    }

Replace core imports of the moved v1 types with their legacy paths:

    use openraft_legacy::network_v1::InstallSnapshotRequest;
    use openraft_legacy::network_v1::InstallSnapshotError;

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1909)
<!-- Reviewable:end -->
