### PR TITLE
test: declare the tools.cli dependency

### DIFF
--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -4,6 +4,7 @@
   :license {:name "Apache License 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.12.5"]
+                 [org.clojure/tools.cli "1.4.256"]
                  [jepsen "0.3.12-SNAPSHOT"]
                  [cheshire "5.6.3"]]
   :jvm-opts ["-Djava.awt.headless=true"


### PR DESCRIPTION
The CLI tests require tools.cli directly but previously received it only through Jepsen. Pin the currently resolved version so Jepsen dependency changes cannot silently remove it.

CLOSES #1925

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1927)
<!-- Reviewable:end -->
