### PR TITLE
test: jepsen: fix partition teardown analysis

### DIFF
--- a/jepsen/src/jepsen/openraft/nemesis/partition.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/partition.clj
@@ -1,5 +1,5 @@
 (ns jepsen.openraft.nemesis.partition
-  (:require [clojure.tools.logging :refer [info]]
+  (:require [clojure.tools.logging :refer [info warn]]
             [jepsen [checker :as checker]
              [generator :as gen]
              [nemesis :as nemesis]
@@ -83,7 +83,19 @@
         (assoc op :value :network-healed))))
 
   (teardown! [_ test]
-    (nemesis/teardown! partitioner test))
+    (try
+      (nemesis/teardown! partitioner test)
+      (catch InterruptedException e
+        (.interrupt (Thread/currentThread))
+        (throw e))
+      (catch Exception e
+        (if (= :interrupted (:kind (ex-data e)))
+          (do
+            (.interrupt (Thread/currentThread))
+            (throw e))
+          (warn e
+                "Failed to heal network partition during teardown"
+                {:nodes (:nodes test)})))))
 
   nemesis/Reflection
   (fs [_]

--- a/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
@@ -9,6 +9,15 @@
 
 (def nodes ["n1" "n2" "n3"])
 
+(defn- teardown-partitioner [teardown]
+  (reify nemesis/Nemesis
+    (setup! [this _test]
+      this)
+    (invoke! [_ _test op]
+      op)
+    (teardown! [_ _test]
+      (teardown))))
+
 (deftest places-leader-in-requested-component
   (let [configs [(set nodes)]
         quorums (set (quorum/quorum-sets configs))]
@@ -69,6 +78,38 @@
         (is (= :no-supported-leader
                (:value (nemesis/invoke! subject {:nodes nodes} op))))
         (is (empty? @invocations))))))
+
+(deftest preserves-analysis-after-partition-cleanup-failure
+  (testing "ordinary cleanup failures do not escape teardown"
+    (let [attempted? (atom false)
+          partitioner (teardown-partitioner
+                       #(do
+                          (reset! attempted? true)
+                          (throw (ex-info "unreachable"
+                                          {:kind :unreachable}))))]
+      (nemesis/teardown! (partition/->PartitionNemesis partitioner)
+                         {:nodes nodes})
+      (is @attempted?)))
+
+  (testing "interruptions still stop the test"
+    (doseq [[label error] [[:raw (InterruptedException. "interrupted")]
+                           [:wrapped (ex-info "interrupted"
+                                              {:kind :interrupted})]]]
+      (testing (name label)
+        (Thread/interrupted)
+        (let [partitioner (teardown-partitioner #(throw error))
+              subject (partition/->PartitionNemesis partitioner)]
+          (try
+            (let [thrown (try
+                           (nemesis/teardown! subject {:nodes nodes})
+                           nil
+                           (catch Exception e
+                             e))
+                  interrupted? (.isInterrupted (Thread/currentThread))]
+              (is (identical? error thrown))
+              (is interrupted?))
+            (finally
+              (Thread/interrupted))))))))
 
 (deftest requires-both-partitions-and-an-intact-cluster
   (let [subject (#'partition/coverage-checker)


### PR DESCRIPTION
A best-effort network heal could abort the run before Jepsen analyzed an already completed history. Preserve checker analysis while continuing to propagate interruption signals.

CLOSES #1965

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1966)
<!-- Reviewable:end -->
