### PR TITLE
chore: release: bump version to v0.10.0-alpha.34

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Beyond `rustfmt`, OpenRaft follows the conventions in [`CLAUDE.md`](CLAUDE.md). 
 
 ## Documentation
 
-Public documentation lives in Rustdoc comments under `openraft/src/docs/` and is published on [docs.rs](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/index.html). Update it when a public API or user-facing behavior changes.
+Public documentation lives in Rustdoc comments under `openraft/src/docs/` and is published on [docs.rs](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/index.html). Update it when a public API or user-facing behavior changes.
 
 ## Working with git
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.10.0-alpha.33"
+version = "0.10.0-alpha.34"
 edition = "2024"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Crates.io](https://img.shields.io/crates/v/openraft.svg)](https://crates.io/crates/openraft)
 [![docs.rs](https://docs.rs/openraft/badge.svg)](https://docs.rs/openraft)
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-openraft-blue.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==)](https://deepwiki.com/databendlabs/openraft)
-[![guides](https://img.shields.io/badge/guide-%E2%86%97-brightgreen)](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/index.html)
+[![guides](https://img.shields.io/badge/guide-%E2%86%97-brightgreen)](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/index.html)
 [![Discord Chat](https://img.shields.io/discord/1015845055434588200?logo=discord)](https://discord.gg/ZKw3WG7FQ9)
 <br/>
 [![CI](https://github.com/databendlabs/openraft/actions/workflows/ci.yaml/badge.svg)](https://github.com/databendlabs/openraft/actions/workflows/ci.yaml)
@@ -25,18 +25,18 @@ Currently, openraft is the consensus engine of meta-service cluster in [databend
 
 
 - 🚀 **Get started**:
-    - [OpenRaft guide](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/getting_started/index.html) is the best place to get started,
-    - [OpenRaft docs](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/index.html) for more in-depth details,
-    - [OpenRaft FAQ](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/faq/index.html) explains some common questions.
+    - [OpenRaft guide](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/getting_started/index.html) is the best place to get started,
+    - [OpenRaft docs](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/index.html) for more in-depth details,
+    - [OpenRaft FAQ](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/faq/index.html) explains some common questions.
     - [OpenRaft on DeepWiki](https://deepwiki.com/databendlabs/openraft) provides detailed architectural documentation to help understand OpenRaft internals.
 
 - 💡 **Example Applications**:
 
-    - [Examples with OpenRaft 0.10](https://github.com/databendlabs/openraft/tree/release-0.10/examples) require OpenRaft `0.10.0-alpha.33` (alpha) on [crates.io/openraft](https://crates.io/crates/openraft);
+    - [Examples with OpenRaft 0.10](https://github.com/databendlabs/openraft/tree/release-0.10/examples) require OpenRaft `0.10.0-alpha.34` (alpha) on [crates.io/openraft](https://crates.io/crates/openraft);
     - [Examples with OpenRaft 0.9](https://github.com/databendlabs/openraft/tree/release-0.9/examples) require OpenRaft 0.9 on [crates.io/openraft](https://crates.io/crates/openraft).
 
 - 🙌 **Questions**?
-    - Why not take a peek at our [FAQ](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/faq/index.html)? You might find just what you need.
+    - Why not take a peek at our [FAQ](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/faq/index.html)? You might find just what you need.
     - Wanna chat? Come hang out with us on [Discord](https://discord.gg/ZKw3WG7FQ9)!
     - Or start a new discussion over on [GitHub](https://github.com/databendlabs/openraft/discussions/new).
     - Or join our [Feishu group](https://applink.feishu.cn/client/chat/chatter/add_by_link?link_token=d20l9084-6d36-4470-bac5-4bad7378d003).
@@ -69,7 +69,7 @@ Whatever your style, we're here to support you. 🚀 Let's make something awesom
 
 - **Branch main** has been under active development.
     The main branch is for the [release-0.10](https://github.com/databendlabs/openraft/tree/release-0.10).
-    Latest alpha on crates.io: [v0.10.0-alpha.33](https://crates.io/crates/openraft/0.10.0-alpha.33).
+    Latest alpha on crates.io: [v0.10.0-alpha.34](https://crates.io/crates/openraft/0.10.0-alpha.34).
     The `0.10` line is in **alpha** — the API may still change before the final `0.10.0` release.
 
 - **Branch [release-0.9](https://github.com/databendlabs/openraft/tree/release-0.9)**:
@@ -93,10 +93,10 @@ Whatever your style, we're here to support you. 🚀 Let's make something awesom
 
 # Roadmap
 
-- [x] **2022-10-31** [Extended joint membership](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/data/extended_membership/index.html)
+- [x] **2022-10-31** [Extended joint membership](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/data/extended_membership/index.html)
 - [x] **2023-02-14** Minimize confliction rate when electing;
-  See: [OpenRaft Vote design](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/data/vote/index.html);
-  Or use [standard Raft leader-ID mode](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/data/leader_id/index.html).
+  See: [OpenRaft Vote design](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/data/vote/index.html);
+  Or use [standard Raft leader-ID mode](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/data/leader_id/index.html).
 - [x] **2023-04-26** Goal performance is 1,000,000 put/sec.
 - [ ] Reduce the complexity of vote and pre-vote: [get rid of pre-vote RPC](https://github.com/databendlabs/openraft/discussions/15);
 - [ ] Support flexible quorum, e.g.: [Hierarchical Quorums](https://zookeeper.apache.org/doc/r3.5.9/zookeeperHierarchicalQuorums.html)
@@ -137,8 +137,8 @@ For benchmark detail, go to the [./benchmarks/minimal](./benchmarks/minimal) fol
 
 What sets OpenRaft apart from a standard Raft implementation:
 
-- **Generalized membership change**: [extended joint membership](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/data/extended_membership/index.html) changes an arbitrary set of nodes in a single operation; standard Raft's one-node-at-a-time change is a restricted special case.
-- **Fewer election conflicts**: the redesigned [Vote](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/data/vote/index.html) minimizes election conflict rate — a split vote does not force a new term; the [standard Raft leader-ID mode](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/data/leader_id/index.html) is also supported.
+- **Generalized membership change**: [extended joint membership](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/data/extended_membership/index.html) changes an arbitrary set of nodes in a single operation; standard Raft's one-node-at-a-time change is a restricted special case.
+- **Fewer election conflicts**: the redesigned [Vote](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/data/vote/index.html) minimizes election conflict rate — a split vote does not force a new term; the [standard Raft leader-ID mode](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/data/leader_id/index.html) is also supported.
 - **Async and event-driven**: state transitions are driven by Raft events without periodic ticks; messages are batched, reaching millions of writes/sec in the [framework benchmark](#performance).
 - **Fully pluggable**: storage (`RaftLogStorage`, `RaftStateMachine`), networking (`RaftNetworkV2`, including application-defined snapshot transport), and every core type — node ID, node, term, vote, log entry — via `RaftTypeConfig`.
 - **Runtime-agnostic**: tokio by default, [compio](./rt-compio) and [monoio](./rt-monoio) via the `AsyncRuntime` trait, and a `single-threaded` mode that removes `Send` bounds.
@@ -153,10 +153,10 @@ What sets OpenRaft apart from a standard Raft implementation:
 - ✅ **Non-voter(learner) Role**: refer to [`add_learner()`][].
 - ✅ **Log Compaction**(snapshot of state machine): by policy or manually ([`Trigger::snapshot()`][]).
 - ✅ **Snapshot replication**.
-- ✅ **Dynamic Membership**: using joint membership config change. Refer to [dynamic membership](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/cluster_control/dynamic_membership/index.html)
+- ✅ **Dynamic Membership**: using joint membership config change. Refer to [dynamic membership](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/cluster_control/dynamic_membership/index.html)
 - ✅ **Linearizable read**: [`ensure_linearizable()`][].
 - ✅ **Metrics**: [`Raft::metrics()`][], [`Raft::data_metrics()`][], and [`Raft::server_metrics()`][].
-- ⛔️ **Won't support**: Single-step config change. Single-step membership change is a restricted subset of joint consensus that only allows changing one node at a time. Openraft uses the more general [joint consensus](https://docs.rs/openraft/0.10.0-alpha.33/openraft/docs/cluster_control/dynamic_membership/index.html) approach which supports arbitrary membership changes in a single operation.
+- ⛔️ **Won't support**: Single-step config change. Single-step membership change is a restricted subset of joint consensus that only allows changing one node at a time. Openraft uses the more general [joint consensus](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/cluster_control/dynamic_membership/index.html) approach which supports arbitrary membership changes in a single operation.
 - ✅ Toggle heartbeat / election: [`RuntimeConfigHandle::heartbeat()`][] / [`RuntimeConfigHandle::elect()`][].
 - ✅ Trigger snapshot / election manually: [`Trigger::snapshot()`][] / [`Trigger::elect()`][].
 - ✅ Purge log by policy or manually: [`Trigger::purge_log()`][].
@@ -297,18 +297,18 @@ OpenRaft is licensed under the terms of the [MIT License](https://en.wikipedia.o
 or the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0), at your choosing.
 
 
-[`change_membership()`]: https://docs.rs/openraft/0.10.0-alpha.33/openraft/raft/struct.Raft.html#method.change_membership
-[`add_learner()`]: https://docs.rs/openraft/0.10.0-alpha.33/openraft/raft/struct.Raft.html#method.add_learner
-[`Trigger::purge_log()`]: https://docs.rs/openraft/0.10.0-alpha.33/openraft/raft/trigger/struct.Trigger.html#method.purge_log
+[`change_membership()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/struct.Raft.html#method.change_membership
+[`add_learner()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/struct.Raft.html#method.add_learner
+[`Trigger::purge_log()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/trigger/struct.Trigger.html#method.purge_log
 
-[`RuntimeConfigHandle::heartbeat()`]: https://docs.rs/openraft/0.10.0-alpha.33/openraft/raft/struct.RuntimeConfigHandle.html#method.heartbeat
-[`RuntimeConfigHandle::elect()`]: https://docs.rs/openraft/0.10.0-alpha.33/openraft/raft/struct.RuntimeConfigHandle.html#method.elect
+[`RuntimeConfigHandle::heartbeat()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/struct.RuntimeConfigHandle.html#method.heartbeat
+[`RuntimeConfigHandle::elect()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/struct.RuntimeConfigHandle.html#method.elect
 
-[`Trigger::elect()`]: https://docs.rs/openraft/0.10.0-alpha.33/openraft/raft/trigger/struct.Trigger.html#method.elect
-[`Trigger::snapshot()`]: https://docs.rs/openraft/0.10.0-alpha.33/openraft/raft/trigger/struct.Trigger.html#method.snapshot
-[`Trigger::transfer_leader()`]: https://docs.rs/openraft/0.10.0-alpha.33/openraft/raft/trigger/struct.Trigger.html#method.transfer_leader
-[`Config::enable_pre_vote`]: https://docs.rs/openraft/0.10.0-alpha.33/openraft/struct.Config.html#structfield.enable_pre_vote
-[`Raft::metrics()`]: https://docs.rs/openraft/0.10.0-alpha.33/openraft/raft/struct.Raft.html#method.metrics
-[`Raft::data_metrics()`]: https://docs.rs/openraft/0.10.0-alpha.33/openraft/raft/struct.Raft.html#method.data_metrics
-[`Raft::server_metrics()`]: https://docs.rs/openraft/0.10.0-alpha.33/openraft/raft/struct.Raft.html#method.server_metrics
-[`ensure_linearizable()`]: https://docs.rs/openraft/0.10.0-alpha.33/openraft/raft/struct.Raft.html#method.ensure_linearizable
+[`Trigger::elect()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/trigger/struct.Trigger.html#method.elect
+[`Trigger::snapshot()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/trigger/struct.Trigger.html#method.snapshot
+[`Trigger::transfer_leader()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/trigger/struct.Trigger.html#method.transfer_leader
+[`Config::enable_pre_vote`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/struct.Config.html#structfield.enable_pre_vote
+[`Raft::metrics()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/struct.Raft.html#method.metrics
+[`Raft::data_metrics()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/struct.Raft.html#method.data_metrics
+[`Raft::server_metrics()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/struct.Raft.html#method.server_metrics
+[`ensure_linearizable()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/struct.Raft.html#method.ensure_linearizable

--- a/benchmarks/minimal/Cargo.toml
+++ b/benchmarks/minimal/Cargo.toml
@@ -17,8 +17,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft            = { path = "../../openraft", version = "0.10.0-alpha.33", features = ["serde", "type-alias", "runtime-stats"] }
-openraft-legacy = { path = "../../legacy", version = "0.10.0-alpha.33" }
+openraft            = { path = "../../openraft", version = "0.10.0-alpha.34", features = ["serde", "type-alias", "runtime-stats"] }
+openraft-legacy = { path = "../../legacy", version = "0.10.0-alpha.34" }
 
 anyhow     = { version = "1.0.63" }
 clap       = { version = "4.2", features = ["derive"] }

--- a/examples/log-rocks/Cargo.toml
+++ b/examples/log-rocks/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft = { path = "../../openraft", version = "0.10.0-alpha.33", features = ["serde", "type-alias"] }
+openraft = { path = "../../openraft", version = "0.10.0-alpha.34", features = ["serde", "type-alias"] }
 
 byteorder  = { version = "1.4.3" }
 rocksdb    = { version = "0.22.0" }

--- a/examples/sm-rocks/Cargo.toml
+++ b/examples/sm-rocks/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
 log-rocks = { path = "../log-rocks" }
-openraft = { path = "../../openraft", version = "0.10.0-alpha.33", features = ["serde", "type-alias"] }
+openraft = { path = "../../openraft", version = "0.10.0-alpha.34", features = ["serde", "type-alias"] }
 types-kv = { path = "../types-kv" }
 
 futures    = { version = "0.3" }

--- a/legacy/Cargo.toml
+++ b/legacy/Cargo.toml
@@ -14,8 +14,8 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-openraft = { path = "../openraft", version = "0.10.0-alpha.33", default-features = false }
-openraft-macros = { path = "../macros", version = "0.10.0-alpha.33" }
+openraft = { path = "../openraft", version = "0.10.0-alpha.34", default-features = false }
+openraft-macros = { path = "../macros", version = "0.10.0-alpha.34" }
 
 derive_more = { workspace = true }
 display-more = { workspace = true }
@@ -26,7 +26,7 @@ tokio = { workspace = true, features = ["io-util", "sync"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
-openraft = { path = "../openraft", version = "0.10.0-alpha.33", default-features = false, features = ["tokio-rt"] }
+openraft = { path = "../openraft", version = "0.10.0-alpha.34", default-features = false, features = ["tokio-rt"] }
 serde_json = { workspace = true }
 
 [features]

--- a/metrics-otel/Cargo.toml
+++ b/metrics-otel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openraft-metrics-otel"
-version = "0.10.0-alpha.33"
+version = "0.10.0-alpha.34"
 edition = "2024"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",
@@ -13,5 +13,5 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft = { path = "../openraft", version = "0.10.0-alpha.33" }
+openraft = { path = "../openraft", version = "0.10.0-alpha.34" }
 opentelemetry = "0.30.0"

--- a/multiraft/Cargo.toml
+++ b/multiraft/Cargo.toml
@@ -3,7 +3,7 @@ name = "openraft-multi"
 description = "Multi-Raft adapters for connection sharing across Raft groups"
 documentation = "https://docs.rs/openraft-multiraft"
 readme = "README.md"
-version = "0.10.0-alpha.33"
+version = "0.10.0-alpha.34"
 edition = "2024"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 categories = ["network-programming", "asynchronous", "data-structures"]
@@ -13,6 +13,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft  = { path = "../openraft", version = "0.10.0-alpha.33", default-features = false }
+openraft  = { path = "../openraft", version = "0.10.0-alpha.34", default-features = false }
 anyerror  = { version = "0.1" }
 

--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -15,9 +15,9 @@ repository    = { workspace = true }
 
 
 [dependencies]
-openraft-rt = { path = "../rt", version = "0.10.0-alpha.33" }
-openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.33", optional = true }
-openraft-macros = { path = "../macros", version = "0.10.0-alpha.33" }
+openraft-rt = { path = "../rt", version = "0.10.0-alpha.34" }
+openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.34", optional = true }
+openraft-macros = { path = "../macros", version = "0.10.0-alpha.34" }
 
 anyerror        = { workspace = true }
 anyhow          = { workspace = true, optional = true }
@@ -46,7 +46,7 @@ peel-off        = { workspace = true }
 anyhow            = { workspace = true }
 bincode           = { workspace = true }
 criterion         = { workspace = true }
-openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.33" }
+openraft-rt-tokio = { path = "../rt-tokio", version = "0.10.0-alpha.34" }
 pretty_assertions = { workspace = true }
 serde_json        = { workspace = true }
 

--- a/rt-compio/Cargo.toml
+++ b/rt-compio/Cargo.toml
@@ -3,7 +3,7 @@ name = "openraft-rt-compio"
 description = "compio AsyncRuntime support for Openraft"
 documentation = "https://docs.rs/openraft-rt-compio"
 readme = "README.md"
-version = "0.10.0-alpha.33"
+version = "0.10.0-alpha.34"
 edition = "2024"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 categories = ["algorithms", "asynchronous", "data-structures"]
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft-rt = { path = "../rt", version = "0.10.0-alpha.33", features = ["single-threaded"] }
+openraft-rt = { path = "../rt", version = "0.10.0-alpha.34", features = ["single-threaded"] }
 
 compio           = { version = ">=0.19.0", features = ["runtime", "time"] }
 compio-executor  = { version = ">=0.1"}

--- a/rt-monoio/Cargo.toml
+++ b/rt-monoio/Cargo.toml
@@ -3,7 +3,7 @@ name = "openraft-rt-monoio"
 description = "monoio AsyncRuntime support for Openraft"
 documentation = "https://docs.rs/openraft-rt-monoio"
 readme = "README.md"
-version = "0.10.0-alpha.33"
+version = "0.10.0-alpha.34"
 edition = "2024"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/databendlabs/openraft"
 
 [dependencies]
-openraft-rt = { path = "../rt", version = "0.10.0-alpha.33", features = ["single-threaded"] }
+openraft-rt = { path = "../rt", version = "0.10.0-alpha.34", features = ["single-threaded"] }
 
 futures-util = { version = "0.3" }
 local-sync   = { version = "0.1.1" }

--- a/rt-tokio/Cargo.toml
+++ b/rt-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.33"
+version = "0.10.0-alpha.34"
 edition = "2024"
 authors = [
     "drdrxp <drdr.xp@gmail.com>",
@@ -13,7 +13,7 @@ readme = "README.md"
 description = "Tokio runtime implementation for Openraft"
 
 [dependencies]
-openraft-rt  = { path = "../rt", version = "0.10.0-alpha.33" }
+openraft-rt  = { path = "../rt", version = "0.10.0-alpha.34" }
 tokio        = { version = "1.39", default-features = false, features = ["rt", "rt-multi-thread", "sync", "time"] }
 futures-util = { version = "0.3" }
 rand         = { version = "0.10", default-features = false, features = ["std", "std_rng", "thread_rng"] }

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -20,6 +20,6 @@ single-threaded = ["openraft-macros/single-threaded"]
 [dependencies]
 futures-channel = { workspace = true }
 futures-util    = { workspace = true }
-openraft-macros    = { version = "0.10.0-alpha.33", path = "../macros" }
+openraft-macros    = { version = "0.10.0-alpha.34", path = "../macros" }
 pin-project-lite   = { version = "0.2" }
 rand               = { workspace = true }

--- a/stores/memstore-custom-node-id/Cargo.toml
+++ b/stores/memstore-custom-node-id/Cargo.toml
@@ -13,7 +13,7 @@ license       = { workspace = true }
 repository    = { workspace = true }
 
 [dependencies]
-openraft  = { path = "../../openraft", version = "0.10.0-alpha.33", features = ["serde", "type-alias"] }
+openraft  = { path = "../../openraft", version = "0.10.0-alpha.34", features = ["serde", "type-alias"] }
 
 futures    = { workspace = true }
 serde      = { workspace = true }

--- a/stores/memstore/Cargo.toml
+++ b/stores/memstore/Cargo.toml
@@ -14,8 +14,8 @@ license       = { workspace = true }
 repository    = { workspace = true }
 
 [dependencies]
-openraft = { path = "../../openraft", version = "0.10.0-alpha.33", features = ["serde", "type-alias"] }
-openraft-legacy = { path = "../../legacy", version = "0.10.0-alpha.33" }
+openraft = { path = "../../openraft", version = "0.10.0-alpha.34", features = ["serde", "type-alias"] }
+openraft-legacy = { path = "../../legacy", version = "0.10.0-alpha.34" }
 
 derive_more = { workspace = true }
 futures     = { workspace = true }

--- a/tests-turmoil/Cargo.lock
+++ b/tests-turmoil/Cargo.lock
@@ -698,7 +698,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.33"
+version = "0.10.0-alpha.34"
 dependencies = [
  "anyerror",
  "backoff-series",
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.33"
+version = "0.10.0-alpha.34"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.33"
+version = "0.10.0-alpha.34"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.33"
+version = "0.10.0-alpha.34"
 dependencies = [
  "futures-util",
  "openraft-rt",

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -19,7 +19,7 @@ repository    = { workspace = true }
 [dependencies]
 
 [dev-dependencies]
-openraft           = { path = "../openraft", version = "0.10.0-alpha.33", features = ["type-alias"] }
+openraft           = { path = "../openraft", version = "0.10.0-alpha.34", features = ["type-alias"] }
 openraft-memstore  = { path = "../stores/memstore" }
 openraft-legacy    = { path = "../legacy", features = ["serde"] }
 


### PR DESCRIPTION

## Changelog

##### chore: release: bump version to v0.10.0-alpha.34
# Summary

Prepare the workspace for the next alpha release by updating package
versions, local dependency requirements, lockfile entries, and documented
release links to v0.10.0-alpha.34.

# Details

Keep publishable crates, examples, benchmarks, and tests aligned on the
same prerelease version so local and published dependency resolution
stays consistent.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1991)
<!-- Reviewable:end -->
