### PR TITLE
test: membership: stabilize learner transfer test

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -29,8 +29,6 @@ jobs:
           toolchain: "${{ matrix.toolchain }}"
           components: rustfmt, clippy
 
-
-        # TODO: unit test should be replaced
       - name: Unit Tests, with and without defensive store
         run: cargo test
         env:

--- a/examples/raft-kv-memstore-grpc/build.rs
+++ b/examples/raft-kv-memstore-grpc/build.rs
@@ -10,9 +10,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut config = prost_build::Config::new();
     config.protoc_arg("--experimental_allow_proto3_optional");
     let proto_files = ["proto/raft.proto", "proto/app_types.proto", "proto/app.proto"];
-
-    // TODO: remove serde
-
     tonic_prost_build::configure()
         .btree_map(".")
         .type_attribute("openraftpb.NodeIdSet", "#[derive(Eq)]")

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -227,7 +227,7 @@ randomness, and thread, network, and election timing can still differ. The
 recorded history and Nemesis operations are therefore the authoritative account
 of the fault schedule; the seed is only an aid for rerunning similar conditions.
 
-## TODO
+## Implemented coverage
 
 - [x] Add the Leiningen project definition and CLI skeleton.
 - [x] Add Docker-based Jepsen control and node containers.

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -350,8 +350,6 @@ where
     /// To ensure linearizability, a read request proposed at time `T1` confirms this node's
     /// leadership to guarantee that all the committed entries proposed before `T1` are present in
     /// this node.
-    // TODO: the second condition is such a read request can only read from state machine only when the last log it sees
-    //       at `T1` is committed.
     #[tracing::instrument(level = "trace", skip(self, tx))]
     pub(super) async fn handle_ensure_linearizable_read(&mut self, read_policy: ReadPolicy, tx: ClientReadTx<C>) {
         // Setup sentinel values to track when we've received majority confirmation of leadership.
@@ -691,8 +689,6 @@ where
             }
         };
 
-        // TODO: it should returns membership config error etc. currently this is done by the
-        //       caller.
         let entry_count = payloads.len() as u64;
         let log_ids = lh.leader_append_entries(payloads)?;
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -26,6 +26,7 @@ use crate::OptionalSend;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::async_runtime::MpscReceiver;
+use crate::async_runtime::Mutex;
 use crate::async_runtime::OneshotSender;
 use crate::async_runtime::TryRecvError;
 use crate::async_runtime::watch::WatchSender;
@@ -132,6 +133,7 @@ use crate::type_config::alias::JoinErrorOf;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::MpscReceiverOf;
 use crate::type_config::alias::MpscSenderOf;
+use crate::type_config::alias::MutexOf;
 use crate::type_config::alias::NodeIdOf;
 use crate::type_config::alias::OneshotReceiverOf;
 use crate::type_config::alias::StoredMembershipOf;
@@ -192,7 +194,7 @@ where
     pub(crate) core_state: CoreState<C>,
 
     /// The `RaftNetworkFactory` implementation.
-    pub(crate) network_factory: NF,
+    pub(crate) network_factory: Arc<MutexOf<C, NF>>,
 
     /// The [`RaftLogStorage`] implementation.
     pub(crate) log_store: LS,
@@ -351,7 +353,7 @@ where
     /// leadership to guarantee that all the committed entries proposed before `T1` are present in
     /// this node.
     #[tracing::instrument(level = "trace", skip(self, tx))]
-    pub(super) async fn handle_ensure_linearizable_read(&mut self, read_policy: ReadPolicy, tx: ClientReadTx<C>) {
+    pub(super) fn handle_ensure_linearizable_read(&mut self, read_policy: ReadPolicy, tx: ClientReadTx<C>) {
         // Setup sentinel values to track when we've received majority confirmation of leadership.
 
         let resp = {
@@ -395,7 +397,7 @@ where
             return;
         }
 
-        let pending = self.spawn_leadership_probes(&my_vote, &eff_mem).await;
+        let pending = self.spawn_leadership_probes(&my_vote, &eff_mem);
 
         // TODO: do not spawn, manage read requests with a queue by RaftCore
 
@@ -409,7 +411,7 @@ where
     /// Probe every other voter with an empty AppendEntries, to confirm this node is still leading.
     ///
     /// The returned probes complete in arrival order; joining one may fail if its task panicked.
-    async fn spawn_leadership_probes(
+    fn spawn_leadership_probes(
         &mut self,
         my_vote: &VoteOf<C>,
         eff_mem: &StoredMembershipOf<C>,
@@ -442,15 +444,20 @@ where
 
             // Safe unwrap(): target is in membership
             let target_node = eff_mem.get_node(&target).unwrap().clone();
-            let mut client = self.network_factory.new_heartbeat_client(target.clone(), &target_node).await;
 
             let option = RPCOption::new(ttl);
 
             let fu = {
                 let my_id = my_id.clone();
+                let network_factory = self.network_factory.clone();
                 let target = target.clone();
 
                 async move {
+                    let mut client = {
+                        let mut factory = network_factory.lock().await;
+                        factory.new_heartbeat_client(target.clone(), &target_node).await
+                    };
+
                     let input_stream = Box::pin(futures_util::stream::once(async { rpc }));
 
                     let outer_res = C::timeout(ttl, async {
@@ -1099,7 +1106,10 @@ where
         leader_vote: CommittedVoteOf<C>,
         prog: &TargetProgress<C>,
     ) -> ReplicationHandle<C> {
-        let network = self.network_factory.new_client(prog.target.clone(), &prog.target_node).await;
+        let network = {
+            let mut factory = self.network_factory.lock().await;
+            factory.new_client(prog.target.clone(), &prog.target_node).await
+        };
 
         let (replicate_tx, replicate_rx) = C::watch_channel(Replicate::default());
 
@@ -1376,7 +1386,7 @@ where
                 break;
             };
 
-            self.handle_api_msg(msg).await;
+            self.handle_api_msg(msg);
             processed += 1;
             total += 1;
 
@@ -1589,7 +1599,10 @@ where
 
             // Safe unwrap(): target must be in membership
             let target_node = self.engine.state.membership_state.effective().get_node(&target).unwrap().clone();
-            let client = self.network_factory.new_client(target.clone(), &target_node).await;
+            let client = {
+                let mut factory = self.network_factory.lock().await;
+                factory.new_client(target.clone(), &target_node).await
+            };
 
             let fut = make_rpc(target, client, RPCOption::new(ttl));
 
@@ -1659,10 +1672,9 @@ where
         self.engine.handle_install_full_snapshot(req.vote, req.snapshot, req.tx);
     }
 
-    // TODO: Make this method non-async. It does not need to run any async command in it.
     #[tracing::instrument(level = "debug", skip(self, msg), fields(state = debug(self.engine.state.server_state), id=display(&self.id)
     ))]
-    pub(crate) async fn handle_api_msg(&mut self, msg: RaftMsg<C>) {
+    pub(crate) fn handle_api_msg(&mut self, msg: RaftMsg<C>) {
         tracing::debug!("RAFT_event id={:<2}  input: {}", self.id, msg);
 
         self.runtime_stats.record_raft_msg(msg.name());
@@ -1688,7 +1700,7 @@ where
                 self.handle_pre_vote_request(rpc, tx);
             }
             RaftMsg::GetLinearizer { read_policy, tx } => {
-                self.handle_ensure_linearizable_read(read_policy, tx).await;
+                self.handle_ensure_linearizable_read(read_policy, tx);
             }
             RaftMsg::ClientWrite {
                 payloads,
@@ -2436,7 +2448,10 @@ where
             self.new_replication_task_context(leader_vote, stream_id, target.clone());
 
         let target_node = self.engine.state.membership_state.effective().get_node(&target).unwrap();
-        let snapshot_network = self.network_factory.new_snapshot_client(target.clone(), target_node).await;
+        let snapshot_network = {
+            let mut factory = self.network_factory.lock().await;
+            factory.new_snapshot_client(target.clone(), target_node).await
+        };
 
         let handle = SnapshotTransmitter::<C, NF, SM>::spawn(
             replication_task_context,
@@ -2468,15 +2483,18 @@ where
         targets: Vec<TargetProgress<C>>,
         close_old_streams: bool,
     ) {
-        self.heartbeat_handle
-            .spawn_workers::<NF>(
-                leader_vote.clone(),
-                &mut self.network_factory,
-                &self.tx_notification,
-                &targets,
-                close_old_streams,
-            )
-            .await;
+        {
+            let mut factory = self.network_factory.lock().await;
+            self.heartbeat_handle
+                .spawn_workers::<NF>(
+                    leader_vote.clone(),
+                    &mut *factory,
+                    &self.tx_notification,
+                    &targets,
+                    close_old_streams,
+                )
+                .await;
+        }
 
         let mut new_replications = BTreeMap::new();
 

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -547,7 +547,7 @@ where
             config: config.clone(),
             runtime_config: runtime_config.clone(),
             core_state: Default::default(),
-            network_factory: network,
+            network_factory: Arc::new(C::mutex(network)),
             log_store,
             sm_handle,
 

--- a/tests/tests/membership/t11_add_learner.rs
+++ b/tests/tests/membership/t11_add_learner.rs
@@ -14,6 +14,8 @@ use openraft::errors::ChangeMembershipError;
 use openraft::errors::ClientWriteError;
 use openraft::errors::InProgress;
 use openraft::type_config::TypeConfigExt;
+use openraft_memstore::ClientRequest;
+use openraft_memstore::IntoMemClientRequest;
 use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
@@ -257,14 +259,10 @@ async fn add_learner_when_previous_membership_not_committed() -> Result<()> {
 #[tracing::instrument]
 #[test_harness::test(harness = ut_harness)]
 async fn check_learner_after_leader_transferred() -> Result<()> {
-    // TODO(1): flaky with --features single-term-leader
-
     // Setup test dependencies.
     let config = Arc::new(
         Config {
-            election_timeout_min: 200,
-            election_timeout_max: 250,
-            enable_heartbeat: false,
+            enable_elect: false,
             ..Default::default()
         }
         .validate()?,
@@ -341,8 +339,11 @@ async fn check_learner_after_leader_transferred() -> Result<()> {
         // committed vote pointing to itself, so we must not rely on it.
         let metrics = router.wait(&1, timeout()).metrics(|m| m.current_leader.is_some(), "wait for new leader").await?;
         let new_leader = metrics.current_leader.unwrap();
-        router.client_request_many(new_leader, "0", 1).await?;
-        log_index += 1;
+
+        let request = ClientRequest::make_request("0", 0);
+        let node = router.get_raft_handle(&new_leader)?;
+        let response = node.client_write(request).await?;
+        log_index = response.log_id.index();
 
         for i in [1, 2, 3, 4] {
             router.wait(&i, timeout()).applied_index_at_least(Some(log_index), "learner recv new log").await?;


### PR DESCRIPTION

## Changelog

##### test: membership: stabilize learner transfer test
# Summary

Learner replication after leader transfer is now checked against observed
Raft state in both leader-ID modes.

# Details

Disable autonomous elections while retaining heartbeat-driven leadership
transfer, preventing concurrent election churn during the scenario.

Use the client write's returned log ID for the replication target so
additional leader-initialization logs cannot satisfy the learner check.


##### refactor: core: make API message handling synchronous
# Summary

ReadIndex probe setup no longer makes RaftCore's API message dispatcher
asynchronous.

# Details

Share the network factory behind the configured runtime mutex so detached
leadership probes can create clients without borrowing RaftCore.

Limit each lock to client construction, preserving serialized factory access
while releasing it before network RPCs. Existing replication, heartbeat, and
snapshot client creation uses the same guarded factory.


##### docs: todo: drop resolved and duplicate markers
# Summary

A repository-wide audit of TODO markers found four that no longer
describe pending work. This removes them and renames the Jepsen README
section whose items are all finished.

# Details

`handle_ensure_linearizable_read()` carried a marker asking that a read
reach the state machine only once the last log it observes is
committed. The returned `Linearizer` now enforces that condition: it
carries the read log ID the caller must wait to be applied.

`write_entries()` carried a marker asking it to return membership
configuration errors instead of leaving that to its caller. The same
design point is already recorded at the public write API in
`raft/api/app.rs`, where the error type is declared, so the copy in the
core is redundant.

The gRPC example's build script asked for serde removal; the generated
protobuf types no longer derive serde.

The chaos workflow's marker said the unit test job should be replaced,
without naming a replacement or a reason.

Every item under the Jepsen README's `## TODO` heading is checked, so
the heading becomes `## Implemented coverage`.

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1992)
<!-- Reviewable:end -->
