### PR TITLE
test: retry skipped Jepsen faults promptly

### DIFF
--- a/jepsen/src/jepsen/openraft/nemesis.clj
+++ b/jepsen/src/jepsen/openraft/nemesis.clj
@@ -60,7 +60,7 @@
 
         (and operation-event? (= :completion stage))
         (IntervalSchedule. interval
-                           (+ operation-time
+                           (+ (if retry? (:time event) operation-time)
                               (jittered-interval
                                (if retry?
                                  (gen/secs->nanos retry-interval-seconds)

--- a/jepsen/src/jepsen/openraft/nemesis.clj
+++ b/jepsen/src/jepsen/openraft/nemesis.clj
@@ -8,6 +8,7 @@
             [jepsen.openraft.cluster :as cluster]))
 
 (def ^:private initial-healthy-seconds 5)
+(def ^:private retry-interval-seconds 1)
 (def ^:private retryable-skip-results
   #{:no-reachable-pause-target :no-supported-leader})
 
@@ -43,6 +44,7 @@
     (let [generator' (gen/update generator test context event)
           retry-generator' (some-> retry-generator
                                    (gen/update test context event))
+          retry? (contains? retryable-skip-results (:value event))
           operation-event? (and stage
                                 (= :nemesis (:process event))
                                 (= operation-f (:f event)))]
@@ -59,8 +61,11 @@
         (and operation-event? (= :completion stage))
         (IntervalSchedule. interval
                            (+ operation-time
-                              (jittered-interval interval))
-                           (if (contains? retryable-skip-results (:value event))
+                              (jittered-interval
+                               (if retry?
+                                 (gen/secs->nanos retry-interval-seconds)
+                                 interval)))
+                           (if retry?
                              retry-generator'
                              generator')
                            nil

--- a/jepsen/test/jepsen/openraft/nemesis_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis_test.clj
@@ -25,14 +25,18 @@
                        (gen/nemesis (gen/time-limit 40 faults))
                        (gen/clients
                         (gen/stagger 0.1 (repeat {:f :read}))))
+            completion-latency (gen/secs->nanos 2)
             first-attempt? (atom true)
             history (gen-test/simulate
                      generator
                      (fn [_ operation]
-                       (cond-> (assoc operation :type :ok)
-                         (and (= :first (:f operation))
-                              (compare-and-set! first-attempt? true false))
-                         (assoc :value skip-result))))
+                       (let [skip? (and (= :first (:f operation))
+                                        (compare-and-set! first-attempt?
+                                                          true
+                                                          false))]
+                         (cond-> (assoc operation :type :ok)
+                           skip? (assoc :value skip-result)
+                           skip? (update :time + completion-latency)))))
             fault-ops (->> history
                            (filter #(and (= :nemesis (:process %))
                                          (= :info (:type %))))
@@ -40,9 +44,9 @@
             [_ retry next-fault] fault-ops]
         (is (= [:first :first :second] (mapv :f fault-ops)))
         (is (= (gen/secs->nanos 3) (:time (first fault-ops))))
-        (is (<= (gen/secs->nanos 3.5)
+        (is (<= (gen/secs->nanos 5.5)
                 (:time retry)
-                (gen/secs->nanos 4.5)))
+                (gen/secs->nanos 6.5)))
         (is (<= (+ (:time retry) (gen/secs->nanos 5))
                 (:time next-fault)
                 (+ (:time retry) (gen/secs->nanos 15))))))))

--- a/jepsen/test/jepsen/openraft/nemesis_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis_test.clj
@@ -36,12 +36,16 @@
             fault-ops (->> history
                            (filter #(and (= :nemesis (:process %))
                                          (= :info (:type %))))
-                           (take 3))]
+                           (take 3))
+            [_ retry next-fault] fault-ops]
         (is (= [:first :first :second] (mapv :f fault-ops)))
         (is (= (gen/secs->nanos 3) (:time (first fault-ops))))
-        (is (<= (gen/secs->nanos 8)
-                (:time (second fault-ops))
-                (gen/secs->nanos 18)))))))
+        (is (<= (gen/secs->nanos 3.5)
+                (:time retry)
+                (gen/secs->nanos 4.5)))
+        (is (<= (+ (:time retry) (gen/secs->nanos 5))
+                (:time next-fault)
+                (+ (:time retry) (gen/secs->nanos 15))))))))
 
 (deftest cleans-up-all-faults-before-confirming-recovery
   (let [database (db/db {})


### PR DESCRIPTION

## Changelog

##### test: retry skipped Jepsen faults promptly
# Summary

Retry transiently skipped Jepsen faults on a short cadence so chaos
runs can exercise every selected fault class within their time limit.

# Details

In the failing chaos seed, both process-kill attempts coincided with
partition or membership disruption and found no quorum-supported leader.
The scheduler correctly rewound the skipped operation, but delayed each
retry by the normal jittered 5-15 seconds. The run ended without an
observed process fault, making the strict coverage checker fail even
though linearizability and recovery passed.

Skipped operations now retry after a jittered 0.5-1.5 seconds, while
successful faults keep their existing 5-15 second cadence. The scheduler
test verifies both timings and that the skipped operation is retried
before advancing.

Observed in GitHub Actions run 30994678524 with seed
8826210567654596503.

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1951)
<!-- Reviewable:end -->
