### PR TITLE
test: improve Jepsen failure diagnostics

### DIFF
--- a/jepsen/Makefile
+++ b/jepsen/Makefile
@@ -3,12 +3,11 @@ APP_MANIFEST := openraft-test-app/Cargo.toml
 NODES ?= n1,n2,n3,n4,n5
 CONCURRENCY ?= 3
 NEMESIS ?= partition
-SEED ?=
 SSH_KEY ?= /root/.ssh/openraft-jepsen
 ARGS ?= --nodes $(NODES) --concurrency $(CONCURRENCY) --nemesis $(NEMESIS) --ssh-private-key $(SSH_KEY)
 
 ifneq ($(SEED),)
-ARGS += --seed $(SEED)
+override ARGS += --seed $(SEED)
 endif
 
 app-lint:

--- a/jepsen/Makefile
+++ b/jepsen/Makefile
@@ -3,8 +3,13 @@ APP_MANIFEST := openraft-test-app/Cargo.toml
 NODES ?= n1,n2,n3,n4,n5
 CONCURRENCY ?= 3
 NEMESIS ?= partition
+SEED ?=
 SSH_KEY ?= /root/.ssh/openraft-jepsen
 ARGS ?= --nodes $(NODES) --concurrency $(CONCURRENCY) --nemesis $(NEMESIS) --ssh-private-key $(SSH_KEY)
+
+ifneq ($(SEED),)
+ARGS += --seed $(SEED)
+endif
 
 app-lint:
 	cargo fmt --check --manifest-path $(APP_MANIFEST)

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -115,6 +115,9 @@ $ make -C jepsen test NEMESIS=process
 # Run the membership change test.
 $ make -C jepsen test NEMESIS=membership
 
+# Reuse a recorded seed for Jepsen random choices.
+$ make -C jepsen test NEMESIS=partition SEED=123456
+
 # Stop and remove the Jepsen containers.
 $ make -C jepsen down
 ```
@@ -140,6 +143,15 @@ The membership nemesis starts with a shrink and grow for deterministic coverage,
 then randomly mixes additional membership changes. Removed nodes are stopped
 and wiped only after the new voter set is committed. The final recovery restores
 all five nodes as voters and waits for every node to agree on a leader.
+
+Every run records a `:seed` in its stored Jepsen test data. Supplying that seed
+again repeats choices made through `jepsen.random`, including the random node
+selection used by the partition, process, and membership nemeses. It does not
+make the whole run deterministic: client operation mixing and timing use
+separate generator randomness, and thread, network, and election timing can
+still differ. The recorded history and Nemesis operations are therefore the
+authoritative account of the fault schedule; the seed is only an aid for
+rerunning similar conditions.
 
 ## TODO
 

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -13,6 +13,9 @@
 (def nemesis-types
   #{:membership :partition :process})
 
+(def ^:private node-crash-pattern
+  #"(panicked at|fatal runtime error)")
+
 (def cli-opts
   [[nil "--api-port PORT" "OpenRaft application HTTP port."
     :default 21001
@@ -56,6 +59,10 @@
                         (:final-generator workload))
             :checker (checker/compose
                       {:stats (checker/stats)
+                       :exceptions (checker/unhandled-exceptions)
+                       :crash (checker/log-file-pattern
+                               node-crash-pattern
+                               "openraft.log")
                        :nemesis (:checker nemesis-package)
                        :workload (:checker workload)})})))
 

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -3,6 +3,7 @@
   (:require [jepsen [checker :as checker]
              [cli :as cli]
              [generator :as gen]
+             [random :as random]
              [tests :as tests]]
             [jepsen.openraft [db :as openraft-db]
              [workload :as workload]]
@@ -28,9 +29,21 @@
    [nil "--nemesis TYPE" "Fault type: membership, partition, or process."
     :default :partition
     :parse-fn keyword
-    :validate [nemesis-types (cli/one-of nemesis-types)]]])
+    :validate [nemesis-types (cli/one-of nemesis-types)]]
+
+   [nil "--seed SEED" "Seed for Jepsen random choices."
+    :parse-fn parse-long]])
+
+(defn- ensure-random-seed [parsed]
+  (update parsed :options
+          (fn [options]
+            (if (:seed options)
+              options
+              (assoc options :seed (random/long Long/MAX_VALUE))))))
 
 (defn openraft-test [opts]
+  (when-some [seed (:seed opts)]
+    (random/set-seed! seed))
   (let [database (openraft-db/db opts)
         workload (workload/workload opts)
         nemesis-type (:nemesis opts :partition)
@@ -68,6 +81,7 @@
 
 (defn -main [& args]
   (cli/run! (cli/single-test-cmd {:test-fn openraft-test
+                                  :opt-fn ensure-random-seed
                                   :opt-spec cli-opts
                                   :usage (cli/test-usage)})
             args))

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -5,6 +5,7 @@
              [generator :as gen]
              [random :as random]
              [tests :as tests]]
+            [jepsen.store :as store]
             [jepsen.openraft [db :as openraft-db]
              [workload :as workload]]
             [jepsen.openraft.nemesis [membership :as membership]
@@ -32,18 +33,49 @@
     :validate [nemesis-types (cli/one-of nemesis-types)]]
 
    [nil "--seed SEED" "Seed for Jepsen random choices."
-    :parse-fn parse-long]])
+    :parse-fn parse-long
+    :validate [some? "Must be an integer."]]])
 
 (defn- ensure-random-seed [parsed]
   (update parsed :options
           (fn [options]
-            (if (:seed options)
-              options
-              (assoc options :seed (random/long Long/MAX_VALUE))))))
+            (let [seed (or (:seed options)
+                           (random/long Long/MAX_VALUE))]
+              (random/set-seed! seed)
+              (assoc options :seed seed)))))
+
+(defn- random-seed-checker []
+  (reify checker/Checker
+    (check [_ test _history _opts]
+      {:valid? true
+       :seed (:seed test)})))
+
+(defn- strict-unhandled-exceptions []
+  (let [delegate (checker/unhandled-exceptions)]
+    (reify checker/Checker
+      (check [_ test history opts]
+        (let [result (checker/check delegate test history opts)]
+          (if (seq (:exceptions result))
+            (assoc result :valid? :unknown)
+            result))))))
+
+(defn- required-log-file-pattern [pattern filename]
+  (let [delegate (checker/log-file-pattern pattern filename)]
+    (reify checker/Checker
+      (check [_ test history opts]
+        (let [missing-nodes (->> (:nodes test)
+                                 (remove (fn [node]
+                                           (.isFile
+                                            ^java.io.File
+                                            (store/path test node filename))))
+                                 vec)]
+          (if (seq missing-nodes)
+            {:valid? :unknown
+             :filename filename
+             :missing-nodes missing-nodes}
+            (checker/check delegate test history opts)))))))
 
 (defn openraft-test [opts]
-  (when-some [seed (:seed opts)]
-    (random/set-seed! seed))
   (let [database (openraft-db/db opts)
         workload (workload/workload opts)
         nemesis-type (:nemesis opts :partition)
@@ -71,9 +103,10 @@
                          (:generator workload))
                         (:final-generator workload))
             :checker (checker/compose
-                      {:stats (checker/stats)
-                       :exceptions (checker/unhandled-exceptions)
-                       :crash (checker/log-file-pattern
+                      {:seed (random-seed-checker)
+                       :stats (checker/stats)
+                       :exceptions (strict-unhandled-exceptions)
+                       :crash (required-log-file-pattern
                                node-crash-pattern
                                "openraft.log")
                        :nemesis (:checker nemesis-package)

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -2,7 +2,25 @@
   (:require [clojure.test :refer [deftest is testing]]
             [jepsen.checker :as checker]
             [jepsen.history :as history]
-            [jepsen.openraft.cli :as cli]))
+            [jepsen.openraft.cli :as cli]
+            [jepsen.random :as random]))
+
+(deftest records-and-applies-the-random-seed
+  (testing "a seed is generated when none is supplied"
+    (let [seed (get-in (#'cli/ensure-random-seed {:options {}})
+                       [:options :seed])]
+      (is (integer? seed))))
+
+  (testing "an explicit seed is preserved, stored, and applied"
+    (let [applied-seed (atom nil)
+          parsed (#'cli/ensure-random-seed
+                  {:options {:nemesis :partition
+                             :seed 41
+                             :time-limit 10}})]
+      (with-redefs [random/set-seed! #(reset! applied-seed %)]
+        (let [test (cli/openraft-test (:options parsed))]
+          (is (= 41 (:seed test)))
+          (is (= 41 @applied-seed)))))))
 
 (deftest configures-worker-exception-and-node-crash-checkers
   (let [checkers (-> (cli/openraft-test {:nemesis :partition

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -1,32 +1,56 @@
 (ns jepsen.openraft.cli-test
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.tools.cli :as tools-cli]
             [jepsen.checker :as checker]
             [jepsen.history :as history]
             [jepsen.openraft.cli :as cli]
-            [jepsen.random :as random]))
+            [jepsen.random :as random]
+            [jepsen.store :as store]))
 
 (deftest records-and-applies-the-random-seed
-  (testing "a seed is generated when none is supplied"
-    (let [seed (get-in (#'cli/ensure-random-seed {:options {}})
-                       [:options :seed])]
-      (is (integer? seed))))
+  (testing "a generated seed is recorded and applied once"
+    (let [applied-seeds (atom [])
+          parsed (with-redefs [random/set-seed!
+                               #(swap! applied-seeds conj %)]
+                   (#'cli/ensure-random-seed {:options {}}))]
+      (is (integer? (get-in parsed [:options :seed])))
+      (is (= [(get-in parsed [:options :seed])]
+             @applied-seeds))))
 
-  (testing "an explicit seed is preserved, stored, and applied"
-    (let [applied-seed (atom nil)
-          parsed (#'cli/ensure-random-seed
-                  {:options {:nemesis :partition
-                             :seed 41
-                             :time-limit 10}})]
-      (with-redefs [random/set-seed! #(reset! applied-seed %)]
-        (let [test (cli/openraft-test (:options parsed))]
-          (is (= 41 (:seed test)))
-          (is (= 41 @applied-seed)))))))
+  (testing "test construction does not restart an explicit seed"
+    (let [applied-seeds (atom [])
+          opts {:nemesis :partition
+                :seed 41
+                :time-limit 10}]
+      (with-redefs [random/set-seed! #(swap! applied-seeds conj %)]
+        (let [parsed (#'cli/ensure-random-seed {:options opts})]
+          (cli/openraft-test (:options parsed))
+          (cli/openraft-test (:options parsed))))
+      (is (= [41] @applied-seeds)))))
+
+(deftest validates-the-random-seed
+  (testing "a malformed seed is rejected"
+    (let [parsed (tools-cli/parse-opts ["--seed" "12e5"] cli/cli-opts)]
+      (is (some #(re-find #"Must be an integer" %)
+                (:errors parsed)))))
+
+  (testing "the seed remains optional"
+    (is (empty? (:errors (tools-cli/parse-opts [] cli/cli-opts))))))
 
 (deftest configures-worker-exception-and-node-crash-checkers
   (let [checkers (-> (cli/openraft-test {:nemesis :partition
+                                         :seed 41
                                          :time-limit 10})
                      :checker
                      :checkers)]
+    (testing "the random seed is included in checker results"
+      (is (= {:valid? true
+              :seed 41}
+             (checker/check (:seed checkers)
+                            {:seed 41}
+                            (history/history [])
+                            {}))))
+
     (testing "unhandled worker exceptions are reported"
       (let [op {:type :info
                 :f :read
@@ -36,15 +60,30 @@
                                   (history/history [op])
                                   {})
             exception (first (:exceptions result))]
-        (is (true? (:valid? result)))
+        (is (= :unknown (:valid? result)))
         (is (= {:count 1
                 :class 'java.lang.IllegalStateException}
-               (select-keys exception [:count :class])))))
+               (select-keys exception [:count :class])))
+        (is (true? (:valid? (checker/check (:exceptions checkers)
+                                           {}
+                                           (history/history [])
+                                           {}))))))
 
     (testing "node panic and fatal messages are matched"
-      (let [{:keys [filename pattern]} (:crash checkers)]
-        (is (= "openraft.log" filename))
+      (let [pattern @#'cli/node-crash-pattern]
         (is (re-find pattern
                      "thread 'main' panicked at src/main.rs:10:5"))
         (is (re-find pattern "fatal runtime error: stack overflow"))
-        (is (not (re-find pattern "INFO openraft::raft: vote committed")))))))
+        (is (not (re-find pattern "INFO openraft::raft: vote committed")))))
+
+    (testing "missing node logs make the crash result indeterminate"
+      (with-redefs [store/path
+                    (fn [_test _node _filename]
+                      (java.io.File.
+                       (str "/tmp/missing-openraft-log-" (random-uuid))))]
+        (let [result (checker/check (:crash checkers)
+                                    {:nodes [:n1]}
+                                    (history/history [])
+                                    {})]
+          (is (= :unknown (:valid? result)))
+          (is (= [:n1] (:missing-nodes result))))))))

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -1,0 +1,32 @@
+(ns jepsen.openraft.cli-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen.checker :as checker]
+            [jepsen.history :as history]
+            [jepsen.openraft.cli :as cli]))
+
+(deftest configures-worker-exception-and-node-crash-checkers
+  (let [checkers (-> (cli/openraft-test {:nemesis :partition
+                                         :time-limit 10})
+                     :checker
+                     :checkers)]
+    (testing "unhandled worker exceptions are reported"
+      (let [op {:type :info
+                :f :read
+                :exception {:via [{:type 'java.lang.IllegalStateException}]}}
+            result (checker/check (:exceptions checkers)
+                                  {}
+                                  (history/history [op])
+                                  {})
+            exception (first (:exceptions result))]
+        (is (true? (:valid? result)))
+        (is (= {:count 1
+                :class 'java.lang.IllegalStateException}
+               (select-keys exception [:count :class])))))
+
+    (testing "node panic and fatal messages are matched"
+      (let [{:keys [filename pattern]} (:crash checkers)]
+        (is (= "openraft.log" filename))
+        (is (re-find pattern
+                     "thread 'main' panicked at src/main.rs:10:5"))
+        (is (re-find pattern "fatal runtime error: stack overflow"))
+        (is (not (re-find pattern "INFO openraft::raft: vote committed")))))))


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

## Summary

- report unhandled worker, client, and Nemesis exceptions in checker results
- fail a run when OpenRaft logs contain Rust panic or fatal runtime messages
- generate and record a random seed for every Jepsen run
- allow a recorded seed to be reused through `--seed` or `SEED`
- document the limits of seed-based reproduction

## Motivation

A Jepsen run could previously appear valid while background exceptions or
node crashes were overlooked.

Random fault choices were also difficult to investigate because the seed used
by `jepsen.random` was not recorded. Preserving it makes failed runs easier to
analyze and allows similar fault selections to be exercised again.

The history remains the authoritative record of a run. Reusing a seed does not
fully reproduce concurrent scheduling, network timing, elections, or client
generator timing.

## Verification

- added tests for generated and explicitly supplied seeds
- added tests for applying the recorded seed to `jepsen.random`
- added tests for unhandled-exception reporting
- added tests for panic and fatal-runtime log matching
- passed Clojure formatting and lint checks

## Dependency

This PR is based on #1911 and should be reviewed after that PR.



**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1913)
<!-- Reviewable:end -->
