### PR TITLE
feat: linearizable-read: queue quorum confirmations

### DIFF
--- a/openraft/src/core/linearizable_read/mod.rs
+++ b/openraft/src/core/linearizable_read/mod.rs
@@ -1,0 +1,12 @@
+mod pending_read;
+mod pending_read_deadline_key;
+mod pending_read_deadline_notifier;
+mod pending_read_key;
+mod pending_read_queue;
+
+pub(crate) use pending_read::PendingRead;
+pub(crate) use pending_read_deadline_notifier::PendingReadDeadlineNotifier;
+pub(crate) use pending_read_queue::PendingReadQueue;
+
+#[cfg(test)]
+mod pending_read_queue_test;

--- a/openraft/src/core/linearizable_read/pending_read.rs
+++ b/openraft/src/core/linearizable_read/pending_read.rs
@@ -1,0 +1,30 @@
+use crate::RaftTypeConfig;
+use crate::core::raft_msg::ClientReadTx;
+use crate::raft::linearizable_read::Linearizer;
+use crate::type_config::alias::InstantOf;
+
+/// A linearizable read waiting for the quorum-acknowledgement clock to satisfy its threshold.
+pub(crate) struct PendingRead<C>
+where C: RaftTypeConfig
+{
+    /// The deadline for responding to this read request.
+    pub(super) deadline: InstantOf<C>,
+
+    /// The Linearizer to send back to the client.
+    pub(super) linearizer: Linearizer<C>,
+
+    /// The channel to send the linearizer back to the client.
+    pub(super) response_tx: ClientReadTx<C>,
+}
+
+impl<C> PendingRead<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(deadline: InstantOf<C>, linearizer: Linearizer<C>, response_tx: ClientReadTx<C>) -> Self {
+        Self {
+            deadline,
+            linearizer,
+            response_tx,
+        }
+    }
+}

--- a/openraft/src/core/linearizable_read/pending_read_deadline_key.rs
+++ b/openraft/src/core/linearizable_read/pending_read_deadline_key.rs
@@ -1,0 +1,12 @@
+/// Orders pending reads by response deadline and insertion sequence.
+///
+/// A read's deadline is independent of its quorum-acknowledgement threshold, because
+/// [`LinearizerOption::wait_timeout`] is chosen per request. This key therefore forms a secondary
+/// index over the same reads, ordered by the instant at which each read must be answered.
+///
+/// [`LinearizerOption::wait_timeout`]: crate::raft::linearizable_read::LinearizerOption
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) struct PendingReadDeadlineKey<I> {
+    pub(super) deadline: I,
+    pub(super) sequence: u64,
+}

--- a/openraft/src/core/linearizable_read/pending_read_deadline_notifier.rs
+++ b/openraft/src/core/linearizable_read/pending_read_deadline_notifier.rs
@@ -1,0 +1,111 @@
+use crate::RaftTypeConfig;
+use crate::async_runtime::MpscSender;
+use crate::async_runtime::watch::WatchReceiver;
+use crate::async_runtime::watch::WatchSender;
+use crate::core::notification::Notification;
+use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::JoinHandleOf;
+use crate::type_config::alias::MpscSenderOf;
+use crate::type_config::alias::WatchReceiverOf;
+use crate::type_config::alias::WatchSenderOf;
+
+/// Wakes `RaftCore` when the earliest pending linearizable read reaches its deadline.
+///
+/// After firing, the worker waits on `changed()` instead of re-arming on the deadline it just
+/// reported, which cannot lose a wake-up: the `drain_expired` that the notification triggers always
+/// moves `earliest_deadline()` to a different value, because every deadline left in the queue
+/// exceeds `now` and an emptied queue reports `None`. `set_deadline` therefore always observes a
+/// change and re-arms the worker. Watch versioning covers the interleaving where the new deadline
+/// is set before the worker starts awaiting.
+pub(crate) struct PendingReadDeadlineNotifier<C>
+where C: RaftTypeConfig
+{
+    deadline_tx: WatchSenderOf<C, Option<InstantOf<C>>>,
+    _join_handle: JoinHandleOf<C, ()>,
+}
+
+impl<C> PendingReadDeadlineNotifier<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn spawn(notification_tx: MpscSenderOf<C, Notification<C>>) -> Self {
+        let (deadline_tx, deadline_rx) = C::watch_channel(None);
+        let join_handle = C::spawn(Self::run(deadline_rx, notification_tx));
+
+        Self {
+            deadline_tx,
+            _join_handle: join_handle,
+        }
+    }
+
+    pub(crate) fn set_deadline(&self, deadline: Option<InstantOf<C>>) {
+        self.deadline_tx.send_if_different(deadline);
+    }
+
+    async fn run(
+        mut deadline_rx: WatchReceiverOf<C, Option<InstantOf<C>>>,
+        notification_tx: MpscSenderOf<C, Notification<C>>,
+    ) {
+        loop {
+            let deadline = *deadline_rx.borrow_and_update();
+            let Some(deadline) = deadline else {
+                if deadline_rx.changed().await.is_err() {
+                    return;
+                }
+                continue;
+            };
+
+            let wait_result = C::timeout_at(deadline, deadline_rx.changed()).await;
+            match wait_result {
+                Ok(Ok(())) => continue,
+                Ok(Err(_)) => return,
+                Err(_) => {}
+            }
+
+            let send_result = notification_tx.send(Notification::PendingReadDeadlineReached).await;
+            if send_result.is_err() {
+                return;
+            }
+
+            if deadline_rx.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::async_runtime::MpscReceiver;
+    use crate::engine::testing::UTConfig;
+
+    type C = UTConfig;
+
+    #[test]
+    fn deadline_notifier_uses_latest_deadline_and_rearms() {
+        C::run(async {
+            let (tx, mut rx) = C::mpsc(4);
+            let notifier = PendingReadDeadlineNotifier::<C>::spawn(tx);
+
+            let late = C::now() + Duration::from_secs(1);
+            notifier.set_deadline(Some(late));
+
+            let early = C::now() + Duration::from_millis(10);
+            notifier.set_deadline(Some(early));
+
+            let received = C::timeout(Duration::from_secs(1), rx.recv()).await;
+            let notification = received.unwrap().unwrap();
+            assert!(matches!(notification, Notification::PendingReadDeadlineReached));
+
+            let next = C::now() + Duration::from_millis(10);
+            notifier.set_deadline(Some(next));
+
+            let received = C::timeout(Duration::from_secs(1), rx.recv()).await;
+            let notification = received.unwrap().unwrap();
+            assert!(matches!(notification, Notification::PendingReadDeadlineReached));
+        });
+    }
+}

--- a/openraft/src/core/linearizable_read/pending_read_key.rs
+++ b/openraft/src/core/linearizable_read/pending_read_key.rs
@@ -1,0 +1,6 @@
+/// Orders pending reads by quorum-acknowledgement threshold and insertion sequence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) struct PendingReadKey<I> {
+    pub(super) min_quorum_acked_at: I,
+    pub(super) sequence: u64,
+}

--- a/openraft/src/core/linearizable_read/pending_read_queue.rs
+++ b/openraft/src/core/linearizable_read/pending_read_queue.rs
@@ -1,0 +1,118 @@
+use std::collections::BTreeMap;
+
+use rt::OneshotSender;
+
+use super::pending_read::PendingRead;
+use super::pending_read_deadline_key::PendingReadDeadlineKey;
+use super::pending_read_key::PendingReadKey;
+use crate::RaftTypeConfig;
+use crate::errors::LinearizableReadError;
+use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::LogIdOf;
+
+#[derive(Default)]
+pub(crate) struct PendingReadQueue<C>
+where C: RaftTypeConfig
+{
+    next_sequence: u64,
+
+    /// The pending reads, ordered by the quorum-acknowledgement instant each one requires.
+    reads: BTreeMap<PendingReadKey<InstantOf<C>>, PendingRead<C>>,
+
+    /// A secondary index over the same reads, ordered by deadline.
+    ///
+    /// Each entry points at the primary key of the read it describes. A per-request
+    /// `wait_timeout` makes deadline order differ from `reads` order, so expiry needs its own
+    /// ordering to answer the earliest deadline first.
+    deadlines: BTreeMap<PendingReadDeadlineKey<InstantOf<C>>, PendingReadKey<InstantOf<C>>>,
+}
+
+impl<C> PendingReadQueue<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn push(&mut self, min_quorum_acked_at: InstantOf<C>, pending_read: PendingRead<C>) {
+        let sequence = self.next_sequence;
+        self.next_sequence = sequence.checked_add(1).expect("pending read sequence overflow");
+
+        let key = PendingReadKey {
+            min_quorum_acked_at,
+            sequence,
+        };
+        let deadline_key = PendingReadDeadlineKey {
+            deadline: pending_read.deadline,
+            sequence,
+        };
+        self.reads.insert(key, pending_read);
+        self.deadlines.insert(deadline_key, key);
+        self.debug_assert_indexes_agree();
+    }
+
+    pub(crate) fn drain_expired(
+        &mut self,
+        now: InstantOf<C>,
+        mut make_error: impl FnMut(InstantOf<C>) -> LinearizableReadError<C>,
+    ) {
+        while let Some((deadline_key, key)) = self.deadlines.first_key_value() {
+            if deadline_key.deadline > now {
+                break;
+            }
+
+            let key = *key;
+            self.deadlines.pop_first();
+            let pending_read = self.reads.remove(&key).expect("a deadline entry must have its read");
+            let err = make_error(key.min_quorum_acked_at);
+            pending_read.response_tx.send(Err(err)).ok();
+        }
+        self.debug_assert_indexes_agree();
+    }
+
+    /// Answer every read whose threshold is exceeded, reporting `applied` as the log id applied by
+    /// the state machine now rather than when each read was queued.
+    pub(crate) fn drain_satisfied(&mut self, quorum_acked_at: InstantOf<C>, applied: Option<LogIdOf<C>>) {
+        while let Some((key, _)) = self.reads.first_key_value() {
+            if key.min_quorum_acked_at >= quorum_acked_at {
+                break;
+            }
+
+            let sequence = key.sequence;
+            let (_, pending_read) = self.reads.pop_first().unwrap();
+            let deadline_key = PendingReadDeadlineKey {
+                deadline: pending_read.deadline,
+                sequence,
+            };
+            self.deadlines.remove(&deadline_key).expect("a read must have its deadline entry");
+
+            let linearizer = pending_read.linearizer.with_applied(applied.clone());
+            pending_read.response_tx.send(Ok(linearizer)).ok();
+        }
+        self.debug_assert_indexes_agree();
+    }
+
+    pub(crate) fn drain_all_with_error(&mut self, err: LinearizableReadError<C>) {
+        self.deadlines.clear();
+        let pending_reads = std::mem::take(&mut self.reads);
+        for pending_read in pending_reads.into_values() {
+            pending_read.response_tx.send(Err(err.clone())).ok();
+        }
+    }
+
+    pub(crate) fn earliest_deadline(&self) -> Option<InstantOf<C>> {
+        let (deadline_key, _) = self.deadlines.first_key_value()?;
+        Some(deadline_key.deadline)
+    }
+
+    /// Both indexes describe the same set of reads, so their sizes must match.
+    fn debug_assert_indexes_agree(&self) {
+        debug_assert_eq!(
+            self.reads.len(),
+            self.deadlines.len(),
+            "pending read indexes hold different numbers of reads"
+        );
+    }
+
+    #[cfg(test)]
+    pub(super) fn is_empty(&self) -> bool {
+        self.debug_assert_indexes_agree();
+        self.reads.is_empty()
+    }
+}

--- a/openraft/src/core/linearizable_read/pending_read_queue_test.rs
+++ b/openraft/src/core/linearizable_read/pending_read_queue_test.rs
@@ -1,0 +1,321 @@
+use std::time::Duration;
+
+use super::*;
+use crate::engine::testing::UTConfig;
+use crate::engine::testing::log_id;
+use crate::errors::ForwardToLeader;
+use crate::errors::LinearizableReadError;
+use crate::raft::linearizable_read::Linearizer;
+use crate::raft::linearizable_read::ReadLogId;
+use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::OneshotReceiverOf;
+
+type C = UTConfig;
+type ReadResult = Result<Linearizer<C>, LinearizableReadError<C>>;
+type ReadRx = OneshotReceiverOf<C, ReadResult>;
+
+const CLOCK_ADVANCE: Duration = Duration::from_nanos(1);
+
+struct PendingReadSpec {
+    min_quorum_acked_at: InstantOf<C>,
+    deadline: InstantOf<C>,
+    node_id: u64,
+}
+
+fn push_read(queue: &mut PendingReadQueue<C>, read_log_id: &ReadLogId<C>, spec: PendingReadSpec) -> ReadRx {
+    let (tx, rx) = C::oneshot();
+    let linearizer = Linearizer::new(spec.node_id, *read_log_id, None);
+    let pending_read = PendingRead::new(spec.deadline, linearizer, tx);
+    queue.push(spec.min_quorum_acked_at, pending_read);
+    rx
+}
+
+fn assert_linearizer(rx: &mut ReadRx, node_id: u64, read_log_id: &ReadLogId<C>) {
+    let linearizer = rx.try_recv().unwrap().unwrap();
+    assert_eq!(&node_id, linearizer.node_id());
+    assert_eq!(read_log_id, linearizer.read_log_id());
+    assert_eq!(None, linearizer.applied());
+}
+
+#[test]
+fn test_drain_all_with_error() {
+    let mut queue = PendingReadQueue::<C>::default();
+    let read_log_id = ReadLogId::from_log_id(log_id(1, 1, 1));
+    let linearizer = Linearizer::new(1, read_log_id, None);
+    let now = C::now();
+    let mut receivers = Vec::new();
+
+    for _ in 0..2 {
+        let (tx, rx) = C::oneshot::<ReadResult>();
+        let pending_read = PendingRead::new(now, linearizer.clone(), tx);
+        queue.push(now, pending_read);
+        receivers.push(rx);
+    }
+
+    let want = ForwardToLeader::new(2, ());
+    let err = LinearizableReadError::ForwardToLeader(want.clone());
+    queue.drain_all_with_error(err);
+
+    assert!(queue.is_empty());
+    for receiver in &mut receivers {
+        let response = receiver.try_recv().unwrap();
+        let err = response.unwrap_err();
+        let LinearizableReadError::ForwardToLeader(got) = err else {
+            panic!("expected ForwardToLeader");
+        };
+        assert_eq!(want, got);
+    }
+}
+
+#[test]
+fn test_drain_satisfied_requires_newer_ack_and_keeps_duplicates() {
+    let mut queue = PendingReadQueue::<C>::default();
+    let read_log_id = ReadLogId::from_log_id(log_id(1, 1, 1));
+    let now = C::now();
+    let deadline = now + Duration::from_secs(1);
+    let lower_threshold = now + Duration::from_millis(10);
+    let higher_threshold = now + Duration::from_millis(20);
+
+    let mut rx1 = push_read(&mut queue, &read_log_id, PendingReadSpec {
+        min_quorum_acked_at: higher_threshold,
+        deadline,
+        node_id: 1,
+    });
+    let mut rx2 = push_read(&mut queue, &read_log_id, PendingReadSpec {
+        min_quorum_acked_at: lower_threshold,
+        deadline,
+        node_id: 2,
+    });
+    let mut rx3 = push_read(&mut queue, &read_log_id, PendingReadSpec {
+        min_quorum_acked_at: lower_threshold,
+        deadline,
+        node_id: 3,
+    });
+
+    queue.drain_satisfied(lower_threshold, None);
+
+    assert!(rx1.try_recv().is_err());
+    assert!(rx2.try_recv().is_err());
+    assert!(rx3.try_recv().is_err());
+
+    let lower_acked_at = lower_threshold + CLOCK_ADVANCE;
+    queue.drain_satisfied(lower_acked_at, None);
+
+    assert!(rx1.try_recv().is_err());
+    assert_linearizer(&mut rx2, 2, &read_log_id);
+    assert_linearizer(&mut rx3, 3, &read_log_id);
+
+    let higher_acked_at = higher_threshold + CLOCK_ADVANCE;
+    queue.drain_satisfied(higher_acked_at, None);
+
+    assert_linearizer(&mut rx1, 1, &read_log_id);
+    assert!(queue.is_empty());
+}
+
+#[test]
+fn test_drain_expired_removes_expired_prefix() {
+    let mut queue = PendingReadQueue::<C>::default();
+    let read_log_id = ReadLogId::from_log_id(log_id(1, 1, 1));
+    let now = C::now();
+    let timeout = Duration::from_millis(100);
+    let threshold1 = now;
+    let threshold2 = now + Duration::from_millis(10);
+    let threshold3 = now + Duration::from_millis(20);
+    let deadline1 = threshold1 + timeout;
+    let deadline2 = threshold2 + timeout;
+    let deadline3 = threshold3 + timeout;
+
+    let mut rx1 = push_read(&mut queue, &read_log_id, PendingReadSpec {
+        min_quorum_acked_at: threshold1,
+        deadline: deadline1,
+        node_id: 1,
+    });
+    let mut rx2 = push_read(&mut queue, &read_log_id, PendingReadSpec {
+        min_quorum_acked_at: threshold2,
+        deadline: deadline2,
+        node_id: 2,
+    });
+    let mut rx3 = push_read(&mut queue, &read_log_id, PendingReadSpec {
+        min_quorum_acked_at: threshold3,
+        deadline: deadline3,
+        node_id: 3,
+    });
+
+    assert_eq!(Some(deadline1), queue.earliest_deadline());
+
+    let want = ForwardToLeader::new(4, ());
+    let mut thresholds = Vec::new();
+    queue.drain_expired(deadline2, |min_quorum_acked_at| {
+        thresholds.push(min_quorum_acked_at);
+        LinearizableReadError::ForwardToLeader(want.clone())
+    });
+
+    assert_eq!(vec![threshold1, threshold2], thresholds);
+
+    for receiver in [&mut rx1, &mut rx2] {
+        let response = receiver.try_recv().unwrap();
+        let LinearizableReadError::ForwardToLeader(got) = response.unwrap_err() else {
+            panic!("expected ForwardToLeader");
+        };
+        assert_eq!(want, got);
+    }
+    assert_eq!(Some(deadline3), queue.earliest_deadline());
+
+    let quorum_acked_at = threshold3 + CLOCK_ADVANCE;
+    queue.drain_satisfied(quorum_acked_at, None);
+    assert_linearizer(&mut rx3, 3, &read_log_id);
+    assert!(queue.is_empty());
+}
+
+/// A per-request wait timeout lets the read with the earlier threshold hold the later deadline,
+/// so expiry must follow deadline order instead of threshold order.
+#[test]
+fn test_drain_expired_follows_deadline_order_not_threshold_order() {
+    let mut queue = PendingReadQueue::<C>::default();
+    let read_log_id = ReadLogId::from_log_id(log_id(1, 1, 1));
+    let now = C::now();
+
+    let threshold1 = now + Duration::from_millis(10);
+    let deadline1 = now + Duration::from_millis(300);
+    let threshold2 = now + Duration::from_millis(20);
+    let deadline2 = now + Duration::from_millis(100);
+
+    let mut rx1 = push_read(&mut queue, &read_log_id, PendingReadSpec {
+        min_quorum_acked_at: threshold1,
+        deadline: deadline1,
+        node_id: 1,
+    });
+    let mut rx2 = push_read(&mut queue, &read_log_id, PendingReadSpec {
+        min_quorum_acked_at: threshold2,
+        deadline: deadline2,
+        node_id: 2,
+    });
+
+    assert_eq!(Some(deadline2), queue.earliest_deadline());
+
+    let want = ForwardToLeader::new(3, ());
+    let mut thresholds = Vec::new();
+    queue.drain_expired(deadline2, |min_quorum_acked_at| {
+        thresholds.push(min_quorum_acked_at);
+        LinearizableReadError::ForwardToLeader(want.clone())
+    });
+
+    assert_eq!(vec![threshold2], thresholds);
+
+    let response = rx2.try_recv().unwrap();
+    let LinearizableReadError::ForwardToLeader(got) = response.unwrap_err() else {
+        panic!("expected ForwardToLeader");
+    };
+    assert_eq!(want, got);
+
+    assert!(rx1.try_recv().is_err());
+    assert_eq!(Some(deadline1), queue.earliest_deadline());
+
+    let quorum_acked_at = threshold1 + CLOCK_ADVANCE;
+    queue.drain_satisfied(quorum_acked_at, None);
+    assert_linearizer(&mut rx1, 1, &read_log_id);
+    assert!(queue.is_empty());
+}
+
+/// Answering a read from the middle of the deadline order must leave both indexes describing the
+/// same remaining reads.
+#[test]
+fn test_satisfied_removes_read_from_the_middle_of_deadline_order() {
+    let mut queue = PendingReadQueue::<C>::default();
+    let read_log_id = ReadLogId::from_log_id(log_id(1, 1, 1));
+    let now = C::now();
+
+    let threshold1 = now + Duration::from_millis(10);
+    let deadline1 = now + Duration::from_millis(200);
+    let threshold2 = now + Duration::from_millis(20);
+    let deadline2 = now + Duration::from_millis(100);
+    let threshold3 = now + Duration::from_millis(30);
+    let deadline3 = now + Duration::from_millis(300);
+
+    let mut rx1 = push_read(&mut queue, &read_log_id, PendingReadSpec {
+        min_quorum_acked_at: threshold1,
+        deadline: deadline1,
+        node_id: 1,
+    });
+    let mut rx2 = push_read(&mut queue, &read_log_id, PendingReadSpec {
+        min_quorum_acked_at: threshold2,
+        deadline: deadline2,
+        node_id: 2,
+    });
+    let mut rx3 = push_read(&mut queue, &read_log_id, PendingReadSpec {
+        min_quorum_acked_at: threshold3,
+        deadline: deadline3,
+        node_id: 3,
+    });
+
+    let quorum_acked_at = threshold1 + CLOCK_ADVANCE;
+    queue.drain_satisfied(quorum_acked_at, None);
+    assert_linearizer(&mut rx1, 1, &read_log_id);
+    assert_eq!(Some(deadline2), queue.earliest_deadline());
+
+    let want = ForwardToLeader::new(4, ());
+    let mut thresholds = Vec::new();
+    queue.drain_expired(deadline3, |min_quorum_acked_at| {
+        thresholds.push(min_quorum_acked_at);
+        LinearizableReadError::ForwardToLeader(want.clone())
+    });
+
+    assert_eq!(vec![threshold2, threshold3], thresholds);
+
+    for receiver in [&mut rx2, &mut rx3] {
+        let response = receiver.try_recv().unwrap();
+        let LinearizableReadError::ForwardToLeader(got) = response.unwrap_err() else {
+            panic!("expected ForwardToLeader");
+        };
+        assert_eq!(want, got);
+    }
+
+    assert_eq!(None, queue.earliest_deadline());
+    assert!(queue.is_empty());
+}
+
+/// A read queued before the state machine advanced must report the applied log id observed when it
+/// is answered, not the one observed when it was queued.
+#[test]
+fn test_drain_satisfied_refreshes_applied() {
+    let mut queue = PendingReadQueue::<C>::default();
+    let read_log_id = ReadLogId::from_log_id(log_id(1, 1, 1));
+    let now = C::now();
+
+    let mut rx = push_read(&mut queue, &read_log_id, PendingReadSpec {
+        min_quorum_acked_at: now,
+        deadline: now + Duration::from_millis(100),
+        node_id: 1,
+    });
+
+    let applied = log_id(1, 1, 5);
+    let quorum_acked_at = now + CLOCK_ADVANCE;
+    queue.drain_satisfied(quorum_acked_at, Some(applied));
+
+    let linearizer = rx.try_recv().unwrap().unwrap();
+    assert_eq!(&1, linearizer.node_id());
+    assert_eq!(&read_log_id, linearizer.read_log_id());
+    assert_eq!(Some(&log_id(1, 1, 5)), linearizer.applied());
+}
+
+#[test]
+fn test_satisfied_takes_precedence_over_expired() {
+    let mut queue = PendingReadQueue::<C>::default();
+    let read_log_id = ReadLogId::from_log_id(log_id(1, 1, 1));
+    let now = C::now();
+    let mut rx = push_read(&mut queue, &read_log_id, PendingReadSpec {
+        min_quorum_acked_at: now,
+        deadline: now,
+        node_id: 1,
+    });
+
+    let quorum_acked_at = now + CLOCK_ADVANCE;
+    queue.drain_satisfied(quorum_acked_at, None);
+
+    let err = LinearizableReadError::ForwardToLeader(ForwardToLeader::new(2, ()));
+    queue.drain_expired(now, |_| err.clone());
+
+    assert_linearizer(&mut rx, 1, &read_log_id);
+    assert!(queue.is_empty());
+}

--- a/openraft/src/core/mod.rs
+++ b/openraft/src/core/mod.rs
@@ -36,6 +36,7 @@ pub(crate) mod sm;
 pub(crate) mod stage;
 
 mod client_responder_queue;
+mod linearizable_read;
 mod metrics_channels;
 mod notification_name;
 mod raft_core;
@@ -47,6 +48,9 @@ mod tick;
 
 pub(crate) use client_responder_queue::ClientResponderQueue;
 pub(crate) use io_broadcast::IoBroadcast;
+pub(crate) use linearizable_read::PendingRead;
+pub(crate) use linearizable_read::PendingReadDeadlineNotifier;
+pub(crate) use linearizable_read::PendingReadQueue;
 pub(crate) use metrics_channels::MetricsChannels;
 pub use notification_name::NotificationName;
 pub(crate) use raft_core::ApplyResult;

--- a/openraft/src/core/notification.rs
+++ b/openraft/src/core/notification.rs
@@ -95,6 +95,9 @@ where C: RaftTypeConfig
         /// ith tick
         i: u64,
     },
+
+    /// The earliest pending linearizable read reached its deadline.
+    PendingReadDeadlineReached,
 }
 
 impl<C> Notification<C>
@@ -116,6 +119,7 @@ where C: RaftTypeConfig
             Self::HeartbeatProgress { .. } => NotificationName::HeartbeatProgress,
             Self::StateMachine { .. } => NotificationName::StateMachine,
             Self::Tick { .. } => NotificationName::Tick,
+            Self::PendingReadDeadlineReached => NotificationName::PendingReadDeadlineReached,
         }
     }
 }
@@ -191,6 +195,9 @@ where C: RaftTypeConfig
             }
             Self::Tick { i } => {
                 write!(f, "Tick {}", i)
+            }
+            Self::PendingReadDeadlineReached => {
+                write!(f, "PendingReadDeadlineReached")
             }
         }
     }

--- a/openraft/src/core/notification_name.rs
+++ b/openraft/src/core/notification_name.rs
@@ -1,4 +1,5 @@
 use openraft_macros::VariantName;
+use openraft_macros::since;
 
 /// Enum representing the name of each `Notification` variant.
 ///
@@ -7,6 +8,10 @@ use openraft_macros::VariantName;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[derive(VariantName)]
 #[variant_name(prefix = "Notify::")]
+#[since(
+    version = "0.10.0",
+    change = "renamed from `CheckPendingLinearizableReads` to `PendingReadDeadlineReached`"
+)]
 pub enum NotificationName {
     VoteResponse,
     PreVoteResponse,
@@ -17,6 +22,7 @@ pub enum NotificationName {
     HeartbeatProgress,
     StateMachine,
     Tick,
+    PendingReadDeadlineReached,
 }
 
 #[cfg(test)]

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::collections::BTreeSet;
 use std::fmt;
 use std::fmt::Debug;
 use std::future::Future;
@@ -10,11 +9,6 @@ use std::time::Duration;
 use display_more::DisplayOptionExt;
 use display_more::DisplaySliceExt;
 use futures_util::FutureExt;
-use futures_util::Stream;
-use futures_util::StreamExt;
-use futures_util::TryFutureExt;
-use futures_util::stream::FuturesUnordered;
-use maplit::btreeset;
 use tracing::Instrument;
 use tracing::Level;
 use tracing::Span;
@@ -36,6 +30,9 @@ use crate::config::RuntimeConfig;
 use crate::core::ClientResponderQueue;
 use crate::core::IoBroadcast;
 use crate::core::MetricsChannels;
+use crate::core::PendingRead;
+use crate::core::PendingReadDeadlineNotifier;
+use crate::core::PendingReadQueue;
 use crate::core::ServerState;
 use crate::core::SharedReplicateBatch;
 use crate::core::balancer::Balancer;
@@ -71,9 +68,7 @@ use crate::errors::Fatal;
 use crate::errors::ForwardToLeader;
 use crate::errors::Infallible;
 use crate::errors::InitializeError;
-use crate::errors::NetworkError;
-use crate::errors::QuorumNotEnough;
-use crate::errors::RPCError;
+use crate::errors::LinearizableReadError;
 use crate::errors::StorageIOResult;
 use crate::errors::Timeout;
 use crate::impls::ProgressResponder;
@@ -86,7 +81,6 @@ use crate::metrics::RaftServerMetrics;
 use crate::metrics::ReplicationMetrics;
 use crate::metrics::SerdeInstant;
 use crate::network::NetSnapshot;
-use crate::network::NetStreamAppend;
 use crate::network::NetTransferLeader;
 use crate::network::NetVote;
 use crate::network::RPCOption;
@@ -95,16 +89,13 @@ use crate::network::RaftNetworkFactory;
 use crate::progress::VecProgressEntry;
 use crate::progress::inflight_id::InflightId;
 use crate::progress::stream_id::StreamId;
-use crate::quorum::QuorumSet;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::ClientWriteResult;
 use crate::raft::LogSegment;
-use crate::raft::ReadPolicy;
-use crate::raft::StreamAppendError;
-use crate::raft::StreamAppendResult;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::raft::linearizable_read::Linearizer;
+use crate::raft::linearizable_read::LinearizerOption;
 use crate::raft::message::TransferLeaderRequest;
 use crate::raft::responder::Responder;
 use crate::raft::responder::core_responder::CoreResponder;
@@ -129,14 +120,11 @@ use crate::type_config::alias::CommittedLeaderIdOf;
 use crate::type_config::alias::CommittedVoteOf;
 use crate::type_config::alias::EntryPayloadOf;
 use crate::type_config::alias::InstantOf;
-use crate::type_config::alias::JoinErrorOf;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::MpscReceiverOf;
 use crate::type_config::alias::MpscSenderOf;
 use crate::type_config::alias::MutexOf;
-use crate::type_config::alias::NodeIdOf;
 use crate::type_config::alias::OneshotReceiverOf;
-use crate::type_config::alias::StoredMembershipOf;
 use crate::type_config::alias::VoteOf;
 use crate::type_config::alias::WatchReceiverOf;
 use crate::type_config::alias::WatchSenderOf;
@@ -208,6 +196,12 @@ where
 
     /// Responders to send result back to client when logs are applied.
     pub(crate) client_responders: ClientResponderQueue<CoreResponder<C>>,
+
+    /// Linearizable reads waiting for the quorum acknowledgement clock to exceed their thresholds.
+    pub(crate) pending_reads: PendingReadQueue<C>,
+
+    /// Wakes this core when a pending linearizable read reaches its deadline.
+    pub(crate) pending_read_deadline_notifier: PendingReadDeadlineNotifier<C>,
 
     /// A mapping of node IDs the replication state of the target node.
     pub(crate) replications: BTreeMap<C::NodeId, ReplicationHandle<C>>,
@@ -285,10 +279,6 @@ impl VoteRequestKind {
     }
 }
 
-/// The outcome of one leadership probe sent by [`RaftCore::spawn_leadership_probes`]: the target
-/// that answered and its append result, or the target that did not and the error that stopped it.
-type ProbeResult<C> = Result<(NodeIdOf<C>, StreamAppendResult<C>), (NodeIdOf<C>, RPCError<C>)>;
-
 impl<C, NF, LS, SM> RaftCore<C, NF, LS, SM>
 where
     C: RaftTypeConfig,
@@ -352,234 +342,70 @@ where
     /// To ensure linearizability, a read request proposed at time `T1` confirms this node's
     /// leadership to guarantee that all the committed entries proposed before `T1` are present in
     /// this node.
+    ///
+    /// Both the fast path and the queue require `now < acked + age`; an acknowledgement at the
+    /// exact threshold is not fresh enough.
+    ///
+    /// Broadcasting a heartbeat per read does not amplify RPCs: heartbeat events reach each target
+    /// through a watch channel, so a burst coalesces to the latest event, and a heartbeat sent
+    /// later also satisfies the thresholds of the reads queued before it.
     #[tracing::instrument(level = "trace", skip(self, tx))]
-    pub(super) fn handle_ensure_linearizable_read(&mut self, read_policy: ReadPolicy, tx: ClientReadTx<C>) {
+    pub(super) fn handle_get_linearizer(&mut self, linearizer_option: LinearizerOption, tx: ClientReadTx<C>) {
         // Setup sentinel values to track when we've received majority confirmation of leadership.
 
-        let resp = {
-            let lh = match self.ensure_leader_handler() {
-                Ok(leading_handler) => leading_handler,
-                Err(forward) => {
-                    tx.send(Err(forward.into())).ok();
-                    return;
-                }
-            };
+        let now = C::now();
+        let leader_lease = self.engine.config.timer_config.leader_lease;
+        let max_quorum_ack_age = linearizer_option.effective_max_quorum_ack_age(leader_lease);
+        let applied = self.engine.state.io_applied().cloned();
+        let id = self.id.clone();
 
-            if read_policy == ReadPolicy::LeaseRead && !lh.is_lease_valid() {
-                tracing::debug!("{}: lease expired during lease read", self.id);
-                tx.send(Err(ForwardToLeader::empty().into())).ok();
+        let mut lh = match self.ensure_leader_handler() {
+            Ok(leading_handler) => leading_handler,
+            Err(forward) => {
+                tx.send(Err(forward.into())).ok();
                 return;
             }
-
-            let read_log_id = lh.get_read_log_id();
-
-            // TODO: this applied is a little stale when being returned to client.
-            //       Fix this when the following heartbeats are replaced with calling RaftNetwork.
-            let applied = self.engine.state.io_applied().cloned();
-
-            Linearizer::new(self.id.clone(), read_log_id, applied)
         };
 
-        if read_policy == ReadPolicy::LeaseRead {
-            tx.send(Ok(resp)).ok();
+        let read_log_id = lh.get_read_log_id();
+
+        let linearizer = Linearizer::new(id, read_log_id, applied);
+
+        if lh.leader.is_self_quorum() {
+            tx.send(Ok(linearizer)).ok();
             return;
         }
 
-        let my_vote = self.engine.state.vote_ref().clone();
-        let eff_mem = self.engine.state.membership_state.effective().clone();
-        let core_tx = self.tx_notification.clone();
+        let last_quorum_acked_at = lh.leader.last_quorum_acked_time();
 
-        let granted = btreeset! {self.id.clone()};
-
-        // single-node quorum, fast path, return quickly.
-        if eff_mem.is_quorum(granted.iter()) {
-            tx.send(Ok(resp)).ok();
+        // This comparison must remain strict. A zero `max_quorum_ack_age` selects ReadIndex,
+        // which requires a fresh heartbeat round to be acknowledged by a quorum. It must not reuse
+        // a recorded acknowledgement, even when its timestamp equals `now`; using `<=` would take
+        // this fast path and skip the new quorum confirmation.
+        if last_quorum_acked_at.is_some_and(|last_quorum_acked_at| now < last_quorum_acked_at + max_quorum_ack_age) {
+            tx.send(Ok(linearizer)).ok();
             return;
         }
 
-        let pending = self.spawn_leadership_probes(&my_vote, &eff_mem);
+        let min_quorum_acked_at = now - max_quorum_ack_age;
+        let wait_timeout = linearizer_option.effective_wait_timeout(leader_lease);
 
-        // TODO: do not spawn, manage read requests with a queue by RaftCore
-
-        let waiting_fu = Self::wait_for_leadership_quorum(pending, my_vote, eff_mem, granted, core_tx, resp, tx);
-
-        // False positive lint warning(`non-binding `let` on a future`): https://github.com/rust-lang/rust-clippy/issues/9932
-        #[allow(clippy::let_underscore_future)]
-        let _ = C::spawn(waiting_fu.instrument(tracing::debug_span!("spawn_is_leader_waiting")));
-    }
-
-    /// Probe every other voter with an empty AppendEntries, to confirm this node is still leading.
-    ///
-    /// The returned probes complete in arrival order; joining one may fail if its task panicked.
-    fn spawn_leadership_probes(
-        &mut self,
-        my_vote: &VoteOf<C>,
-        eff_mem: &StoredMembershipOf<C>,
-    ) -> impl Stream<Item = Result<ProbeResult<C>, (NodeIdOf<C>, JoinErrorOf<C>)>> + Unpin + use<C, NF, LS, SM> {
-        let my_id = self.id.clone();
-        let ttl = Duration::from_millis(self.config.heartbeat_interval);
-
-        // Spawn parallel requests, all with the standard timeout for heartbeats.
-        let pending = FuturesUnordered::new();
-
-        let voter_progresses = {
-            let l = &self.engine.leader.as_ref().unwrap();
-            l.progress.iter().filter(|item| l.progress.is_voter(&item.id) == Some(true))
-        };
-
-        for item in voter_progresses {
-            let target = item.id.clone();
-            let progress = item;
-
-            if target == my_id {
-                continue;
-            }
-
-            let rpc = AppendEntriesRequest {
-                vote: my_vote.clone(),
-                prev_log_id: progress.matching().cloned(),
-                entries: vec![],
-                leader_commit: self.engine.state.cluster_committed().cloned(),
-            };
-
-            // Safe unwrap(): target is in membership
-            let target_node = eff_mem.get_node(&target).unwrap().clone();
-
-            let option = RPCOption::new(ttl);
-
-            let fu = {
-                let my_id = my_id.clone();
-                let network_factory = self.network_factory.clone();
-                let target = target.clone();
-
-                async move {
-                    let mut client = {
-                        let mut factory = network_factory.lock().await;
-                        factory.new_heartbeat_client(target.clone(), &target_node).await
-                    };
-
-                    let input_stream = Box::pin(futures_util::stream::once(async { rpc }));
-
-                    let outer_res = C::timeout(ttl, async {
-                        let mut output = client.stream_append(input_stream, option).await?;
-                        output.next().await.transpose()
-                    })
-                    .await;
-
-                    match outer_res {
-                        Ok(Ok(Some(stream_result))) => Ok((target, stream_result)),
-                        Ok(Ok(None)) => {
-                            // Stream returned no response - treat as network error
-                            Err((
-                                target,
-                                RPCError::Network(NetworkError::from_string("stream_append returned no response")),
-                            ))
-                        }
-                        Ok(Err(rpc_err)) => Err((target, rpc_err)),
-                        Err(_timeout) => {
-                            let timeout_err = Timeout {
-                                action: RPCTypes::AppendEntries,
-                                id: my_id,
-                                target: target.clone(),
-                                timeout: ttl,
-                            };
-
-                            Err((target, RPCError::Timeout(timeout_err)))
-                        }
-                    }
-                }
-            };
-
-            let fu = fu.instrument(tracing::debug_span!("spawn_is_leader", target = target.to_string()));
-            let task = C::spawn(fu).map_err(move |err| (target, err));
-
-            pending.push(task);
+        // A read that will not wait cannot benefit from a newer quorum acknowledgement.
+        if wait_timeout.is_zero() {
+            let quorum_not_enough = lh.leader.clock_quorum_not_enough(min_quorum_acked_at);
+            let err = LinearizableReadError::QuorumNotEnough(quorum_not_enough);
+            tx.send(Err(err)).ok();
+            return;
         }
 
-        pending
-    }
-
-    /// Answer a read request as soon as a quorum of `pending` probes confirms this node still
-    /// leads.
-    ///
-    /// A probe reporting a higher vote ends the request immediately: the vote is forwarded to
-    /// [`RaftCore`] and the caller is told to look for the new leader. Exhausting the probes
-    /// without reaching a quorum yields [`QuorumNotEnough`].
-    async fn wait_for_leadership_quorum<S>(
-        mut pending: S,
-        my_vote: VoteOf<C>,
-        eff_mem: Arc<StoredMembershipOf<C>>,
-        mut granted: BTreeSet<NodeIdOf<C>>,
-        core_tx: MpscSenderOf<C, Notification<C>>,
-        resp: Linearizer<C>,
-        tx: ClientReadTx<C>,
-    ) where
-        S: Stream<Item = Result<ProbeResult<C>, (NodeIdOf<C>, JoinErrorOf<C>)>> + Unpin,
-    {
-        // Handle responses as they return.
-        while let Some(res) = pending.next().await {
-            let (target, stream_result) = match res {
-                Ok(Ok(res)) => res,
-                Ok(Err((target, err))) => {
-                    tracing::error!(
-                        "timeout while confirming leadership for read request, target: {}, error: {}",
-                        target,
-                        err
-                    );
-                    continue;
-                }
-                Err((target, err)) => {
-                    tracing::error!("failed to join task: {}, target: {}", err, target);
-                    continue;
-                }
-            };
-
-            // If we receive a response with a greater vote, then revert to follower and abort this
-            // request.
-            if let Err(StreamAppendError::HigherVote(vote)) = stream_result {
-                debug_assert!(
-                    vote.as_ref_vote() > my_vote.as_ref_vote(),
-                    "committed vote({}) has total order relation with other votes({})",
-                    my_vote,
-                    vote
-                );
-
-                let send_res = core_tx
-                    .send(Notification::HigherVote {
-                        target,
-                        higher: vote,
-                        leader_vote: my_vote.to_committed(),
-                    })
-                    .await;
-
-                if let Err(_e) = send_res {
-                    tracing::error!("failed to send HigherVote to RaftCore");
-                }
-
-                // we are no longer leader so error out early
-                let err = ForwardToLeader::empty();
-                tx.send(Err(err.into())).ok();
-                return;
-            }
-
-            // Success or Conflict both confirm leadership (got valid response from follower)
-            granted.insert(target);
-
-            if eff_mem.is_quorum(granted.iter()) {
-                tx.send(Ok(resp)).ok();
-                return;
-            }
+        if linearizer_option.heartbeat_if_quorum_ack_stale {
+            lh.send_heartbeat(true);
         }
 
-        // If we've hit this location, then we've failed to gather needed confirmations due to
-        // request failures.
-
-        tx.send(Err(QuorumNotEnough {
-            cluster: eff_mem.membership().to_string(),
-            got: granted,
-        }
-        .into()))
-            .ok();
+        let deadline = now + wait_timeout;
+        let pending_read = PendingRead::new(deadline, linearizer, tx);
+        self.pending_reads.push(min_quorum_acked_at, pending_read);
+        self.reschedule_pending_read_check();
     }
 
     /// Submit change-membership by writing a Membership log entry.
@@ -745,7 +571,7 @@ where
             return false;
         }
 
-        lh.send_heartbeat();
+        lh.send_heartbeat(false);
 
         // Record heartbeat to external metrics recorder
         if let Some(r) = &self.metrics_recorder {
@@ -1001,6 +827,50 @@ where
         if let Some(submitted) = self.engine.state.log_progress().submitted().cloned() {
             self.io_broadcast.submitted.send_if_greater(submitted);
         }
+
+        self.process_pending_reads();
+    }
+
+    fn process_pending_reads(&mut self) {
+        let now = C::now();
+        let applied = self.engine.state.io_applied().cloned();
+
+        let lh_res = self.engine.try_leader_handler();
+        match lh_res {
+            Ok(lh) => {
+                // Quorum satisfaction takes precedence over a delayed timeout wake-up.
+                let quorum_acked_at = lh.leader.last_quorum_acked_time();
+                if let Some(quorum_acked_at) = quorum_acked_at {
+                    self.pending_reads.drain_satisfied(quorum_acked_at, applied);
+                }
+
+                let leader = &*lh.leader;
+                let make_error = |min_quorum_acked_at| {
+                    let quorum_not_enough = leader.clock_quorum_not_enough(min_quorum_acked_at);
+                    LinearizableReadError::QuorumNotEnough(quorum_not_enough)
+                };
+
+                self.pending_reads.drain_expired(now, make_error);
+            }
+            Err(forward) => {
+                let err = LinearizableReadError::ForwardToLeader(forward);
+                self.pending_reads.drain_all_with_error(err);
+            }
+        }
+
+        self.reschedule_pending_read_check();
+    }
+
+    fn fail_pending_reads(&mut self) {
+        let forward = self.engine.state.forward_to_leader();
+        let err = LinearizableReadError::ForwardToLeader(forward);
+        self.pending_reads.drain_all_with_error(err);
+        self.reschedule_pending_read_check();
+    }
+
+    fn reschedule_pending_read_check(&self) {
+        let deadline = self.pending_reads.earliest_deadline();
+        self.pending_read_deadline_notifier.set_deadline(deadline);
     }
 
     /// Return the current leader node ID based on the committed vote.
@@ -1699,8 +1569,8 @@ where
 
                 self.handle_pre_vote_request(rpc, tx);
             }
-            RaftMsg::GetLinearizer { read_policy, tx } => {
-                self.handle_ensure_linearizable_read(read_policy, tx);
+            RaftMsg::GetLinearizer { linearizer_option, tx } => {
+                self.handle_get_linearizer(linearizer_option, tx);
             }
             RaftMsg::ClientWrite {
                 payloads,
@@ -1976,6 +1846,7 @@ where
             }
 
             Notification::StateMachine { command_result } => self.handle_state_machine_result(command_result)?,
+            Notification::PendingReadDeadlineReached => self.process_pending_reads(),
         };
         Ok(())
     }
@@ -2203,7 +2074,7 @@ where
     ///
     /// This method validates the session and sends heartbeat events only if the current
     /// session matches the requested session (no leader change or membership change).
-    fn broadcast_heartbeat(&mut self, session_id: ReplicationSessionId<C>) {
+    fn broadcast_heartbeat(&mut self, session_id: ReplicationSessionId<C>, bypass_min_interval: bool) {
         // Lazy get the progress data for heartbeat. If the leader changes or replication
         // config changes, no need to send heartbeat.
         let Ok(lh) = self.engine.try_leader_handler() else {
@@ -2228,7 +2099,9 @@ where
             .progress
             .iter()
             .filter(|progress_entry| progress_entry.id != self.id)
-            .filter(|progress_entry| leader.need_heartbeat(&progress_entry.id, now, min_interval))
+            .filter(|progress_entry| {
+                bypass_min_interval || leader.need_heartbeat(&progress_entry.id, now, min_interval)
+            })
             .map(|progress_entry| {
                 (progress_entry.id.clone(), HeartbeatEvent {
                     time: now,
@@ -2603,7 +2476,10 @@ where
             Command::ReplicateCommitted { committed } => {
                 self.io_broadcast.committed.send_if_greater(committed);
             }
-            Command::BroadcastHeartbeat { session_id } => self.broadcast_heartbeat(session_id),
+            Command::BroadcastHeartbeat {
+                session_id,
+                bypass_min_interval,
+            } => self.broadcast_heartbeat(session_id, bypass_min_interval),
             Command::SaveCommittedAndApply { already_applied, upto } => {
                 self.run_save_committed_and_apply(already_applied, upto).await?
             }
@@ -2618,6 +2494,7 @@ where
             } => self.run_replicate_snapshot(leader_vote, target, inflight_id).await,
             Command::BroadcastTransferLeader { req } => self.broadcast_transfer_leader(req).await,
             Command::CloseReplicationStreams => self.run_close_replication_streams(),
+            Command::FailPendingReads => self.fail_pending_reads(),
             Command::RebuildReplicationStreams {
                 leader_vote,
                 targets,

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -17,10 +17,10 @@ use crate::errors::LinearizableReadError;
 use crate::impls::ProgressResponder;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::ClientWriteResult;
-use crate::raft::ReadPolicy;
 use crate::raft::VoteRequest;
 use crate::raft::VoteResponse;
 use crate::raft::linearizable_read::Linearizer;
+use crate::raft::linearizable_read::LinearizerOption;
 use crate::raft::responder::core_responder::CoreResponder;
 use crate::raft::stream_append::StreamAppendResult;
 use crate::type_config::alias::BatchOf;
@@ -82,7 +82,7 @@ where C: RaftTypeConfig
     },
 
     GetLinearizer {
-        read_policy: ReadPolicy,
+        linearizer_option: LinearizerOption,
         tx: ClientReadTx<C>,
     },
 
@@ -168,8 +168,8 @@ where C: RaftTypeConfig
                 write!(f, "RequestPreVote: {}", rpc)
             }
             RaftMsg::ClientWrite { .. } => write!(f, "ClientWrite"),
-            RaftMsg::GetLinearizer { read_policy, .. } => {
-                write!(f, "GetLinearizer: {}", read_policy)
+            RaftMsg::GetLinearizer { linearizer_option, .. } => {
+                write!(f, "GetLinearizer: {}", linearizer_option)
             }
             RaftMsg::Initialize { members, .. } => {
                 write!(f, "Initialize: {}", members.display())

--- a/openraft/src/engine/command.rs
+++ b/openraft/src/engine/command.rs
@@ -72,7 +72,10 @@ where
     ReplicateCommitted { committed: Option<LogIdOf<C>> },
 
     /// Broadcast heartbeat to all other nodes.
-    BroadcastHeartbeat { session_id: ReplicationSessionId<C> },
+    BroadcastHeartbeat {
+        session_id: ReplicationSessionId<C>,
+        bypass_min_interval: bool,
+    },
 
     /// Save the committed log id `upto` to [`RaftLogStorage`].
     ///
@@ -111,6 +114,9 @@ where
 
     /// Close replication streams and heartbeat streams.
     CloseReplicationStreams,
+
+    /// Fail all pending linearizable reads after losing leadership.
+    FailPendingReads,
 
     /// Membership config changed, need to update replication streams.
     /// The Runtime has to close all old replications and start new ones.
@@ -196,8 +202,15 @@ where
             Command::ReplicateCommitted { committed } => {
                 write!(f, "ReplicateCommitted: {}", committed.display())
             }
-            Command::BroadcastHeartbeat { session_id } => {
-                write!(f, "BroadcastHeartbeat: session_id:{}", session_id)
+            Command::BroadcastHeartbeat {
+                session_id,
+                bypass_min_interval,
+            } => {
+                write!(
+                    f,
+                    "BroadcastHeartbeat: session_id:{}, bypass_min_interval:{}",
+                    session_id, bypass_min_interval
+                )
             }
             Command::SaveCommittedAndApply {
                 already_applied: already_committed,
@@ -219,6 +232,7 @@ where
             }
             Command::BroadcastTransferLeader { req } => write!(f, "TransferLeader: {}", req),
             Command::CloseReplicationStreams => write!(f, "CloseReplicationStreams"),
+            Command::FailPendingReads => write!(f, "FailPendingReads"),
             Command::RebuildReplicationStreams {
                 leader_vote,
                 targets,
@@ -267,7 +281,7 @@ where
             (Command::UpdateIOProgress { when, io_id },        Command::UpdateIOProgress { when: wb, io_id: ab }, )                  => when == wb && io_id == ab,
             (Command::AppendEntries { committed_vote: vote, entries },    Command::AppendEntries { committed_vote: vb, entries: b }, )               => vote == vb && entries == b,
             (Command::ReplicateCommitted { committed },        Command::ReplicateCommitted { committed: b }, )                       =>  committed == b,
-            (Command::BroadcastHeartbeat { session_id },       Command::BroadcastHeartbeat { session_id: sb }, )                     => session_id == sb,
+            (Command::BroadcastHeartbeat { session_id, bypass_min_interval },       Command::BroadcastHeartbeat { session_id: sb, bypass_min_interval: ib }, ) => session_id == sb && bypass_min_interval == ib,
             (Command::SaveCommittedAndApply { already_applied: already_committed, upto, },      Command::SaveCommittedAndApply { already_applied: b_committed, upto: b_upto, }, )  => already_committed == b_committed && upto == b_upto,
             (Command::Replicate { target, req },               Command::Replicate { target: b_target, req: other_req, }, )           => target == b_target && req == other_req,
             (Command::BroadcastTransferLeader { req },         Command::BroadcastTransferLeader { req: b, }, )                       => req == b,
@@ -280,6 +294,7 @@ where
             (Command::Respond { when, resp: send },            Command::Respond { when: b_when, resp: b })                           => send == b && when == b_when,
             (Command::StateMachine { command },                Command::StateMachine { command: b })                                 => command == b,
             (Command::CloseReplicationStreams,                 Command::CloseReplicationStreams)                                     => true,
+            (Command::FailPendingReads,                        Command::FailPendingReads)                                            => true,
             (Command::ReplicateSnapshot { leader_vote, target, inflight_id }, Command::ReplicateSnapshot { leader_vote: lb, target: tb, inflight_id: ib }) => leader_vote == lb && target == tb && inflight_id == ib,
 
             // Two different commands are never equal. These arms are spelled out per variant
@@ -295,6 +310,7 @@ where
             (Command::ReplicateSnapshot { .. },         _) => false,
             (Command::BroadcastTransferLeader { .. },   _) => false,
             (Command::CloseReplicationStreams,          _) => false,
+            (Command::FailPendingReads,                 _) => false,
             (Command::RebuildReplicationStreams { .. }, _) => false,
             (Command::SaveVote { .. },                  _) => false,
             (Command::SendVote { .. },                  _) => false,
@@ -325,6 +341,7 @@ where
             Command::ReplicateSnapshot { .. }         => CommandName::ReplicateSnapshot,
             Command::BroadcastTransferLeader { .. }   => CommandName::BroadcastTransferLeader,
             Command::CloseReplicationStreams          => CommandName::CloseReplicationStreams,
+            Command::FailPendingReads                 => CommandName::FailPendingReads,
             Command::RebuildReplicationStreams { .. } => CommandName::RebuildReplicationStreams,
             Command::SaveVote { .. }                  => CommandName::SaveVote,
             Command::SendVote { .. }                  => CommandName::SendVote,
@@ -341,6 +358,7 @@ where
     pub(crate) fn kind(&self) -> CommandKind {
         match self {
             Command::CloseReplicationStreams          => CommandKind::Main,
+            Command::FailPendingReads                 => CommandKind::Main,
             Command::RebuildReplicationStreams { .. } => CommandKind::Main,
             Command::Respond { .. }                   => CommandKind::Respond,
             // Apply is firstly handled by RaftCore, then forwarded to state machine worker.
@@ -371,6 +389,7 @@ where
     pub(crate) fn condition(&self) -> Option<Condition<C>> {
         match self {
             Command::CloseReplicationStreams          => None,
+            Command::FailPendingReads                 => None,
             Command::RebuildReplicationStreams { .. } => None,
             Command::Respond { when, .. }             => when.clone(),
 

--- a/openraft/src/engine/command_name.rs
+++ b/openraft/src/engine/command_name.rs
@@ -28,6 +28,7 @@ pub enum CommandName {
     ReplicateSnapshot,
     BroadcastTransferLeader,
     CloseReplicationStreams,
+    FailPendingReads,
     RebuildReplicationStreams,
     SaveVote,
     SendVote,
@@ -92,6 +93,7 @@ mod tests {
         // BroadcastHeartbeat
         let cmd: Command<C> = Command::BroadcastHeartbeat {
             session_id: ReplicationSessionId::new(cv.clone(), None),
+            bypass_min_interval: false,
         };
         assert_eq!(cmd.name(), CommandName::BroadcastHeartbeat);
 
@@ -129,6 +131,10 @@ mod tests {
         // CloseReplicationStreams
         let cmd: Command<C> = Command::CloseReplicationStreams;
         assert_eq!(cmd.name(), CommandName::CloseReplicationStreams);
+
+        // FailPendingReads
+        let cmd: Command<C> = Command::FailPendingReads;
+        assert_eq!(cmd.name(), CommandName::FailPendingReads);
 
         // RebuildReplicationStreams
         let cmd: Command<C> = Command::RebuildReplicationStreams {
@@ -199,6 +205,7 @@ mod tests {
         assert_eq!(CommandName::ReplicateSnapshot.as_str(), "ReplicateSnapshot");
         assert_eq!(CommandName::BroadcastTransferLeader.as_str(), "BroadcastTransferLeader");
         assert_eq!(CommandName::CloseReplicationStreams.as_str(), "CloseReplicationStreams");
+        assert_eq!(CommandName::FailPendingReads.as_str(), "FailPendingReads");
         assert_eq!(
             CommandName::RebuildReplicationStreams.as_str(),
             "RebuildReplicationStreams"

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -64,7 +64,9 @@ use crate::vote::raft_vote::RaftVoteExt;
 ///
 /// This structure only contains necessary information to run raft algorithm,
 /// but none of the application specific data.
-/// TODO: make the fields private
+///
+/// Fields are crate-visible because `RaftCore` executes this engine's output and advances its
+/// I/O progress. Protocol state transitions should still go through `Engine` or its handlers.
 #[derive(Debug)]
 pub(crate) struct Engine<C, SM = ()>
 where

--- a/openraft/src/engine/engine_output.rs
+++ b/openraft/src/engine/engine_output.rs
@@ -59,6 +59,11 @@ where
         self.commands.push_back(cmd)
     }
 
+    pub(crate) fn prepend_command(&mut self, cmd: Command<C, SM>) {
+        tracing::debug!("push front command: {:?}", cmd);
+        self.commands.push_front(cmd)
+    }
+
     /// Put the command to the head of the queue or to a separate pending queue.
     ///
     /// This will be used when the command is not ready to be executed.

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -128,11 +128,14 @@ where
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn send_heartbeat(&mut self) {
+    pub(crate) fn send_heartbeat(&mut self, bypass_min_interval: bool) {
         let membership_log_id = self.state.membership_state.effective().log_id();
         let session_id = ReplicationSessionId::new(self.leader.committed_vote.clone(), membership_log_id.clone());
 
-        self.output.push_command(Command::BroadcastHeartbeat { session_id });
+        self.output.push_command(Command::BroadcastHeartbeat {
+            session_id,
+            bypass_min_interval,
+        });
     }
 
     /// Get the log id for a linearizable read.

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -55,12 +55,13 @@ fn test_leader_send_heartbeat() -> anyhow::Result<()> {
 
     // A heartbeat is a normal AppendEntries RPC if there are pending data to send.
     {
-        eng.try_leader_handler()?.send_heartbeat();
+        eng.try_leader_handler()?.send_heartbeat(false);
         assert_eq!(
             vec![
                 //
                 Command::BroadcastHeartbeat {
                     session_id: ReplicationSessionId::new(Vote::new(3, 1).to_committed(), Some(log_id(2, 1, 3))),
+                    bypass_min_interval: false,
                 },
             ],
             eng.output.take_commands()
@@ -70,12 +71,13 @@ fn test_leader_send_heartbeat() -> anyhow::Result<()> {
     // Heartbeat will be resent
     {
         eng.output.clear_commands();
-        eng.try_leader_handler()?.send_heartbeat();
+        eng.try_leader_handler()?.send_heartbeat(false);
         assert_eq!(
             vec![
                 //
                 Command::BroadcastHeartbeat {
                     session_id: ReplicationSessionId::new(Vote::new(3, 1).to_committed(), Some(log_id(2, 1, 3))),
+                    bypass_min_interval: false,
                 },
             ],
             eng.output.take_commands()

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -84,6 +84,7 @@ fn test_accept_vote_granted_greater_vote() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![
+            Command::FailPendingReads,
             Command::SaveVote { vote: Vote::new(3, 3) },
             Command::CloseReplicationStreams,
         ],

--- a/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
@@ -87,6 +87,7 @@ fn test_handle_message_vote_committed_vote() -> anyhow::Result<()> {
     assert!(eng.state.vote_last_modified() <= Some(now + Duration::from_millis(20)));
     assert_eq!(
         vec![
+            Command::FailPendingReads,
             Command::SaveVote {
                 vote: Vote::new_committed(3, 2)
             },
@@ -118,7 +119,10 @@ fn test_handle_message_vote_granted_equal_vote() -> anyhow::Result<()> {
     assert!(Some(now) <= eng.state.vote_last_modified());
     assert!(eng.state.vote_last_modified() <= Some(now + Duration::from_millis(20)));
 
-    assert_eq!(vec![Command::CloseReplicationStreams], eng.output.take_commands());
+    assert_eq!(
+        vec![Command::FailPendingReads, Command::CloseReplicationStreams,],
+        eng.output.take_commands()
+    );
     Ok(())
 }
 
@@ -139,6 +143,7 @@ fn test_handle_message_vote_granted_greater_vote() -> anyhow::Result<()> {
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
         vec![
+            Command::FailPendingReads,
             Command::SaveVote { vote: Vote::new(3, 1) },
             Command::CloseReplicationStreams,
         ],
@@ -168,6 +173,7 @@ fn test_handle_message_vote_granted_follower_learner_does_not_emit_update_server
         assert_eq!(st, eng.state.server_state);
         assert_eq!(
             vec![
+                Command::FailPendingReads,
                 Command::SaveVote { vote: Vote::new(3, 1) },
                 Command::CloseReplicationStreams,
             ],
@@ -191,6 +197,7 @@ fn test_handle_message_vote_granted_follower_learner_does_not_emit_update_server
         assert_eq!(st, eng.state.server_state);
         assert_eq!(
             vec![
+                Command::FailPendingReads,
                 Command::SaveVote { vote: Vote::new(3, 1) },
                 Command::CloseReplicationStreams,
             ],

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -248,6 +248,7 @@ where
         *self.candidate = None;
         *self.pre_candidate = None;
 
+        self.output.prepend_command(Command::FailPendingReads);
         self.output.push_command(Command::CloseReplicationStreams);
 
         self.server_state_handler().update_server_state_if_changed();

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -126,6 +126,7 @@ fn test_append_entries_prev_log_id_is_applied() -> anyhow::Result<()> {
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
         vec![
+            Command::FailPendingReads,
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
@@ -178,6 +179,7 @@ fn test_append_entries_prev_log_id_conflict() -> anyhow::Result<()> {
     assert_eq!(ServerState::Learner, eng.state.server_state);
     assert_eq!(
         vec![
+            Command::FailPendingReads,
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
@@ -225,6 +227,7 @@ fn test_append_entries_prev_log_id_is_committed() -> anyhow::Result<()> {
     assert_eq!(ServerState::Learner, eng.state.server_state);
     assert_eq!(
         vec![
+            Command::FailPendingReads,
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
@@ -284,6 +287,7 @@ fn test_append_entries_prev_log_id_not_exists() -> anyhow::Result<()> {
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
         vec![
+            Command::FailPendingReads,
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
@@ -333,6 +337,7 @@ fn test_append_entries_conflict() -> anyhow::Result<()> {
     assert_eq!(ServerState::Learner, eng.state.server_state);
     assert_eq!(
         vec![
+            Command::FailPendingReads,
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },

--- a/openraft/src/engine/tests/handle_pre_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_pre_vote_resp_test.rs
@@ -164,6 +164,7 @@ fn test_handle_pre_vote_resp_reject_adopts_higher_vote() -> anyhow::Result<()> {
 
     assert_eq!(
         vec![
+            Command::FailPendingReads,
             Command::SaveVote { vote: Vote::new(10, 2) },
             Command::CloseReplicationStreams,
         ],

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -94,6 +94,7 @@ fn test_handle_vote_req_leadership_transfer_overrides_leader_lease() -> anyhow::
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
         vec![
+            Command::FailPendingReads,
             Command::SaveVote { vote: Vote::new(3, 2) },
             Command::CloseReplicationStreams,
         ],
@@ -170,7 +171,10 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
     assert!(eng.leader.is_none());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
-    assert_eq!(vec![Command::CloseReplicationStreams], eng.output.take_commands());
+    assert_eq!(
+        vec![Command::FailPendingReads, Command::CloseReplicationStreams,],
+        eng.output.take_commands()
+    );
     Ok(())
 }
 
@@ -200,6 +204,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
         vec![
+            Command::FailPendingReads,
             Command::SaveVote { vote: Vote::new(3, 1) },
             Command::CloseReplicationStreams,
         ],
@@ -231,6 +236,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
         assert_eq!(st, eng.state.server_state);
         assert_eq!(
             vec![
+                Command::FailPendingReads,
                 Command::SaveVote { vote: Vote::new(3, 1) },
                 Command::CloseReplicationStreams,
             ],
@@ -256,6 +262,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
         assert_eq!(st, eng.state.server_state);
         assert_eq!(
             vec![
+                Command::FailPendingReads,
                 Command::SaveVote { vote: Vote::new(3, 1) },
                 Command::CloseReplicationStreams,
             ],

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -130,6 +130,7 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         assert_eq!(
             eng.output.take_commands(),
             vec![
+                Command::FailPendingReads,
                 Command::SaveVote { vote: Vote::new(3, 2) },
                 Command::CloseReplicationStreams,
             ],

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -89,10 +89,14 @@ fn test_handle_install_full_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
 
     let (dummy_tx, _rx) = UTConfig::<()>::oneshot();
     assert_eq!(
-        vec![Command::CloseReplicationStreams, Command::Respond {
-            when: None,
-            resp: Respond::new(SnapshotResponse::new(curr_vote), dummy_tx),
-        },],
+        vec![
+            Command::FailPendingReads,
+            Command::CloseReplicationStreams,
+            Command::Respond {
+                when: None,
+                resp: Respond::new(SnapshotResponse::new(curr_vote), dummy_tx),
+            },
+        ],
         eng.output.take_commands()
     );
 
@@ -133,6 +137,7 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
     let (dummy_tx, _rx) = UTConfig::<()>::oneshot();
     assert_eq!(
         vec![
+            Command::FailPendingReads,
             Command::CloseReplicationStreams,
             Command::from(sm::Command::install_full_snapshot(
                 SnapshotOf::<UTConfig, ()> {

--- a/openraft/src/engine/tests/refresh_server_state_test.rs
+++ b/openraft/src/engine/tests/refresh_server_state_test.rs
@@ -107,7 +107,10 @@ fn test_refresh_server_state_removed_leader_uncommitted_membership() -> anyhow::
 
     assert!(eng.leader.is_none());
     assert_eq!(ServerState::Learner, eng.state.server_state);
-    assert_eq!(vec![Command::CloseReplicationStreams], eng.output.take_commands());
+    assert_eq!(
+        vec![Command::FailPendingReads, Command::CloseReplicationStreams,],
+        eng.output.take_commands()
+    );
 
     Ok(())
 }
@@ -121,7 +124,10 @@ fn test_refresh_server_state_removed_leader_committed_membership() -> anyhow::Re
 
     assert!(eng.leader.is_none());
     assert_eq!(ServerState::Learner, eng.state.server_state);
-    assert_eq!(vec![Command::CloseReplicationStreams], eng.output.take_commands());
+    assert_eq!(
+        vec![Command::FailPendingReads, Command::CloseReplicationStreams,],
+        eng.output.take_commands()
+    );
 
     Ok(())
 }

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -146,6 +146,7 @@ pub use crate::node::NodeInfo;
 pub use crate::raft::Raft;
 pub use crate::raft::ReadPolicy;
 pub use crate::raft::WatchChangeHandle;
+pub use crate::raft::linearizable_read::LinearizerOption;
 pub use crate::raft_state::MembershipState;
 pub use crate::raft_state::RaftState;
 pub use crate::raft_types::SnapshotId;

--- a/openraft/src/progress/vec_progress.rs
+++ b/openraft/src/progress/vec_progress.rs
@@ -402,6 +402,10 @@ where
         new_prog
     }
 
+    pub(crate) fn quorum_set(&self) -> &QS {
+        &self.quorum_set
+    }
+
     /// Replace the entry for the same ID and update quorum-accepted progress.
     fn replace(&mut self, entry: Entry) -> Result<&Entry::Progress, &Entry::Progress> {
         self.stat.update_count += 1;

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fmt;
 use std::time::Duration;
 
@@ -5,6 +6,7 @@ use crate::LogIdOptionExt;
 use crate::RaftTypeConfig;
 use crate::base::shared_id_generator::SharedIdGenerator;
 use crate::engine::leader_log_ids::LeaderLogIds;
+use crate::errors::QuorumNotEnough;
 use crate::progress::VecProgress;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::id_val::IdVal;
@@ -216,6 +218,36 @@ where
         *self.clock_progress.quorum_accepted()
     }
 
+    /// Report the clock progress as a [`QuorumNotEnough`] error.
+    ///
+    /// The reported `got` set names the voters whose last acknowledged RPC was sent after
+    /// `min_acked_at`, so the caller can see how far the clock is from a quorum. Learners are left
+    /// out because they never grant a value. This leader is always included when it is a voter: it
+    /// grants its own RPCs, while [`Self::update_clock`] records that grant only once a follower
+    /// responds.
+    pub(crate) fn clock_quorum_not_enough(&self, min_acked_at: InstantOf<C>) -> QuorumNotEnough<C>
+    where QS: fmt::Display {
+        let voter_count = self.clock_progress.voter_count();
+
+        let mut got: BTreeSet<C::NodeId> = self
+            .clock_progress
+            .iter()
+            .take(voter_count)
+            .filter(|entry| entry.val.is_some_and(|acked_at| acked_at > min_acked_at))
+            .map(|entry| entry.id.clone())
+            .collect();
+
+        let leader_node_id = self.committed_vote.to_leader_node_id();
+        if self.clock_progress.is_voter(&leader_node_id) == Some(true) {
+            got.insert(leader_node_id);
+        }
+
+        QuorumNotEnough {
+            cluster: self.clock_progress.quorum_set().to_string(),
+            got,
+        }
+    }
+
     /// Return whether this leader's lease is valid.
     pub(crate) fn is_lease_valid(&self, leader_lease: Duration) -> bool {
         if self.is_self_quorum() {
@@ -273,10 +305,12 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::sync::Arc;
     use std::time::Duration;
 
     use maplit::btreeset;
 
+    use crate::Membership;
     use crate::Vote;
     use crate::base::shared_id_generator::SharedIdGenerator;
     use crate::engine::leader_log_ids::LeaderLogIds;
@@ -466,6 +500,47 @@ mod tests {
         leading.update_clock(&3, t3);
         let t = leading.last_quorum_acked_time();
         assert_eq!(Some(t2), t, "n2 and n3 acked");
+    }
+
+    #[test]
+    fn test_clock_quorum_not_enough() {
+        // Voters {1,2,3} with learner {4}; node 1 is the leader.
+        let membership = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1, 2, 3}], [4]);
+        let quorum_set = Arc::new(membership);
+        let mut leading = Leader::<UTConfig, _>::new(
+            Vote::new(2, 1).to_committed(),
+            quorum_set.clone(),
+            [4],
+            None,
+            SharedIdGenerator::new(),
+        );
+
+        let t1 = UTConfig::<()>::now();
+        let t2 = t1 + Duration::from_millis(10);
+
+        let err = leading.clock_quorum_not_enough(t1);
+        assert_eq!(
+            btreeset! {1},
+            err.got,
+            "the leader grants its own RPCs before any response"
+        );
+        assert_eq!(quorum_set.to_string(), err.cluster);
+
+        leading.update_clock(&2, t1);
+        let err = leading.clock_quorum_not_enough(t1);
+        assert_eq!(btreeset! {1}, err.got, "an RPC sent at t1 is not newer than t1");
+
+        leading.update_clock(&2, t2);
+        let err = leading.clock_quorum_not_enough(t1);
+        assert_eq!(btreeset! {1, 2}, err.got, "n2 acked an RPC sent after t1");
+
+        leading.update_clock(&4, t2);
+        let err = leading.clock_quorum_not_enough(t2);
+        assert_eq!(
+            btreeset! {1},
+            err.got,
+            "learner n4 is not counted, and n2's ack is too old"
+        );
     }
 
     #[test]

--- a/openraft/src/raft/api/app.rs
+++ b/openraft/src/raft/api/app.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use openraft_macros::since;
 
 use crate::RaftTypeConfig;
-use crate::ReadPolicy;
 use crate::base::BoxStream;
 use crate::batch::Batch;
 use crate::core::raft_msg::RaftMsg;
@@ -14,6 +13,7 @@ use crate::impls::ProgressResponder;
 use crate::raft::ClientWriteResponse;
 use crate::raft::ClientWriteResult;
 use crate::raft::linearizable_read::Linearizer;
+use crate::raft::linearizable_read::LinearizerOption;
 use crate::raft::message::WriteResult;
 use crate::raft::message::into_write_result;
 use crate::raft::raft_inner::RaftInner;
@@ -48,9 +48,9 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn get_read_linearizer(
         &self,
-        read_policy: ReadPolicy,
+        linearizer_option: LinearizerOption,
     ) -> Result<Result<Linearizer<C>, LinearizableReadError<C>>, Fatal<C>> {
-        self.inner.call_core_oneshot(|tx| RaftMsg::GetLinearizer { read_policy, tx }).await
+        self.inner.call_core_oneshot(|tx| RaftMsg::GetLinearizer { linearizer_option, tx }).await
     }
 
     #[since(version = "0.10.0")]

--- a/openraft/src/raft/linearizable_read/linearizer.rs
+++ b/openraft/src/raft/linearizable_read/linearizer.rs
@@ -58,6 +58,17 @@ where C: RaftTypeConfig
         }
     }
 
+    /// Replace the last applied log id this linearizer reports.
+    ///
+    /// A queued read observes the applied log id when it is created, which may lag by a heartbeat
+    /// round when the read is finally answered. Refreshing it lets the caller skip waiting for
+    /// apply progress the leader has already made.
+    pub(crate) fn with_applied(self, applied: Option<LogIdOf<C>>) -> Self {
+        let node_id = self.state.node_id().clone();
+        let state = self.state.with_applied(node_id, applied);
+        Self { state }
+    }
+
     /// Waits indefinitely for the state machine to apply all required log entries for linearizable
     /// reads.
     ///

--- a/openraft/src/raft/linearizable_read/linearizer_option.rs
+++ b/openraft/src/raft/linearizable_read/linearizer_option.rs
@@ -1,0 +1,182 @@
+use std::fmt;
+use std::time::Duration;
+
+use openraft_macros::since;
+
+use crate::raft::ReadPolicy;
+
+/// Configures the quorum-acknowledgement requirement used to obtain a [`Linearizer`].
+///
+/// A read may proceed when the leader has an acknowledgement from a quorum for RPCs sent at
+/// `quorum_acked_at` and:
+///
+/// ```text
+/// requested_at < quorum_acked_at + effective_max_quorum_ack_age
+/// ```
+///
+/// `effective_max_quorum_ack_age` is `max_quorum_ack_age` capped at the configured leader lease, or
+/// the leader lease when `max_quorum_ack_age` is absent. A zero duration requires a quorum to
+/// acknowledge an RPC sent after `requested_at`, as in ReadIndex. A nonzero duration allows a
+/// recent quorum acknowledgement to be reused as a leader lease.
+///
+/// `heartbeat_if_quorum_ack_stale` controls whether [`RaftCore`] immediately broadcasts heartbeats
+/// when the recorded acknowledgement is missing or reaches the effective age limit. It does not
+/// control whether the read waits: a stale read may also be satisfied by a periodic heartbeat or
+/// replication acknowledgement.
+///
+/// `wait_timeout` bounds how long such a read waits for a qualifying acknowledgement. The leader
+/// lease bounds `max_quorum_ack_age` only; it is the default wait, not a limit on it.
+///
+/// [`RaftCore`]: crate::core::RaftCore
+#[since(version = "0.10.0", change = "renamed from `LinearizableReadRequest`")]
+#[since(version = "0.10.0")]
+#[derive(Debug, Clone)]
+pub struct LinearizerOption {
+    /// The maximum age of a quorum acknowledgement accepted by this read.
+    ///
+    /// If the latest quorum-acknowledged RPC was sent at `quorum_acked_at`, the read may proceed
+    /// when `requested_at < quorum_acked_at + max_quorum_ack_age`.
+    ///
+    /// `None` uses the configured leader lease. `Some(duration)` overrides that value for this read
+    /// and is capped at the configured leader lease. `Some(Duration::ZERO)` requires a quorum
+    /// acknowledgement for an RPC sent after `requested_at`.
+    pub(crate) max_quorum_ack_age: Option<Duration>,
+
+    /// Whether to broadcast heartbeats immediately when the latest quorum acknowledgement is
+    /// missing or reaches the effective maximum age.
+    pub(crate) heartbeat_if_quorum_ack_stale: bool,
+
+    /// The maximum time this read waits for a qualifying quorum acknowledgement.
+    ///
+    /// The wait applies only to a read that cannot be answered from the recorded acknowledgement.
+    /// `None` uses the configured leader lease.
+    /// `Some(Duration::ZERO)` fails the read at once instead of queueing it.
+    ///
+    /// The wait starts when [`RaftCore`] begins handling the request rather than when the caller
+    /// submits it, and it has no upper bound: a large value keeps the read in [`RaftCore`] memory
+    /// until it elapses.
+    ///
+    /// [`RaftCore`]: crate::core::RaftCore
+    pub(crate) wait_timeout: Option<Duration>,
+}
+
+impl fmt::Display for LinearizerOption {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "LinearizerOption {{ max_quorum_ack_age: {:?}, heartbeat_if_quorum_ack_stale: {}, wait_timeout: {:?} }}",
+            self.max_quorum_ack_age, self.heartbeat_if_quorum_ack_stale, self.wait_timeout
+        )
+    }
+}
+
+impl LinearizerOption {
+    /// Creates a linearizer option.
+    ///
+    /// `max_quorum_ack_age` is the maximum age of a quorum acknowledgement accepted by this read.
+    /// `None` uses the configured leader lease. Values exceeding the leader lease are capped at
+    /// the leader lease when the option is handled.
+    ///
+    /// If `heartbeat_if_quorum_ack_stale` is `true`, the leader immediately broadcasts heartbeats
+    /// when its latest quorum acknowledgement is too old for this read. Otherwise, the read waits
+    /// for a periodic heartbeat or replication acknowledgement without initiating one.
+    #[since(version = "0.10.0")]
+    pub fn new(max_quorum_ack_age: Option<Duration>, heartbeat_if_quorum_ack_stale: bool) -> Self {
+        Self {
+            max_quorum_ack_age,
+            heartbeat_if_quorum_ack_stale,
+            wait_timeout: None,
+        }
+    }
+
+    /// Sets how long this read waits for a qualifying quorum acknowledgement.
+    ///
+    /// The wait applies only to a read that needs a newer quorum acknowledgement, and it replaces
+    /// the default wait of one leader lease. `Duration::ZERO` fails such a read at once instead of
+    /// queueing it. The value is not capped, so a long wait keeps the read in memory on the leader
+    /// until it elapses or the leader steps down.
+    #[since(version = "0.10.0")]
+    pub fn with_wait_timeout(mut self, wait_timeout: Duration) -> Self {
+        self.wait_timeout = Some(wait_timeout);
+        self
+    }
+
+    pub(crate) fn effective_max_quorum_ack_age(&self, leader_lease: Duration) -> Duration {
+        let requested_age = self.max_quorum_ack_age.unwrap_or(leader_lease);
+        requested_age.min(leader_lease)
+    }
+
+    pub(crate) fn effective_wait_timeout(&self, leader_lease: Duration) -> Duration {
+        self.wait_timeout.unwrap_or(leader_lease)
+    }
+
+    pub(crate) fn from_read_policy(read_policy: ReadPolicy) -> Self {
+        match read_policy {
+            ReadPolicy::LeaseRead => Self::new(None, false).with_wait_timeout(Duration::ZERO),
+            ReadPolicy::ReadIndex => Self::new(Some(Duration::ZERO), true),
+        }
+    }
+}
+
+impl From<ReadPolicy> for LinearizerOption {
+    fn from(read_policy: ReadPolicy) -> Self {
+        Self::from_read_policy(read_policy)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_effective_max_quorum_ack_age() {
+        let leader_lease = Duration::from_millis(500);
+        let cases = [
+            (None, leader_lease),
+            (Some(Duration::ZERO), Duration::ZERO),
+            (Some(Duration::from_millis(300)), Duration::from_millis(300)),
+            (Some(leader_lease), leader_lease),
+            (Some(Duration::from_millis(700)), leader_lease),
+        ];
+
+        for (max_quorum_ack_age, want) in cases {
+            let linearizer_option = LinearizerOption::new(max_quorum_ack_age, false);
+            let got = linearizer_option.effective_max_quorum_ack_age(leader_lease);
+            assert_eq!(want, got);
+        }
+    }
+
+    /// Unlike the acknowledgement age, the wait timeout is not capped at the leader lease.
+    #[test]
+    fn test_effective_wait_timeout() {
+        let leader_lease = Duration::from_millis(500);
+        let cases = [
+            (None, leader_lease),
+            (Some(Duration::ZERO), Duration::ZERO),
+            (Some(Duration::from_millis(300)), Duration::from_millis(300)),
+            (Some(Duration::from_millis(700)), Duration::from_millis(700)),
+        ];
+
+        for (wait_timeout, want) in cases {
+            let mut linearizer_option = LinearizerOption::new(None, false);
+            if let Some(wait_timeout) = wait_timeout {
+                linearizer_option = linearizer_option.with_wait_timeout(wait_timeout);
+            }
+            let got = linearizer_option.effective_wait_timeout(leader_lease);
+            assert_eq!(want, got);
+        }
+    }
+
+    #[test]
+    fn test_from_read_policy() {
+        let lease_read = LinearizerOption::from_read_policy(ReadPolicy::LeaseRead);
+        assert_eq!(None, lease_read.max_quorum_ack_age);
+        assert!(!lease_read.heartbeat_if_quorum_ack_stale);
+        assert_eq!(Some(Duration::ZERO), lease_read.wait_timeout);
+
+        let read_index = LinearizerOption::from_read_policy(ReadPolicy::ReadIndex);
+        assert_eq!(Some(Duration::ZERO), read_index.max_quorum_ack_age);
+        assert!(read_index.heartbeat_if_quorum_ack_stale);
+        assert_eq!(None, read_index.wait_timeout);
+    }
+}

--- a/openraft/src/raft/linearizable_read/mod.rs
+++ b/openraft/src/raft/linearizable_read/mod.rs
@@ -2,8 +2,10 @@
 
 mod linearize_state;
 mod linearizer;
+mod linearizer_option;
 mod read_log_id;
 
 pub use linearize_state::LinearizeState;
 pub use linearizer::Linearizer;
+pub use linearizer_option::LinearizerOption;
 pub use read_log_id::ReadLogId;

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -38,6 +38,7 @@ use core_state::CoreState;
 use derive_more::Display;
 use futures_util::FutureExt;
 use linearizable_read::Linearizer;
+use linearizable_read::LinearizerOption;
 use linearizable_read::ReadLogId;
 pub use message::AppendEntriesRequest;
 pub use message::AppendEntriesResponse;
@@ -85,6 +86,8 @@ use crate::config::RuntimeConfig;
 use crate::core::ClientResponderQueue;
 use crate::core::IoBroadcast;
 use crate::core::MetricsChannels;
+use crate::core::PendingReadDeadlineNotifier;
+use crate::core::PendingReadQueue;
 use crate::core::RaftCore;
 use crate::core::SharedReplicateBatch;
 use crate::core::StepDownWatcher;
@@ -250,6 +253,7 @@ pub enum ReadPolicy {
     /// With `LeaseRead`, the leader can serve reads locally without contacting followers
     /// as long as it believes its leadership lease is still valid. This provides better
     /// performance compared to `ReadIndex` but assumes clock drift between nodes is negligible.
+    /// It returns an error immediately when the lease is stale.
     ///
     /// Note: This offers slightly weaker consistency guarantees than `ReadIndex` in exchange
     /// for lower latency.
@@ -556,6 +560,8 @@ where
             // initially, allocate for 8 kilo outstanding requests.
             client_responders: ClientResponderQueue::with_capacity(1024 * 8),
 
+            pending_reads: PendingReadQueue::default(),
+            pending_read_deadline_notifier: PendingReadDeadlineNotifier::spawn(tx_notify.clone()),
             replications: Default::default(),
 
             heartbeat_handle: HeartbeatWorkersHandle::new(id.clone(), config.clone()),
@@ -1049,7 +1055,7 @@ where
     }
 
     /// Ensures reads performed after this method are linearizable across the cluster
-    /// using an explicitly provided policy. This method is just a shorthand for calling
+    /// using explicitly provided options. This method is just a shorthand for calling
     /// [`get_read_log_id()`](Raft::get_read_log_id) and then calling [Raft::wait].
     ///
     /// This method is just a shorthand for combining calling
@@ -1063,7 +1069,8 @@ where
     /// To support follower read, i.e., get `read_log_id` on a remote leader then read on local
     /// state machine, see [`Raft::get_read_linearizer`].
     ///
-    /// The `read_policy` defines the policy to ensure leadership. See: [`ReadPolicy`].
+    /// The option defines how to ensure leadership. It may be a [`LinearizerOption`] or a
+    /// [`ReadPolicy`], which is converted into one.
     ///
     /// Returns:
     /// - `Ok(read_log_id)` on successful confirmation that the node is the leader. `read_log_id`
@@ -1082,14 +1089,18 @@ where
     /// // Then proceed with the state machine read
     /// ```
     /// Read more about how it works: [Read Operation](crate::docs::protocol::read)
+    #[since(
+        version = "0.10.0",
+        change = "accept `impl Into<LinearizerOption>` instead of `ReadPolicy`"
+    )]
     #[since(version = "0.10.0", change = "return ReadLogId instead of Option<LogId>")]
     #[since(version = "0.9.0")]
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn ensure_linearizable(
         &self,
-        read_policy: ReadPolicy,
+        linearizer_option: impl Into<LinearizerOption>,
     ) -> Result<ReadLogId<C>, RaftError<C, LinearizableReadError<C>>> {
-        let linearizer = self.app_api().get_read_linearizer(read_policy).await.into_raft_result()?;
+        let linearizer = self.app_api().get_read_linearizer(linearizer_option.into()).await.into_raft_result()?;
 
         // Safe unwrap: it never times out.
         let state = linearizer.await_ready(self).await?;
@@ -1108,14 +1119,18 @@ where
     /// **For new code, use [`Raft::get_read_linearizer`]** which provides a better API.
     ///
     /// See [`Raft::get_read_linearizer`] for full documentation.
+    #[since(
+        version = "0.10.0",
+        change = "accept `impl Into<LinearizerOption>` instead of `ReadPolicy`"
+    )]
     #[since(version = "0.10.0", change = "return ReadLogId instead of Option<LogId>")]
     #[since(version = "0.9.0")]
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn get_read_log_id(
         &self,
-        read_policy: ReadPolicy,
+        linearizer_option: impl Into<LinearizerOption>,
     ) -> Result<(ReadLogId<C>, Option<LogIdOf<C>>), RaftError<C, LinearizableReadError<C>>> {
-        let linearizer = self.app_api().get_read_linearizer(read_policy).await.into_raft_result()?;
+        let linearizer = self.app_api().get_read_linearizer(linearizer_option.into()).await.into_raft_result()?;
 
         let read_log_id = linearizer.read_log_id();
         let applied = linearizer.applied();
@@ -1127,7 +1142,8 @@ where
     ///
     /// This method confirms leadership and provides the necessary information to linearize reads
     /// across the cluster. The leadership is ensured by sending heartbeats or by lease according
-    /// to the specified policy. See: [`ReadPolicy`].
+    /// to the specified [`LinearizerOption`]. [`ReadPolicy`] is also accepted and converted into
+    /// an option.
     ///
     /// Returns:
     /// - `Ok(Linearizer<C>)` on successful confirmation that the node is the leader. The
@@ -1167,13 +1183,18 @@ where
     /// ```
     ///
     /// See: [Read Operation](crate::docs::protocol::read)
+    #[since(
+        version = "0.10.0",
+        change = "accept `impl Into<LinearizerOption>` instead of `ReadPolicy`"
+    )]
     #[since(version = "0.10.0")]
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn get_read_linearizer(
         &self,
-        read_policy: ReadPolicy,
+        linearizer_option: impl Into<LinearizerOption>,
     ) -> Result<Linearizer<C>, RaftError<C, LinearizableReadError<C>>> {
-        self.app_api().get_read_linearizer(read_policy).await.into_raft_result()
+        let linearizer_option = linearizer_option.into();
+        self.app_api().get_read_linearizer(linearizer_option).await.into_raft_result()
     }
 
     /// Submit a mutating client request to Raft to update the state of the system (§5.1).

--- a/openraft/src/runtime/mod.rs
+++ b/openraft/src/runtime/mod.rs
@@ -16,48 +16,9 @@ use crate::storage::RaftStateMachine;
 ///
 /// A `RaftRuntime` talks to `RaftLogStorage` and `RaftNetworkV2` to get things done.
 ///
-/// The workflow of writing something through raft protocol with engine and runtime would be like
-/// this:
+/// See the [Engine and Runtime Architecture guide] for the write flow and command/event loop.
 ///
-/// ```text
-/// Client                    Engine                         Runtime      Storage      Network
-///   |                         |      write x=1                |            |            |
-///   |-------------------------------------------------------->|            |            |
-///   |        event:write      |                               |            |            |
-///   |        .------------------------------------------------|            |            |
-///   |        '--------------->|                               |            |            |
-///   |                         |      cmd:append-log-1         |            |            |
-///   |                         |--+--------------------------->|   append   |            |
-///   |                         |  |                            |----------->|            |
-///   |                         |  |                            |<-----------|            |
-///   |                         |  |   cmd:replicate-log-1      |   ok       |            |
-///   |                         |  '--------------------------->|            |            |
-///   |                         |                               |            |   send     |
-///   |                         |                               |------------------------>|
-///   |                         |                               |            |   send     |
-///   |                         |                               |------------------------>|
-///   |                         |                               |            |            |
-///   |                         |                               |<------------------------|
-///   |         event:ok        |                               |   ok       |            |
-///   |        .------------------------------------------------|            |            |
-///   |        '--------------->|                               |            |            |
-///   |                         |                               |<------------------------|
-///   |         event:ok        |                               |   ok       |            |
-///   |        .------------------------------------------------|            |            |
-///   |        '--------------->|                               |            |            |
-///   |                         |     cmd:commit-log-1          |            |            |
-///   |                         |------------------------------>|            |            |
-///   |                         |     cmd:apply-log-1           |            |            |
-///   |                         |------------------------------>|            |            |
-///   |                         |                               |   apply    |            |
-///   |                         |                               |----------->|            |
-///   |                         |                               |<-----------|            |
-///   |                         |                               |   ok       |            |
-///   |<--------------------------------------------------------|            |            |
-///   |        response         |                               |            |            |
-/// ```
-///
-/// TODO: add this diagram to guides/
+/// [Engine and Runtime Architecture guide]: crate::docs::components::engine_runtime
 #[add_async_trait]
 pub(crate) trait RaftRuntime<C, SM = ()>
 where

--- a/tests/tests/client_api/t11_client_reads.rs
+++ b/tests/tests/client_api/t11_client_reads.rs
@@ -1,5 +1,7 @@
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use anyhow::Result;
 use maplit::btreeset;
@@ -10,8 +12,11 @@ use openraft::ReadPolicy;
 use openraft::ServerState;
 use openraft::async_runtime::WatchReceiver;
 use openraft::base::BoxFuture;
+use openraft::errors::LinearizableReadError;
 use openraft::errors::NetworkError;
 use openraft::errors::RPCError;
+use openraft::errors::RaftError;
+use openraft::raft::linearizable_read::LinearizerOption;
 use openraft::type_config::TypeConfigExt;
 use openraft::vote::RaftLeaderId;
 use openraft_memstore::TypeConfig;
@@ -43,7 +48,7 @@ async fn client_reads() -> Result<()> {
     router.network_send_delay(0);
 
     tracing::info!("--- initializing cluster");
-    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+    let log_index = router.new_cluster(btreeset! {0,1,2,3}, btreeset! {}).await?;
 
     // Get the ID of the leader, and assert that ensure_linearizable succeeds.
     let leader = router.leader().expect("leader not found");
@@ -61,6 +66,10 @@ async fn client_reads() -> Result<()> {
         .ensure_linearizable(2, ReadPolicy::ReadIndex)
         .await
         .expect_err("ensure_linearizable on follower node 2 to fail");
+    router
+        .ensure_linearizable(3, ReadPolicy::ReadIndex)
+        .await
+        .expect_err("ensure_linearizable on follower node 3 to fail");
 
     tracing::info!(log_index, "--- isolate node 1 then ensure_linearizable should work");
 
@@ -69,11 +78,24 @@ async fn client_reads() -> Result<()> {
 
     tracing::info!(log_index, "--- isolate node 2 then ensure_linearizable should fail");
 
-    router.set_network_error(2, true);
-    let rst = router.ensure_linearizable(leader, ReadPolicy::ReadIndex).await;
-    tracing::debug!(?rst, "ensure_linearizable with majority down");
+    for node_id in 0..4 {
+        let node = router.get_raft_handle(&node_id)?;
+        node.runtime_config().tick(false);
+    }
+    TypeConfig::sleep(Duration::from_millis(config.election_timeout_max)).await;
 
-    assert!(rst.is_err());
+    router.set_network_error(2, true);
+    let read_future = router.get_read_log_id(leader, ReadPolicy::ReadIndex);
+    let result = TypeConfig::timeout(Duration::from_secs(2), read_future)
+        .await
+        .expect("pending read deadline should wake RaftCore without ticks");
+    tracing::debug!(?result, "ensure_linearizable with majority down");
+
+    let err = result.unwrap_err();
+    let LinearizableReadError::QuorumNotEnough(err) = err else {
+        panic!("expected QuorumNotEnough");
+    };
+    assert_eq!(btreeset! {0, 3}, err.got);
 
     Ok(())
 }
@@ -279,6 +301,94 @@ async fn ensure_linearizable_with_read_index() -> Result<()> {
     Ok(())
 }
 
+/// A queued read waits for `LinearizerOption::wait_timeout` instead of the leader lease, and a
+/// zero wait timeout fails the read without queueing it.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn ensure_linearizable_with_wait_timeout() -> Result<()> {
+    // The leader lease equals `election_timeout_max`, so both wait timeouts below are far shorter
+    // than the wait a read would inherit from the lease.
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            heartbeat_interval: 100,
+            election_timeout_min: 999,
+            election_timeout_max: 1000,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    router.network_send_delay(0);
+
+    tracing::info!("--- initializing cluster");
+    router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let leader = router.get_raft_handle(&0)?;
+
+    tracing::info!("--- isolate both followers so no quorum acknowledgement can arrive");
+    router.set_network_error(1, true);
+    router.set_network_error(2, true);
+
+    let leader_lease = Duration::from_millis(config.election_timeout_max);
+    let lease_read_margin = leader_lease / 2;
+
+    tracing::info!("--- a zero wait timeout fails at once instead of queueing the read");
+    {
+        let option = LinearizerOption::new(Some(Duration::ZERO), true).with_wait_timeout(Duration::ZERO);
+
+        let start = Instant::now();
+        let rst = leader.get_read_linearizer(option).await;
+        let elapsed = start.elapsed();
+
+        let got = expect_quorum_not_enough(rst.unwrap_err());
+        assert_eq!(btreeset! {0}, got);
+        assert!(
+            elapsed < lease_read_margin,
+            "a zero wait timeout must not wait: {:?}",
+            elapsed
+        );
+    }
+
+    tracing::info!("--- a short wait timeout expires long before the leader lease would");
+    {
+        let wait_timeout = Duration::from_millis(100);
+        let option = LinearizerOption::new(Some(Duration::ZERO), true).with_wait_timeout(wait_timeout);
+
+        let start = Instant::now();
+        let rst = leader.get_read_linearizer(option).await;
+        let elapsed = start.elapsed();
+
+        let got = expect_quorum_not_enough(rst.unwrap_err());
+        assert_eq!(btreeset! {0}, got);
+        assert!(
+            elapsed >= wait_timeout,
+            "the read must wait for its timeout: {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed < lease_read_margin,
+            "the read must not wait for the leader lease: {:?}",
+            elapsed
+        );
+    }
+
+    Ok(())
+}
+
+/// Unwrap the voter set reported by a read that failed to confirm a quorum acknowledgement.
+fn expect_quorum_not_enough(err: RaftError<TypeConfig, LinearizableReadError<TypeConfig>>) -> BTreeSet<u64> {
+    let RaftError::APIError(api_error) = err else {
+        panic!("expected an API error");
+    };
+    let LinearizableReadError::QuorumNotEnough(quorum_not_enough) = api_error else {
+        panic!("expected QuorumNotEnough");
+    };
+    quorum_not_enough.got
+}
+
 #[tracing::instrument]
 #[test_harness::test(harness = ut_harness)]
 async fn ensure_linearizable_with_lease_read() -> Result<()> {
@@ -330,14 +440,13 @@ async fn ensure_linearizable_with_lease_read() -> Result<()> {
             before, after
         );
 
-        // lease time elapsed, lease read will return error.
+        // LeaseRead fails immediately after the lease expires.
         TypeConfig::sleep(Duration::from_millis(config.election_timeout_max)).await;
-        let rst = router.ensure_linearizable(leader, ReadPolicy::LeaseRead).await;
-        tracing::debug!(?rst, "ensure_linearizable with LeaseRead after lease expired");
+        let rst = leader_handle.get_read_linearizer(ReadPolicy::LeaseRead).await;
+        let got = expect_quorum_not_enough(rst.unwrap_err());
+        assert_eq!(btreeset! {0}, got);
 
-        assert!(rst.is_err());
-
-        // lease read should ok after new a round of heartbeat.
+        // A new heartbeat round refreshes the lease.
         let refresh_started = TypeConfig::now();
         leader_handle.trigger().heartbeat().await?;
         leader_handle
@@ -366,6 +475,78 @@ async fn ensure_linearizable_with_lease_read() -> Result<()> {
         router.set_network_error(2, true);
         router.ensure_linearizable(leader, ReadPolicy::LeaseRead).await?;
     }
+
+    Ok(())
+}
+
+/// A stale read waits for a periodic heartbeat when it is configured not to send one immediately.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn linearizer_waits_for_periodic_heartbeat_when_immediate_heartbeat_disabled() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_heartbeat: false,
+            enable_elect: false,
+            heartbeat_interval: 100,
+            election_timeout_min: 1001,
+            election_timeout_max: 1002,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+    router.network_send_delay(0);
+
+    tracing::info!("--- initializing cluster");
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    let leader = router.leader().expect("leader not found");
+    assert_eq!(0, leader);
+
+    TypeConfig::sleep(Duration::from_millis(300)).await;
+
+    let leader_handle = router.get_raft_handle(&leader).unwrap();
+    let metrics = leader_handle.metrics().borrow_watched().clone();
+    let expected_leader_id = metrics.vote.leader_id().to_committed();
+    let expected_applied = metrics.last_applied;
+
+    TypeConfig::sleep(Duration::from_millis(config.election_timeout_max)).await;
+
+    let rpc_count_before = router.get_rpc_count();
+    let before = *rpc_count_before.get(&RPCTypes::AppendEntries).unwrap_or(&0);
+
+    let option = LinearizerOption::new(None, false);
+    let mut read_future = Box::pin(leader_handle.get_read_linearizer(option));
+    let submitted_status = futures::poll!(read_future.as_mut());
+    assert!(
+        submitted_status.is_pending(),
+        "the read should be submitted asynchronously"
+    );
+
+    leader_handle.with_raft_state(|_| ()).await?;
+    let queued_status = futures::poll!(read_future.as_mut());
+    assert!(queued_status.is_pending(), "the read should remain queued");
+
+    let rpc_count_after = router.get_rpc_count();
+    let after = *rpc_count_after.get(&RPCTypes::AppendEntries).unwrap_or(&0);
+    assert_eq!(before, after, "the read should not send an immediate heartbeat");
+
+    leader_handle.runtime_config().heartbeat(true);
+    let heartbeat_wait = Duration::from_millis(config.heartbeat_interval * 5);
+    let heartbeat_result = TypeConfig::timeout(heartbeat_wait, read_future).await;
+    leader_handle.runtime_config().heartbeat(false);
+
+    let linearizer = heartbeat_result.expect("periodic heartbeat should complete the queued read")?;
+    assert_eq!(
+        (&leader, &expected_leader_id, log_index, expected_applied.as_ref()),
+        (
+            linearizer.node_id(),
+            linearizer.read_log_id().committed_leader_id(),
+            linearizer.read_log_id().index(),
+            linearizer.applied()
+        )
+    );
 
     Ok(())
 }

--- a/tests/tests/public_api_test.rs
+++ b/tests/tests/public_api_test.rs
@@ -24,6 +24,7 @@ use openraft::EntryPayload;
 use openraft::ErrorSubject;
 use openraft::ErrorVerb;
 use openraft::Instant;
+use openraft::LinearizerOption;
 use openraft::LogId;
 use openraft::LogIdOptionExt;
 use openraft::LogIndexOptionExt;
@@ -296,5 +297,6 @@ use openraft_legacy::network_v1::SnapshotSegmentId;
 
 #[test]
 fn test_public_api_accessible() {
-    // This test just needs to compile to verify all paths are publicly accessible
+    let age = std::time::Duration::from_millis(100);
+    let _linearizer_option = LinearizerOption::new(Some(age), true);
 }


### PR DESCRIPTION

## Changelog

##### feat: linearizable-read: queue quorum confirmations
# Summary

Route linearizable reads that require new quorum evidence through RaftCore's
pending-read queue, replacing independent per-read heartbeat probes.
Replication acknowledgement progress now completes batched reads with
per-request deadlines.

# Details

LinearizerOption configures reusable acknowledgement age, heartbeat fallback,
and wait timeout. Existing ReadPolicy calls convert automatically, preserving
the current API.

The queue indexes reads by required acknowledgement time and deadline. It wakes
RaftCore when a deadline expires without ticks, returns completion-time applied
state, and fails queued reads on leadership loss.

ReadIndex requires quorum progress strictly newer than the request threshold.
Required heartbeats still coalesce across bursts of reads.


##### docs: todo: document Engine field visibility, link runtime guide
# Summary

Two TODO markers in the engine and runtime docs are replaced with what
is actually true: `Engine`'s fields stay crate-visible by design, and
the client write-flow diagram already lives in the engine-runtime
guide.

# Details

`Engine` carried a marker asking that its fields be made private.
`RaftCore` reads `engine.state` and `engine.leader` and pushes onto
`engine.output` while executing engine commands and advancing I/O
progress, so crate visibility is the intended design rather than an
unfinished cleanup. The doc now says so, and names the boundary that
does hold: protocol state transitions go through `Engine` or its
handlers.

`RaftRuntime` carried an ASCII sequence diagram of a client write
travelling through engine, runtime, storage and network, plus a marker
asking that the diagram be added to the guides. That diagram is already
in `docs::components::engine_runtime`, so the trait now links to the
guide instead of keeping a second copy to hold in sync.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1993)
<!-- Reviewable:end -->
