### PR TITLE
test: jepsen: assert the whole plan a failed pause retains

### DIFF
--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -20,6 +20,18 @@
     (teardown! [this _test]
       this)))
 
+(defn- failing-nemesis [invocations failing-f error]
+  (reify nemesis/Nemesis
+    (setup! [this _test]
+      this)
+    (invoke! [_ _test op]
+      (swap! invocations conj op)
+      (when (= failing-f (:f op))
+        (throw error))
+      op)
+    (teardown! [this _test]
+      this)))
+
 (defn- failing-resume-nemesis [events error]
   (reify nemesis/Nemesis
     (setup! [this _test]
@@ -76,16 +88,9 @@
 
 (deftest restarts-all-planned-processes-after-a-kill-error
   (let [invocations (atom [])
-        delegate (reify nemesis/Nemesis
-                   (setup! [this _test]
-                     this)
-                   (invoke! [_ _test op]
-                     (swap! invocations conj op)
-                     (when (= :kill (:f op))
-                       (throw (ex-info "kill failed" {})))
-                     op)
-                   (teardown! [this _test]
-                     this))
+        delegate (failing-nemesis invocations
+                                  :kill
+                                  (ex-info "kill failed" {}))
         subject (process/->ProcessNemesis delegate (atom nil))
         test {:nodes voters}
         planned #{"n2" "n3"}
@@ -113,16 +118,9 @@
 
 (deftest rejects-a-pause-after-a-pause-error
   (let [invocations (atom [])
-        delegate (reify nemesis/Nemesis
-                   (setup! [this _test]
-                     this)
-                   (invoke! [_ _test op]
-                     (swap! invocations conj [(:f op) (:value op)])
-                     (when (= :pause (:f op))
-                       (throw (ex-info "pause failed" {})))
-                     op)
-                   (teardown! [this _test]
-                     this))
+        delegate (failing-nemesis invocations
+                                  :pause
+                                  (ex-info "pause failed" {}))
         subject (process/->PauseNemesis delegate (atom nil))
         test {:nodes ["n1" "n2" "n3"]}
         status {:leader "n1"
@@ -142,11 +140,17 @@
            (nemesis/invoke! subject test {:type :info
                                           :f :pause-process
                                           :value :leader-unpaused})))
-      (is (= [[:pause ["n1"]]] @invocations))
+      (is (= [[:pause ["n1"]]]
+             (mapv (juxt :f :value) @invocations)))
       (let [resumed (nemesis/invoke! subject
                                      test
                                      {:type :info :f :resume-process})]
-        (is (= ["n1"] (get-in resumed [:value :paused :nodes])))))))
+        (is (= {:mode :leader-paused
+                :leader "n1"
+                :nodes ["n1"]
+                :voter-configs [#{"n1" "n2" "n3"}]
+                :survivors ["n2" "n3"]}
+               (get-in resumed [:value :paused])))))))
 
 (deftest records-pause-recovery-history
   (let [invocations (atom [])


### PR DESCRIPTION

## Changelog

##### test: jepsen: assert the whole plan a failed pause retains
# Summary

`rejects-a-pause-after-a-pause-error` now pins every key of the
disruption plan that a failed pause keeps, rather than only the node
list. This test is the only path on which a retained plan is
observable, because `resume-process` clears it everywhere else.

# Details

`:leader`, `:survivors` and `:voter-configs` had no coverage anywhere
in the tree: nothing reads them back, so they exist only as diagnostic
payload carried into the Jepsen history for post-hoc analysis, and a
regression in them would have gone unnoticed until it degraded an
analysis. `:mode` was already pinned end-to-end through the pause
coverage checker. The assertion is deterministic without redefining
`random/shuffle`, since on three nodes only one fault set contains the
leader.

A new `failing-nemesis` delegate constructor replaces the inline
`reify` in this test and in
`restarts-all-planned-processes-after-a-kill-error`. It records whole
ops, so the pause test projects them with `(juxt :f :value)` at the
assertion like every other test in the file, instead of recording that
pair at invocation time.

- Fix: #1986

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1990)
<!-- Reviewable:end -->
