### PR TITLE
test: run Jepsen app tests in CI

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Check | Test app
         run: make -C jepsen app-lint
 
+      - name: Test | Test app
+        run: make -C jepsen app-test
+
       - name: Test | Clojure
         run: make -C jepsen unit-test
 

--- a/jepsen/Makefile
+++ b/jepsen/Makefile
@@ -18,6 +18,9 @@ app-lint:
 	cargo fmt --check --manifest-path $(APP_MANIFEST)
 	cargo clippy --no-deps --manifest-path $(APP_MANIFEST) --all-targets -- -D warnings
 
+app-test:
+	cargo test --manifest-path $(APP_MANIFEST)
+
 clojure-lint:
 	clj-kondo --lint src test
 	cljfmt check src test
@@ -55,4 +58,4 @@ down:
 	@echo "[jepsen] stopping containers"
 	@$(COMPOSE) down
 
-.PHONY: app-lint clojure-lint lint unit-test jepsen key build up test down
+.PHONY: app-lint app-test clojure-lint lint unit-test jepsen key build up test down


### PR DESCRIPTION
Clippy compiles the Rust test targets without executing their assertions. Run the test app suite on Jepsen pull requests so parser regressions cannot pass CI unnoticed.

CLOSES #1940

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1943)
<!-- Reviewable:end -->
