### PR TITLE
test: jepsen: fix recovery after partial process kills

### DIFF
--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -96,11 +96,16 @@
                                                 eligible-nodes)]
           (let [targets (:nodes disruption)]
             (info start-message disruption)
+            ;; A multi-node kill may partially succeed before the delegate
+            ;; reports an error, so retain every node that may need restarting.
+            (when (= :process kind)
+              (reset! active disruption))
             (nemesis/invoke! delegate test
                              (assoc op
                                     :f delegate-f
                                     :value targets))
-            (reset! active disruption)
+            (when (= :pause kind)
+              (reset! active disruption))
             (assoc op :value disruption))
           (case kind
             :process

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -74,6 +74,40 @@
                 [:start ["n1"]]]
                (mapv (juxt :f :value) @invocations)))))))
 
+(deftest restarts-all-planned-processes-after-a-kill-error
+  (let [invocations (atom [])
+        delegate (reify nemesis/Nemesis
+                   (setup! [this _test]
+                     this)
+                   (invoke! [_ _test op]
+                     (swap! invocations conj op)
+                     (when (= :kill (:f op))
+                       (throw (ex-info "kill failed" {})))
+                     op)
+                   (teardown! [this _test]
+                     this))
+        subject (process/->ProcessNemesis delegate (atom nil))
+        test {:nodes voters}
+        planned #{"n2" "n3"}
+        prefer-planned (fn [candidates]
+                         (cons planned (remove #{planned} candidates)))]
+    (with-redefs [cluster/membership-status (constantly {:leader "n1"})
+                  cluster/voter-configs (fn [_test _status]
+                                          [(set voters)])
+                  random/shuffle prefer-planned]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"kill failed"
+           (nemesis/invoke! subject
+                            test
+                            {:type :info
+                             :f :kill-process
+                             :value :leader-survives})))
+      (nemesis/invoke! subject test {:type :info :f :restart-process})
+      (is (= [[:kill ["n2" "n3"]]
+              [:start ["n2" "n3"]]]
+             (mapv (juxt :f :value) @invocations))))))
+
 (deftest records-pause-recovery-history
   (let [invocations (atom [])
         delegate (recording-nemesis invocations)


### PR DESCRIPTION
A multi-node kill may partially succeed before the delegate reports an error. Keeping the planned targets lets final cleanup restart every node that may have been stopped.

CLOSES #1976

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1977)
<!-- Reviewable:end -->
