### PR TITLE
fix: openraft: anchor tick deadlines to a fixed origin

### DIFF
--- a/openraft/src/core/tick.rs
+++ b/openraft/src/core/tick.rs
@@ -99,11 +99,13 @@ where C: RaftTypeConfig
 
         let mut cancel = std::pin::pin!(cancel_rx);
 
-        let period = self.period;
-        let mut delay = self.first_wait;
+        let first_wait_at = C::now() + self.first_wait;
+        let mut at = first_wait_at;
+        // Microsecond resolution is far finer than any tick period, and the floor of one keeps
+        // the modulo below defined for a zero period, which stays a busy loop as it was before.
+        let step_us = self.period.as_micros().max(1);
 
         loop {
-            let at = C::now() + delay;
             let sleep_fut = std::pin::pin!(C::sleep_until(at));
             let cancel_fut = cancel.as_mut();
 
@@ -117,7 +119,17 @@ where C: RaftTypeConfig
                 }
             }
 
-            delay = period;
+            // Round the time elapsed since the origin up to the next whole multiple of the
+            // period, so every deadline is `first_wait_at + k * step_us`. Deriving it from the fixed
+            // origin rather than from this wake keeps wake latency out of the phase: re-anchoring
+            // would stretch the effective period and let the sampled offset wander until
+            // instances fell into a shared timer slot, where they would stay. Whole periods
+            // missed during a stall are stepped over by the same arithmetic, so a stall cannot
+            // shift the phase either, nor emit one catch-up tick per period it covered.
+            let mut offset_us = (C::now() - first_wait_at).as_micros();
+            offset_us -= offset_us % step_us;
+            offset_us += step_us;
+            at = first_wait_at + Duration::from_micros(offset_us as u64);
 
             if !self.enabled.load(Ordering::Relaxed) {
                 continue;
@@ -362,6 +374,105 @@ mod tests {
 
             th.shutdown().unwrap().await.unwrap();
             assert!(rx.recv().await.is_none(), "the channel must close after shutdown");
+        });
+    }
+
+    /// A tick delayed inside `send()` must not push the following deadlines back.
+    ///
+    /// Deriving each deadline from `now()` instead would restart the period at the end of the
+    /// delay, so every wake latency would accumulate into the phase and the sampled offset would
+    /// wash out after a few dozen ticks.
+    #[test]
+    fn test_a_delayed_tick_does_not_shift_the_schedule() {
+        const PERIOD: Duration = Duration::from_millis(100);
+        // Outlasts the second tick, which fires before `2 * PERIOD` because `first_wait` is drawn
+        // from `[PERIOD, 2 * PERIOD)`.
+        const STALL: Duration = Duration::from_millis(350);
+
+        TickUTConfig::run(async {
+            // Capacity one: the first tick fills the channel, so the second blocks in `send()`
+            // until this task drains it, and the tick loop is held past its own schedule.
+            let (tx, mut rx) = TickUTConfig::mpsc(1);
+            let th = Tick::<TickUTConfig>::spawn(PERIOD, tx, true);
+
+            TickUTConfig::sleep(STALL).await;
+
+            assert_eq!(1, recv_tick::<TickUTConfig>(&mut rx).await);
+            assert_eq!(2, recv_tick::<TickUTConfig>(&mut rx).await);
+
+            // The third tick kept the deadline it was given before the stall, which is at most one
+            // period away; restarting the period after the stall would place it a full period out.
+            let third = TickUTConfig::timeout(PERIOD * 3 / 4, recv_tick::<TickUTConfig>(&mut rx))
+                .await
+                .expect("the delayed send must not postpone the third tick");
+            assert_eq!(3, third);
+
+            th.shutdown().unwrap().await.unwrap();
+        });
+    }
+
+    /// A zero period must keep degenerating into a busy loop rather than dividing by zero.
+    ///
+    /// `Config::validate()` accepts `heartbeat_interval == 0`, so the period reaches the loop.
+    #[test]
+    fn test_a_zero_period_keeps_ticking() {
+        TickUTConfig::run(async {
+            // Capacity one throttles the busy loop to this task's receive rate.
+            let (tx, mut rx) = TickUTConfig::mpsc(1);
+            let th = Tick::<TickUTConfig>::spawn(Duration::ZERO, tx, true);
+
+            for expected in 1..=3 {
+                let i = TickUTConfig::timeout(Duration::from_secs(1), recv_tick::<TickUTConfig>(&mut rx))
+                    .await
+                    .expect("a zero period must keep ticking");
+                assert_eq!(expected, i);
+            }
+
+            // Dropping the receiver releases the loop if it is waiting on the full channel.
+            drop(rx);
+            th.shutdown().unwrap().await.unwrap();
+        });
+    }
+
+    /// A stall spanning whole periods must leave the schedule on its original grid.
+    ///
+    /// Skipping the missed periods in whole multiples of the period preserves the sampled phase,
+    /// so one stall shared by every instance cannot pull their phases together. Re-anchoring on
+    /// `now()` would hand them all the same phase, and firing the missed periods instead would
+    /// emit one catch-up tick each.
+    #[test]
+    fn test_a_stall_skips_missed_periods_and_keeps_the_phase() {
+        const SEED: u64 = 0;
+        const PERIOD: Duration = Duration::from_millis(100);
+        // Ends half a period before the grid line at `first_wait + 5 * PERIOD`.
+        const STALL: Duration = Duration::from_millis(450);
+
+        let first_wait = run_seeded(SEED, async { Tick::<SeededTickConfig>::sample_first_wait(PERIOD) });
+
+        run_seeded(SEED, async {
+            // Capacity one: the second tick stays blocked in `send()` for the whole stall, so the
+            // loop sleeps through the deadlines at `first_wait + 3 * PERIOD` and `+ 4 * PERIOD`.
+            let (tx, mut rx) = SeededTickConfig::mpsc(1);
+            let th = Tick::<SeededTickConfig>::spawn(PERIOD, tx, true);
+
+            SeededTickConfig::sleep(first_wait + STALL).await;
+
+            assert_eq!(1, recv_tick::<SeededTickConfig>(&mut rx).await);
+            assert_eq!(2, recv_tick::<SeededTickConfig>(&mut rx).await);
+            // The deadline the loop already held when the stall began, so it is due at once.
+            assert_eq!(3, recv_tick::<SeededTickConfig>(&mut rx).await);
+
+            // Only now does the loop see how far behind it is. The two periods it slept through
+            // are skipped rather than fired, leaving the next tick half a period out.
+            let early = SeededTickConfig::timeout(PERIOD / 4, recv_tick::<SeededTickConfig>(&mut rx)).await;
+            assert!(early.is_err(), "the missed periods must be skipped, not emitted");
+
+            let fourth = SeededTickConfig::timeout(PERIOD / 2, recv_tick::<SeededTickConfig>(&mut rx))
+                .await
+                .expect("the tick after the stall must land on the original grid");
+            assert_eq!(4, fourth);
+
+            th.shutdown().unwrap().await.unwrap();
         });
     }
 }


### PR DESCRIPTION

## Changelog

##### fix: openraft: anchor tick deadlines to a fixed origin
# Summary

`tick_loop` derived every deadline from the clock read after the
previous tick's work, so each wake latency was folded into the
instance's phase. The randomized startup offset added in a12b6871
washed out within a few dozen ticks and instances re-clustered, which
is what that commit set out to prevent.

# Details

Reported on a12b6871 by running 20 tick loops for 200 iterations at a
20 ms period. Re-binning that run at a 1 ms gap gives 11 -> 8 -> 6 -> 3
-> 2 -> 1 clusters by iteration 20, holding at one cluster through
iteration 200, and the measured period is 23.7 ms rather than the
configured 20 ms.

One cause, two effects. Re-anchoring on `now()` makes each period
`period + that iteration's latency`, so the effective period
overshoots. It also makes the phase mobile: the latency jitters, so the
gap between two loops performs a random walk. Wandering alone would
only disperse them; what clusters them is tokio rounding every deadline
up to the next whole millisecond into a wheel whose finest level holds
1 ms slots. A slot is an absorbing state -- once two loops land in the
same millisecond, one driver pass wakes both, they read `now()`
microseconds apart, and they never separate. A random walk with
absorbing states is a ratchet, so the cluster count only ever falls.

Ablating the reported setup confirms the deadline computation is the
whole cause: the collapse still happens with the debug printing
removed, on 8 worker threads, and with the channel traffic removed, and
it stops under a fixed schedule, which also holds the period at
20.000 ms.

`tick_loop` now rounds the time elapsed since `first_wait_at` up to the
next whole multiple of the period, so every deadline is
`first_wait_at + k * period` by construction. The same rounding steps
over whole periods missed during a stall, which matters beyond avoiding
a catch-up burst: clamping the deadline to `now()` instead would hand
every instance whatever phase the stall ended on, so one stall shared
across a deployment would weld them all together at once.

The arithmetic runs in microseconds, finer than any tick period in
practice. `Config::validate()` accepts `heartbeat_interval == 0`, so a
zero period reaches the loop and would divide by zero; a floor of one
microsecond keeps the modulo defined and leaves the degenerate case the
busy loop it already was.

The tests pin what load-dependent experiments cannot: a delayed send
must not postpone the following tick, a stall spanning several periods
must resume on the original grid rather than fire the backlog, and a
zero period must keep ticking. Both schedule tests fail against the
previous loop.

- Fix: #1959

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1988)
<!-- Reviewable:end -->
