### PR TITLE
test: jepsen: fix exhausted membership routing

### DIFF
--- a/jepsen/src/jepsen/openraft/nemesis.clj
+++ b/jepsen/src/jepsen/openraft/nemesis.clj
@@ -44,7 +44,11 @@
     (let [generator' (gen/update generator test context event)
           retry-generator' (some-> retry-generator
                                    (gen/update test context event))
-          retry? (contains? retryable-skip-results (:value event))
+          completion-value (:value event)
+          retry-result (if (map? completion-value)
+                         (:status completion-value)
+                         completion-value)
+          retry? (contains? retryable-skip-results retry-result)
           operation-event? (and stage
                                 (= :nemesis (:process event))
                                 (= operation-f (:f event)))]

--- a/jepsen/src/jepsen/openraft/nemesis/membership.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/membership.clj
@@ -38,6 +38,11 @@
              (or (nil? status)
                  (<= 500 status 599))))))
 
+(defn- leader-routing-error? [e]
+  (let [{:keys [kind error]} (ex-data e)]
+    (or (= :unreachable kind)
+        (contains? error :ForwardToLeader))))
+
 (defn- membership-change-in-progress? [e]
   (contains? (get-in (ex-data e)
                      [:error :ChangeMembershipError])
@@ -68,6 +73,9 @@
     :completed
     (catch Exception e
       (cond
+        (leader-routing-error? e)
+        :no-supported-leader
+
         (ambiguous-request-error? e)
         (do
           (info "OpenRaft membership change result is indeterminate"
@@ -144,12 +152,19 @@
      #(client/add-learner! % node-id api-addr raft-addr))
     :completed
     (catch Exception e
-      (when-not (ambiguous-request-error? e)
-        (throw e))
-      (info "OpenRaft learner addition result is indeterminate"
-            {:node node
-             :error (ex-message e)})
-      :indeterminate)))
+      (cond
+        (leader-routing-error? e)
+        :no-supported-leader
+
+        (ambiguous-request-error? e)
+        (do
+          (info "OpenRaft learner addition result is indeterminate"
+                {:node node
+                 :error (ex-message e)})
+          :indeterminate)
+
+        :else
+        (throw e)))))
 
 (defn- add-learner-and-confirm!
   [test leader-endpoint node node-id api-addr raft-addr]

--- a/jepsen/test/jepsen/openraft/nemesis/membership_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/membership_test.clj
@@ -149,6 +149,38 @@
         (is (= :indeterminate (get-in result [:value :status])))
         (is (false? @changed?))))))
 
+(deftest defers-a-grow-when-leader-routing-is-exhausted
+  (let [before #{"n1" "n2" "n3" "n4"}
+        status (update (stable-status before) :metrics assoc "n5" {})
+        attempts (atom [])]
+    (with-redefs [cluster/membership-status (constantly status)
+                  client/add-learner!
+                  (fn [endpoint node-id api-addr raft-addr]
+                    (swap! attempts conj
+                           [endpoint node-id api-addr raft-addr])
+                    (throw (ex-info "unreachable" {:kind :unreachable})))
+                  client/change-membership!
+                  (fn [& _]
+                    (throw (ex-info "MUST NOT change membership" {})))]
+      (let [result (nemesis/invoke! (membership-nemesis)
+                                    test-config
+                                    {:type :info
+                                     :f :grow})]
+        (is (= (mapv #(vector % "n5" "n5:21001" "n5:22001")
+                     ["n1:21001" "n2:21001" "n3:21001"
+                      "n4:21001" "n5:21001"])
+               @attempts))
+        (is (= {:type :info
+                :f :grow
+                :value {:change :grow
+                        :node "n5"
+                        :source :non-member
+                        :leader "n1"
+                        :before before
+                        :target (conj before "n5")
+                        :status :no-supported-leader}}
+               result))))))
+
 (deftest confirms-an-indeterminate-grow-from-membership-state
   (let [before #{"n1" "n2" "n3" "n4"}
         after (conj before "n5")
@@ -259,6 +291,43 @@
                 :after after}
                (select-keys (:value resolved)
                             [:change :before :after])))))))
+
+(deftest defers-a-shrink-when-leader-routing-is-exhausted
+  (let [before (set nodes)
+        after (disj before "n5")
+        attempts (atom [])]
+    (with-redefs [cluster/membership-status
+                  (constantly (stable-status before))
+                  random/shuffle reverse
+                  client/change-membership!
+                  (fn [endpoint node-ids]
+                    (swap! attempts conj [endpoint node-ids])
+                    (throw (ex-info
+                            "forward"
+                            {:kind :openraft-error
+                             :error {:ForwardToLeader
+                                     {:leader_id nil
+                                      :leader_node nil}}})))
+                  openraft-db/stop-and-wipe-node!
+                  (fn [& _]
+                    (throw (ex-info "MUST NOT clean up" {})))]
+      (let [result (nemesis/invoke! (membership-nemesis)
+                                    test-config
+                                    {:type :info
+                                     :f :shrink})]
+        (is (= (mapv #(vector % ["n1" "n2" "n3" "n4"])
+                     ["n1:21001" "n2:21001" "n3:21001"
+                      "n4:21001" "n5:21001"])
+               @attempts))
+        (is (= {:type :info
+                :f :shrink
+                :value {:change :shrink
+                        :node "n5"
+                        :leader "n1"
+                        :before before
+                        :target after
+                        :status :no-supported-leader}}
+               result))))))
 
 (deftest advances-a-joint-membership-without-waiting
   (let [before #{"n1" "n2" "n3"}

--- a/jepsen/test/jepsen/openraft/nemesis_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis_test.clj
@@ -14,8 +14,9 @@
 
 (deftest schedules-and-retries-skipped-faults
   (doseq [skip-result [:no-supported-leader
-                       :no-reachable-pause-target]]
-    (testing (name skip-result)
+                       :no-reachable-pause-target
+                       {:status :no-supported-leader}]]
+    (testing (str skip-result)
       (let [faults (#'openraft-nemesis/interval-schedule
                     10
                     3


### PR DESCRIPTION

## Changelog

##### test: jepsen: fix exhausted membership routing
# Summary

Chaos membership operations now remain pending when overlapping faults leave
no endpoint able to route a leader request.

# Details

Exhausted connection and leader-forwarding attempts are classified as a
missing supported leader instead of crashing the Jepsen nemesis worker.

Pending membership skips use the existing prompt retry schedule, preserving
fault coverage while the cluster elects a reachable leader.

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1970)
<!-- Reviewable:end -->
