### PR TITLE
test: fix model resume invocation accurately

### DIFF
--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -307,7 +307,6 @@
 
       :resume-process
       (cond
-        (= :invoke (:type op)) state
         error? :unknown
         (and (coll? resumed-nodes)
              (= expected-nodes (set resumed-nodes))) :recovery-pending

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -200,6 +200,7 @@
         (is (= :no-reachable-pause-target (:value completion)))
         (is (empty? @invocations))
         (is (empty? (:observed-modes result)))))))
+
 (deftest teardown-cleanup-failure-does-not-mask-analysis
   (let [events (atom [])
         delegate (failing-resume-nemesis
@@ -234,6 +235,7 @@
                    @events)))
           (finally
             (Thread/interrupted)))))))
+
 (deftest skips-disruptions-without-a-supported-leader
   (let [invocations (atom [])
         delegate (recording-nemesis invocations)
@@ -344,8 +346,11 @@
                                     {:f :pause-process
                                      :value :leader-paused
                                      :error :pause-failed})
-        resuming-history (conj indeterminate-history
-                               {:type :invoke
+        paused-history (conj complete-history
+                             {:f :pause-process
+                              :value {:mode :leader-paused}})
+        resuming-history (conj paused-history
+                               {:type :info
                                 :f :resume-process})
         recovered-history (into resuming-history
                                 [{:f :resume-process
@@ -381,7 +386,7 @@
              (select-keys (check indeterminate-history)
                           [:valid? :cluster-state]))))
 
-    (testing "a resume invocation does not resolve an indeterminate pause"
+    (testing "a resume invocation makes a paused state indeterminate"
       (is (= {:valid? :unknown
               :cluster-state :unknown}
              (select-keys (check resuming-history)
@@ -393,7 +398,7 @@
              (select-keys (check partial-resume-history)
                           [:valid? :cluster-state]))))
 
-    (testing "global resume and recovery resolve an indeterminate pause"
+    (testing "resume completion and recovery resolve an in-flight resume"
       (is (= {:valid? true
               :cluster-state :intact}
              (select-keys (check recovered-history)


### PR DESCRIPTION
Jepsen journals nemesis invocations as :info operations. Keep in-flight resumes indeterminate and align tests with real histories.

CLOSES #1947

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1956)
<!-- Reviewable:end -->
