### PR TITLE
test: jepsen: verify every register after recovery

### DIFF
--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -139,10 +139,11 @@ as its OpenRaft node ID.
 
 This starts the five-node Docker environment, then runs the Jepsen control
 process from the control container. Every test checks a concurrent mix of
-linearizable reads, writes, and compare-and-set operations with Knossos. The
-default `chaos` profile independently schedules partition, process, pause, and
-membership faults, so their active intervals can overlap. `NEMESIS` accepts a
-comma-separated subset when a narrower combination is needed.
+linearizable reads, writes, and compare-and-set operations across five
+independent registers with Knossos. The default `chaos` profile independently
+schedules partition, process, pause, and membership faults, so their active
+intervals can overlap. `NEMESIS` accepts a comma-separated subset when a
+narrower combination is needed.
 
 The partition nemesis alternates between partitions where the current leader is
 in the majority and in the minority. A focused partition run requires both
@@ -174,7 +175,8 @@ short fault tests without a snapshot-specific Nemesis. Set
 After the fault schedule ends, Jepsen heals partitions, restarts killed
 processes, resumes paused processes, restores membership, and then performs one
 shared readiness check. Client operations continue while faults are active and
-during recovery. The final recovery write and read must also succeed.
+during recovery. Final recovery writes and then reads every register; all ten
+operations must succeed.
 
 ### Interpreting Results
 
@@ -185,14 +187,21 @@ three possible values:
 - `true` exits with status 0. Every checker accepted the run.
 - `false` exits with status 1. At least one checker established a failing
   condition. Inspect `:workload`, `:nemesis`, `:crash`, and `:stats` to identify
-  it. Only `[:workload :linearizable :valid?]` being `false` means the register
-  history was not linearizable.
+  it. Only `[:workload :linearizable :valid?]` being `false` means one or more
+  register histories were not linearizable.
 - `:unknown` exits with status 2. The harness could not establish a conclusive
   result, so the run must not be treated as passing. Unhandled worker or Nemesis
   exceptions appear at `[:exceptions :exceptions]`. Missing node logs appear at
   `[:crash :missing-nodes]`. Individual workload and Nemesis checkers may also
   report `:unknown`; locate the nested checker with that validity for its
   diagnostic fields.
+
+The test name begins with `openraft linearizable registers`, which also names
+its directory under `jepsen/store`. The independent linearizability checker
+lists failing keys at `[:workload :linearizable :failures]` and stores each
+key's result at `[:workload :linearizable :results <key>]`. Per-key histories
+and checker output are written under
+`jepsen/store/<test-name>/<timestamp>/independent/<key>/`.
 
 Every run also records its random seed in `results.edn`, in a checker result of
 the following form:

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -101,7 +101,7 @@
                nemesis-types))]
     (merge tests/noop-test
            opts
-           {:name (str "openraft linearizable register "
+           {:name (str "openraft linearizable registers "
                        (str/join "," (map name nemesis-types)))
             :db database
             :client (:client workload)

--- a/jepsen/src/jepsen/openraft/workload.clj
+++ b/jepsen/src/jepsen/openraft/workload.clj
@@ -285,16 +285,18 @@
                          (map #(gen/once
                                 (bootstrap-write-op % value-counter))
                               key-names))
-        final-key (first key-names)]
+        final (apply gen/phases
+                     (concat
+                      (map #(gen/once
+                             (final-write-op % value-counter))
+                           key-names)
+                      (map #(gen/once (final-read-op %)) key-names)))]
     {:client (client/validate (KVClient. nil nil nil latest-values))
      :generator (gen/clients
                  (gen/phases
                   bootstrap
                   (gen/stagger 0.1 operations)))
-     :final-generator (gen/clients
-                       (gen/phases
-                        (gen/once (final-write-op final-key value-counter))
-                        (gen/once (final-read-op final-key))))
+     :final-generator (gen/clients final)
      :checker (checker/compose
                {:linearizable (independent/checker
                                (checker/linearizable

--- a/jepsen/test/jepsen/openraft/workload_test.clj
+++ b/jepsen/test/jepsen/openraft/workload_test.clj
@@ -191,30 +191,58 @@
     (is (false? (get-in result [:results other-key :valid?])))))
 
 (deftest generates-multiple-independent-registers
-  (let [invocations
-        (random/with-seed 41
-          (->> (gen-test/simulate
-                (gen/limit 20 (:generator (workload/workload {})))
-                (fn [_test op]
-                  (assoc op :type :ok)))
-               (filter #(= :invoke (:type %)))
-               vec))
-        bootstrap (take 5 invocations)
-        main (drop 5 invocations)
+  (let [workload (workload/workload {})
+        version (atom 0)
+        values (atom {})
+        store! (fn [k value]
+                 (let [versioned {:value value
+                                  :version (swap! version inc)}]
+                   (swap! values assoc k versioned)
+                   versioned))
+        test {:nodes ["n1"]}
+        subject (client/open! (:client workload) test "n1")
+        invocations
+        (with-redefs [http/write! (fn [_endpoint k value]
+                                    (store! k value))
+                      http/linearizable-read! (fn [_endpoint k]
+                                                (get @values k))
+                      http/cas! (fn [_endpoint k _expected-version new-value]
+                                  (store! k new-value))]
+          (random/with-seed 41
+            (->> (gen-test/simulate
+                  (gen/limit 20 (:generator workload))
+                  (fn [_test op]
+                    (client/invoke! subject test op)))
+                 (filter #(= :invoke (:type %)))
+                 vec)))
+        expected-keys (set @#'workload/key-names)
+        bootstrap (take (count expected-keys) invocations)
+        main (drop (count expected-keys) invocations)
         bootstrap-keys (set (map (comp key :value) bootstrap))
-        main-keys (set (map (comp key :value) main))]
-    (is (= (repeat 5 [:bootstrap :write])
+        main-keys (set (map (comp key :value) main))
+        cas-keys (->> main
+                      (filter #(= :cas (:f %)))
+                      (map (comp key :value))
+                      set)]
+    (is (= (repeat (count expected-keys) [:bootstrap :write])
            (map (juxt :phase :f) bootstrap)))
-    (is (= 5 (count bootstrap-keys)))
+    (is (= expected-keys bootstrap-keys main-keys))
+    (is (= #{:main} (set (map :phase main))))
+    (is (<= 2 (count cas-keys)))
     (is (every? #(independent/tuple? (:value %)) invocations))
-    (is (< 1 (count main-keys)))
-    (is (every? bootstrap-keys main-keys))))
+    (client/close! subject test)))
 
-(deftest tags-final-recovery-operations
-  (let [write ((#'workload/final-write-op test-key (atom 0)) nil nil)
-        read ((#'workload/final-read-op test-key) nil nil)]
-    (is (= :final (:phase write)))
-    (is (= :final (:phase read)))))
+(deftest final-recovery-checks-every-register
+  (let [keys @#'workload/key-names
+        invocations (->> (gen-test/simulate
+                          (:final-generator (workload/workload {}))
+                          (fn [_test op]
+                            (assoc op :type :ok)))
+                         (filter #(= :invoke (:type %))))]
+    (is (= (concat (map #(vector :write :final true %) keys)
+                   (map #(vector :read :final true %) keys))
+           (map (juxt :f :phase :final? (comp key :value))
+                invocations)))))
 
 (deftest generates-cas-only-with-a-known-version
   (testing "a version observed for another key still produces a write"


### PR DESCRIPTION
Only the first independent register was checked after fault cleanup, leaving recovery of the other keys unverified. Exercise every register and document the per-key checker output.

CLOSES #1963

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1971)
<!-- Reviewable:end -->
