### PR TITLE
chore: ci: check the jepsen test app in pull request CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -561,3 +561,34 @@ jobs:
         run: |
           cd examples/${{ matrix.example }}
           cargo clippy --no-deps --all-targets -- -D warnings
+
+  # The jepsen test app is a standalone workspace built only inside the jepsen
+  # workflow's docker image, and that workflow runs on push to main only.
+  # Check the crate here so a pull request cannot silently break it.
+  jepsen-app:
+    name: jepsen app
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Same system-RocksDB shortcut as the examples job: link the system
+    # librocksdb instead of compiling the bundled RocksDB C++ from source.
+    env:
+      ROCKSDB_LIB_DIR: /usr/lib/x86_64-linux-gnu
+      ROCKSDB_INCLUDE_DIR: /usr/include
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
+          # The app is excluded from the root workspace, so the default cache
+          # misses its target dir. Cache its own workspace.
+          cache-workspaces: jepsen/openraft-test-app
+
+      - name: Install system RocksDB
+        run: sudo apt-get update && sudo apt-get install -y librocksdb-dev
+
+      - name: Format
+        run: cargo fmt --manifest-path jepsen/openraft-test-app/Cargo.toml -- --check
+
+      - name: Clippy
+        run: cargo clippy --no-deps --manifest-path jepsen/openraft-test-app/Cargo.toml --all-targets -- -D warnings

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ lint:
 	cargo fmt --manifest-path examples/raft-kv-rocksdb/Cargo.toml
 	cargo fmt --manifest-path examples/multi-raft-kv/Cargo.toml
 	cargo fmt --manifest-path tests-turmoil/Cargo.toml
+	cargo fmt --manifest-path jepsen/openraft-test-app/Cargo.toml
 	@# The three workspace clippy runs mirror the CI lint job
 	@# (.github/workflows/ci.yaml); keep them in sync so `make lint` fails
 	@# exactly where CI would, feature unification included.
@@ -151,6 +152,7 @@ lint:
 	@# which supplies `--cfg tokio_unstable`; `--manifest-path` from the repo
 	@# root would not pick it up.
 	cd tests-turmoil && cargo clippy --no-deps --all-targets -- -D warnings
+	cargo clippy --no-deps --manifest-path jepsen/openraft-test-app/Cargo.toml                        --all-targets -- -D warnings
 	@# Bug: clippy --all-targets reports false warning about unused dep in
 	@# `[dev-dependencies]`:
 	@# https://github.com/rust-lang/rust/issues/72686#issuecomment-635539688
@@ -228,6 +230,7 @@ clean:
 	cargo clean --manifest-path examples/raft-kv-memstore/Cargo.toml
 	cargo clean --manifest-path examples/raft-kv-rocksdb/Cargo.toml
 	cargo clean --manifest-path examples/multi-raft-kv/Cargo.toml
+	cargo clean --manifest-path jepsen/openraft-test-app/Cargo.toml
 	rm -rf tests/_log
 
 .PHONY: test fmt lint clean doc guide detsim


### PR DESCRIPTION

## Changelog

##### chore: ci: check the jepsen test app in pull request CI
# Summary

The jepsen test app is a standalone workspace compiled only inside the
jepsen workflow's docker build, which runs on push to main, so a pull
request could break it without any signal — the `snapshot_id` removal
did exactly that. The crate is now format- and clippy-checked in the
`ci` workflow and in `make lint`.

# Details

A new `jepsen-app` job runs `cargo fmt --check` and
`cargo clippy --no-deps --all-targets -- -D warnings` on the crate.
Clippy type-checks the lib and the binary, and the app has no tests, so
this is full compile coverage. The job reuses the examples job's
system-RocksDB shortcut and caches the app's own workspace, which the
default root-workspace cache misses. A dedicated job keeps the
matrix-derived job names of the examples job untouched, since required
status checks may reference them.

`make lint` formats and clippy-checks the crate, and `make clean`
clears its target dir, keeping local checks aligned with CI.

---

- Build/Testing/CI
