### PR TITLE
change: openraft: tick every heartbeat_interval * 13 / 64

### DIFF
--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -193,6 +193,10 @@ pub struct Config {
     pub election_timeout_max: u64,
 
     /// The heartbeat interval in milliseconds at which leaders will send heartbeats to followers
+    ///
+    /// A heartbeat is only sent when a tick fires, and the tick loop fires every
+    /// `heartbeat_interval * 13 / 64` milliseconds, so a heartbeat goes out at the first tick at
+    /// or after this interval, up to one tick interval later than it.
     #[cfg_attr(feature = "clap", clap(long, default_value_t = DEFAULTS.heartbeat_interval))]
     pub heartbeat_interval: u64,
 
@@ -205,10 +209,12 @@ pub struct Config {
     /// redundant. Under sustained writes this eliminates most heartbeat RPCs; heartbeats resume
     /// automatically once replication idles.
     ///
-    /// It must hold that `heartbeat_interval + heartbeat_min_interval < election_timeout_min`,
-    /// so that suppression can never delay a heartbeat past a follower's election timeout.
+    /// A suppressed heartbeat resumes at the first tick at or after its deadline, so it must hold
+    /// that `heartbeat_interval + heartbeat_min_interval` plus one tick interval is smaller than
+    /// `election_timeout_min`, so that suppression can never delay a heartbeat past a follower's
+    /// election timeout.
     ///
-    /// Defaults to 0, meaning heartbeats are always sent at `heartbeat_interval`.
+    /// Defaults to 0, which disables suppression: every tick sends a heartbeat to every follower.
     #[since(version = "0.10.0")]
     #[cfg_attr(feature = "clap", clap(long, default_value = "0"))]
     pub heartbeat_min_interval: Option<u64>,
@@ -688,6 +694,15 @@ impl Config {
         self.heartbeat_min_interval.unwrap_or(0)
     }
 
+    /// Get the interval in milliseconds at which the tick loop fires.
+    ///
+    /// A heartbeat is only sent when a tick fires, so every heartbeat deadline is rounded up to
+    /// this interval.
+    pub(crate) fn tick_interval(&self) -> u64 {
+        let interval = self.heartbeat_interval * 13 / 64;
+        interval.max(1)
+    }
+
     /// Validate the state of this config.
     pub fn validate(self) -> Result<Config, ConfigError> {
         if self.election_timeout_min >= self.election_timeout_max {
@@ -704,11 +719,21 @@ impl Config {
             });
         }
 
-        if self.election_timeout_min <= self.heartbeat_interval + self.heartbeat_min_interval() {
+        // A heartbeat is sent at the first tick at or after its deadline, so heartbeats to a
+        // suppressed follower are up to `heartbeat_min_interval + heartbeat_interval` plus one
+        // tick interval apart.
+        //
+        // A `heartbeat_min_interval` of 0 disables suppression and leaves the heartbeat cadence
+        // unchanged, so the constraint does not apply to it.
+        let heartbeat_min_interval = self.heartbeat_min_interval();
+        let suppression_enabled = heartbeat_min_interval > 0;
+        let max_heartbeat_gap = heartbeat_min_interval + self.heartbeat_interval + self.tick_interval();
+
+        if suppression_enabled && self.election_timeout_min <= max_heartbeat_gap {
             return Err(ConfigError::HeartbeatMinIntervalTooLarge {
                 election_timeout_min: self.election_timeout_min,
                 heartbeat_interval: self.heartbeat_interval,
-                heartbeat_min_interval: self.heartbeat_min_interval(),
+                heartbeat_min_interval,
             });
         }
 

--- a/openraft/src/config/config_test.rs
+++ b/openraft/src/config/config_test.rs
@@ -64,11 +64,14 @@ fn test_invalid_election_timeout_config_produces_expected_error() {
 
 #[test]
 fn test_invalid_heartbeat_min_interval_produces_expected_error() {
+    // The tick interval is `heartbeat_interval * 13 / 64` == 101, so the greatest accepted
+    // `heartbeat_min_interval` is `election_timeout_min - heartbeat_interval - 101 - 1` == 398.
+
     let config = Config {
         election_timeout_min: 1000,
         election_timeout_max: 2000,
         heartbeat_interval: 500,
-        heartbeat_min_interval: Some(500),
+        heartbeat_min_interval: Some(399),
         ..Default::default()
     };
 
@@ -77,14 +80,28 @@ fn test_invalid_heartbeat_min_interval_produces_expected_error() {
     assert_eq!(err, ConfigError::HeartbeatMinIntervalTooLarge {
         election_timeout_min: 1000,
         heartbeat_interval: 500,
-        heartbeat_min_interval: 500,
+        heartbeat_min_interval: 399,
     });
 
     let config = Config {
         election_timeout_min: 1000,
         election_timeout_max: 2000,
         heartbeat_interval: 500,
-        heartbeat_min_interval: Some(499),
+        heartbeat_min_interval: Some(398),
+        ..Default::default()
+    };
+    assert!(config.validate().is_ok());
+}
+
+/// Suppression disabled leaves the heartbeat cadence unchanged, so `election_timeout_min` only has
+/// to exceed `heartbeat_interval`, not the tick interval.
+#[test]
+fn test_disabled_heartbeat_min_interval_ignores_tick_interval() {
+    let config = Config {
+        election_timeout_min: 101,
+        election_timeout_max: 200,
+        heartbeat_interval: 100,
+        heartbeat_min_interval: None,
         ..Default::default()
     };
     assert!(config.validate().is_ok());

--- a/openraft/src/config/error.rs
+++ b/openraft/src/config/error.rs
@@ -41,7 +41,7 @@ pub enum ConfigError {
     /// Heartbeat suppression must not delay a heartbeat past a follower's election timeout.
     #[since(version = "0.10.0")]
     #[error(
-        "heartbeat_interval({heartbeat_interval}) + heartbeat_min_interval({heartbeat_min_interval}) must be < election_timeout_min({election_timeout_min})"
+        "heartbeat_interval({heartbeat_interval}) + heartbeat_min_interval({heartbeat_min_interval}) + tick interval(heartbeat_interval * 13 / 64) must be < election_timeout_min({election_timeout_min})"
     )]
     HeartbeatMinIntervalTooLarge {
         /// Minimum election timeout value.

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -500,7 +500,7 @@ where
         let (tx_progress, progress_watcher) = IoProgressWatcher::new();
         let (tx_shutdown, rx_shutdown) = C::oneshot();
 
-        let tick_period = Duration::from_millis(config.heartbeat_interval * 3 / 2);
+        let tick_period = Duration::from_millis(config.tick_interval());
         let tick_handle = Tick::spawn(tick_period, tx_notify.clone(), config.enable_tick);
 
         let runtime_config = Arc::new(RuntimeConfig::new(&config));


### PR DESCRIPTION

## Changelog

##### change: openraft: tick every heartbeat_interval * 13 / 64
# Summary

The tick loop now fires about five times per `heartbeat_interval`
instead of once every one and a half of them, so RaftCore samples its
deadlines at a finer resolution than the shortest deadline it checks.
The config check on heartbeat suppression now counts the tick grid the
heartbeat lands on.

# Details

Every deadline RaftCore checks is sampled on the tick grid, so a tick
longer than the deadline itself guaranteed an overshoot. With the
defaults the heartbeat now goes out 50ms or 60ms after the previous one,
depending on where its deadline falls relative to the 10ms grid, instead
of a fixed 75ms, and an expired election timeout is noticed within 10ms
instead of 75ms.

`13 / 64` truncates to zero for a `heartbeat_interval` below 5, and a
zero tick period turns the tick loop into a busy loop, so the interval
has a floor of one millisecond.

Two heartbeats to a suppressed follower are
`heartbeat_min_interval + heartbeat_interval` plus one tick apart:
suppression holds the follower back, the leader re-arms its heartbeat
deadline one `heartbeat_interval` after it fires, and that deadline is
only sampled at the next tick. The check counted the first two terms and
missed the tick, so under the defaults it accepted
`heartbeat_min_interval = 99`, where two heartbeats can be 159ms apart
against an `election_timeout_min` of 150ms — long enough for the
follower to start an election. Found while answering #1853.

Upgrade tip:

A config with a non-zero `heartbeat_min_interval` must now satisfy:

    heartbeat_interval + heartbeat_min_interval + heartbeat_interval * 13 / 64 < election_timeout_min

The added term is the tick interval, so a config sitting within one tick
of the previous boundary is now rejected by `Config::validate()` with
`ConfigError::HeartbeatMinIntervalTooLarge`; lower
`heartbeat_min_interval` or raise `election_timeout_min`.

- Part: #1853

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1989)
<!-- Reviewable:end -->
