### PR TITLE
chore: disable unused tabled features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ semver             = { version = "1.0.14" }
 serde              = { version = "1.0.114", features = ["derive", "rc"] }
 serde_json         = { version = "1.0.57" }
 syn                = { version = "3.0" }
-tabled             = { version = "0.20.0" }
+tabled             = { version = "0.20.0", default-features = false, features = ["std"] }
 tempfile           = { version = "3.4.0" }
 test-harness       = { version = "0.3.0" }
 thiserror          = { version = "2.0.18" }


### PR DESCRIPTION
OpenRaft only uses tabled's builder and styling APIs. Disabling its default features removes the unmaintained proc-macro-error2 dependency.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1939)
<!-- Reviewable:end -->
