### PR TITLE
change: move `snapshot_id` out of `SnapshotMeta`

### DIFF
--- a/benchmarks/minimal/src/store.rs
+++ b/benchmarks/minimal/src/store.rs
@@ -7,8 +7,6 @@ use std::io;
 use std::io::Cursor;
 use std::ops::RangeBounds;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
 
 use futures::Stream;
 use openraft::EntryPayload;
@@ -123,7 +121,6 @@ impl Default for LogStore {
 
 pub struct StateMachineStore {
     sm: RwLock<StateMachine>,
-    snapshot_idx: AtomicU64,
     current_snapshot: RwLock<Option<StoredSnapshot>>,
 }
 
@@ -131,7 +128,6 @@ impl StateMachineStore {
     pub fn new() -> Self {
         Self {
             sm: RwLock::new(StateMachine::default()),
-            snapshot_idx: AtomicU64::new(0),
             current_snapshot: RwLock::new(None),
         }
     }
@@ -184,18 +180,9 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
 
         let snapshot_size = data.len();
 
-        let snapshot_idx = self.snapshot_idx.fetch_add(1, Ordering::Relaxed);
-
-        let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
-        } else {
-            format!("--{}", snapshot_idx)
-        };
-
         let meta = SnapshotMetaOf::<TypeConfig> {
             last_log_id: last_applied_log,
             last_membership,
-            snapshot_id,
         };
 
         let snapshot = StoredSnapshot {

--- a/examples/raft-kv-memstore-grpc/proto/raft.proto
+++ b/examples/raft-kv-memstore-grpc/proto/raft.proto
@@ -119,7 +119,8 @@ message SnapshotRequestMeta {
 
   Membership last_membership = 4;
 
-  string snapshot_id = 5;
+  // Was `snapshot_id`; keep the tag from being reused with a different meaning.
+  reserved 5;
 }
 
 // The item of snapshot chunk stream.

--- a/examples/raft-kv-memstore-grpc/src/grpc/raft_service.rs
+++ b/examples/raft-kv-memstore-grpc/src/grpc/raft_service.rs
@@ -130,7 +130,6 @@ impl RaftService for RaftServiceImpl {
                     meta.last_membership_log_id.map(|x| x.into()),
                     meta.last_membership.unwrap().into(),
                 ),
-                snapshot_id: meta.snapshot_id,
             };
         }
 

--- a/examples/raft-kv-memstore-grpc/src/network/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/network/mod.rs
@@ -188,7 +188,6 @@ impl NetSnapshot<TypeConfig> for NetworkConnection {
                 last_log_id: meta.last_log_id.map(|log_id| log_id.into()),
                 last_membership_log_id: meta.last_membership.log_id().map(|log_id| log_id.into()),
                 last_membership: Some(meta.last_membership.membership().clone().into()),
-                snapshot_id: meta.snapshot_id.to_string(),
             })),
         };
 

--- a/examples/raft-kv-memstore-grpc/src/store/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/store/mod.rs
@@ -33,21 +33,8 @@ pub struct StateMachineStore {
     /// The Raft state machine.
     pub state_machine: Mutex<pb::StateMachineData>,
 
-    snapshot_idx: StdMutex<u64>,
-
     /// The last received snapshot.
     current_snapshot: StdMutex<Option<StoredSnapshot>>,
-}
-
-impl StateMachineStore {
-    /// Generates a unique snapshot ID based on the last applied log and snapshot index.
-    fn generate_snapshot_id(last_applied: &Option<LogId>, snapshot_idx: u64) -> String {
-        if let Some(last) = last_applied {
-            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
-        } else {
-            format!("--{}", snapshot_idx)
-        }
-    }
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
@@ -71,18 +58,9 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
             data = prost::Message::encode_to_vec(&state_machine);
         }
 
-        let snapshot_idx = {
-            let mut l = self.snapshot_idx.lock().unwrap();
-            *l += 1;
-            *l
-        };
-
-        let snapshot_id = StateMachineStore::generate_snapshot_id(&last_applied, snapshot_idx);
-
         let meta = SnapshotMeta {
             last_log_id: last_applied,
             last_membership,
-            snapshot_id,
         };
 
         let stored = StoredSnapshot {

--- a/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
+++ b/examples/raft-kv-memstore-opendal-snapshot-data/src/store.rs
@@ -50,7 +50,6 @@ pub struct StateMachineStore {
     /// The Raft state machine.
     pub state_machine: Mutex<StateMachineData>,
 
-    snapshot_idx: StdMutex<u64>,
     storage: Operator,
 
     /// The last received snapshot.
@@ -61,7 +60,6 @@ impl StateMachineStore {
     pub fn new(storage: Operator) -> Self {
         Self {
             state_machine: Mutex::new(StateMachineData::default()),
-            snapshot_idx: StdMutex::new(0),
             storage,
             current_snapshot: StdMutex::new(None),
         }
@@ -86,33 +84,26 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
             data = state_machine;
         }
 
-        let snapshot_idx = {
-            let mut l = self.snapshot_idx.lock().unwrap();
-            *l += 1;
-            *l
-        };
-
-        let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
+        // Generate a unique path to store the snapshot at.
+        // Users can design their own logic for this like using uuid.
+        let nanos = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos();
+        let snapshot_filename = if let Some(last) = last_applied_log {
+            format!("{}-{}-{}", last.committed_leader_id(), last.index(), nanos)
         } else {
-            format!("--{}", snapshot_idx)
+            format!("--{}", nanos)
         };
 
         // Save the snapshot to the storage.
-        //
-        // In this example, we use `snapshot_id` as the snapshot store path.
-        // Users can design their own logic for this like using uuid.
-        self.storage.write(&snapshot_id, encode(&data)).await.unwrap();
+        self.storage.write(&snapshot_filename, encode(&data)).await.unwrap();
 
         let meta = SnapshotMeta {
             last_log_id: last_applied_log,
             last_membership,
-            snapshot_id: snapshot_id.clone(),
         };
 
         let snapshot = StoredSnapshot {
             meta: meta.clone(),
-            data: snapshot_id.clone(),
+            data: snapshot_filename.clone(),
         };
 
         {
@@ -122,7 +113,7 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {
 
         Ok(Snapshot {
             meta,
-            snapshot: snapshot_id,
+            snapshot: snapshot_filename,
         })
     }
 }

--- a/examples/raft-kv-memstore-single-threaded/src/store.rs
+++ b/examples/raft-kv-memstore-single-threaded/src/store.rs
@@ -103,8 +103,6 @@ pub struct StateMachineStore {
     /// The Raft state machine.
     pub state_machine: RefCell<StateMachineData>,
 
-    snapshot_idx: RefCell<u64>,
-
     /// The last received snapshot.
     current_snapshot: RefCell<Option<StoredSnapshot>>,
 }
@@ -155,22 +153,9 @@ impl RaftSnapshotBuilder<TypeConfig> for Rc<StateMachineStore> {
             last_membership = state_machine.last_membership.clone();
         }
 
-        let snapshot_idx = {
-            let mut l = self.snapshot_idx.borrow_mut();
-            *l += 1;
-            *l
-        };
-
-        let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
-        } else {
-            format!("--{}", snapshot_idx)
-        };
-
         let meta = SnapshotMeta {
             last_log_id: last_applied_log,
             last_membership,
-            snapshot_id,
         };
 
         let snapshot = StoredSnapshot {

--- a/examples/raft-kv-rocksdb/src/store.rs
+++ b/examples/raft-kv-rocksdb/src/store.rs
@@ -35,12 +35,6 @@ pub struct StoredSnapshot {
 pub struct StateMachineStore {
     pub data: StateMachineData,
 
-    /// snapshot index is not persisted in this example.
-    ///
-    /// It is only used as a suffix of snapshot id, and should be globally unique.
-    /// In practice, using a timestamp in micro-second would be good enough.
-    snapshot_idx: u64,
-
     /// State machine stores snapshot in db.
     db: Arc<DB>,
 }
@@ -67,16 +61,9 @@ impl RaftSnapshotBuilder<TypeConfig> for StateMachineStore {
             serde_json::to_vec(&*kvs).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
         };
 
-        let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.committed_leader_id(), last.index(), self.snapshot_idx)
-        } else {
-            format!("--{}", self.snapshot_idx)
-        };
-
         let meta = SnapshotMeta {
             last_log_id: last_applied_log,
             last_membership,
-            snapshot_id,
         };
 
         let snapshot = StoredSnapshot {
@@ -101,7 +88,6 @@ impl StateMachineStore {
                 last_membership: Default::default(),
                 kvs: Arc::new(Mutex::new(BTreeMap::new())),
             },
-            snapshot_idx: 0,
             db,
         };
 
@@ -205,7 +191,6 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
     }
 
     async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
-        self.snapshot_idx += 1;
         self.clone()
     }
 

--- a/examples/sm-mem/src/lib.rs
+++ b/examples/sm-mem/src/lib.rs
@@ -4,8 +4,6 @@ use std::collections::BTreeMap;
 use std::io;
 use std::io::Cursor;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
 
 use futures::Stream;
 use futures::TryStreamExt;
@@ -50,9 +48,6 @@ pub struct StateMachineStoreInner<C: RaftTypeConfig> {
     /// The Raft state machine.
     pub state_machine: StateMachineData,
 
-    /// Used in identifier for snapshot.
-    snapshot_idx: AtomicU64,
-
     /// The last received snapshot.
     pub current_snapshot: Option<StoredSnapshot<C>>,
 }
@@ -63,15 +58,8 @@ impl<C: RaftTypeConfig> Default for StateMachineStoreInner<C> {
             last_applied_log: None,
             last_membership: StoredMembershipOf::<C>::default(),
             state_machine: StateMachineData::default(),
-            snapshot_idx: AtomicU64::new(0),
             current_snapshot: None,
         }
-    }
-}
-
-impl<C: RaftTypeConfig> StateMachineStoreInner<C> {
-    fn next_snapshot_idx(&self) -> u64 {
-        self.snapshot_idx.fetch_add(1, Ordering::Relaxed) + 1
     }
 }
 
@@ -108,17 +96,9 @@ where C: RaftTypeConfig<D = types_kv::Request, R = types_kv::Response, Entry = D
         let data =
             serde_json::to_vec(&inner.state_machine.data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
-        let snapshot_idx = inner.next_snapshot_idx();
-        let snapshot_id = if let Some(last) = inner.last_applied_log.clone() {
-            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
-        } else {
-            format!("--{}", snapshot_idx)
-        };
-
         let meta = SnapshotMetaOf::<C> {
             last_log_id: inner.last_applied_log.clone(),
             last_membership: inner.last_membership.clone(),
-            snapshot_id,
         };
 
         let snapshot = StoredSnapshot {

--- a/examples/sm-rocks/Cargo.toml
+++ b/examples/sm-rocks/Cargo.toml
@@ -22,7 +22,6 @@ openraft = { path = "../../openraft", version = "0.10.0-alpha.32", features = ["
 types-kv = { path = "../types-kv" }
 
 futures    = { version = "0.3" }
-rand       = { version = "0.9" }
 rocksdb    = { version = "0.22.0" }
 serde      = { version = "1.0.114", features = ["derive"] }
 serde_json = { version = "1.0.57" }

--- a/examples/sm-rocks/src/state_machine.rs
+++ b/examples/sm-rocks/src/state_machine.rs
@@ -22,7 +22,6 @@ use openraft::entry::RaftEntry;
 use openraft::storage::EntryResponder;
 use openraft::storage::RaftStateMachine;
 use openraft::type_config::TypeConfigExt;
-use rand::Rng;
 use rocksdb::DB;
 use serde::Deserialize;
 use serde::Serialize;
@@ -81,6 +80,18 @@ impl RocksStateMachine {
 
         Ok((last_applied_log, last_membership))
     }
+
+    /// The file name a snapshot is stored under, derived from the position it covers.
+    ///
+    /// [`Self::get_current_snapshot()`] picks the greatest file name, thus every writer
+    /// ([`RaftSnapshotBuilder::build_snapshot()`] and [`RaftStateMachine::install_snapshot()`])
+    /// must name files with this same scheme.
+    fn snapshot_filename(meta: &SnapshotMetaOf<TypeConfig>) -> String {
+        match &meta.last_log_id {
+            Some(last) => format!("{}-{}", last.committed_leader_id(), last.index()),
+            None => "--".to_string(),
+        }
+    }
 }
 
 fn serialize<T: Serialize>(value: &T) -> Result<Vec<u8>, StorageError<TypeConfig>> {
@@ -105,19 +116,9 @@ impl RaftSnapshotBuilder<TypeConfig> for RocksStateMachine {
     async fn build_snapshot(&mut self) -> Result<SnapshotOf<TypeConfig, Cursor<Vec<u8>>>, io::Error> {
         let (last_applied_log, last_membership) = self.get_meta()?;
 
-        // Generate a random snapshot index.
-        let snapshot_idx: u64 = rand::rng().random_range(0..1000);
-
-        let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
-        } else {
-            format!("--{}", snapshot_idx)
-        };
-
         let meta = SnapshotMetaOf::<TypeConfig> {
             last_log_id: last_applied_log,
             last_membership,
-            snapshot_id: snapshot_id.clone(),
         };
 
         // Use RocksDB snapshot for consistent point-in-time view
@@ -150,7 +151,7 @@ impl RaftSnapshotBuilder<TypeConfig> for RocksStateMachine {
         })?;
 
         // Write complete snapshot to file
-        let snapshot_path = self.snapshot_dir.join(&snapshot_id);
+        let snapshot_path = self.snapshot_dir.join(Self::snapshot_filename(&meta));
         fs::write(&snapshot_path, &file_bytes).map_err(|e| {
             StorageError::<TypeConfig>::write_snapshot(Some(meta.signature()), TypeConfig::err_from_error(&e))
         })?;
@@ -342,7 +343,7 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
         let file_bytes =
             serialize(&snapshot_file).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
-        let snapshot_path = self.snapshot_dir.join(&meta.snapshot_id);
+        let snapshot_path = self.snapshot_dir.join(Self::snapshot_filename(meta));
         fs::write(&snapshot_path, &file_bytes)?;
 
         Ok(())

--- a/examples/sm-rocks/src/state_machine.rs
+++ b/examples/sm-rocks/src/state_machine.rs
@@ -85,10 +85,13 @@ impl RocksStateMachine {
     ///
     /// [`Self::get_current_snapshot()`] picks the greatest file name, thus every writer
     /// ([`RaftSnapshotBuilder::build_snapshot()`] and [`RaftStateMachine::install_snapshot()`])
-    /// must name files with this same scheme.
+    /// must name files with this same scheme, and names must sort in position order: the
+    /// zero-padded log index leads, so that lexicographic order equals numeric order.
+    /// Committed log ids are totally ordered by index alone, so the leader id is a
+    /// readability suffix that never decides the comparison.
     fn snapshot_filename(meta: &SnapshotMetaOf<TypeConfig>) -> String {
         match &meta.last_log_id {
-            Some(last) => format!("{}-{}", last.committed_leader_id(), last.index()),
+            Some(last) => format!("{:020}-{}", last.index(), last.committed_leader_id()),
             None => "--".to_string(),
         }
     }
@@ -444,6 +447,28 @@ mod tests {
 
             assert_eq!("B", value.value);
             assert!(value.version > initial_value.version);
+        });
+    }
+
+    #[test]
+    fn get_current_snapshot_returns_greatest_position() {
+        TypeConfig::run(async {
+            let td = TempDir::new().unwrap();
+            let (_, mut state_machine) = crate::new::<TypeConfig, _>(td.path()).await.unwrap();
+
+            let empty_data = || Cursor::new(serialize(&Vec::<(Vec<u8>, Vec<u8>)>::new()).unwrap());
+            let meta = |index: u64| SnapshotMetaOf::<TypeConfig> {
+                last_log_id: Some(openraft::testing::log_id::<TypeConfig>(1, 1, index)),
+                last_membership: Default::default(),
+            };
+
+            // Index 9 vs 10 exposes lexicographic-vs-numeric filename ordering.
+            state_machine.install_snapshot(&meta(9), empty_data()).await.unwrap();
+            state_machine.install_snapshot(&meta(10), empty_data()).await.unwrap();
+
+            let current = state_machine.get_current_snapshot().await.unwrap().unwrap();
+            assert_eq!(meta(10), current.meta);
+            assert_eq!(b"[]".to_vec(), current.snapshot.into_inner());
         });
     }
 }

--- a/legacy/Cargo.toml
+++ b/legacy/Cargo.toml
@@ -18,11 +18,16 @@ openraft = { path = "../openraft", version = "0.10.0-alpha.32", default-features
 openraft-macros = { path = "../macros", version = "0.10.0-alpha.32" }
 
 derive_more = { workspace = true }
+display-more = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "sync"] }
 tracing = { workspace = true }
+
+[dev-dependencies]
+openraft = { path = "../openraft", version = "0.10.0-alpha.32", default-features = false, features = ["tokio-rt"] }
+serde_json = { workspace = true }
 
 [features]
 default = []

--- a/legacy/src/lib.rs
+++ b/legacy/src/lib.rs
@@ -29,6 +29,9 @@
 
 pub mod network_v1;
 
+#[cfg(test)]
+mod testing;
+
 /// Prelude for convenient imports of commonly used legacy types.
 ///
 /// # Usage
@@ -43,6 +46,7 @@ pub mod prelude {
     pub use crate::network_v1::InstallSnapshotRequest;
     pub use crate::network_v1::InstallSnapshotResponse;
     pub use crate::network_v1::RaftNetwork;
+    pub use crate::network_v1::SnapshotMeta;
     pub use crate::network_v1::SnapshotMismatch;
     pub use crate::network_v1::SnapshotReceiverFactory;
     pub use crate::network_v1::SnapshotSegmentId;

--- a/legacy/src/network_v1/message/install_snapshot_request.rs
+++ b/legacy/src/network_v1/message/install_snapshot_request.rs
@@ -1,11 +1,16 @@
 use std::fmt;
 
 use openraft::RaftTypeConfig;
-use openraft::type_config::alias::SnapshotMetaOf;
 use openraft::type_config::alias::VoteOf;
 use openraft_macros::since;
 
+use super::snapshot_meta::SnapshotMeta;
+
 /// An RPC sent by the Raft leader to send chunks of a snapshot to a follower (§7).
+///
+/// The serialized layout is identical to the 0.9 `openraft::raft::InstallSnapshotRequest`,
+/// so 0.9 and 0.10 peers can exchange this RPC under positional formats too; see
+/// [`SnapshotMeta`], which keeps the transfer id in its 0.9 position.
 #[since(version = "0.10.0", change = "moved from `openraft::raft::InstallSnapshotRequest`")]
 #[derive(Clone, Debug)]
 #[derive(PartialEq, Eq)]
@@ -16,8 +21,8 @@ where C: RaftTypeConfig
     /// The leader's current vote.
     pub vote: VoteOf<C>,
 
-    /// Metadata of a snapshot: snapshot_id, last_log_ed membership, etc.
-    pub meta: SnapshotMetaOf<C>,
+    /// Metadata of a snapshot: snapshot_id, last_log_id, membership, etc.
+    pub meta: SnapshotMeta<C>,
 
     /// The byte offset where this chunk of data is positioned in the snapshot file.
     pub offset: u64,
@@ -41,5 +46,50 @@ where C: RaftTypeConfig
             self.data.len(),
             self.done
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_install_snapshot_request_serde() {
+        use std::collections::BTreeSet;
+
+        use openraft::Membership;
+        use openraft::StoredMembership;
+        use openraft::Vote;
+        use openraft::testing::log_id;
+
+        use super::InstallSnapshotRequest;
+        use super::SnapshotMeta;
+        use crate::testing::TestConfig;
+
+        let req = InstallSnapshotRequest::<TestConfig> {
+            vote: Vote::new_committed(2, 1),
+            meta: SnapshotMeta {
+                last_log_id: Some(log_id::<TestConfig>(1, 2, 3)),
+                last_membership: StoredMembership::new(
+                    Some(log_id::<TestConfig>(4, 5, 6)),
+                    Membership::new_with_defaults(vec![BTreeSet::from([1, 2])], []),
+                ),
+                snapshot_id: "1-2-3-4".to_string(),
+            },
+            offset: 7,
+            data: vec![1, 2, 3],
+            done: true,
+        };
+
+        // Five fields with the transfer id inside `meta`: the exact 0.9 wire layout. The
+        // field count and order are the compatibility contract with 0.9 peers under
+        // positional formats (bincode, postcard), which encode a struct as a bare sequence.
+        let want = r#"{"vote":{"leader_id":{"term":2,"node_id":1},"committed":true},"meta":{"last_log_id":{"leader_id":{"term":1,"node_id":2},"index":3},"last_membership":{"log_id":{"leader_id":{"term":4,"node_id":5},"index":6},"membership":{"configs":[[1,2]],"nodes":{"1":{"addr":"localhost"},"2":{"addr":"localhost"}}}},"snapshot_id":"1-2-3-4"},"offset":7,"data":[1,2,3],"done":true}"#;
+
+        assert_eq!(want, serde_json::to_string(&req).unwrap());
+        assert_eq!(
+            req,
+            serde_json::from_str::<InstallSnapshotRequest<TestConfig>>(want).unwrap()
+        );
     }
 }

--- a/legacy/src/network_v1/message/mod.rs
+++ b/legacy/src/network_v1/message/mod.rs
@@ -2,6 +2,8 @@
 
 mod install_snapshot_request;
 mod install_snapshot_response;
+mod snapshot_meta;
 
 pub use install_snapshot_request::InstallSnapshotRequest;
 pub use install_snapshot_response::InstallSnapshotResponse;
+pub use snapshot_meta::SnapshotMeta;

--- a/legacy/src/network_v1/message/snapshot_meta.rs
+++ b/legacy/src/network_v1/message/snapshot_meta.rs
@@ -1,0 +1,121 @@
+use std::fmt;
+
+use display_more::DisplayOptionExt;
+use openraft::RaftTypeConfig;
+use openraft::SnapshotId;
+use openraft::type_config::alias::LogIdOf;
+use openraft::type_config::alias::SnapshotMetaOf;
+use openraft::type_config::alias::SnapshotSignatureOf;
+use openraft::type_config::alias::StoredMembershipOf;
+use openraft_macros::since;
+
+/// The metadata of a snapshot in the chunked v1 snapshot protocol.
+///
+/// This is the 0.9 `openraft::SnapshotMeta`, kept with its exact 0.9 serialized layout —
+/// `snapshot_id` included — so that [`InstallSnapshotRequest`] stays wire-compatible with 0.9
+/// peers: a 0.9 receiver reads the transfer id from this position.
+///
+/// The 0.10 [`SnapshotMeta`](openraft::storage::SnapshotMeta) no longer carries the id, because
+/// it identifies a transfer rather than a snapshot; see its compatibility note. [`Self::new()`]
+/// combines that metadata with a transfer id on the sending side, and [`Self::into_meta()`]
+/// drops the id again on the receiving side.
+///
+/// [`InstallSnapshotRequest`]: crate::network_v1::InstallSnapshotRequest
+#[since(
+    version = "0.10.0",
+    change = "split from `openraft::storage::SnapshotMeta` to keep the 0.9 wire layout"
+)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+pub struct SnapshotMeta<C>
+where C: RaftTypeConfig
+{
+    /// Log entries up to which this snapshot includes, inclusive.
+    pub last_log_id: Option<LogIdOf<C>>,
+
+    /// The last applied membership config.
+    pub last_membership: StoredMembershipOf<C>,
+
+    /// To identify a snapshot when transferring.
+    ///
+    /// Caveat: even when two snapshots are built with the same `last_log_id`, they still could
+    /// be different in bytes.
+    pub snapshot_id: SnapshotId,
+}
+
+impl<C> SnapshotMeta<C>
+where C: RaftTypeConfig
+{
+    /// Combine a snapshot's metadata with the id of the transfer it is sent in.
+    pub fn new(meta: SnapshotMetaOf<C>, snapshot_id: SnapshotId) -> Self {
+        Self {
+            last_log_id: meta.last_log_id,
+            last_membership: meta.last_membership,
+            snapshot_id,
+        }
+    }
+
+    /// The snapshot's own metadata, without the transfer id.
+    pub fn into_meta(self) -> SnapshotMetaOf<C> {
+        SnapshotMetaOf::<C> {
+            last_log_id: self.last_log_id,
+            last_membership: self.last_membership,
+        }
+    }
+
+    /// Get the signature of this snapshot metadata for comparison and identification.
+    ///
+    /// The transfer id is not part of it: a signature identifies the snapshot, and the id
+    /// identifies a transfer session.
+    pub fn signature(&self) -> SnapshotSignatureOf<C> {
+        self.clone().into_meta().signature()
+    }
+}
+
+impl<C> fmt::Display for SnapshotMeta<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{{snapshot_id: {}, last_log:{}, last_membership: {}}}",
+            self.snapshot_id,
+            self.last_log_id.display(),
+            self.last_membership
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_snapshot_meta_serde() {
+        use std::collections::BTreeSet;
+
+        use openraft::Membership;
+        use openraft::StoredMembership;
+        use openraft::testing::log_id;
+
+        use super::SnapshotMeta;
+        use crate::testing::TestConfig;
+
+        let meta = SnapshotMeta::<TestConfig> {
+            last_log_id: Some(log_id::<TestConfig>(1, 2, 3)),
+            last_membership: StoredMembership::new(
+                Some(log_id::<TestConfig>(4, 5, 6)),
+                Membership::new_with_defaults(vec![BTreeSet::from([1, 2])], []),
+            ),
+            snapshot_id: "1-2-3-4".to_string(),
+        };
+
+        // The exact 0.9 `SnapshotMeta` layout, with a meaningful `snapshot_id` third field.
+        // The field count and order are the compatibility contract with 0.9 peers under
+        // positional formats (bincode, postcard), which encode a struct as a bare sequence.
+        let want = r#"{"last_log_id":{"leader_id":{"term":1,"node_id":2},"index":3},"last_membership":{"log_id":{"leader_id":{"term":4,"node_id":5},"index":6},"membership":{"configs":[[1,2]],"nodes":{"1":{"addr":"localhost"},"2":{"addr":"localhost"}}}},"snapshot_id":"1-2-3-4"}"#;
+
+        assert_eq!(want, serde_json::to_string(&meta).unwrap());
+        assert_eq!(meta, serde_json::from_str::<SnapshotMeta<TestConfig>>(want).unwrap());
+    }
+}

--- a/legacy/src/network_v1/mod.rs
+++ b/legacy/src/network_v1/mod.rs
@@ -60,6 +60,7 @@ pub use errors::SnapshotMismatch;
 pub use errors::SnapshotSegmentId;
 pub use message::InstallSnapshotRequest;
 pub use message::InstallSnapshotResponse;
+pub use message::SnapshotMeta;
 pub use raft_network::RaftNetwork;
 pub use receiver::ChunkedSnapshotReceiver;
 pub use snapshot_receiver_factory::SnapshotReceiverFactory;

--- a/legacy/src/network_v1/receiver/chunked_snapshot_receiver.rs
+++ b/legacy/src/network_v1/receiver/chunked_snapshot_receiver.rs
@@ -94,12 +94,12 @@ where
         req: InstallSnapshotRequest<C>,
     ) -> Result<InstallSnapshotResponse<C>, RaftError<C, InstallSnapshotError>> {
         let vote = req.vote.clone();
-        let snapshot_id = &req.meta.snapshot_id;
+        let snapshot_id = req.meta.snapshot_id.clone();
         let snapshot_meta = req.meta.clone();
         let done = req.done;
 
         tracing::info!(
-            snapshot_id = display(snapshot_id),
+            snapshot_id = display(&snapshot_id),
             offset = req.offset,
             done,
             "ChunkedSnapshotReceiver::install_snapshot"
@@ -112,7 +112,7 @@ where
         // Check if this is a new snapshot or continuation
         let curr_id = streaming.as_ref().map(|s| s.snapshot_id());
 
-        if curr_id != Some(snapshot_id) {
+        if curr_id != Some(&snapshot_id) {
             // New snapshot - must start at offset 0
             if req.offset != 0 {
                 let mismatch = InstallSnapshotError::SnapshotMismatch(SnapshotMismatch {
@@ -163,7 +163,7 @@ where
             tracing::info!(snapshot_meta = debug(&snapshot_meta), "Finished streaming snapshot");
 
             let snapshot = SnapshotOf::<C, Self::SnapshotData> {
-                meta: snapshot_meta,
+                meta: snapshot_meta.into_meta(),
                 snapshot: data,
             };
 

--- a/legacy/src/network_v1/sender.rs
+++ b/legacy/src/network_v1/sender.rs
@@ -3,6 +3,8 @@
 use std::future::Future;
 use std::io::SeekFrom;
 use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use futures::FutureExt;
 use openraft::ErrorSubject;
@@ -25,6 +27,7 @@ use tokio::io::AsyncSeekExt;
 use crate::network_v1::InstallSnapshotError;
 use crate::network_v1::InstallSnapshotRequest;
 use crate::network_v1::RaftNetwork;
+use crate::network_v1::SnapshotMeta;
 
 /// Sends snapshots in chunks via `RaftNetwork::install_snapshot()`.
 ///
@@ -60,7 +63,17 @@ where
     where
         Net: RaftNetwork<C> + ?Sized,
     {
-        let subject_verb = || (ErrorSubject::Snapshot(Some(snapshot.meta.signature())), ErrorVerb::Read);
+        // One id per transfer session: a retransmitted snapshot must not be mistaken for a
+        // continuation of an earlier aborted transfer.
+        let snapshot_id = format!(
+            "{}-{}-{}",
+            snapshot.meta.last_log_id.as_ref().map(|l| l.index()).unwrap_or(0),
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos()
+        );
+        let meta = SnapshotMeta::new(snapshot.meta.clone(), snapshot_id);
+
+        let subject_verb = || (ErrorSubject::Snapshot(Some(meta.signature())), ErrorVerb::Read);
 
         let mut offset = 0;
         let end = snapshot.snapshot.seek(SeekFrom::End(0)).await.sto_res(subject_verb)?;
@@ -94,7 +107,7 @@ where
             let done = (offset + n_read as u64) == end;
             let req = InstallSnapshotRequest {
                 vote: vote.clone(),
-                meta: snapshot.meta.clone(),
+                meta: meta.clone(),
                 offset,
                 data: buf,
                 done,

--- a/legacy/src/testing.rs
+++ b/legacy/src/testing.rs
@@ -1,0 +1,3 @@
+//! Type config for unit tests.
+
+openraft::declare_raft_types!(pub(crate) TestConfig);

--- a/openraft/src/docs/upgrade_guide/mod.rs
+++ b/openraft/src/docs/upgrade_guide/mod.rs
@@ -12,3 +12,6 @@ pub mod upgrade_083_084 {
 pub mod upgrade_08_09 {
     #![doc = include_str!("upgrade-v08-v09.md")]
 }
+pub mod upgrade_09_10 {
+    #![doc = include_str!("upgrade-v09-v10.md")]
+}

--- a/openraft/src/docs/upgrade_guide/upgrade-v09-v10.md
+++ b/openraft/src/docs/upgrade_guide/upgrade-v09-v10.md
@@ -1,0 +1,64 @@
+# Guide for upgrading from [v0.9](https://github.com/databendlabs/openraft/tree/release-0.9) to v0.10:
+
+> This guide is under construction; it currently covers the `snapshot_id` changes.
+
+## `snapshot_id` moved out of snapshot metadata
+
+A snapshot is identified by the position it covers: two snapshots at the same
+`last_log_id` represent the same state, even when they differ in bytes. The
+0.9 `snapshot_id` identified a snapshot *transfer*, not the snapshot, so it no
+longer belongs in the metadata. It now lives only in the chunked v1 protocol,
+which is the only code that needs it: the receiver compares it against the
+in-flight stream to tell a new transfer from a continuation.
+
+API changes:
+
+- [`SnapshotMeta`][] loses its `snapshot_id` field. State machines no longer
+  invent an id when building a snapshot:
+
+  ```ignore
+  let meta = SnapshotMeta {
+      last_log_id,
+      last_membership,
+  };
+  ```
+
+- [`SnapshotSignature`][] loses its `snapshot_id` field.
+
+- A [`RaftNetworkV2`][] (full-snapshot) implementation needs no change.
+
+- A chunked v1 implementation uses `openraft-legacy`, where
+  `InstallSnapshotRequest` keeps the exact 0.9 five-field wire layout. Its
+  `meta` field is `openraft_legacy::network_v1::SnapshotMeta`, the 0.9-shaped
+  type that still carries the id; only the import changes:
+
+  ```ignore
+  use openraft_legacy::network_v1::{InstallSnapshotRequest, SnapshotMeta};
+
+  let req = InstallSnapshotRequest {
+      vote,
+      meta: SnapshotMeta { last_log_id, last_membership, snapshot_id },
+      offset,
+      data,
+      done,
+  };
+  ```
+
+  The v1 sender now generates a fresh id per transfer session, so a
+  retransmitted snapshot is never mistaken for a continuation of an aborted
+  one.
+
+No data migration is needed. The serialized layouts of [`SnapshotMeta`][] and
+[`SnapshotSignature`][] are unchanged — three fields, with an always-empty
+`snapshot_id` written and ignored on read — so snapshots stored by 0.9 load in
+0.10 and vice versa, under named and positional (`bincode`, `postcard`)
+formats alike.
+
+Mixed-version caveat: request and metadata layouts interoperate with 0.9 peers
+in both directions, but error bodies do not — `StorageError` was an enum in
+0.9 and is a struct in 0.10 — so a peer of a different version should treat a
+serialized error response as diagnostic text rather than parse it.
+
+[`SnapshotMeta`]:      `crate::storage::SnapshotMeta`
+[`SnapshotSignature`]: `crate::storage::SnapshotSignature`
+[`RaftNetworkV2`]:     `crate::network::RaftNetworkV2`

--- a/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
+++ b/openraft/src/engine/handler/following_handler/install_snapshot_test.rs
@@ -49,7 +49,6 @@ fn eng() -> Engine<UTConfig> {
     eng.state.snapshot_meta = SnapshotMetaOf::<UTConfig> {
         last_log_id: Some(log_id(2, 1, 2)),
         last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12()),
-        snapshot_id: "1-2-3-4".to_string(),
     };
     eng.state.server_state = eng.calc_server_state();
 
@@ -66,7 +65,6 @@ fn test_install_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
         meta: SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(2, 1, 2)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         snapshot: (),
     });
@@ -77,7 +75,6 @@ fn test_install_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
         SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(2, 1, 2)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
     );
@@ -98,7 +95,6 @@ fn test_install_snapshot_lt_committed() -> anyhow::Result<()> {
         meta: SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(4, 1, 5)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         snapshot: (),
     });
@@ -109,7 +105,6 @@ fn test_install_snapshot_lt_committed() -> anyhow::Result<()> {
         SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(2, 1, 2)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
     );
@@ -135,7 +130,6 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
         meta: SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(4, 1, 6)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         snapshot: (),
     });
@@ -151,7 +145,6 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
         SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(4, 1, 6)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
     );
@@ -170,7 +163,6 @@ fn test_install_snapshot_not_conflict() -> anyhow::Result<()> {
                     meta: SnapshotMetaOf::<UTConfig> {
                         last_log_id: Some(log_id(4, 1, 6)),
                         last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-                        snapshot_id: "1-2-3-4".to_string(),
                     },
                     snapshot: (),
                 },
@@ -206,7 +198,6 @@ fn test_install_snapshot_resets_purged_effective_membership() -> anyhow::Result<
         meta: SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(5, 1, 9)),
             last_membership: snapshot_membership.clone(),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         snapshot: (),
     });
@@ -254,7 +245,6 @@ fn test_install_snapshot_resets_purged_effective_without_truncating() -> anyhow:
         meta: SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(5, 1, 9)),
             last_membership: snapshot_membership.clone(),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         snapshot: (),
     });
@@ -278,7 +268,6 @@ fn test_install_snapshot_resets_purged_effective_without_truncating() -> anyhow:
                     meta: SnapshotMetaOf::<UTConfig> {
                         last_log_id: Some(log_id(5, 1, 9)),
                         last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(5, 1, 4)), m12()),
-                        snapshot_id: "1-2-3-4".to_string(),
                     },
                     snapshot: (),
                 },
@@ -316,7 +305,6 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
         eng.state.snapshot_meta = SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(2, 1, 2)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12()),
-            snapshot_id: "1-2-3-4".to_string(),
         };
 
         eng.state.server_state = eng.calc_server_state();
@@ -328,7 +316,6 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
         meta: SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(5, 1, 6)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         snapshot: (),
     });
@@ -344,7 +331,6 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
         SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(5, 1, 6)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
     );
@@ -367,7 +353,6 @@ fn test_install_snapshot_conflict() -> anyhow::Result<()> {
                     meta: SnapshotMetaOf::<UTConfig> {
                         last_log_id: Some(log_id(5, 1, 6)),
                         last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-                        snapshot_id: "1-2-3-4".to_string(),
                     },
                     snapshot: (),
                 },
@@ -396,7 +381,6 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
         meta: SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(100, 1, 100)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         snapshot: (),
     });
@@ -412,7 +396,6 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
         SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(100, 1, 100)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
     );
@@ -435,7 +418,6 @@ fn test_install_snapshot_advance_last_log_id() -> anyhow::Result<()> {
                     meta: SnapshotMetaOf::<UTConfig> {
                         last_log_id: Some(log_id(100, 1, 100)),
                         last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-                        snapshot_id: "1-2-3-4".to_string(),
                     },
                     snapshot: (),
                 },
@@ -466,7 +448,6 @@ fn test_install_snapshot_update_accepted() -> anyhow::Result<()> {
         meta: SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(100, 1, 100)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         snapshot: (),
     });
@@ -499,7 +480,6 @@ fn test_install_snapshot_beyond_leader_vote() {
         meta: SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(4, 1, 6)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         snapshot: (),
     });
@@ -522,7 +502,6 @@ fn test_install_snapshot_conflict_with_committed() {
         meta: SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(5, 1, 3)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         snapshot: (),
     });
@@ -543,7 +522,6 @@ fn test_install_snapshot_conflict_at_committed_index() {
             // A greater log id at the committed index identifies a different committed entry.
             last_log_id: Some(log_id(5, 1, 5)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         snapshot: (),
     });

--- a/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
+++ b/openraft/src/engine/handler/snapshot_handler/update_snapshot_test.rs
@@ -23,7 +23,6 @@ fn eng() -> Engine<UTConfig> {
     eng.state.snapshot_meta = SnapshotMetaOf::<UTConfig> {
         last_log_id: Some(log_id(2, 1, 2)),
         last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12()),
-        snapshot_id: "1-2-3-4".to_string(),
     };
     eng
 }
@@ -36,7 +35,6 @@ fn test_update_snapshot_no_update() -> anyhow::Result<()> {
     let got = eng.snapshot_handler().update_snapshot(SnapshotMetaOf::<UTConfig> {
         last_log_id: Some(log_id(2, 1, 2)),
         last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-        snapshot_id: "1-2-3-4".to_string(),
     });
 
     assert_eq!(false, got);
@@ -45,7 +43,6 @@ fn test_update_snapshot_no_update() -> anyhow::Result<()> {
         SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(2, 1, 2)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
     );
@@ -63,7 +60,6 @@ fn test_update_snapshot_updated() -> anyhow::Result<()> {
     let got = eng.snapshot_handler().update_snapshot(SnapshotMetaOf::<UTConfig> {
         last_log_id: Some(log_id(2, 1, 3)),
         last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(2, 1, 2)), m1234()),
-        snapshot_id: "1-2-3-4".to_string(),
     });
 
     assert_eq!(true, got);
@@ -72,7 +68,6 @@ fn test_update_snapshot_updated() -> anyhow::Result<()> {
         SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(2, 1, 3)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(2, 1, 2)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
     );

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -48,7 +48,6 @@ fn eng() -> Engine<UTConfig> {
     eng.state.snapshot_meta = SnapshotMetaOf::<UTConfig> {
         last_log_id: Some(log_id(2, 1, 2)),
         last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12()),
-        snapshot_id: "1-2-3-4".to_string(),
     };
     eng.state.server_state = eng.calc_server_state();
 
@@ -74,7 +73,6 @@ fn test_handle_install_full_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
             meta: SnapshotMetaOf::<UTConfig> {
                 last_log_id: Some(log_id(1, 1, 2)),
                 last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-                snapshot_id: "1-2-3-4".to_string(),
             },
             snapshot: (),
         },
@@ -85,7 +83,6 @@ fn test_handle_install_full_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
         SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(2, 1, 2)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m12()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
     );
@@ -119,7 +116,6 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
             meta: SnapshotMetaOf::<UTConfig> {
                 last_log_id: Some(log_id(4, 1, 6)),
                 last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-                snapshot_id: "1-2-3-4".to_string(),
             },
             snapshot: (),
         },
@@ -130,7 +126,6 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
         SnapshotMetaOf::<UTConfig> {
             last_log_id: Some(log_id(4, 1, 6)),
             last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-            snapshot_id: "1-2-3-4".to_string(),
         },
         eng.state.snapshot_meta
     );
@@ -144,7 +139,6 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
                     meta: SnapshotMetaOf::<UTConfig> {
                         last_log_id: Some(log_id(4, 1, 6)),
                         last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), m1234()),
-                        snapshot_id: "1-2-3-4".to_string(),
                     },
                     snapshot: (),
                 },

--- a/openraft/src/engine/tests/trigger_purge_log_test.rs
+++ b/openraft/src/engine/tests/trigger_purge_log_test.rs
@@ -52,7 +52,6 @@ fn test_trigger_purge_log_already_scheduled() -> anyhow::Result<()> {
     eng.state.snapshot_meta = SnapshotMeta {
         last_log_id: Some(log_id(1, 0, 3)),
         last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 0, 1)), m12()),
-        snapshot_id: "1".to_string(),
     };
     eng.state.purge_upto = Some(log_id(1, 0, 2));
     eng.state.io_state.purged = Some(log_id(1, 0, 2));
@@ -72,7 +71,6 @@ fn test_trigger_purge_log_delete_only_in_snapshot_logs() -> anyhow::Result<()> {
     eng.state.snapshot_meta = SnapshotMeta {
         last_log_id: Some(log_id(1, 0, 3)),
         last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 0, 1)), m12()),
-        snapshot_id: "1".to_string(),
     };
     eng.state.purge_upto = Some(log_id(1, 0, 2));
     eng.state.io_state.purged = Some(log_id(1, 0, 2));
@@ -100,7 +98,6 @@ fn test_trigger_purge_log_in_used_wont_be_delete() -> anyhow::Result<()> {
     eng.state.snapshot_meta = SnapshotMeta {
         last_log_id: Some(log_id(1, 0, 3)),
         last_membership: StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 0, 1)), m12()),
-        snapshot_id: "1".to_string(),
     };
     eng.state.purge_upto = Some(log_id(1, 0, 2));
     eng.state.io_state.purged = Some(log_id(1, 0, 2));

--- a/openraft/src/progress/entry/tests.rs
+++ b/openraft/src/progress/entry/tests.rs
@@ -106,7 +106,6 @@ fn new_raft_state(purge_upto: u64, snap_last: u64, last: u64) -> RaftState<UTCon
     st.snapshot_meta = SnapshotMetaOf::<UTConfig> {
         last_log_id: Some(log_id(snap_last)),
         last_membership: StoredMembershipOf::<UTConfig>::default(),
-        snapshot_id: "".to_string(),
     };
 
     st.log_ids = LogIdList::new(None, [log_id(purge_upto - 1), log_id(last)]);

--- a/openraft/src/storage/snapshot_meta.rs
+++ b/openraft/src/storage/snapshot_meta.rs
@@ -83,7 +83,6 @@ where
         SnapshotSignature {
             last_log_id: self.last_log_id.clone(),
             last_membership_log_id: self.last_membership.log_id().as_ref().map(|x| Box::new(x.clone())),
-            snapshot_id: self.snapshot_id.clone(),
         }
     }
 

--- a/openraft/src/storage/snapshot_meta.rs
+++ b/openraft/src/storage/snapshot_meta.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use display_more::DisplayOptionExt;
 use openraft_macros::since;
 
-use crate::SnapshotId;
 use crate::StoredMembership;
 use crate::log_id::LogId;
 use crate::node::Node;
@@ -13,15 +12,37 @@ use crate::vote::RaftCommittedLeaderId;
 
 /// The metadata of a snapshot.
 ///
-/// Including the last log id that is included in this snapshot,
-/// the last membership included,
-/// and a snapshot id.
+/// Including the last log id that is included in this snapshot
+/// and the last membership included.
+///
+/// # Compatibility with 0.9
+///
+/// Before 0.10.0 this type also carried a `snapshot_id`, declared last. It identified a transfer,
+/// not the snapshot: two snapshots at the same `last_log_id` cover the same state, even when they
+/// differ in bytes. The id now lives on the wire, in
+/// `openraft_legacy::network_v1::SnapshotMeta`, the metadata type of the chunked v1 protocol,
+/// which keeps the full 0.9 layout.
+///
+/// Dropping it from the serialized form as well would have broken stored 0.9 data. A positional
+/// format (`bincode`, `postcard`, `rmp-serde::to_vec`) encodes a struct as a bare sequence with no
+/// field names, so two fields cannot be read off a three-element record. Worse, when this type is
+/// nested in a larger struct, some of those formats misparse it *silently*: the leftover
+/// `snapshot_id` bytes get consumed as the enclosing struct's next field, with no error.
+///
+/// So the slot is reserved rather than removed. This type serializes as three fields, the third
+/// being an always-empty `snapshot_id`, and ignores that field when reading. 0.9 and 0.10 data are
+/// therefore interchangeable in both directions, under named and positional formats alike.
+#[since(version = "0.10.0", change = "removed `snapshot_id`")]
 #[since(
     version = "0.10.0",
     change = "from `SnapshotMeta<C>` to `SnapshotMeta<CLID, NID, N>`"
 )]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize),
+    serde(bound = "", from = "SnapshotMetaWire<CLID, NID, N>")
+)]
 pub struct SnapshotMeta<CLID, NID, N>
 where
     CLID: RaftCommittedLeaderId,
@@ -33,11 +54,66 @@ where
 
     /// The last applied membership config.
     pub last_membership: StoredMembership<CLID, NID, N>,
+}
 
-    /// To identify a snapshot when transferring.
-    /// Caveat: even when two snapshots are built with the same `last_log_id`, they still could be
-    /// different in bytes.
-    pub snapshot_id: SnapshotId,
+/// The serialized layout of [`SnapshotMeta`], which still carries the 0.9 `snapshot_id` slot.
+///
+/// Written always-empty and ignored on read; see the compatibility note on [`SnapshotMeta`].
+#[cfg(feature = "serde")]
+#[derive(serde::Deserialize)]
+#[serde(bound = "")]
+struct SnapshotMetaWire<CLID, NID, N>
+where
+    CLID: RaftCommittedLeaderId,
+    NID: NodeId,
+    N: Node,
+{
+    last_log_id: Option<LogId<CLID>>,
+
+    last_membership: StoredMembership<CLID, NID, N>,
+
+    /// Reserved. Cannot be [`serde::de::IgnoredAny`]: that requires `deserialize_any`, which a
+    /// positional format cannot provide.
+    #[serde(default)]
+    #[allow(dead_code)]
+    snapshot_id: crate::SnapshotId,
+}
+
+#[cfg(feature = "serde")]
+impl<CLID, NID, N> From<SnapshotMetaWire<CLID, NID, N>> for SnapshotMeta<CLID, NID, N>
+where
+    CLID: RaftCommittedLeaderId,
+    NID: NodeId,
+    N: Node,
+{
+    fn from(wire: SnapshotMetaWire<CLID, NID, N>) -> Self {
+        SnapshotMeta {
+            last_log_id: wire.last_log_id,
+            last_membership: wire.last_membership,
+        }
+    }
+}
+
+/// Hand-written rather than `#[serde(into = "SnapshotMetaWire<CLID, NID, N>")]`, which would
+/// require `Self: Clone` and thus narrow this impl to `N: Clone`.
+#[cfg(feature = "serde")]
+impl<CLID, NID, N> serde::Serialize for SnapshotMeta<CLID, NID, N>
+where
+    CLID: RaftCommittedLeaderId,
+    NID: NodeId,
+    N: Node,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: serde::Serializer {
+        use serde::ser::SerializeStruct;
+
+        // The field count is the compatibility contract: it must stay 3.
+        let mut s = serializer.serialize_struct("SnapshotMeta", 3)?;
+        s.serialize_field("last_log_id", &self.last_log_id)?;
+        s.serialize_field("last_membership", &self.last_membership)?;
+        s.serialize_field("snapshot_id", "")?;
+        s.end()
+    }
 }
 
 impl<CLID, NID, N> Default for SnapshotMeta<CLID, NID, N>
@@ -50,7 +126,6 @@ where
         Self {
             last_log_id: None,
             last_membership: StoredMembership::default(),
-            snapshot_id: SnapshotId::default(),
         }
     }
 }
@@ -64,8 +139,7 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{{snapshot_id: {}, last_log:{}, last_membership: {}}}",
-            self.snapshot_id,
+            "{{last_log:{}, last_membership: {}}}",
             self.last_log_id.display(),
             self.last_membership
         )
@@ -89,5 +163,43 @@ where
     /// Returns a ref to the id of the last log that is included in this snapshot.
     pub fn last_log_id(&self) -> Option<&LogId<CLID>> {
         self.last_log_id.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_snapshot_meta_serde() {
+        use maplit::btreeset;
+
+        use crate::Membership;
+        use crate::StoredMembership;
+        use crate::engine::testing::UTConfig;
+        use crate::engine::testing::log_id;
+        use crate::type_config::alias::SnapshotMetaOf;
+
+        let meta = SnapshotMetaOf::<UTConfig> {
+            last_log_id: Some(log_id(1, 2, 3)),
+            last_membership: StoredMembership::new(
+                Some(log_id(4, 5, 6)),
+                Membership::new_with_defaults(vec![btreeset! {1,2}], []),
+            ),
+        };
+
+        // Three fields, the last an empty `snapshot_id`. The count is the compatibility
+        // contract: a positional format (bincode, postcard) encodes only the count, so this
+        // assertion is what keeps 0.9 data readable there too.
+        let want = r#"{"last_log_id":{"leader_id":{"term":1,"node_id":2},"index":3},"last_membership":{"log_id":{"leader_id":{"term":4,"node_id":5},"index":6},"membership":{"configs":[[1,2]],"nodes":{"1":null,"2":null}}},"snapshot_id":""}"#;
+
+        assert_eq!(want, serde_json::to_string(&meta).unwrap());
+        assert_eq!(meta, serde_json::from_str::<SnapshotMetaOf<UTConfig>>(want).unwrap());
+
+        // Data written by openraft 0.9, when `snapshot_id` was still a field of `SnapshotMeta`,
+        // deserializes to the same value; the id is ignored.
+        let v09 = r#"{"last_log_id":{"leader_id":{"term":1,"node_id":2},"index":3},"last_membership":{"log_id":{"leader_id":{"term":4,"node_id":5},"index":6},"membership":{"configs":[[1,2]],"nodes":{"1":null,"2":null}}},"snapshot_id":"1-2-3-4"}"#;
+
+        assert_eq!(meta, serde_json::from_str::<SnapshotMetaOf<UTConfig>>(v09).unwrap());
     }
 }

--- a/openraft/src/storage/snapshot_signature.rs
+++ b/openraft/src/storage/snapshot_signature.rs
@@ -1,16 +1,43 @@
 use openraft_macros::since;
 
-use crate::SnapshotId;
 use crate::log_id::LogId;
 use crate::vote::RaftCommittedLeaderId;
 
 /// A small piece of information for identifying a snapshot and error tracing.
+///
+/// A snapshot is identified by the position it covers: two snapshots at the same `last_log_id`
+/// cover the same state, even when they differ in bytes. The 0.9 `snapshot_id` identified a
+/// transfer, not the snapshot, and is gone from the API.
+///
+/// # Compatibility with 0.9
+///
+/// Before 0.10.0 this type also carried the `snapshot_id`, declared last. Signatures are not
+/// stored, but they travel inside errors: a `Fatal(StorageError)` returned over the v1 protocol
+/// carries one to a 0.9 peer. Under a positional format (`bincode`, `postcard`,
+/// `rmp-serde::to_vec`) a changed field count makes such a record unreadable, and nested inside
+/// the error enums it can be misparsed silently instead of failing.
+///
+/// So, as in [`SnapshotMeta`](crate::storage::SnapshotMeta), the slot is reserved rather than
+/// removed: this type serializes as three fields, the third being an always-empty
+/// `snapshot_id`, and ignores that field when reading. 0.9 and 0.10 signatures are therefore
+/// interchangeable in both directions, under named and positional formats alike.
+///
+/// The guarantee covers this type alone. [`StorageError`](crate::StorageError), which carries
+/// the signature, was an enum in 0.9 and is a struct in 0.10, so a whole 0.10 error is not
+/// parseable by a 0.9 peer regardless. Reserving the slot means the signature is never the
+/// incompatibility; peers of a different version should treat error bodies as diagnostic
+/// rather than parse them.
+#[since(version = "0.10.0", change = "removed `snapshot_id`")]
 #[since(
     version = "0.10.0",
     change = "from `SnapshotSignature<C>` to `SnapshotSignature<CLID>`"
 )]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize),
+    serde(bound = "", from = "SnapshotSignatureWire<CLID>")
+)]
 pub struct SnapshotSignature<CLID>
 where CLID: RaftCommittedLeaderId
 {
@@ -19,9 +46,59 @@ where CLID: RaftCommittedLeaderId
 
     /// The last applied membership log id.
     pub last_membership_log_id: Option<Box<LogId<CLID>>>,
+}
 
-    /// To identify a snapshot when transferring.
-    pub snapshot_id: SnapshotId,
+/// The serialized layout of [`SnapshotSignature`], which still carries the 0.9 `snapshot_id`
+/// slot.
+///
+/// Written always-empty and ignored on read; see the compatibility note on
+/// [`SnapshotSignature`].
+#[cfg(feature = "serde")]
+#[derive(serde::Deserialize)]
+#[serde(bound = "")]
+struct SnapshotSignatureWire<CLID>
+where CLID: RaftCommittedLeaderId
+{
+    last_log_id: Option<LogId<CLID>>,
+
+    last_membership_log_id: Option<Box<LogId<CLID>>>,
+
+    /// Reserved. Cannot be [`serde::de::IgnoredAny`]: that requires `deserialize_any`, which a
+    /// positional format cannot provide.
+    #[serde(default)]
+    #[allow(dead_code)]
+    snapshot_id: crate::SnapshotId,
+}
+
+#[cfg(feature = "serde")]
+impl<CLID> From<SnapshotSignatureWire<CLID>> for SnapshotSignature<CLID>
+where CLID: RaftCommittedLeaderId
+{
+    fn from(wire: SnapshotSignatureWire<CLID>) -> Self {
+        SnapshotSignature {
+            last_log_id: wire.last_log_id,
+            last_membership_log_id: wire.last_membership_log_id,
+        }
+    }
+}
+
+/// Hand-written rather than `#[serde(into = "SnapshotSignatureWire<CLID>")]`, which would
+/// require `Self: Clone` and thus narrow this impl to `CLID: Clone`.
+#[cfg(feature = "serde")]
+impl<CLID> serde::Serialize for SnapshotSignature<CLID>
+where CLID: RaftCommittedLeaderId
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: serde::Serializer {
+        use serde::ser::SerializeStruct;
+
+        // The field count is the compatibility contract: it must stay 3.
+        let mut s = serializer.serialize_struct("SnapshotSignature", 3)?;
+        s.serialize_field("last_log_id", &self.last_log_id)?;
+        s.serialize_field("last_membership_log_id", &self.last_membership_log_id)?;
+        s.serialize_field("snapshot_id", "")?;
+        s.end()
+    }
 }
 
 #[cfg(test)]
@@ -31,19 +108,26 @@ mod tests {
     #[test]
     fn test_snapshot_signature_serde() {
         use super::SnapshotSignature;
+        use crate::engine::testing::UtClid;
         use crate::engine::testing::log_id;
 
-        let sig = SnapshotSignature {
+        let sig = SnapshotSignature::<UtClid> {
             last_log_id: Some(log_id(1, 2, 3)),
             last_membership_log_id: Some(Box::new(log_id(4, 5, 6))),
-            snapshot_id: "test".to_string(),
         };
-        let s = serde_json::to_string(&sig).unwrap();
-        assert_eq!(
-            s,
-            r#"{"last_log_id":{"leader_id":{"term":1,"node_id":2},"index":3},"last_membership_log_id":{"leader_id":{"term":4,"node_id":5},"index":6},"snapshot_id":"test"}"#
-        );
-        let sig2: SnapshotSignature<crate::engine::testing::UtClid> = serde_json::from_str(&s).unwrap();
-        assert_eq!(sig, sig2);
+
+        // Three fields, the last an empty `snapshot_id`. The count is the compatibility
+        // contract: a positional format (bincode, postcard) encodes only the count, so this
+        // assertion is what keeps errors readable to 0.9 peers there too.
+        let want = r#"{"last_log_id":{"leader_id":{"term":1,"node_id":2},"index":3},"last_membership_log_id":{"leader_id":{"term":4,"node_id":5},"index":6},"snapshot_id":""}"#;
+
+        assert_eq!(want, serde_json::to_string(&sig).unwrap());
+        assert_eq!(sig, serde_json::from_str::<SnapshotSignature<UtClid>>(want).unwrap());
+
+        // Data written by openraft 0.9, when `snapshot_id` was still a field, deserializes to
+        // the same value; the id is ignored.
+        let v09 = r#"{"last_log_id":{"leader_id":{"term":1,"node_id":2},"index":3},"last_membership_log_id":{"leader_id":{"term":4,"node_id":5},"index":6},"snapshot_id":"1-2-3-4"}"#;
+
+        assert_eq!(sig, serde_json::from_str::<SnapshotSignature<UtClid>>(v09).unwrap());
     }
 }

--- a/stores/memstore-custom-node-id/src/lib.rs
+++ b/stores/memstore-custom-node-id/src/lib.rs
@@ -8,7 +8,6 @@ use std::io;
 use std::io::Cursor;
 use std::ops::RangeBounds;
 use std::sync::Arc;
-use std::sync::Mutex;
 
 use futures::Stream;
 use openraft::EntryPayload;
@@ -94,7 +93,6 @@ struct StateMachine {
 
 pub struct MemStateMachine {
     sm: RwLock<StateMachine>,
-    snapshot_idx: Mutex<u64>,
     current_snapshot: RwLock<Option<(SnapshotMetaOf<TypeConfig>, Vec<u8>)>>,
 }
 
@@ -102,7 +100,6 @@ impl MemStateMachine {
     fn new() -> Self {
         Self {
             sm: RwLock::new(StateMachine::default()),
-            snapshot_idx: Mutex::new(0),
             current_snapshot: RwLock::new(None),
         }
     }
@@ -230,21 +227,9 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<MemStateMachine> {
         let sm = self.sm.read().await;
         let data = serde_json::to_vec(&*sm).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
-        let snapshot_idx = {
-            let mut idx = self.snapshot_idx.lock().unwrap();
-            *idx += 1;
-            *idx
-        };
-
-        let snapshot_id = match sm.last_applied_log {
-            Some(last) => format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx),
-            None => format!("--{}", snapshot_idx),
-        };
-
         let meta = SnapshotMetaOf::<TypeConfig> {
             last_log_id: sm.last_applied_log,
             last_membership: sm.last_membership.clone(),
-            snapshot_id,
         };
 
         *self.current_snapshot.write().await = Some((meta.clone(), data.clone()));

--- a/stores/memstore/src/lib.rs
+++ b/stores/memstore/src/lib.rs
@@ -216,8 +216,6 @@ pub struct MemStateMachine {
 
     allow_build_snapshot: Arc<AtomicBool>,
 
-    snapshot_idx: Arc<Mutex<u64>>,
-
     /// The current snapshot.
     current_snapshot: RwLock<Option<MemStoreSnapshot>>,
 
@@ -240,7 +238,6 @@ impl MemStateMachine {
         Self {
             sm,
             allow_build_snapshot: Arc::new(AtomicBool::new(true)),
-            snapshot_idx: Arc::new(Mutex::new(0)),
             current_snapshot,
             block,
             try_create_snapshot_builder_count: Arc::new(AtomicU64::new(0)),
@@ -365,22 +362,9 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<MemStateMachine> {
 
         let snapshot_size = data.len();
 
-        let snapshot_idx = {
-            let mut l = self.snapshot_idx.lock().unwrap();
-            *l += 1;
-            *l
-        };
-
-        let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.committed_leader_id(), last.index(), snapshot_idx)
-        } else {
-            format!("--{}", snapshot_idx)
-        };
-
         let meta = SnapshotMetaOf::<TypeConfig> {
             last_log_id: last_applied_log,
             last_membership,
-            snapshot_id,
         };
 
         let snapshot = MemStoreSnapshot {

--- a/tests-turmoil/src/store.rs
+++ b/tests-turmoil/src/store.rs
@@ -198,15 +198,9 @@ impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachine> {
         let data = self.data.lock().unwrap();
         let snapshot_data = serde_json::to_vec(&*data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
-        let snapshot_idx = {
-            let snap = self.snapshot.lock().unwrap();
-            snap.as_ref().map(|(m, _)| m.snapshot_id.parse::<u64>().unwrap_or(0) + 1).unwrap_or(1)
-        };
-
         let meta = SnapshotMeta {
             last_log_id: data.last_applied,
             last_membership: data.last_membership.clone(),
-            snapshot_id: snapshot_idx.to_string(),
         };
 
         *self.snapshot.lock().unwrap() = Some((meta.clone(), snapshot_data.clone()));

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -21,16 +21,18 @@ repository    = { workspace = true }
 [dev-dependencies]
 openraft           = { path = "../openraft", version = "0.10.0-alpha.32", features = ["type-alias"] }
 openraft-memstore  = { path = "../stores/memstore" }
-openraft-legacy    = { path = "../legacy" }
+openraft-legacy    = { path = "../legacy", features = ["serde"] }
 
 anyerror           = { workspace = true }
 anyhow             = { workspace = true }
+bincode            = { workspace = true }
 derive_more        = { workspace = true }
 futures            = { workspace = true }
 lazy_static        = { workspace = true }
 maplit             = { workspace = true }
 pretty_assertions  = { workspace = true }
 rand               = { workspace = true }
+serde              = { workspace = true }
 test-harness       = { workspace = true }
 tracing            = { workspace = true }
 tracing-appender   = { workspace = true }

--- a/tests/tests/snapshot_streaming/main.rs
+++ b/tests/tests/snapshot_streaming/main.rs
@@ -6,6 +6,7 @@ mod fixtures;
 
 mod t10_api_install_snapshot;
 mod t10_api_install_snapshot_with_lower_vote;
+mod t10_wire_compat_09;
 mod t20_startup_snapshot;
 mod t30_purge_in_snapshot_logs;
 mod t31_snapshot_overrides_membership;

--- a/tests/tests/snapshot_streaming/t10_api_install_snapshot.rs
+++ b/tests/tests/snapshot_streaming/t10_api_install_snapshot.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::Vote;
-use openraft::storage::SnapshotMeta;
 use openraft_legacy::prelude::*;
 
 use crate::fixtures::RaftRouter;
@@ -41,9 +40,9 @@ async fn snapshot_arguments() -> Result<()> {
         // force it to be a follower
         vote: Vote::new_committed(2, 1),
         meta: SnapshotMeta {
-            snapshot_id: "ss1".into(),
             last_log_id: Some(log_id(1, 0, 0)),
             last_membership: Default::default(),
+            snapshot_id: "ss1".into(),
         },
         offset: 0,
         data: vec![1, 2, 3],

--- a/tests/tests/snapshot_streaming/t10_api_install_snapshot_with_lower_vote.rs
+++ b/tests/tests/snapshot_streaming/t10_api_install_snapshot_with_lower_vote.rs
@@ -37,10 +37,10 @@ async fn install_snapshot_lower_vote() -> Result<()> {
     let (n0, _, _) = router.remove_node(0).unwrap();
     let make_req = || InstallSnapshotRequest {
         vote: Vote::new_committed(2, 1),
-        meta: SnapshotMetaOf::<openraft_memstore::TypeConfig> {
-            snapshot_id: "ss1".into(),
+        meta: SnapshotMeta::<openraft_memstore::TypeConfig> {
             last_log_id: Some(log_id(1, 0, 0)),
             last_membership: Default::default(),
+            snapshot_id: "ss1".into(),
         },
         offset: 0,
         data: vec![1, 2, 3],

--- a/tests/tests/snapshot_streaming/t10_wire_compat_09.rs
+++ b/tests/tests/snapshot_streaming/t10_wire_compat_09.rs
@@ -1,0 +1,183 @@
+//! Positional-format compatibility with the 0.9 serialized layouts.
+//!
+//! A positional format such as bincode encodes a struct as a bare sequence: no field names,
+//! only the count and order. The exact-JSON unit tests in `openraft` and `openraft-legacy` pin
+//! that count by proxy; these tests exercise it directly, in both directions, for each type
+//! that crosses a 0.9/0.10 boundary: stored `SnapshotMeta`, `SnapshotSignature` inside errors,
+//! and the v1 chunked `InstallSnapshotRequest`.
+//!
+//! The 0.9 replicas below reuse the current inner types (`LogId`, `Vote`, `StoredMembership`),
+//! whose layouts are unchanged since 0.9; the field under test is `snapshot_id`.
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Membership;
+use openraft::Vote;
+use openraft::alias::LogIdOf;
+use openraft::alias::SnapshotMetaOf;
+use openraft::alias::SnapshotSignatureOf;
+use openraft::alias::StoredMembershipOf;
+use openraft::alias::VoteOf;
+use openraft_legacy::network_v1::InstallSnapshotRequest;
+use openraft_legacy::network_v1::SnapshotMeta as SnapshotMetaV1;
+use openraft_memstore::TypeConfig;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::fixtures::log_id;
+
+/// The 0.9 `SnapshotMeta` layout: `snapshot_id` is a third, meaningful field.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct SnapshotMeta09 {
+    last_log_id: Option<LogIdOf<TypeConfig>>,
+    last_membership: StoredMembershipOf<TypeConfig>,
+    snapshot_id: String,
+}
+
+/// The 0.9 `SnapshotSignature` layout.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct SnapshotSignature09 {
+    last_log_id: Option<LogIdOf<TypeConfig>>,
+    last_membership_log_id: Option<Box<LogIdOf<TypeConfig>>>,
+    snapshot_id: String,
+}
+
+/// The 0.9 `InstallSnapshotRequest` layout: five fields, the id inside `meta`.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct InstallSnapshotRequest09 {
+    vote: VoteOf<TypeConfig>,
+    meta: SnapshotMeta09,
+    offset: u64,
+    data: Vec<u8>,
+    done: bool,
+}
+
+fn membership() -> StoredMembershipOf<TypeConfig> {
+    StoredMembershipOf::<TypeConfig>::new(
+        Some(log_id(1, 1, 1)),
+        Membership::new_with_defaults(vec![btreeset! {1,2}], []),
+    )
+}
+
+/// A `SnapshotMeta` written by 0.9 loads as the 0.10 type; the id is ignored.
+#[test]
+fn test_snapshot_meta_bincode_from_09() -> Result<()> {
+    let old = SnapshotMeta09 {
+        last_log_id: Some(log_id(1, 2, 3)),
+        last_membership: membership(),
+        snapshot_id: "1-2-3-4".to_string(),
+    };
+
+    let new: SnapshotMetaOf<TypeConfig> = bincode::deserialize(&bincode::serialize(&old)?)?;
+
+    assert_eq!(
+        SnapshotMetaOf::<TypeConfig> {
+            last_log_id: Some(log_id(1, 2, 3)),
+            last_membership: membership(),
+        },
+        new
+    );
+    Ok(())
+}
+
+/// A `SnapshotMeta` written by 0.10 loads as the 0.9 layout; the reserved id slot is empty.
+#[test]
+fn test_snapshot_meta_bincode_to_09() -> Result<()> {
+    let new = SnapshotMetaOf::<TypeConfig> {
+        last_log_id: Some(log_id(1, 2, 3)),
+        last_membership: membership(),
+    };
+
+    let old: SnapshotMeta09 = bincode::deserialize(&bincode::serialize(&new)?)?;
+
+    assert_eq!(
+        SnapshotMeta09 {
+            last_log_id: Some(log_id(1, 2, 3)),
+            last_membership: membership(),
+            snapshot_id: "".to_string(),
+        },
+        old
+    );
+    Ok(())
+}
+
+/// A `SnapshotSignature` from a 0.9 error loads as the 0.10 type; the id is ignored.
+#[test]
+fn test_snapshot_signature_bincode_from_09() -> Result<()> {
+    let old = SnapshotSignature09 {
+        last_log_id: Some(log_id(1, 2, 3)),
+        last_membership_log_id: Some(Box::new(log_id(1, 1, 1))),
+        snapshot_id: "1-2-3-4".to_string(),
+    };
+
+    let new: SnapshotSignatureOf<TypeConfig> = bincode::deserialize(&bincode::serialize(&old)?)?;
+
+    assert_eq!(
+        SnapshotSignatureOf::<TypeConfig> {
+            last_log_id: Some(log_id(1, 2, 3)),
+            last_membership_log_id: Some(Box::new(log_id(1, 1, 1))),
+        },
+        new
+    );
+    Ok(())
+}
+
+/// A `SnapshotSignature` from a 0.10 error loads as the 0.9 layout; the id slot is empty.
+#[test]
+fn test_snapshot_signature_bincode_to_09() -> Result<()> {
+    let new = SnapshotSignatureOf::<TypeConfig> {
+        last_log_id: Some(log_id(1, 2, 3)),
+        last_membership_log_id: Some(Box::new(log_id(1, 1, 1))),
+    };
+
+    let old: SnapshotSignature09 = bincode::deserialize(&bincode::serialize(&new)?)?;
+
+    assert_eq!(
+        SnapshotSignature09 {
+            last_log_id: Some(log_id(1, 2, 3)),
+            last_membership_log_id: Some(Box::new(log_id(1, 1, 1))),
+            snapshot_id: "".to_string(),
+        },
+        old
+    );
+    Ok(())
+}
+
+/// The v1 RPC round-trips between the 0.9 and 0.10 layouts with the transfer id preserved:
+/// unlike the storage types above, the id inside the request `meta` is meaningful.
+#[test]
+fn test_install_snapshot_request_bincode_roundtrip_09() -> Result<()> {
+    let old = InstallSnapshotRequest09 {
+        vote: Vote::new_committed(2, 1),
+        meta: SnapshotMeta09 {
+            last_log_id: Some(log_id(1, 2, 3)),
+            last_membership: membership(),
+            snapshot_id: "ss-1".to_string(),
+        },
+        offset: 7,
+        data: vec![1, 2, 3],
+        done: true,
+    };
+
+    let new: InstallSnapshotRequest<TypeConfig> = bincode::deserialize(&bincode::serialize(&old)?)?;
+
+    assert_eq!(
+        InstallSnapshotRequest::<TypeConfig> {
+            vote: Vote::new_committed(2, 1),
+            meta: SnapshotMetaV1 {
+                last_log_id: Some(log_id(1, 2, 3)),
+                last_membership: membership(),
+                snapshot_id: "ss-1".to_string(),
+            },
+            offset: 7,
+            data: vec![1, 2, 3],
+            done: true,
+        },
+        new
+    );
+
+    let back: InstallSnapshotRequest09 = bincode::deserialize(&bincode::serialize(&new)?)?;
+    assert_eq!(old, back);
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### change: move `snapshot_id` out of `SnapshotMeta`
# Summary

`snapshot_id` identified a snapshot transfer rather than a snapshot, so
it no longer belongs in snapshot metadata. It now lives only on
`InstallSnapshotRequest`, used by the chunked v1 protocol that actually
needs it. State machines no longer invent an id when building a
snapshot.

# Details

Two snapshots covering the same `last_log_id` represent the same state
even when they differ in bytes, so the id was never part of a snapshot's
identity. The only code that needs it is the v1 chunked receiver, which
compares it against the in-flight stream to tell a new transfer from a
continuation. A v2 full-snapshot transfer completes in one call and
never needs one.

Breaking: `SnapshotMeta` loses its `snapshot_id` field;
`SnapshotSignature::snapshot_id` becomes an `Option`, with the new
`with_snapshot_id()` to attach one; `InstallSnapshotRequest` gains
`snapshot_id`.

Both serialized layouts are deliberately unchanged, so stored 0.9 data
still loads. `SnapshotMeta` keeps writing three fields with an
always-empty `snapshot_id`, and `SnapshotSignature` keeps writing a
plain string, empty for `None`. This matters because a positional format
(bincode, postcard, `rmp-serde::to_vec`) encodes a struct as a bare
sequence: a changed field count or an added `Option` discriminant makes
old records unreadable, and when the type is nested in a larger struct
some of those formats misparse it silently instead of failing. Tests
assert the exact JSON of both types, since the field count is the part
the binary formats depend on.

The v1 sender now generates a fresh id per transfer session instead of
reusing the one baked into the snapshot at build time. Retransmitting a
snapshot after a failure can no longer be mistaken for a continuation of
the aborted attempt.

The rocksstore example named snapshot files by `meta.snapshot_id` from
both the builder and `install_snapshot()`. Both now derive the name from
the snapshot position through one helper, because
`get_current_snapshot()` resolves the latest snapshot by picking the
greatest file name, which requires every writer to share one scheme.

The gRPC example drops `snapshot_id` from its `SnapshotRequestMeta`
message; it mirrored the metadata field and the v2 receiver has no use
for it.

Upgrade tip:

Construct `SnapshotMeta` without the id:

    SnapshotMeta {
        last_log_id,
        last_membership,
    }

A `RaftNetworkV2` implementation needs no change. A chunked v1
implementation sets `InstallSnapshotRequest::snapshot_id` once per
transfer.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1931)
<!-- Reviewable:end -->
