### PR TITLE
refactor: fix-jepsen: refresh stale Jepsen membership metrics

### DIFF
--- a/jepsen/src/jepsen/openraft/cluster.clj
+++ b/jepsen/src/jepsen/openraft/cluster.clj
@@ -26,6 +26,18 @@
                (= leader-id (:current_leader metrics)))
       vote)))
 
+(defn- committed-vote-key [vote]
+  (when (:committed vote)
+    [(get-in vote [:leader_id :term])
+     (vote-leader-id vote)]))
+
+(defn- latest-committed-vote-key [metrics]
+  (->> metrics
+       vals
+       (keep (comp committed-vote-key :vote))
+       sort
+       last))
+
 (defn- membership-committed? [metrics]
   (= (get-in metrics [:committed_membership_config :log_id])
      (get-in metrics [:membership_config :log_id])))
@@ -63,7 +75,7 @@
                    (.initCause e))))
         (throw e)))))
 
-(defn- collect-reachable-metrics [test]
+(defn- collect-reachable-metrics-from [test nodes]
   (into {}
         (keep
          (fn [node]
@@ -73,7 +85,10 @@
                (throw e))
              (catch Exception _
                nil)))
-         (:nodes test))))
+         nodes)))
+
+(defn- collect-reachable-metrics [test]
+  (collect-reachable-metrics-from test (:nodes test)))
 
 (defn- cluster-status [test]
   (let [metrics (collect-reachable-metrics test)
@@ -96,6 +111,7 @@
 (defn- supported-leader? [metrics [leader leader-metrics]]
   (let [leader-id (client/node-host leader)
         leader-vote (committed-leader-vote leader-metrics leader-id)
+        latest-vote-key (latest-committed-vote-key metrics)
         configs (get-in leader-metrics
                         [:membership_config :membership :configs])
         supporters (->> metrics
@@ -106,9 +122,22 @@
                                   (client/node-host node))))
                         set)]
     (and leader-vote
+         (= latest-vote-key (committed-vote-key leader-vote))
          (= "Leader" (:state leader-metrics))
          (seq configs)
          (quorum/quorum? configs supporters))))
+
+(defn- supported-leader [metrics]
+  (let [leaders (filter #(supported-leader? metrics %) metrics)]
+    (when (= 1 (count leaders))
+      (first leaders))))
+
+(defn- membership-metrics [test]
+  (let [metrics (collect-reachable-metrics test)]
+    (if (supported-leader metrics)
+      metrics
+      ;; Timeouts can make the first scan straddle a leader election.
+      (collect-reachable-metrics-from test (keys metrics)))))
 
 (defn- serialized-node-id [id]
   (if (keyword? id)
@@ -118,11 +147,9 @@
 (defn membership-status
   "Returns the membership view of a leader supported by a voter quorum, or nil."
   [test]
-  (let [metrics (collect-reachable-metrics test)
-        leaders (filter #(supported-leader? metrics %) metrics)]
-    (when (= 1 (count leaders))
-      (let [[leader leader-metrics] (first leaders)
-            effective (get leader-metrics :membership_config)
+  (let [metrics (membership-metrics test)]
+    (when-let [[leader leader-metrics] (supported-leader metrics)]
+      (let [effective (get leader-metrics :membership_config)
             committed (get leader-metrics :committed_membership_config)
             effective-configs (get-in effective [:membership :configs])
             committed-configs (get-in committed [:membership :configs])

--- a/jepsen/test/jepsen/openraft/cluster_test.clj
+++ b/jepsen/test/jepsen/openraft/cluster_test.clj
@@ -115,6 +115,18 @@
   {:nodes ["n1" "n2" "n3" "n4" "n5"]
    :api-port 21001})
 
+(defn- stable-status [leader metrics voters]
+  {:leader leader
+   :metrics metrics
+   :effective-log-id {:index 7}
+   :committed-log-id {:index 7}
+   :effective-voter-configs [voters]
+   :committed-voter-configs [voters]
+   :voters voters
+   :learners #{}
+   :non-members #{}
+   :stable? true})
+
 (deftest observes-a-stable-membership
   (let [membership (stored-membership
                     7
@@ -141,6 +153,110 @@
         (is (= #{"n1" "n2" "n3"} (:voters status)))
         (is (= #{"n4"} (:learners status)))
         (is (= #{"n5"} (:non-members status)))))))
+
+(deftest refreshes-reachable-metrics-after-an-election
+  (let [membership (stored-membership
+                    7
+                    [["n1" "n2" "n3" "n4" "n5"]]
+                    ["n1" "n2" "n3" "n4" "n5"])
+        leader-metrics (metrics "Leader" 18 "n1"
+                                membership membership)
+        follower-metrics (metrics "Follower" 18 "n1"
+                                  membership membership)
+        current {"n1:21001" leader-metrics
+                 "n4:21001" follower-metrics
+                 "n5:21001" follower-metrics}
+        stale (metrics "Follower" 17 "n3" membership membership)
+        voters #{"n1" "n2" "n3" "n4" "n5"}
+        attempts (atom {})]
+    (with-redefs [client/metrics!
+                  (fn [endpoint]
+                    (let [counts (swap! attempts update endpoint
+                                        (fnil inc 0))]
+                      (cond
+                        (#{"n2:21001" "n3:21001"} endpoint)
+                        (throw (ex-info "unreachable" {:kind :unreachable}))
+
+                        (and (= "n1:21001" endpoint)
+                             (= 1 (get counts endpoint)))
+                        stale
+
+                        :else
+                        (get current endpoint))))]
+      (is (= (stable-status "n1"
+                            {"n1" leader-metrics
+                             "n4" follower-metrics
+                             "n5" follower-metrics}
+                            voters)
+             (cluster/membership-status five-node-config)))
+      (is (= {"n1:21001" 2
+              "n2:21001" 1
+              "n3:21001" 1
+              "n4:21001" 2
+              "n5:21001" 2}
+             @attempts)))))
+
+(deftest refreshes-a-stale-quorum-behind-a-newer-committed-vote
+  (let [membership (stored-membership
+                    7
+                    [["n1" "n2" "n3" "n4" "n5"]]
+                    ["n1" "n2" "n3" "n4" "n5"])
+        old-leader (metrics "Leader" 17 "n1" membership membership)
+        old-follower (metrics "Follower" 17 "n1" membership membership)
+        new-leader (metrics "Leader" 18 "n4" membership membership)
+        new-follower (metrics "Follower" 18 "n4" membership membership)
+        first-scan {"n1:21001" old-leader
+                    "n2:21001" old-follower
+                    "n3:21001" old-follower
+                    "n4:21001" new-leader
+                    "n5:21001" new-follower}
+        current-scan {"n1:21001" new-follower
+                      "n2:21001" new-follower
+                      "n3:21001" new-follower
+                      "n4:21001" new-leader
+                      "n5:21001" new-follower}
+        voters #{"n1" "n2" "n3" "n4" "n5"}
+        attempts (atom {})]
+    (with-redefs [client/metrics!
+                  (fn [endpoint]
+                    (let [counts (swap! attempts update endpoint
+                                        (fnil inc 0))]
+                      (get (if (= 1 (get counts endpoint))
+                             first-scan
+                             current-scan)
+                           endpoint)))]
+      (is (= (stable-status "n4"
+                            {"n1" new-follower
+                             "n2" new-follower
+                             "n3" new-follower
+                             "n4" new-leader
+                             "n5" new-follower}
+                            voters)
+             (cluster/membership-status five-node-config)))
+      (is (= {"n1:21001" 2
+              "n2:21001" 2
+              "n3:21001" 2
+              "n4:21001" 2
+              "n5:21001" 2}
+             @attempts)))))
+
+(deftest accepts-a-supported-leader-despite-a-newer-uncommitted-vote
+  (let [membership (stored-membership
+                    7
+                    [["n1" "n2" "n3"]]
+                    ["n1" "n2" "n3"])
+        leader-metrics (metrics "Leader" 17 "n1"
+                                membership membership)
+        follower-metrics (metrics "Follower" 17 "n1"
+                                  membership membership)
+        candidate-metrics (-> (metrics "Candidate" 18 "n3"
+                                       membership membership)
+                              (assoc-in [:vote :committed] false))
+        observed {"n1" leader-metrics
+                  "n2" follower-metrics
+                  "n3" candidate-metrics}]
+    (is (= ["n1" leader-metrics]
+           (#'cluster/supported-leader observed)))))
 
 (deftest observes-a-joint-membership
   (let [committed (stored-membership


### PR DESCRIPTION

## Changelog

##### refactor: fix-jepsen: refresh stale Jepsen membership metrics
# Summary

Membership fault planning now refreshes reachable node metrics when an
initial scan cannot identify a quorum-supported leader.

# Details

Sequential requests to paused nodes could make a metrics scan straddle
an election, combining a stale leader observation with current follower
observations. A second scan now targets only nodes known to be reachable,
avoiding repeated timeout delays and false `:no-supported-leader`
results.

Regression coverage reproduces the election-during-timeouts sequence
from the failed chaos run.

- Refs #1918

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1941)
<!-- Reviewable:end -->
