### PR TITLE
fix: jepsen: adapt test app to SnapshotMeta without snapshot_id

### DIFF
--- a/jepsen/openraft-test-app/src/store.rs
+++ b/jepsen/openraft-test-app/src/store.rs
@@ -35,12 +35,6 @@ pub struct StoredSnapshot {
 pub struct StateMachineStore {
     pub data: StateMachineData,
 
-    /// Snapshot index is not persisted in this test application.
-    ///
-    /// It is only used as a suffix of snapshot id, and should be globally unique.
-    /// In practice, using a timestamp in micro-second would be good enough.
-    snapshot_idx: u64,
-
     /// State machine stores snapshot in db.
     db: Arc<DB>,
 }
@@ -67,16 +61,9 @@ impl RaftSnapshotBuilder<TypeConfig> for StateMachineStore {
             serde_json::to_vec(&*kvs).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
         };
 
-        let snapshot_id = if let Some(ref last) = last_applied_log {
-            format!("{}-{}-{}", last.committed_leader_id(), last.index(), self.snapshot_idx)
-        } else {
-            format!("--{}", self.snapshot_idx)
-        };
-
         let meta = SnapshotMeta {
             last_log_id: last_applied_log,
             last_membership,
-            snapshot_id,
         };
 
         let snapshot = StoredSnapshot {
@@ -101,7 +88,6 @@ impl StateMachineStore {
                 last_membership: Default::default(),
                 kvs: Arc::new(Mutex::new(BTreeMap::new())),
             },
-            snapshot_idx: 0,
             db,
         };
 
@@ -205,7 +191,6 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
     }
 
     async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
-        self.snapshot_idx += 1;
         self.clone()
     }
 


### PR DESCRIPTION

## Changelog

##### fix: jepsen: adapt test app to SnapshotMeta without snapshot_id
# Summary

The jepsen test app still constructed `SnapshotMeta` with the
`snapshot_id` field removed in 28b8c5d5, breaking the jepsen workflow
on main.

# Details

Like tests-turmoil, the app is not a workspace member, so
`cargo check --workspace` never covered it and the break only surfaced
when the jepsen workflow built it inside docker.

Apply the same migration as the in-workspace stores: drop the
`snapshot_idx` counter and the snapshot id computation; the metadata
now carries only `last_log_id` and `last_membership`.

---

- Bug Fix
