### PR TITLE
refactor: jepsen: unify disruption tracking

### DIFF
--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -96,16 +96,13 @@
                                                 eligible-nodes)]
           (let [targets (:nodes disruption)]
             (info start-message disruption)
-            ;; A multi-node kill may partially succeed before the delegate
-            ;; reports an error, so retain every node that may need restarting.
-            (when (= :process kind)
-              (reset! active disruption))
+            ;; A multi-node disruption may partially succeed before the delegate
+            ;; reports an error, so retain every node that may need recovering.
+            (reset! active disruption)
             (nemesis/invoke! delegate test
                              (assoc op
                                     :f delegate-f
                                     :value targets))
-            (when (= :pause kind)
-              (reset! active disruption))
             (assoc op :value disruption))
           (case kind
             :process

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -103,10 +103,13 @@
                             {:type :info
                              :f :kill-process
                              :value :leader-survives})))
-      (nemesis/invoke! subject test {:type :info :f :restart-process})
-      (is (= [[:kill ["n2" "n3"]]
-              [:start ["n2" "n3"]]]
-             (mapv (juxt :f :value) @invocations))))))
+      (let [restarted (nemesis/invoke! subject
+                                       test
+                                       {:type :info :f :restart-process})]
+        (is (= ["n2" "n3"] (get-in restarted [:value :nodes])))
+        (is (= [[:kill ["n2" "n3"]]
+                [:start ["n2" "n3"]]]
+               (mapv (juxt :f :value) @invocations)))))))
 
 (deftest records-pause-recovery-history
   (let [invocations (atom [])


### PR DESCRIPTION
Partial disruptions can succeed before delegation reports an error. Retaining the plan first keeps recovery state and history accurate.

CLOSES #1979

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1982)
<!-- Reviewable:end -->
