### PR TITLE
docs: add KalamDB to the "Who uses it" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ What sets OpenRaft apart from a standard Raft implementation:
 - [raymondshe/matchengine-raft](https://github.com/raymondshe/matchengine-raft) - A example to demonstrate how openraft persists snapshots/logs to disk. <!-- ★56 -->
 - [tsoracle](https://github.com/prisma-risk/tsoracle) - Distributed timestamp and sequence oracle serving strictly monotonic, gapless IDs. <!-- ★55 -->
 - [yuyang0/rrqlite](https://github.com/yuyang0/rrqlite) - A rust implementation of [rqlite](https://github.com/rqlite/rqlite). <!-- ★21 -->
+- [KalamDB](https://github.com/kalamdb/KalamDB) - A SQL-first realtime backend for agent-native apps. <!-- ★47 -->
 
 📣 Using openraft in your project? We'd love to feature it here — [open an issue](https://github.com/databendlabs/openraft/issues/new) to let us know, or skip the wait and [submit a pull request directly](https://github.com/databendlabs/openraft/edit/main/README.md).
 


### PR DESCRIPTION
## Summary

Add [[KalamDB](https://github.com/kalamdb/KalamDB)](https://github.com/kalamdb/KalamDB) to the **Who uses it** section.

KalamDB is a SQL-first realtime backend for agent-native applications. It uses OpenRaft for distributed cluster replication and failover.

## Changes

* Added KalamDB to the existing star-ordered list.
* Used a concise description based on the KalamDB README.
* Included the current star count using the existing hidden HTML comment format.

**Checklist**

* [x] Updated guide with pertinent info.
* [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
* [x] Unittest is a friend:) — Not applicable; this is a documentation-only change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1952)
<!-- Reviewable:end -->
