### PR TITLE
refactor: remove vulnerable rkyv dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/databendlabs/openraft"
 anyerror           = { version = "0.1.10" }
 anyhow             = { version = "1.0.63" }
 backoff-series     = { version = "0.1.1" }
-byte-unit          = { version = "5.1.4" }
+parse-size         = { version = "1.1.0" }
 bytes              = { version = "1.0" }
 chrono             = { version = "0.4" }
 clap               = { version = "4.1.11", features = ["derive", "env"] }

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -23,7 +23,7 @@ anyerror        = { workspace = true }
 anyhow          = { workspace = true, optional = true }
 backoff-series  = { workspace = true }
 base2histogram  = { workspace = true }
-byte-unit       = { workspace = true, optional = true }
+parse-size      = { workspace = true, optional = true }
 chrono          = { workspace = true }
 clap            = { workspace = true, optional = true }
 derive_more     = { workspace = true }
@@ -65,10 +65,10 @@ tokio-rt = ["dep:openraft-rt-tokio"]
 
 # Enable building `Config` from command-line arguments via `Config::build`.
 #
-# When disabled, openraft no longer depends on `clap` or `byte-unit`, and
+# When disabled, openraft no longer depends on `clap` or `parse-size`, and
 # `Config` must be constructed programmatically (via `Config::default()` or
 # struct literal syntax).
-clap = ["dep:clap", "dep:byte-unit"]
+clap = ["dep:clap", "dep:parse-size"]
 
 # Exposes crate internals to the criterion benchmarks in `benches/`, via
 # `openraft::bench_internals`.

--- a/openraft/src/config/config_clap_test.rs
+++ b/openraft/src/config/config_clap_test.rs
@@ -5,9 +5,27 @@
 
 use core::time::Duration;
 
+use super::error::ConfigError;
+use super::parser::parse_bytes_with_unit;
 use crate::Config;
 use crate::SnapshotPolicy;
 use crate::StepDownPolicy;
+
+#[test]
+fn test_parse_bytes_with_unit() -> anyhow::Result<()> {
+    assert_eq!(204, parse_bytes_with_unit("204")?);
+    assert_eq!(3 * 1024 * 1024, parse_bytes_with_unit("3MiB")?);
+    assert_eq!(5_300, parse_bytes_with_unit("5.3 KB")?);
+    assert_eq!(
+        Err(ConfigError::InvalidNumber {
+            invalid: "invalid".to_string(),
+            reason: "invalid digit found in string".to_string(),
+        }),
+        parse_bytes_with_unit("invalid")
+    );
+
+    Ok(())
+}
 
 #[test]
 fn test_build() -> anyhow::Result<()> {

--- a/openraft/src/config/parser.rs
+++ b/openraft/src/config/parser.rs
@@ -3,8 +3,6 @@
 //! Gated behind `feature = "clap"` in [`super`]; functions and the
 //! [`Config::build`] method here are only compiled when that feature is on.
 
-use std::str::FromStr;
-
 use anyerror::AnyError;
 use clap::Parser;
 
@@ -15,12 +13,10 @@ use crate::config::error::ConfigError;
 
 /// Parse number with unit such as 5.3 KB
 pub(super) fn parse_bytes_with_unit(src: &str) -> Result<u64, ConfigError> {
-    let res = byte_unit::Byte::from_str(src).map_err(|e| ConfigError::InvalidNumber {
+    parse_size::parse_size(src).map_err(|e| ConfigError::InvalidNumber {
         invalid: src.to_string(),
         reason: e.to_string(),
-    })?;
-
-    Ok(res.as_u64())
+    })
 }
 
 pub(super) fn parse_snapshot_policy(src: &str) -> Result<SnapshotPolicy, ConfigError> {


### PR DESCRIPTION

## Changelog

##### refactor: remove vulnerable rkyv dependency
# Summary

Byte-size parsing no longer pulls in `rust_decimal` and its vulnerable
lockfile-only `rkyv` 0.7 dependency, allowing dependency audits to pass
without changing common size inputs.

# Details

Replace `byte-unit` with `parse-size`, which provides accurate `u64`
parsing without transitive runtime dependencies. The `rkyv` feature was
never enabled, but Cargo records optional dependency edges in the lockfile
and auditors scan those entries.

Cover plain bytes, SI and IEC units, fractions, and exact invalid-input
mapping to preserve the CLI parser behavior.

- Fixes #1937

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1938)
<!-- Reviewable:end -->
