### PR TITLE
test: jepsen: fix swallowed Jepsen interruptions

### DIFF
--- a/jepsen/src/jepsen/openraft/cluster.clj
+++ b/jepsen/src/jepsen/openraft/cluster.clj
@@ -3,6 +3,7 @@
             [clojure.tools.logging :refer [info]]
             [jepsen.core :as jepsen]
             [jepsen.openraft.client :as client]
+            [jepsen.openraft.interruption :as interruption]
             [jepsen.openraft.quorum :as quorum]
             [jepsen.util :as util]))
 
@@ -64,15 +65,15 @@
   [test node]
   (try
     (client/metrics! (client/api-endpoint test node))
-    (catch InterruptedException e
-      (.interrupt (Thread/currentThread))
-      (throw e))
     (catch Exception e
-      (if (= :interrupted (:kind (ex-data e)))
-        (do
+      (if (interruption/interruption? e)
+        (let [interrupted-exception
+              (if (instance? InterruptedException e)
+                e
+                (doto (InterruptedException. (ex-message e))
+                  (.initCause e)))]
           (.interrupt (Thread/currentThread))
-          (throw (doto (InterruptedException. (ex-message e))
-                   (.initCause e))))
+          (throw interrupted-exception))
         (throw e)))))
 
 (defn- collect-reachable-metrics-from [test nodes]

--- a/jepsen/src/jepsen/openraft/interruption.clj
+++ b/jepsen/src/jepsen/openraft/interruption.clj
@@ -1,0 +1,9 @@
+(ns jepsen.openraft.interruption)
+
+(defn interruption?
+  "True when an exception signals that the current thread was interrupted."
+  [e]
+  (or (instance? InterruptedException e)
+      (instance? java.io.InterruptedIOException e)
+      (instance? java.nio.channels.ClosedByInterruptException e)
+      (= :interrupted (:kind (ex-data e)))))

--- a/jepsen/src/jepsen/openraft/nemesis/partition.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/partition.clj
@@ -5,6 +5,7 @@
              [nemesis :as nemesis]
              [random :as random]]
             [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.interruption :as interruption]
             [jepsen.openraft.quorum :as quorum]))
 
 (def partition-seconds 10)
@@ -85,11 +86,8 @@
   (teardown! [_ test]
     (try
       (nemesis/teardown! partitioner test)
-      (catch InterruptedException e
-        (.interrupt (Thread/currentThread))
-        (throw e))
       (catch Exception e
-        (if (= :interrupted (:kind (ex-data e)))
+        (if (interruption/interruption? e)
           (do
             (.interrupt (Thread/currentThread))
             (throw e))

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -6,6 +6,7 @@
              [random :as random]]
             [jepsen.nemesis.combined :as combined]
             [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.interruption :as interruption]
             [jepsen.openraft.quorum :as quorum]))
 
 (def downtime-seconds 10)
@@ -178,11 +179,8 @@
                        {:type :info
                         :f :resume
                         :value (:nodes test)})
-      (catch InterruptedException e
-        (.interrupt (Thread/currentThread))
-        (throw e))
       (catch Exception e
-        (if (= :interrupted (:kind (ex-data e)))
+        (if (interruption/interruption? e)
           (do
             (.interrupt (Thread/currentThread))
             (throw e))

--- a/jepsen/test/jepsen/openraft/cluster_test.clj
+++ b/jepsen/test/jepsen/openraft/cluster_test.clj
@@ -69,9 +69,15 @@
       (is (nil? (#'cluster/cluster-status test-config))))))
 
 (deftest preserves-metrics-request-interruption
-  (doseq [[label error] [[:raw #(InterruptedException. "interrupted")]
-                         [:wrapped #(ex-info "interrupted"
-                                             {:kind :interrupted})]]]
+  (doseq [[label error]
+          [[:interrupted-exception
+            #(InterruptedException. "interrupted")]
+           [:interrupted-io
+            #(java.io.InterruptedIOException. "interrupted")]
+           [:closed-by-interrupt
+            #(java.nio.channels.ClosedByInterruptException.)]
+           [:wrapped
+            #(ex-info "interrupted" {:kind :interrupted})]]]
     (let [interrupted?
           @(future
              (with-redefs [client/metrics!

--- a/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
@@ -79,37 +79,42 @@
                (:value (nemesis/invoke! subject {:nodes nodes} op))))
         (is (empty? @invocations))))))
 
-(deftest preserves-analysis-after-partition-cleanup-failure
-  (testing "ordinary cleanup failures do not escape teardown"
-    (let [attempted? (atom false)
-          partitioner (teardown-partitioner
-                       #(do
-                          (reset! attempted? true)
-                          (throw (ex-info "unreachable"
-                                          {:kind :unreachable}))))]
-      (nemesis/teardown! (partition/->PartitionNemesis partitioner)
-                         {:nodes nodes})
-      (is @attempted?)))
+(deftest partition-cleanup-failure-does-not-mask-analysis
+  (let [attempted? (atom false)
+        partitioner (teardown-partitioner
+                     #(do
+                        (reset! attempted? true)
+                        (throw (ex-info "unreachable"
+                                        {:kind :unreachable}))))]
+    (nemesis/teardown! (partition/->PartitionNemesis partitioner)
+                       {:nodes nodes})
+    (is @attempted?)))
 
-  (testing "interruptions still stop the test"
-    (doseq [[label error] [[:raw (InterruptedException. "interrupted")]
-                           [:wrapped (ex-info "interrupted"
-                                              {:kind :interrupted})]]]
-      (testing (name label)
-        (Thread/interrupted)
-        (let [partitioner (teardown-partitioner #(throw error))
-              subject (partition/->PartitionNemesis partitioner)]
-          (try
-            (let [thrown (try
-                           (nemesis/teardown! subject {:nodes nodes})
-                           nil
-                           (catch Exception e
-                             e))
-                  interrupted? (.isInterrupted (Thread/currentThread))]
-              (is (identical? error thrown))
-              (is interrupted?))
-            (finally
-              (Thread/interrupted))))))))
+(deftest partition-cleanup-preserves-interruptions
+  (doseq [[label error]
+          [[:interrupted-exception
+            (InterruptedException. "interrupted")]
+           [:interrupted-io
+            (java.io.InterruptedIOException. "interrupted")]
+           [:closed-by-interrupt
+            (java.nio.channels.ClosedByInterruptException.)]
+           [:wrapped
+            (ex-info "interrupted" {:kind :interrupted})]]]
+    (testing (name label)
+      (Thread/interrupted)
+      (let [partitioner (teardown-partitioner #(throw error))
+            subject (partition/->PartitionNemesis partitioner)]
+        (try
+          (let [thrown (try
+                         (nemesis/teardown! subject {:nodes nodes})
+                         nil
+                         (catch Exception e
+                           e))
+                interrupted? (.isInterrupted (Thread/currentThread))]
+            (is (identical? error thrown))
+            (is interrupted?))
+          (finally
+            (Thread/interrupted)))))))
 
 (deftest requires-both-partitions-and-an-intact-cluster
   (let [subject (#'partition/coverage-checker)

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -213,9 +213,15 @@
            @events))))
 
 (deftest teardown-preserves-interruptions
-  (doseq [[label error] [[:raw (InterruptedException. "interrupted")]
-                         [:wrapped (ex-info "interrupted"
-                                            {:kind :interrupted})]]]
+  (doseq [[label error]
+          [[:interrupted-exception
+            (InterruptedException. "interrupted")]
+           [:interrupted-io
+            (java.io.InterruptedIOException. "interrupted")]
+           [:closed-by-interrupt
+            (java.nio.channels.ClosedByInterruptException.)]
+           [:wrapped
+            (ex-info "interrupted" {:kind :interrupted})]]]
     (testing (name label)
       (Thread/interrupted)
       (let [events (atom [])


### PR DESCRIPTION
SSH and NIO can report thread interruption without using InterruptedException. Treating those exceptions as ordinary cleanup failures lets teardown or metrics collection ignore Jepsen's stop signal.

Centralize interruption classification and exercise each production call path so future cleanup changes preserve interruption semantics.

CLOSES #1967

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1972)
<!-- Reviewable:end -->
