### PR TITLE
ci: check Jepsen changes on pull requests

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -1,6 +1,10 @@
 name: jepsen
 
 on:
+  pull_request:
+    paths:
+      - 'jepsen/**'
+      - '.github/workflows/jepsen.yml'
   push:
     branches:
       - main
@@ -14,8 +18,48 @@ permissions:
   contents: read
 
 jobs:
+  check:
+    name: Jepsen lint and unit tests
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup | Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+          cache-dependency-path: jepsen/project.clj
+
+      - name: Setup | Clojure tools
+        uses: DeLaGuardo/setup-clojure@13.6.1
+        with:
+          lein: 2.12.0
+          clj-kondo: 2026.07.24
+          cljfmt: 0.16.5
+
+      - name: Setup | Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
+
+      - name: Check | Clojure
+        run: make -C jepsen clojure-lint
+
+      - name: Check | Test app
+        run: make -C jepsen app-lint
+
+      - name: Test | Clojure
+        run: make -C jepsen unit-test
+
   jepsen:
     name: Jepsen (${{ matrix.nemesis }})
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/jepsen/Makefile
+++ b/jepsen/Makefile
@@ -20,6 +20,9 @@ clojure-lint:
 
 lint: app-lint clojure-lint
 
+unit-test:
+	lein test
+
 jepsen: build
 	@echo "[jepsen] starting containers"
 	@$(COMPOSE) up -d --force-recreate
@@ -48,4 +51,4 @@ down:
 	@echo "[jepsen] stopping containers"
 	@$(COMPOSE) down
 
-.PHONY: app-lint clojure-lint lint jepsen key build up test down
+.PHONY: app-lint clojure-lint lint unit-test jepsen key build up test down


### PR DESCRIPTION
Jepsen harness changes were only exercised after they reached main. Run the cheap lint and unit-test checks on affected pull requests so failures are reported before merge.

CLOSES #1922

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1926)
<!-- Reviewable:end -->
