### PR TITLE
test: verify composed checker wiring

### DIFF
--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -69,6 +69,9 @@
   (let [test (cli/openraft-test {:nemesis [:membership :partition]
                                  :nodes ["n1" "n2" "n3" "n4" "n5"]
                                  :time-limit 10})
-        checkers (get-in test [:checker :checkers :nemesis :checkers])]
+        checkers (get-in test [:checker :checkers])
+        nemesis-checkers (get-in checkers [:nemesis :checkers])]
+    (is (= #{:seed :stats :exceptions :crash :nemesis :workload}
+           (set (keys checkers))))
     (is (= #{:partition :membership}
-           (set (keys checkers))))))
+           (set (keys nemesis-checkers))))))


### PR DESCRIPTION
Behavior tests construct checkers directly, so they cannot detect entries removed from openraft-test's composed checker map.

CLOSES #1946

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1955)
<!-- Reviewable:end -->
