### PR TITLE
change: return leadership-aware read barrier: ReadLogId

### DIFF
--- a/examples/app-http/src/app.rs
+++ b/examples/app-http/src/app.rs
@@ -17,6 +17,7 @@ use openraft::errors::LinearizableReadError;
 use openraft::errors::decompose::DecomposeResult;
 use openraft::raft::ClientWriteResponse;
 use openraft::raft::linearizable_read::Linearizer;
+use openraft::raft::linearizable_read::ReadLogId;
 use openraft::storage::RaftStateMachine;
 use serde::Deserialize;
 use serde::Serialize;
@@ -45,15 +46,12 @@ pub struct AddLearnerRequest<NID = u64> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(
-    serialize = "C::NodeId: Serialize, LogIdOf<C>: Serialize",
-    deserialize = "C::NodeId: Deserialize<'de>, LogIdOf<C>: Deserialize<'de>"
-))]
+#[serde(bound = "")]
 pub struct LinearizerData<C>
 where C: RaftTypeConfig
 {
     pub node_id: C::NodeId,
-    pub read_log_id: LogIdOf<C>,
+    pub read_log_id: ReadLogId<C>,
     pub applied: Option<LogIdOf<C>>,
 }
 

--- a/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
+++ b/openraft/src/engine/handler/leader_handler/get_read_log_id_test.rs
@@ -10,6 +10,7 @@ use crate::Vote;
 use crate::engine::Engine;
 use crate::engine::testing::UTConfig;
 use crate::engine::testing::log_id;
+use crate::raft::linearizable_read::ReadLogId;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::StoredMembershipOf;
 use crate::utime::Leased;
@@ -50,14 +51,16 @@ fn test_get_read_log_id() -> anyhow::Result<()> {
     let mut eng = eng();
 
     eng.state.apply_progress_mut().accept(log_id(0, 1, 0));
-    eng.leader.as_mut().unwrap().noop_log_id = log_id(1, 1, 2);
+    let noop = log_id(3, 1, 4);
+    eng.leader.as_mut().unwrap().noop_log_id = noop;
 
     let got = eng.try_leader_handler()?.get_read_log_id();
-    assert_eq!(log_id(1, 1, 2), got);
+    assert_eq!(ReadLogId::new(noop, None), got);
 
-    eng.state.apply_progress_mut().accept(log_id(2, 1, 3));
+    let committed = log_id(3, 1, 5);
+    eng.state.apply_progress_mut().accept(committed);
     let got = eng.try_leader_handler()?.get_read_log_id();
-    assert_eq!(log_id(2, 1, 3), got);
+    assert_eq!(ReadLogId::new(noop, Some(committed)), got);
 
     Ok(())
 }

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -9,6 +9,7 @@ use crate::entry::RaftEntry;
 use crate::entry::RaftPayload;
 use crate::proposer::Leader;
 use crate::proposer::LeaderQuorumSet;
+use crate::raft::linearizable_read::ReadLogId;
 use crate::raft::message::TransferLeaderRequest;
 use crate::raft_state::IOId;
 use crate::replication::ReplicationSessionId;
@@ -16,7 +17,6 @@ use crate::storage::RaftStateMachine;
 use crate::type_config::alias::BatchOf;
 use crate::type_config::alias::CommittedLeaderIdOf;
 use crate::type_config::alias::EntryPayloadOf;
-use crate::type_config::alias::LogIdOf;
 
 #[cfg(test)]
 mod append_entries_test;
@@ -138,14 +138,8 @@ where
     /// Get the log id for a linearizable read.
     ///
     /// See: [Read Operation](crate::docs::protocol::read)
-    pub(crate) fn get_read_log_id(&self) -> LogIdOf<C> {
-        let committed = self.state.local_committed().cloned();
-        let Some(committed) = committed else {
-            return self.leader.noop_log_id.clone();
-        };
-
-        // noop log id is the first log this leader proposed.
-        std::cmp::max(self.leader.noop_log_id.clone(), committed)
+    pub(crate) fn get_read_log_id(&self) -> ReadLogId<C> {
+        ReadLogId::new(self.leader.noop_log_id.clone(), self.state.local_committed().cloned())
     }
 
     /// Disable proposing new logs for this Leader and transfer Leader to another node

--- a/openraft/src/raft/linearizable_read/linearize_state.rs
+++ b/openraft/src/raft/linearizable_read/linearize_state.rs
@@ -4,6 +4,7 @@ use display_more::DisplayOptionExt;
 use openraft_macros::since;
 
 use crate::RaftTypeConfig;
+use crate::raft::linearizable_read::ReadLogId;
 use crate::type_config::alias::LogIdOf;
 
 /// Represents the state after awaiting the applied log entries for a linearizable read.
@@ -27,7 +28,7 @@ where C: RaftTypeConfig
 {
     /// The node from which this Linearizer collects the applied log ID.
     node_id: C::NodeId,
-    read_log_id: LogIdOf<C>,
+    read_log_id: ReadLogId<C>,
     applied: Option<LogIdOf<C>>,
 }
 
@@ -49,7 +50,7 @@ where C: RaftTypeConfig
 impl<C> LinearizeState<C>
 where C: RaftTypeConfig
 {
-    pub(crate) fn new(node_id: C::NodeId, read_log_id: LogIdOf<C>, applied: Option<LogIdOf<C>>) -> Self {
+    pub(crate) fn new(node_id: C::NodeId, read_log_id: ReadLogId<C>, applied: Option<LogIdOf<C>>) -> Self {
         Self {
             node_id,
             read_log_id,
@@ -73,7 +74,7 @@ where C: RaftTypeConfig
     ///
     /// If the local_node_id is different, the `applied` is unknown.
     pub(crate) fn is_ready_on_node(&self, node_id: &C::NodeId) -> bool {
-        self.node_id == *node_id && self.applied.as_ref() >= Some(&self.read_log_id)
+        self.node_id == *node_id && self.applied.as_ref() >= Some(self.read_log_id.log_id())
     }
 
     /// Return the node id on which the linearizer is created.
@@ -86,8 +87,9 @@ where C: RaftTypeConfig
     ///
     /// It is the max of the current leader noop-log-id and the last committed log id.
     /// See: [`read` docs](crate::docs::protocol::read).
+    #[since(version = "0.10.0", change = "return ReadLogId instead of LogId")]
     #[since(version = "0.10.0")]
-    pub fn read_log_id(&self) -> &LogIdOf<C> {
+    pub fn read_log_id(&self) -> &ReadLogId<C> {
         &self.read_log_id
     }
 
@@ -106,7 +108,8 @@ mod tests {
 
     #[test]
     fn test_display() {
-        let state: LinearizeState<UTConfig> = LinearizeState::new(1, log_id(1, 1, 1), Some(log_id(1, 1, 0)));
+        let read_log_id = ReadLogId::new(log_id(1, 1, 1), None);
+        let state: LinearizeState<UTConfig> = LinearizeState::new(1, read_log_id, Some(log_id(1, 1, 0)));
         assert_eq!(
             format!("{}", state),
             "LinearizeState[id=1]{ read_log_id: T1-N1.1, applied: T1-N1.0 }"

--- a/openraft/src/raft/linearizable_read/linearizer.rs
+++ b/openraft/src/raft/linearizable_read/linearizer.rs
@@ -9,6 +9,7 @@ use crate::async_runtime::watch::WatchReceiver;
 use crate::errors::Fatal;
 use crate::metrics::WaitError;
 use crate::raft::linearizable_read::LinearizeState;
+use crate::raft::linearizable_read::ReadLogId;
 use crate::storage::RaftStateMachine;
 use crate::type_config::alias::LogIdOf;
 
@@ -49,8 +50,9 @@ where C: RaftTypeConfig
 impl<C> Linearizer<C>
 where C: RaftTypeConfig
 {
+    #[since(version = "0.10.0", change = "accept ReadLogId instead of LogId")]
     #[since(version = "0.10.0")]
-    pub fn new(node_id: C::NodeId, read_log_id: LogIdOf<C>, applied: Option<LogIdOf<C>>) -> Self {
+    pub fn new(node_id: C::NodeId, read_log_id: ReadLogId<C>, applied: Option<LogIdOf<C>>) -> Self {
         Self {
             state: LinearizeState::new(node_id, read_log_id, applied),
         }

--- a/openraft/src/raft/linearizable_read/mod.rs
+++ b/openraft/src/raft/linearizable_read/mod.rs
@@ -2,6 +2,8 @@
 
 mod linearize_state;
 mod linearizer;
+mod read_log_id;
 
 pub use linearize_state::LinearizeState;
 pub use linearizer::Linearizer;
+pub use read_log_id::ReadLogId;

--- a/openraft/src/raft/linearizable_read/read_log_id.rs
+++ b/openraft/src/raft/linearizable_read/read_log_id.rs
@@ -1,0 +1,131 @@
+use std::fmt;
+
+use openraft_macros::since;
+
+use crate::RaftTypeConfig;
+use crate::type_config::alias::CommittedLeaderIdOf;
+use crate::type_config::alias::LogIdOf;
+
+/// The least log ID through which a state machine must apply before linearizing a read.
+///
+/// This boundary is inclusive: the state machine must apply this log ID or a later one.
+///
+/// A read log ID is the maximum of the producing leader's no-op log ID and the local committed log
+/// ID. Therefore, it belongs to the leadership that produced it, but the log entry itself may not
+/// yet be committed or applied.
+#[since(version = "0.10.0")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(bound = "", transparent)
+)]
+pub struct ReadLogId<C>
+where C: RaftTypeConfig
+{
+    log_id: LogIdOf<C>,
+}
+
+impl<C> Copy for ReadLogId<C>
+where
+    C: RaftTypeConfig,
+    LogIdOf<C>: Copy,
+{
+}
+
+impl<C> fmt::Display for ReadLogId<C>
+where C: RaftTypeConfig
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.log_id.fmt(f)
+    }
+}
+
+impl<C> ReadLogId<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(noop_log_id: LogIdOf<C>, committed: Option<LogIdOf<C>>) -> Self {
+        let log_id = match committed {
+            Some(committed) => std::cmp::max(noop_log_id.clone(), committed),
+            None => noop_log_id.clone(),
+        };
+
+        debug_assert_eq!(
+            log_id.committed_leader_id(),
+            noop_log_id.committed_leader_id(),
+            "read log ID must belong to the producing leadership"
+        );
+
+        Self { log_id }
+    }
+
+    /// Rebuild a `ReadLogId` from a log ID previously produced by a leader.
+    ///
+    /// Use this on a follower to reconstruct the read log ID received through an
+    /// application-defined wire format when implementing follower reads. The caller is
+    /// responsible for the value originating from a leader, such as via
+    /// [`LinearizeState::read_log_id()`]; this method does not verify it.
+    ///
+    /// [`LinearizeState::read_log_id()`]: crate::raft::linearizable_read::LinearizeState::read_log_id
+    #[since(version = "0.10.0")]
+    pub fn from_log_id(log_id: LogIdOf<C>) -> Self {
+        Self { log_id }
+    }
+
+    /// Return the underlying log ID.
+    #[since(version = "0.10.0")]
+    pub fn log_id(&self) -> &LogIdOf<C> {
+        &self.log_id
+    }
+
+    /// Return the ID of the leadership that produced this read log ID.
+    #[since(version = "0.10.0")]
+    pub fn committed_leader_id(&self) -> &CommittedLeaderIdOf<C> {
+        self.log_id.committed_leader_id()
+    }
+
+    /// Return the log index of this read log ID.
+    #[since(version = "0.10.0")]
+    pub fn index(&self) -> u64 {
+        self.log_id.index()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::testing::UTConfig;
+    use crate::engine::testing::log_id;
+
+    #[test]
+    fn test_new() {
+        let noop = log_id(2, 1, 2);
+
+        let got = ReadLogId::<UTConfig>::new(noop, None);
+        assert_eq!(ReadLogId { log_id: noop }, got);
+
+        let got = ReadLogId::<UTConfig>::new(noop, Some(log_id(1, 1, 3)));
+        assert_eq!(ReadLogId { log_id: noop }, got);
+
+        let committed = log_id(2, 1, 4);
+        let got = ReadLogId::<UTConfig>::new(noop, Some(committed));
+        assert_eq!(ReadLogId { log_id: committed }, got);
+    }
+
+    #[test]
+    fn test_from_log_id() {
+        let log_id = log_id(2, 1, 3);
+        let got = ReadLogId::<UTConfig>::from_log_id(log_id);
+        assert_eq!(ReadLogId { log_id }, got);
+    }
+
+    #[test]
+    fn test_accessors() {
+        let log_id = log_id(2, 1, 3);
+        let read_log_id = ReadLogId::<UTConfig>::new(log_id, None);
+
+        assert_eq!(&log_id, read_log_id.log_id());
+        assert_eq!(log_id.committed_leader_id(), read_log_id.committed_leader_id());
+        assert_eq!(log_id.index(), read_log_id.index());
+    }
+}

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -38,6 +38,7 @@ use core_state::CoreState;
 use derive_more::Display;
 use futures_util::FutureExt;
 use linearizable_read::Linearizer;
+use linearizable_read::ReadLogId;
 pub use message::AppendEntriesRequest;
 pub use message::AppendEntriesResponse;
 pub use message::ClientWriteResponse;
@@ -1084,38 +1085,45 @@ where
     /// // Then proceed with the state machine read
     /// ```
     /// Read more about how it works: [Read Operation](crate::docs::protocol::read)
+    #[since(version = "0.10.0", change = "return ReadLogId instead of Option<LogId>")]
     #[since(version = "0.9.0")]
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn ensure_linearizable(
         &self,
         read_policy: ReadPolicy,
-    ) -> Result<Option<LogIdOf<C>>, RaftError<C, LinearizableReadError<C>>> {
+    ) -> Result<ReadLogId<C>, RaftError<C, LinearizableReadError<C>>> {
         let linearizer = self.app_api().get_read_linearizer(read_policy).await.into_raft_result()?;
 
         // Safe unwrap: it never times out.
         let state = linearizer.await_ready(self).await?;
-        Ok(Some(state.read_log_id().clone()))
+        Ok(state.read_log_id().clone())
     }
 
-    /// Legacy method that returns log IDs directly. Use
+    /// Legacy method that returns read state as a tuple. Use
     /// [`Raft::get_read_linearizer`] instead.
     ///
-    /// This method extracts log IDs from a [`Linearizer`] and returns them as a tuple.
+    /// This method extracts the read log ID and applied log ID from a [`Linearizer`] and returns
+    /// them as a tuple.
+    ///
+    /// The [`ReadLogId`] contains the current leadership and the inclusive log boundary the state
+    /// machine must apply through before serving the read. The applied log ID is the last value
+    /// known to have been applied when the linearizer was created.
     /// **For new code, use [`Raft::get_read_linearizer`]** which provides a better API.
     ///
     /// See [`Raft::get_read_linearizer`] for full documentation.
+    #[since(version = "0.10.0", change = "return ReadLogId instead of Option<LogId>")]
     #[since(version = "0.9.0")]
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn get_read_log_id(
         &self,
         read_policy: ReadPolicy,
-    ) -> Result<(Option<LogIdOf<C>>, Option<LogIdOf<C>>), RaftError<C, LinearizableReadError<C>>> {
+    ) -> Result<(ReadLogId<C>, Option<LogIdOf<C>>), RaftError<C, LinearizableReadError<C>>> {
         let linearizer = self.app_api().get_read_linearizer(read_policy).await.into_raft_result()?;
 
         let read_log_id = linearizer.read_log_id();
         let applied = linearizer.applied();
 
-        Ok((Some(read_log_id.clone()), applied.cloned()))
+        Ok((read_log_id.clone(), applied.cloned()))
     }
 
     /// Ensures this node is leader and returns a [`Linearizer`] to linearize reads.

--- a/tests-turmoil/src/bin/fuzz.rs
+++ b/tests-turmoil/src/bin/fuzz.rs
@@ -1115,7 +1115,7 @@ async fn read_client_loop(
                         barrier
                     );
                 }
-                history.lock().unwrap().record_read(&key, observed.as_ref(), floor, barrier);
+                history.lock().unwrap().record_read(&key, observed.as_ref(), floor, Some(*barrier.log_id()));
             }
             _ => {
                 if dbg_ops() {

--- a/tests/tests/client_api/t11_client_reads.rs
+++ b/tests/tests/client_api/t11_client_reads.rs
@@ -13,6 +13,7 @@ use openraft::base::BoxFuture;
 use openraft::errors::NetworkError;
 use openraft::errors::RPCError;
 use openraft::type_config::TypeConfigExt;
+use openraft::vote::RaftLeaderId;
 use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
@@ -80,6 +81,7 @@ async fn client_reads() -> Result<()> {
 /// - A leader that has not yet committed any log entries returns leader initialization log id(blank
 ///   log id).
 /// - Return the last committed log id if the leader has committed any log entries.
+/// - The returned read log ID contains the current leadership.
 #[tracing::instrument]
 #[test_harness::test(harness = ut_harness)]
 async fn get_read_log_id() -> Result<()> {
@@ -140,6 +142,8 @@ async fn get_read_log_id() -> Result<()> {
 
     n1.wait(timeout()).state(ServerState::Leader, "node 1 becomes leader").await?;
 
+    let leadership = n1.metrics().borrow_watched().vote.leader_id().to_committed();
+
     tracing::info!(log_index = log_index, "--- node 1 appends blank log but cannot commit");
     {
         let res = n1.wait(timeout()).applied_index_at_least(Some(log_index + 1), "blank log cannot commit").await;
@@ -152,9 +156,9 @@ async fn get_read_log_id() -> Result<()> {
     {
         let (read_log_id, applied) = n1.get_read_log_id(ReadPolicy::ReadIndex).await?;
         assert_eq!(
-            read_log_id.index(),
-            Some(blank_log_index),
-            "read-log-id is the blank log"
+            (&leadership, blank_log_index),
+            (read_log_id.committed_leader_id(), read_log_id.index()),
+            "read-log-id is the blank log from the current leader"
         );
         assert_eq!(applied.index(), Some(log_index));
     }
@@ -170,7 +174,11 @@ async fn get_read_log_id() -> Result<()> {
         n1.wait(timeout()).applied_index(Some(log_index), "log applied to state-machine").await?;
 
         let (read_log_id, applied) = n1.get_read_log_id(ReadPolicy::ReadIndex).await?;
-        assert_eq!(read_log_id.index(), Some(log_index), "read-log-id is the committed log");
+        assert_eq!(
+            (&leadership, log_index),
+            (read_log_id.committed_leader_id(), read_log_id.index()),
+            "read-log-id is the current leader's committed log"
+        );
         assert_eq!(applied.index(), Some(log_index));
     }
 
@@ -193,9 +201,9 @@ async fn get_read_log_id() -> Result<()> {
 
         let (read_log_id, _applied) = n1.get_read_log_id(ReadPolicy::ReadIndex).await?;
         assert_eq!(
-            read_log_id.index(),
-            Some(last_committed),
-            "read-log-id is the committed log"
+            (&leadership, last_committed),
+            (read_log_id.committed_leader_id(), read_log_id.index()),
+            "read-log-id is the current leader's committed log"
         );
     };
 

--- a/tests/tests/fixtures/mod.rs
+++ b/tests/tests/fixtures/mod.rs
@@ -54,6 +54,7 @@ use openraft::raft::TransferLeaderRequest;
 use openraft::raft::TransferLeaderResponse;
 use openraft::raft::VoteRequest;
 use openraft::raft::VoteResponse;
+use openraft::raft::linearizable_read::ReadLogId;
 use openraft::type_config::TypeConfigExt;
 use openraft::type_config::alias::MutexOf;
 use openraft::vote::RaftLeaderId;
@@ -712,12 +713,12 @@ impl TypedRaftRouter {
         Ok(())
     }
 
-    /// Get `read_log_id` and last `applied` log
+    /// Get the `ReadLogId` and last applied log ID.
     pub async fn get_read_log_id(
         &self,
         target: MemNodeId,
         read_policy: ReadPolicy,
-    ) -> Result<(Option<LogIdOf<MemConfig>>, Option<LogIdOf<MemConfig>>), LinearizableReadError<MemConfig>> {
+    ) -> Result<(ReadLogId<MemConfig>, Option<LogIdOf<MemConfig>>), LinearizableReadError<MemConfig>> {
         let n = self.get_raft_handle(&target).unwrap();
         n.get_read_log_id(read_policy).await.map_err(|e| e.into_api_error().unwrap())
     }


### PR DESCRIPTION

## Changelog

##### change: return leadership-aware read barrier: ReadLogId
# Summary

Linearizable reads now return a `ReadLogId` that tells the state machine the
least log ID it must apply, inclusively, before serving the read.

# Details

`ReadLogId` contains the current leader's `CommittedLeaderId` together with
the barrier index. This retains the guarantee that the barrier belongs to the
leadership that authorized the read instead of exposing it as an ordinary
`LogId`.

The barrier is always present and is the maximum of the leader's no-op log ID
and the local committed log ID.

Upgrade tip:

Replace `Option<LogId>` handling with `ReadLogId` and use `log_id()` when the
underlying log ID is required.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1945)
<!-- Reviewable:end -->
