### PR TITLE
test: jepsen: cover failed pause tracking

### DIFF
--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -111,6 +111,43 @@
                 [:start ["n2" "n3"]]]
                (mapv (juxt :f :value) @invocations)))))))
 
+(deftest rejects-a-pause-after-a-pause-error
+  (let [invocations (atom [])
+        delegate (reify nemesis/Nemesis
+                   (setup! [this _test]
+                     this)
+                   (invoke! [_ _test op]
+                     (swap! invocations conj [(:f op) (:value op)])
+                     (when (= :pause (:f op))
+                       (throw (ex-info "pause failed" {})))
+                     op)
+                   (teardown! [this _test]
+                     this))
+        subject (process/->PauseNemesis delegate (atom nil))
+        test {:nodes ["n1" "n2" "n3"]}
+        status {:leader "n1"
+                :metrics (zipmap (:nodes test) (repeat {}))}]
+    (with-redefs [cluster/membership-status (fn [_test] status)
+                  cluster/voter-configs (fn [_test _status]
+                                          [(set (:nodes test))])]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"pause failed"
+           (nemesis/invoke! subject test {:type :info
+                                          :f :pause-process
+                                          :value :leader-paused})))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Processes are already paused"
+           (nemesis/invoke! subject test {:type :info
+                                          :f :pause-process
+                                          :value :leader-unpaused})))
+      (is (= [[:pause ["n1"]]] @invocations))
+      (let [resumed (nemesis/invoke! subject
+                                     test
+                                     {:type :info :f :resume-process})]
+        (is (= ["n1"] (get-in resumed [:value :paused :nodes])))))))
+
 (deftest records-pause-recovery-history
   (let [invocations (atom [])
         delegate (recording-nemesis invocations)


### PR DESCRIPTION
Retaining a failed pause plan prevents another pause from stacking a second fault set and preserves recovery history.

CLOSES #1983

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1985)
<!-- Reviewable:end -->
