### PR TITLE
fix: reject conflicting snapshots at committed index

### DIFF
--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -527,3 +527,24 @@ fn test_install_snapshot_conflict_with_committed() {
         snapshot: (),
     });
 }
+
+#[test]
+#[should_panic(expected = "contradicts locally committed logs")]
+fn test_install_snapshot_conflict_at_committed_index() {
+    let mut eng = eng();
+    eng.state.vote.update(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(5, 1),
+    );
+
+    let _ = eng.following_handler().install_full_snapshot(SnapshotOf::<UTConfig, ()> {
+        meta: SnapshotMetaOf::<UTConfig> {
+            // A greater log id at the committed index identifies a different committed entry.
+            last_log_id: Some(log_id(5, 1, 5)),
+            last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
+            snapshot_id: "1-2-3-4".to_string(),
+        },
+        snapshot: (),
+    });
+}

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -270,13 +270,13 @@ where
             self.leader_vote,
         );
 
-        // The snapshot is greater than local committed (checked above). If it is also at a
-        // smaller index, it claims a different history for an index range that is committed
-        // locally; installing it would leave `committed > last_log_id`.
+        // The snapshot is greater than local committed (checked above), so it must also be at a
+        // strictly greater index. An equal index means two different committed entries occupy the
+        // same slot; a smaller index contradicts a committed suffix.
         if let Some(committed) = self.state.local_committed() {
             assert!(
-                snap_last_log_id.index() >= committed.index(),
-                "snapshot last log id {} is greater than the locally committed log id {} but at a smaller index: \
+                snap_last_log_id.index() > committed.index(),
+                "snapshot last log id {} is greater than the locally committed log id {} but not at a greater index: \
                  the snapshot contradicts locally committed logs; \
                  the snapshot or the local store is corrupted",
                 snap_last_log_id,

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -1020,8 +1020,9 @@ where
     /// otherwise this method panics (also in release builds):
     /// - the snapshot's last log id must not be beyond the leadership of `vote`: no leader owns a
     ///   snapshot with a log id greater than its own vote;
-    /// - a snapshot greater than the locally committed log id must not be at a smaller index: it
-    ///   would contradict locally committed logs.
+    /// - a snapshot greater than the locally committed log id must be at a strictly greater index:
+    ///   an equal index identifies a different entry in an already committed slot, while a smaller
+    ///   index contradicts a committed suffix.
     ///
     /// Such input indicates a forged or corrupted snapshot, e.g., one built by a previous
     /// incarnation of the cluster. Installing it would corrupt the log id order.

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -162,12 +162,12 @@ where
 
         // Clean up dirty state: snapshot is installed, but logs are not cleaned.
         if last_log_id < last_applied {
-            // A genuine hole means `last_applied` is also ahead by index. If `last_applied` is
-            // greater but at a smaller index, the log contains a tail that contradicts the state
-            // machine: purging below `last_applied` would not remove it.
-            if last_log_id.next_index() > last_applied.next_index() {
+            // A genuine hole means `last_applied` is strictly ahead by index. An equal index means
+            // the state machine and log store contain different entries in the same slot; a smaller
+            // applied index leaves a conflicting log tail that purging cannot remove.
+            if last_log_id.next_index() >= last_applied.next_index() {
                 let err = C::err_from_string(format!(
-                    "inverted log order: last_applied({}) in the state machine is greater than last_log_id({}) in the log store but at a smaller index; the store is corrupted",
+                    "inverted log order: last_applied({}) in the state machine is greater than last_log_id({}) in the log store but not at a greater index; the store is corrupted",
                     last_applied.display(),
                     last_log_id.display(),
                 ));

--- a/openraft/src/testing/log/suite.rs
+++ b/openraft/src/testing/log/suite.rs
@@ -147,6 +147,7 @@ where
         run_test(builder, Self::get_initial_state_last_log_gt_sm).await?;
         run_test(builder, Self::get_initial_state_last_log_lt_sm).await?;
         run_test(builder, Self::get_initial_state_inverted_log_order).await?;
+        run_test(builder, Self::get_initial_state_conflict_at_same_index).await?;
         run_test(builder, Self::get_initial_state_log_ids).await?;
         run_test(builder, Self::get_initial_state_re_apply_committed).await?;
         run_test(builder, Self::save_vote).await?;
@@ -661,6 +662,22 @@ where
         assert!(
             err.to_string().contains("inverted log order"),
             "expect inverted-log-order error, got: {}",
+            err
+        );
+        Ok(())
+    }
+
+    pub async fn get_initial_state_conflict_at_same_index(mut store: LS, mut sm: SM) -> Result<(), io::Error> {
+        Self::default_vote(&mut store).await?;
+        append(&mut store, [blank_ent_0::<C>(1, 2)]).await?;
+        apply(&mut sm, [blank_ent_0::<C>(3, 2)]).await?;
+
+        let res = StorageHelper::new(&mut store, &mut sm).with_id(NODE_ID.into()).get_initial_state().await;
+
+        let err = res.unwrap_err();
+        assert!(
+            err.to_string().contains("inverted log order"),
+            "expect same-index conflict error, got: {}",
             err
         );
         Ok(())


### PR DESCRIPTION

## Changelog

##### fix: reject conflicting snapshots at committed index
# Summary

Snapshot installation and startup recovery now reject a greater log ID
that identifies a different entry at an already committed index.

# Details

Snapshot input greater than the local committed log ID must advance the
index strictly. An equal index represents two different committed entries
in the same slot and is protocol-impossible.

Startup recovery applies the same rule before repairing a snapshot/log
hole, preventing it from silently adopting a conflicting applied entry.

- Fix: #1892

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1930)
<!-- Reviewable:end -->
