### PR TITLE
fix: handle node changes on uninitialized nodes

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -601,6 +601,11 @@ where
         retain: bool,
         tx: ProgressResponder<C, ClientWriteResult<C>>,
     ) {
+        if let Err(e) = self.ensure_leader_handler() {
+            tx.on_complete(Err(ClientWriteError::ForwardToLeader(e)));
+            return;
+        }
+
         let res = self.engine.state.membership_state.change_handler().apply(changes, retain);
         let new_membership = match res {
             Ok(x) => x,

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -325,7 +325,7 @@ where
 
         let Membership { mut configs, nodes } = self.clone().compute_target_membership(change);
 
-        // Safe unwrap(): `calculate_goal()` yields a uniform config.
+        // Safe unwrap(): membership changes are only evaluated on an initialized leader.
         let target_voter_ids = configs.pop().unwrap();
 
         self.nodes = nodes;

--- a/tests/tests/membership/t52_change_membership_on_uninitialized_node.rs
+++ b/tests/tests/membership/t52_change_membership_on_uninitialized_node.rs
@@ -1,18 +1,19 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use maplit::btreemap;
-use openraft::ChangeMembers;
 use openraft::Config;
+use openraft::errors::ClientWriteError;
+use openraft::errors::ForwardToLeader;
+use openraft::errors::RaftError;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::ut_harness;
 
-/// Call `Raft::change_membership()` on an uninitialized node should not panic due to empty
+/// A membership request to an uninitialized node should be rejected before inspecting its empty
 /// membership.
 #[tracing::instrument]
 #[test_harness::test(harness = ut_harness)]
-async fn change_membership_on_uninitialized_node() -> Result<()> {
+async fn add_learner_on_uninitialized_node() -> Result<()> {
     let config = Arc::new(
         Config {
             enable_heartbeat: false,
@@ -25,13 +26,11 @@ async fn change_membership_on_uninitialized_node() -> Result<()> {
     router.new_raft_node(0).await;
 
     let n0 = router.get_raft_handle(&0)?;
-    let res = n0.change_membership(ChangeMembers::AddVoters(btreemap! {0=>()}), false).await;
-    tracing::info!("{:?}", res);
-
-    let err = res.unwrap_err();
-    tracing::info!("{}", err);
-
-    assert!(err.to_string().contains("forward request to"));
+    let err = n0.add_learner(0, (), false).await.unwrap_err();
+    assert_eq!(
+        RaftError::APIError(ClientWriteError::ForwardToLeader(ForwardToLeader::empty())),
+        err
+    );
 
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### fix: handle node changes on uninitialized nodes
# Summary

Node-only membership changes no longer panic when an uninitialized node has
no voter configuration.

# Details

The batch membership refactor made every change pop a target voter set, but
AddNodes intentionally leaves voter configs untouched. Preserve the computed
membership when no voter target exists so RaftCore can return its normal
leadership error instead of terminating.

Add exact regression coverage for adding a node to the default empty
membership.

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1949)
<!-- Reviewable:end -->
