### PR TITLE
fix: reject jepsen vacuous test results

### DIFF
--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -149,7 +149,7 @@ all five nodes as voters and waits for every node to agree on a leader.
 - [x] Add an HTTP client for the OpenRaft KV APIs.
 - [x] Add Jepsen process lifecycle management for OpenRaft nodes.
 - [x] Bootstrap a five-node OpenRaft cluster.
-- [ ] Record acknowledged write, read, and info operation counts in each run.
+- [x] Record phase-aware ok, fail, and info counts for read, write, and CAS.
 - [x] Add a network partition nemesis.
 - [x] Add nemeses for process kill/restart.
 - [x] Add a membership grow/shrink nemesis.

--- a/jepsen/src/jepsen/openraft/workload.clj
+++ b/jepsen/src/jepsen/openraft/workload.clj
@@ -8,6 +8,15 @@
 
 (def key-name "jepsen-key")
 
+(def ^:private operation-phases
+  [:bootstrap :main :final])
+
+(def ^:private required-main-operations
+  [:read :write :cas])
+
+(def ^:private completion-types
+  [:ok :fail :info])
+
 (defn- remember-latest! [latest-value value]
   (when value
     (swap! latest-value
@@ -27,21 +36,33 @@
 (defn- read-op [_test _process]
   {:type :invoke
    :f :read
+   :phase :main
    :value nil})
 
 (defn- write-op [value-counter]
   (fn [_test _process]
     {:type :invoke
      :f :write
+     :phase :main
      :value (next-value! value-counter)}))
 
+(defn- bootstrap-write-op [value-counter]
+  {:type :invoke
+   :f :write
+   :phase :bootstrap
+   :value (next-value! value-counter)})
+
 (defn- final-read-op [test process]
-  (assoc (read-op test process) :final? true))
+  (assoc (read-op test process)
+         :phase :final
+         :final? true))
 
 (defn- final-write-op [value-counter]
   (let [write (write-op value-counter)]
     (fn [test process]
-      (assoc (write test process) :final? true))))
+      (assoc (write test process)
+             :phase :final
+             :final? true))))
 
 (defn- cas-op
   "Generates a CAS against the latest known value, falling back to a write until
@@ -65,12 +86,14 @@
       (if expected
         {:type :invoke
          :f :cas
+         :phase :main
          ;; Knossos models logical values. The version is request metadata for
          ;; OpenRaft's version-based CAS and is not part of the model value.
          :value [(:value expected) new-value]
          :expected-version (:version expected)}
         {:type :invoke
          :f :write
+         :phase :main
          :value new-value}))))
 
 (defn- mutation? [op]
@@ -152,6 +175,36 @@
          :count (count errors)
          :errors (vec (take 10 errors))}))))
 
+(defn- empty-operation-counts []
+  (into {}
+        (map (fn [phase]
+               [phase
+                (into {}
+                      (map (fn [f]
+                             [f (zipmap completion-types (repeat 0))])
+                           required-main-operations))])
+             operation-phases)))
+
+(defn- meaningful-operations-checker []
+  (reify checker/Checker
+    (check [_ _test history _opts]
+      (let [counts (reduce
+                    (fn [counts {:keys [phase f type]}]
+                      (if (and (some #{phase} operation-phases)
+                               (some #{f} required-main-operations)
+                               (some #{type} completion-types))
+                        (update-in counts [phase f type] inc)
+                        counts))
+                    (empty-operation-counts)
+                    history)
+            missing-ok (->> required-main-operations
+                            (filter #(zero? (get-in counts
+                                                    [:main % :ok])))
+                            vec)]
+        {:valid? (if (seq missing-ok) :unknown true)
+         :missing-ok missing-ok
+         :counts counts}))))
+
 ;; KVClient is the Jepsen client. Jepsen workers call invoke! with logical
 ;; operations from the generator, and this record translates them into OpenRaft
 ;; KV HTTP requests through jepsen.openraft.client.
@@ -220,9 +273,7 @@
     {:client (client/validate (KVClient. nil nil nil latest-value))
      :generator (gen/clients
                  (gen/phases
-                  (gen/once {:type :invoke
-                             :f :write
-                             :value (next-value! value-counter)})
+                  (gen/once (bootstrap-write-op value-counter))
                   (gen/stagger 0.1 operations)))
      :final-generator (gen/clients
                        (gen/phases
@@ -231,4 +282,5 @@
      :checker (checker/compose
                {:linearizable (checker/linearizable
                                {:model (model/cas-register)})
+                :meaningful-operations (meaningful-operations-checker)
                 :unexpected-errors (unexpected-errors-checker)})}))

--- a/jepsen/test/jepsen/openraft/workload_test.clj
+++ b/jepsen/test/jepsen/openraft/workload_test.clj
@@ -113,11 +113,29 @@
     (is (:valid? result)
         "an indeterminate write may have produced the value read later")))
 
+(deftest tags-operations-by-workload-phase
+  (testing "the bootstrap write is tagged separately"
+    (is (= :bootstrap
+           (:phase (#'workload/bootstrap-write-op (atom 0))))))
+
+  (testing "ordinary client operations are tagged as main"
+    (let [read (#'workload/read-op nil nil)
+          write ((#'workload/write-op (atom 0)) nil nil)]
+      (is (= :main (:phase read)))
+      (is (= :main (:phase write)))))
+
+  (testing "final recovery operations are tagged as final"
+    (let [write ((#'workload/final-write-op (atom 0)) nil nil)
+          read (#'workload/final-read-op nil nil)]
+      (is (= :final (:phase write)))
+      (is (= :final (:phase read))))))
+
 (deftest generates-cas-only-with-a-known-version
   (testing "an unknown version produces a write"
     (let [generate (#'workload/cas-op (atom nil) (atom 0))
           op (generate nil nil)]
       (is (= :write (:f op)))
+      (is (= :main (:phase op)))
       (is (= "value-1" (:value op)))
       (is (not (contains? op :expected-version)))))
 
@@ -126,6 +144,7 @@
           generate (#'workload/cas-op latest-value (atom 0))
           op (generate nil nil)]
       (is (= :cas (:f op)))
+      (is (= :main (:phase op)))
       (is (= ["old" "value-1"] (:value op)))
       (is (= 7 (:expected-version op))))))
 
@@ -209,3 +228,76 @@
         (is (not (:valid? result)))
         (is (= 1 (:count result)))
         (is (= [tagged] (:errors result)))))))
+
+(deftest requires-successful-main-phase-operations
+  (let [chk (#'workload/meaningful-operations-checker)
+        history [{:type :invoke :f :write :phase :bootstrap}
+                 {:type :ok :f :write :phase :bootstrap}
+                 {:type :invoke :f :read :phase :main}
+                 {:type :ok :f :read :phase :main}
+                 {:type :invoke :f :write :phase :main}
+                 {:type :ok :f :write :phase :main}
+                 {:type :invoke :f :cas :phase :main}
+                 {:type :ok :f :cas :phase :main}
+                 {:type :invoke :f :write :phase :final}
+                 {:type :ok :f :write :phase :final}
+                 {:type :invoke :f :read :phase :final}
+                 {:type :ok :f :read :phase :final}]]
+    (testing "all required main operations succeeded"
+      (let [result (checker/check chk {} history {})]
+        (is (true? (:valid? result)))
+        (is (empty? (:missing-ok result)))
+        (is (= 1 (get-in result [:counts :main :read :ok])))
+        (is (= 1 (get-in result [:counts :main :write :ok])))
+        (is (= 1 (get-in result [:counts :main :cas :ok])))
+        (is (= 1 (get-in result [:counts :bootstrap :write :ok])))
+        (is (= 1 (get-in result [:counts :final :write :ok])))))
+
+    (testing "non-ok results cannot be hidden by bootstrap or final operations"
+      (doseq [[f completion-type] [[:read :fail]
+                                   [:write :info]
+                                   [:cas :fail]]]
+        (let [incomplete-history
+              (mapv (fn [op]
+                      (if (and (= :main (:phase op))
+                               (= f (:f op))
+                               (= :ok (:type op)))
+                        (assoc op :type completion-type)
+                        op))
+                    history)
+              result (checker/check chk {} incomplete-history {})]
+          (is (= :unknown (:valid? result)))
+          (is (= [f] (:missing-ok result)))
+          (is (= 0 (get-in result [:counts :main f :ok])))
+          (is (= 1 (get-in result
+                           [:counts :main f completion-type]))))))))
+
+(deftest workload-checker-requires-meaningful-main-traffic
+  (let [history [{:process 0
+                  :type :invoke
+                  :f :write
+                  :phase :bootstrap
+                  :value "initial"}
+                 {:process 0
+                  :type :ok
+                  :f :write
+                  :phase :bootstrap
+                  :value "initial"}
+                 {:process 1
+                  :type :invoke
+                  :f :read
+                  :phase :main
+                  :value nil}
+                 {:process 1
+                  :type :ok
+                  :f :read
+                  :phase :main
+                  :value "initial"}]
+        chk (:checker (workload/workload {}))
+        result (checker/check chk {} history {})]
+    (is (true? (get-in result [:linearizable :valid?])))
+    (is (= :unknown
+           (get-in result [:meaningful-operations :valid?])))
+    (is (= [:write :cas]
+           (get-in result [:meaningful-operations :missing-ok])))
+    (is (= :unknown (:valid? result)))))


### PR DESCRIPTION
Successful bootstrap and final operations could make a Jepsen run appear valid even when all main-phase traffic failed under a nemesis.

Track operation outcomes by phase and return unknown unless main-phase reads, writes, and CAS operations each succeed.

Closes #1910

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1911)
<!-- Reviewable:end -->
