### PR TITLE
test: storage: cover vote change during bounded read

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,14 @@ A moved test module stays a child of the module it tests, so it keeps access to 
 
 Both layouts are in use, and the choice follows test size, so a directory containing a mix of inline and separate test modules is expected rather than something to normalize.
 
+## Test Style
+
+- Keep short setup and action sequences inline, even when they occur in one or two tests. Extract a helper only when substantial reuse outweighs the extra abstraction level.
+- Write each test as one linear sequence of purpose-driven phases.
+- Introduce an independent phase with `tracing::info!` that states why the following actions are performed and includes useful runtime context such as the log index, node, or term.
+- Put the phase in a scoped `{ ... }` block after its log entry so temporary values stay local and the phase boundary is visible. Use a block expression when a phase must return a value to later phases; phase blocks may be nested.
+- Prefer runtime logging over standalone comments for explaining test actions.
+
 ## Project Structure
 
 - `openraft/` - Core Raft implementation

--- a/openraft/src/config/error.rs
+++ b/openraft/src/config/error.rs
@@ -1,6 +1,7 @@
-use anyerror::AnyError;
 use backoff_series::ParseError as BackoffParseError;
 use openraft_macros::since;
+
+use crate::impls::BoxedErrorSource;
 
 /// Error variants related to configuration.
 #[since]
@@ -8,10 +9,11 @@ use openraft_macros::since;
 #[derive(PartialEq, Eq)]
 pub enum ConfigError {
     /// Failed to parse configuration from command-line arguments.
+    #[since(version = "0.10.0", change = "`source` from `AnyError` to `BoxedErrorSource`")]
     #[error("ParseError: {source} while parsing ({args:?})")]
     ParseError {
         /// The underlying parse error.
-        source: AnyError,
+        source: BoxedErrorSource,
         /// The arguments that failed to parse.
         args: Vec<String>,
     },

--- a/openraft/src/config/parser.rs
+++ b/openraft/src/config/parser.rs
@@ -3,13 +3,14 @@
 //! Gated behind `feature = "clap"` in [`super`]; functions and the
 //! [`Config::build`] method here are only compiled when that feature is on.
 
-use anyerror::AnyError;
 use clap::Parser;
 
 use crate::Config;
 use crate::SnapshotPolicy;
 use crate::StepDownPolicy;
 use crate::config::error::ConfigError;
+use crate::errors::ErrorSource;
+use crate::impls::BoxedErrorSource;
 
 /// Parse number with unit such as 5.3 KB
 pub(super) fn parse_bytes_with_unit(src: &str) -> Result<u64, ConfigError> {
@@ -83,7 +84,7 @@ impl Config {
     /// ```
     pub fn build(args: &[&str]) -> Result<Config, ConfigError> {
         let config = <Self as Parser>::try_parse_from(args).map_err(|e| ConfigError::ParseError {
-            source: AnyError::from(&e),
+            source: BoxedErrorSource::from_error(&e),
             args: args.iter().map(|x| x.to_string()).collect(),
         })?;
         config.validate()

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1861,8 +1861,6 @@ where
 
         self.handle_tick_election();
 
-        // TODO: test: fixture: make isolated_nodes a single-way isolating.
-
         // Leader send heartbeat
         let heartbeat_at = self.engine.leader_ref().map(|l| l.next_heartbeat);
         if let Some(t) = heartbeat_at

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -39,6 +39,8 @@ use crate::vote::raft_vote::RaftVoteExt;
 #[cfg(test)]
 mod append_membership_test;
 #[cfg(test)]
+mod try_purge_log_test;
+#[cfg(test)]
 mod update_matching_test;
 
 /// Handle replication operations.
@@ -449,9 +451,6 @@ where
     /// Therefore, it is a method of ReplicationHandler.
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn try_purge_log(&mut self) {
-        // TODO refactor this
-        // TODO: test
-
         tracing::debug!(
             "try_purge_log: last_purged_log_id: {}, purge_upto: {}",
             self.state.last_purged_log_id().display(),

--- a/openraft/src/engine/handler/replication_handler/try_purge_log_test.rs
+++ b/openraft/src/engine/handler/replication_handler/try_purge_log_test.rs
@@ -1,0 +1,149 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use pretty_assertions::assert_eq;
+
+use crate::Membership;
+use crate::MembershipState;
+use crate::Vote;
+use crate::engine::Command;
+use crate::engine::Engine;
+use crate::engine::LogIdList;
+use crate::engine::testing::UTConfig;
+use crate::engine::testing::log_id;
+use crate::progress::Inflight;
+use crate::progress::inflight_id::InflightId;
+use crate::raft_state::LogStateReader;
+use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::StoredMembershipOf;
+use crate::utime::Leased;
+
+fn m23() -> Membership<u64, ()> {
+    Membership::new_with_defaults(vec![btreeset! {2, 3}], [])
+}
+
+fn eng() -> Engine<UTConfig> {
+    let mut eng = Engine::testing_default(2);
+    eng.state.enable_validation(false); // The fixture starts with no pending purge.
+    eng.config.id = 2;
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 2),
+    );
+    eng.state.membership_state = MembershipState::new(
+        Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 2)), m23())),
+        Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(2, 2, 3)), m23())),
+    );
+    eng.state.log_ids = LogIdList::new(Some(log_id(1, 1, 2)), [log_id(1, 1, 4), log_id(2, 2, 6)]);
+    eng.state.server_state = eng.calc_server_state();
+    eng.testing_new_leader();
+    eng.output.clear_commands();
+    eng
+}
+
+#[test]
+fn test_try_purge_log_already_purged() {
+    let mut eng = eng();
+    eng.state.purge_upto = Some(log_id(1, 1, 2));
+
+    eng.replication_handler().try_purge_log();
+
+    assert_eq!(
+        (
+            Some(log_id(1, 1, 2)),
+            Some(log_id(1, 1, 2)),
+            vec![log_id(1, 1, 4), log_id(2, 2, 6)],
+            vec![],
+        ),
+        (
+            eng.state.last_purged_log_id().cloned(),
+            eng.state.purge_upto().cloned(),
+            eng.state.log_ids.key_log_ids().to_vec(),
+            eng.output.take_commands(),
+        )
+    );
+}
+
+#[test]
+fn test_try_purge_log_postpones_when_logs_are_inflight() {
+    let mut eng = eng();
+    eng.state.purge_upto = Some(log_id(2, 2, 5));
+    eng.leader.as_mut().unwrap().progress.update_data_with(&3, |data| {
+        data.inflight = Inflight::logs(Some(log_id(1, 1, 4)), Some(log_id(2, 2, 6)), InflightId::new(1));
+    });
+
+    eng.replication_handler().try_purge_log();
+
+    assert_eq!(
+        (
+            Some(log_id(1, 1, 2)),
+            Some(log_id(2, 2, 5)),
+            vec![log_id(1, 1, 4), log_id(2, 2, 6)],
+            vec![],
+        ),
+        (
+            eng.state.last_purged_log_id().cloned(),
+            eng.state.purge_upto().cloned(),
+            eng.state.log_ids.key_log_ids().to_vec(),
+            eng.output.take_commands(),
+        )
+    );
+}
+
+#[test]
+fn test_try_purge_log_retries_after_inflight_clears() {
+    let mut eng = eng();
+    eng.state.purge_upto = Some(log_id(2, 2, 5));
+    eng.leader.as_mut().unwrap().progress.update_data_with(&3, |data| {
+        data.inflight = Inflight::logs(Some(log_id(1, 1, 4)), Some(log_id(2, 2, 6)), InflightId::new(1));
+    });
+
+    eng.replication_handler().try_purge_log();
+    eng.leader.as_mut().unwrap().progress.update_data_with(&3, |data| {
+        data.inflight = Inflight::None;
+    });
+    eng.replication_handler().try_purge_log();
+
+    assert_eq!(
+        (
+            Some(log_id(2, 2, 5)),
+            Some(log_id(2, 2, 5)),
+            vec![log_id(2, 2, 6)],
+            vec![Command::PurgeLog { upto: log_id(2, 2, 5) }],
+        ),
+        (
+            eng.state.last_purged_log_id().cloned(),
+            eng.state.purge_upto().cloned(),
+            eng.state.log_ids.key_log_ids().to_vec(),
+            eng.output.take_commands(),
+        )
+    );
+}
+
+#[test]
+fn test_try_purge_log_excludes_inflight_previous_log() {
+    let mut eng = eng();
+    eng.state.purge_upto = Some(log_id(2, 2, 5));
+    eng.leader.as_mut().unwrap().progress.update_data_with(&3, |data| {
+        data.inflight = Inflight::logs(Some(log_id(2, 2, 5)), Some(log_id(2, 2, 6)), InflightId::new(1));
+    });
+
+    eng.replication_handler().try_purge_log();
+
+    assert_eq!(
+        (
+            Some(log_id(2, 2, 5)),
+            Some(log_id(2, 2, 5)),
+            vec![log_id(2, 2, 6)],
+            vec![Command::PurgeLog { upto: log_id(2, 2, 5) }],
+        ),
+        (
+            eng.state.last_purged_log_id().cloned(),
+            eng.state.purge_upto().cloned(),
+            eng.state.log_ids.key_log_ids().to_vec(),
+            eng.output.take_commands(),
+        )
+    );
+}

--- a/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
+++ b/openraft/src/engine/handler/server_state_handler/update_server_state_test.rs
@@ -57,8 +57,30 @@ fn test_update_server_state_if_changed() -> anyhow::Result<()> {
         assert_eq!(ServerState::Follower, ssh.state.server_state);
     }
 
-    // TODO(3): add more test,
-    //          after migrating to the no-step-down leader:
-    //          A leader keeps working after it is removed from the voters.
+    // A leader kept after it is removed from voters but kept as learner.
+    {
+        let effective = Arc::new(StoredMembershipOf::<UTConfig>::new(
+            Some(log_id(3, 1, 4)),
+            Membership::new_with_defaults(vec![btreeset! {1, 3}], [2]),
+        ));
+        ssh.state.vote = Leased::new(
+            UTConfig::<()>::now(),
+            Duration::from_millis(500),
+            Vote::new_committed(2, 2),
+        );
+        ssh.state.server_state = ServerState::Follower;
+        ssh.state.membership_state.set_effective(effective.clone());
+        ssh.update_server_state_if_changed();
+
+        assert_eq!(
+            (ServerState::Leader, &Vote::new_committed(2, 2), effective.as_ref(),),
+            (
+                ssh.state.server_state,
+                ssh.state.vote_ref(),
+                ssh.state.membership_state.effective().as_ref(),
+            )
+        );
+    }
+
     Ok(())
 }

--- a/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/accept_vote_test.rs
@@ -83,11 +83,7 @@ fn test_accept_vote_granted_greater_vote() -> anyhow::Result<()> {
     assert!(resp.is_some());
 
     assert_eq!(
-        vec![
-            Command::FailPendingReads,
-            Command::SaveVote { vote: Vote::new(3, 3) },
-            Command::CloseReplicationStreams,
-        ],
+        vec![Command::FailPendingReads, Command::SaveVote { vote: Vote::new(3, 3) },],
         eng.output.take_commands()
     );
 

--- a/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
+++ b/openraft/src/engine/handler/vote_handler/handle_message_vote_test.rs
@@ -15,6 +15,7 @@ use crate::engine::LogIdList;
 use crate::engine::testing::UTConfig;
 use crate::engine::testing::log_id;
 use crate::errors::RejectVote;
+use crate::proposer::Candidate;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::StoredMembershipOf;
 use crate::utime::Leased;
@@ -37,6 +38,12 @@ fn eng() -> Engine<UTConfig> {
 
     eng.output.take_commands();
     eng
+}
+
+fn assert_no_leading_state(eng: &Engine<UTConfig>) {
+    assert!(eng.leader.is_none());
+    assert!(eng.candidate.is_none());
+    assert!(eng.pre_candidate.is_none());
 }
 
 #[test]
@@ -86,13 +93,9 @@ fn test_handle_message_vote_committed_vote() -> anyhow::Result<()> {
     assert!(Some(now) <= eng.state.vote_last_modified());
     assert!(eng.state.vote_last_modified() <= Some(now + Duration::from_millis(20)));
     assert_eq!(
-        vec![
-            Command::FailPendingReads,
-            Command::SaveVote {
-                vote: Vote::new_committed(3, 2)
-            },
-            Command::CloseReplicationStreams,
-        ],
+        vec![Command::FailPendingReads, Command::SaveVote {
+            vote: Vote::new_committed(3, 2)
+        },],
         eng.output.take_commands()
     );
 
@@ -119,10 +122,7 @@ fn test_handle_message_vote_granted_equal_vote() -> anyhow::Result<()> {
     assert!(Some(now) <= eng.state.vote_last_modified());
     assert!(eng.state.vote_last_modified() <= Some(now + Duration::from_millis(20)));
 
-    assert_eq!(
-        vec![Command::FailPendingReads, Command::CloseReplicationStreams,],
-        eng.output.take_commands()
-    );
+    assert_eq!(vec![Command::FailPendingReads], eng.output.take_commands());
     Ok(())
 }
 
@@ -142,11 +142,7 @@ fn test_handle_message_vote_granted_greater_vote() -> anyhow::Result<()> {
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
-        vec![
-            Command::FailPendingReads,
-            Command::SaveVote { vote: Vote::new(3, 1) },
-            Command::CloseReplicationStreams,
-        ],
+        vec![Command::FailPendingReads, Command::SaveVote { vote: Vote::new(3, 1) },],
         eng.output.take_commands()
     );
     Ok(())
@@ -172,11 +168,7 @@ fn test_handle_message_vote_granted_follower_learner_does_not_emit_update_server
 
         assert_eq!(st, eng.state.server_state);
         assert_eq!(
-            vec![
-                Command::FailPendingReads,
-                Command::SaveVote { vote: Vote::new(3, 1) },
-                Command::CloseReplicationStreams,
-            ],
+            vec![Command::FailPendingReads, Command::SaveVote { vote: Vote::new(3, 1) },],
             eng.output.take_commands()
         );
     }
@@ -196,13 +188,156 @@ fn test_handle_message_vote_granted_follower_learner_does_not_emit_update_server
 
         assert_eq!(st, eng.state.server_state);
         assert_eq!(
-            vec![
-                Command::FailPendingReads,
-                Command::SaveVote { vote: Vote::new(3, 1) },
-                Command::CloseReplicationStreams,
-            ],
+            vec![Command::FailPendingReads, Command::SaveVote { vote: Vote::new(3, 1) },],
             eng.output.take_commands()
         );
     }
+    Ok(())
+}
+
+#[test]
+fn test_become_following_with_no_leading_state_only_fails_pending_reads() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    eng.vote_handler().become_following();
+
+    assert_eq!(ServerState::Follower, eng.state.server_state);
+    assert_eq!(vec![Command::FailPendingReads], eng.output.take_commands());
+
+    Ok(())
+}
+
+#[test]
+fn test_become_following_with_no_leading_state_and_membership_demotion() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.config.id = 2;
+    eng.state.server_state = ServerState::Follower;
+    eng.state.membership_state.set_effective(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        Some(log_id(2, 1, 3)),
+        Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1, 3}], vec![1, 2, 3]),
+    )));
+
+    eng.vote_handler().become_following();
+
+    assert_eq!(ServerState::Learner, eng.state.server_state);
+    assert_eq!(vec![Command::FailPendingReads], eng.output.take_commands());
+
+    Ok(())
+}
+
+#[test]
+fn test_become_following_active_leader_emits_close() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.testing_new_leader();
+    eng.state.server_state = ServerState::Leader;
+
+    eng.vote_handler().become_following();
+
+    assert_eq!(ServerState::Follower, eng.state.server_state);
+    assert_no_leading_state(&eng);
+    assert_eq!(
+        vec![Command::FailPendingReads, Command::CloseReplicationStreams],
+        eng.output.take_commands()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_become_following_active_candidate_emits_close() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.candidate = Some(Candidate::new(
+        UTConfig::<()>::now(),
+        Vote::new(3, 0),
+        None,
+        Arc::new(m01()),
+        vec![],
+        eng.state.progress_id_gen.clone(),
+    ));
+    eng.state.server_state = ServerState::Candidate;
+
+    eng.vote_handler().become_following();
+
+    assert_eq!(ServerState::Follower, eng.state.server_state);
+    assert_no_leading_state(&eng);
+    assert_eq!(
+        vec![Command::FailPendingReads, Command::CloseReplicationStreams],
+        eng.output.take_commands()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_become_following_active_pre_candidate_emits_close() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.pre_candidate = Some(Candidate::new(
+        UTConfig::<()>::now(),
+        Vote::new(3, 0),
+        None,
+        Arc::new(m01()),
+        vec![],
+        eng.state.progress_id_gen.clone(),
+    ));
+    eng.state.server_state = ServerState::Candidate;
+
+    eng.vote_handler().become_following();
+
+    assert_eq!(ServerState::Follower, eng.state.server_state);
+    assert_no_leading_state(&eng);
+    assert_eq!(
+        vec![Command::FailPendingReads, Command::CloseReplicationStreams],
+        eng.output.take_commands()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_become_following_invalid_role_combination_emits_single_close() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.testing_new_leader();
+    eng.candidate = Some(Candidate::new(
+        UTConfig::<()>::now(),
+        Vote::new(3, 0),
+        None,
+        Arc::new(m01()),
+        vec![],
+        eng.state.progress_id_gen.clone(),
+    ));
+    eng.state.server_state = ServerState::Leader;
+
+    eng.vote_handler().become_following();
+
+    assert_eq!(ServerState::Follower, eng.state.server_state);
+    assert_no_leading_state(&eng);
+    assert_eq!(
+        vec![Command::FailPendingReads, Command::CloseReplicationStreams],
+        eng.output.take_commands()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_become_following_twice_emits_one_close() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.testing_new_leader();
+    eng.state.server_state = ServerState::Leader;
+
+    eng.vote_handler().become_following();
+    eng.vote_handler().become_following();
+
+    assert_eq!(ServerState::Follower, eng.state.server_state);
+    assert_no_leading_state(&eng);
+    assert_eq!(
+        vec![
+            Command::FailPendingReads,
+            Command::FailPendingReads,
+            Command::CloseReplicationStreams,
+        ],
+        eng.output.take_commands()
+    );
+
     Ok(())
 }

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -237,19 +237,22 @@ where
     ///
     /// This node then becomes raft-follower or raft-learner.
     pub(crate) fn become_following(&mut self) {
-        // TODO: if it is already in following state, nothing to do.
         debug_assert!(
             self.state.vote_ref().to_leader_id().node_id() != &self.config.id
                 || !self.state.membership_state.effective().membership().is_voter(&self.config.id),
             "It must hold: vote is not mine, or I am not a voter(leader just left the cluster)"
         );
 
+        let had_leading_state = self.leader.is_some() || self.candidate.is_some() || self.pre_candidate.is_some();
+
         *self.leader = None;
         *self.candidate = None;
         *self.pre_candidate = None;
 
         self.output.prepend_command(Command::FailPendingReads);
-        self.output.push_command(Command::CloseReplicationStreams);
+        if had_leading_state {
+            self.output.push_command(Command::CloseReplicationStreams);
+        }
 
         self.server_state_handler().update_server_state_if_changed();
     }

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -130,7 +130,6 @@ fn test_append_entries_prev_log_id_is_applied() -> anyhow::Result<()> {
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::CloseReplicationStreams,
             Command::UpdateIOProgress {
                 when: Some(Condition::IOFlushed {
                     io_id: IOId::new_log_io(Vote::new(2, 1).to_committed(), None)
@@ -183,7 +182,6 @@ fn test_append_entries_prev_log_id_conflict() -> anyhow::Result<()> {
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::CloseReplicationStreams,
             Command::TruncateLog {
                 after: Some(log_id(1, 1, 1))
             },
@@ -231,7 +229,6 @@ fn test_append_entries_prev_log_id_is_committed() -> anyhow::Result<()> {
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::CloseReplicationStreams,
             Command::TruncateLog {
                 after: Some(log_id(1, 1, 1))
             },
@@ -286,13 +283,9 @@ fn test_append_entries_prev_log_id_not_exists() -> anyhow::Result<()> {
     );
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
-        vec![
-            Command::FailPendingReads,
-            Command::SaveVote {
-                vote: Vote::new_committed(2, 1)
-            },
-            Command::CloseReplicationStreams,
-        ],
+        vec![Command::FailPendingReads, Command::SaveVote {
+            vote: Vote::new_committed(2, 1)
+        },],
         eng.output.take_commands()
     );
 
@@ -341,7 +334,6 @@ fn test_append_entries_conflict() -> anyhow::Result<()> {
             Command::SaveVote {
                 vote: Vote::new_committed(2, 1)
             },
-            Command::CloseReplicationStreams,
             Command::TruncateLog {
                 after: Some(log_id(1, 1, 2))
             },

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -171,10 +171,7 @@ fn test_handle_vote_req_granted_equal_vote_and_last_log_id() -> anyhow::Result<(
     assert!(eng.leader.is_none());
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
-    assert_eq!(
-        vec![Command::FailPendingReads, Command::CloseReplicationStreams,],
-        eng.output.take_commands()
-    );
+    assert_eq!(vec![Command::FailPendingReads], eng.output.take_commands());
     Ok(())
 }
 
@@ -203,11 +200,7 @@ fn test_handle_vote_req_granted_greater_vote() -> anyhow::Result<()> {
 
     assert_eq!(ServerState::Follower, eng.state.server_state);
     assert_eq!(
-        vec![
-            Command::FailPendingReads,
-            Command::SaveVote { vote: Vote::new(3, 1) },
-            Command::CloseReplicationStreams,
-        ],
+        vec![Command::FailPendingReads, Command::SaveVote { vote: Vote::new(3, 1) },],
         eng.output.take_commands()
     );
     Ok(())
@@ -235,11 +228,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
 
         assert_eq!(st, eng.state.server_state);
         assert_eq!(
-            vec![
-                Command::FailPendingReads,
-                Command::SaveVote { vote: Vote::new(3, 1) },
-                Command::CloseReplicationStreams,
-            ],
+            vec![Command::FailPendingReads, Command::SaveVote { vote: Vote::new(3, 1) },],
             eng.output.take_commands()
         );
     }
@@ -261,11 +250,7 @@ fn test_handle_vote_req_granted_follower_learner_does_not_emit_update_server_sta
 
         assert_eq!(st, eng.state.server_state);
         assert_eq!(
-            vec![
-                Command::FailPendingReads,
-                Command::SaveVote { vote: Vote::new(3, 1) },
-                Command::CloseReplicationStreams,
-            ],
+            vec![Command::FailPendingReads, Command::SaveVote { vote: Vote::new(3, 1) },],
             eng.output.take_commands()
         );
     }

--- a/openraft/src/engine/tests/install_full_snapshot_test.rs
+++ b/openraft/src/engine/tests/install_full_snapshot_test.rs
@@ -89,14 +89,10 @@ fn test_handle_install_full_snapshot_lt_last_snapshot() -> anyhow::Result<()> {
 
     let (dummy_tx, _rx) = UTConfig::<()>::oneshot();
     assert_eq!(
-        vec![
-            Command::FailPendingReads,
-            Command::CloseReplicationStreams,
-            Command::Respond {
-                when: None,
-                resp: Respond::new(SnapshotResponse::new(curr_vote), dummy_tx),
-            },
-        ],
+        vec![Command::FailPendingReads, Command::Respond {
+            when: None,
+            resp: Respond::new(SnapshotResponse::new(curr_vote), dummy_tx),
+        },],
         eng.output.take_commands()
     );
 
@@ -138,7 +134,6 @@ fn test_handle_install_full_snapshot_no_conflict() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             Command::FailPendingReads,
-            Command::CloseReplicationStreams,
             Command::from(sm::Command::install_full_snapshot(
                 SnapshotOf::<UTConfig, ()> {
                     meta: SnapshotMetaOf::<UTConfig> {

--- a/openraft/src/lib.rs
+++ b/openraft/src/lib.rs
@@ -5,8 +5,6 @@
 #![cfg_attr(feature = "bt", feature(error_generic_member_access))]
 #![allow(clippy::bool_assert_comparison)]
 #![allow(clippy::bool_comparison)]
-// TODO: `clippy::result-large-err`: StorageError is 136 bytes, try to reduce the size.
-#![allow(clippy::result_large_err)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::uninlined_format_args)]
 #![deny(unused_qualifications)]

--- a/openraft/src/storage/v2/raft_log_reader.rs
+++ b/openraft/src/storage/v2/raft_log_reader.rs
@@ -105,8 +105,6 @@ where C: RaftTypeConfig
     where
         RB: RangeBounds<u64> + Clone + Debug + OptionalSend,
     {
-        // TODO: complete the test that ensures when the vote is changed, stream should be stopped.
-
         use futures_util::stream;
 
         let changed_err = |leader, vote| {
@@ -291,5 +289,73 @@ where C: RaftTypeConfig
         LogIdList::<CommittedLeaderIdOf<C>>::get_key_log_ids(range, self)
             .await
             .map_err(|e| io::Error::other(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use futures_util::StreamExt;
+
+    use super::LeaderBoundedStreamError;
+    use super::RaftLogReader;
+    use crate::engine::testing::UTConfig;
+    use crate::engine::testing::log_id;
+    use crate::entry::RaftEntry;
+    use crate::errors::LeaderChanged;
+    use crate::type_config::TypeConfigExt;
+    use crate::type_config::alias::EntryOf;
+    use crate::type_config::alias::VoteOf;
+
+    struct ChangingVoteReader {
+        votes: VecDeque<Option<VoteOf<UTConfig>>>,
+        entries: Vec<EntryOf<UTConfig>>,
+        calls: Vec<&'static str>,
+    }
+
+    impl ChangingVoteReader {
+        fn new(votes: [Option<VoteOf<UTConfig>>; 2], entries: Vec<EntryOf<UTConfig>>) -> Self {
+            Self {
+                votes: VecDeque::from(votes),
+                entries,
+                calls: vec![],
+            }
+        }
+    }
+
+    impl RaftLogReader<UTConfig> for ChangingVoteReader {
+        async fn try_get_log_entries<RB>(&mut self, _range: RB) -> Result<Vec<EntryOf<UTConfig>>, std::io::Error>
+        where RB: std::ops::RangeBounds<u64> + Clone + std::fmt::Debug + crate::OptionalSend {
+            self.calls.push("read_entries");
+            Ok(self.entries.clone())
+        }
+
+        async fn read_vote(&mut self) -> Result<Option<VoteOf<UTConfig>>, std::io::Error> {
+            self.calls.push("read_vote");
+            Ok(self.votes.pop_front().unwrap_or(None))
+        }
+    }
+
+    #[test]
+    fn leader_bounded_stream_stops_when_vote_changes_between_reads() {
+        UTConfig::<()>::run(async {
+            let expected = VoteOf::<UTConfig>::new_committed(3, 1);
+            let changed = VoteOf::<UTConfig>::new(4, 2);
+            let leader = *expected.leader_id();
+            let entry = EntryOf::<UTConfig>::new_blank(log_id(3, 1, 7));
+
+            let mut reader = ChangingVoteReader::new([Some(expected), Some(changed)], vec![entry]);
+
+            let stream = reader.leader_bounded_stream(leader, 7..8).await;
+            let items: Vec<_> = stream.collect().await;
+
+            let [Err(LeaderBoundedStreamError::LeaderChanged(actual))] = items.as_slice() else {
+                panic!("expected one LeaderChanged item, got: {items:?}");
+            };
+
+            assert_eq!(&LeaderChanged::new(leader, Some(changed)), actual);
+            assert_eq!(vec!["read_vote", "read_entries", "read_vote"], reader.calls);
+        })
     }
 }

--- a/tests/tests/elect/main.rs
+++ b/tests/tests/elect/main.rs
@@ -11,3 +11,4 @@ mod t10_elect_compare_last_log;
 mod t11_elect_seize_leadership;
 mod t12_pre_vote;
 mod t13_elect_while_leader;
+mod t14_one_way_isolation;

--- a/tests/tests/elect/t14_one_way_isolation.rs
+++ b/tests/tests/elect/t14_one_way_isolation.rs
@@ -1,0 +1,193 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::Instant;
+use openraft::ServerState;
+use openraft::TokioInstant;
+use openraft::Vote;
+use openraft::async_runtime::WatchReceiver;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::Direction;
+use crate::fixtures::RaftRouter;
+use crate::fixtures::rpc_error_type::RpcErrorType;
+use crate::fixtures::ut_harness;
+
+const ELECTION_TIMEOUT_MIN: u64 = 150;
+const ELECTION_TIMEOUT_MAX: u64 = 151;
+const ELECTION_OBSERVATION: Duration = Duration::from_millis(ELECTION_TIMEOUT_MAX * 2);
+const WAIT_TIMEOUT: Duration = Duration::from_millis(2_000);
+
+/// A follower must not campaign while it can still receive heartbeats, even if all of its
+/// outbound RPCs fail.
+///
+/// `NetSend` on node 1 leaves `AppendEntries` from node 0 deliverable. The test first observes a
+/// heartbeat received after installing the fault, then waits through two maximum election
+/// timeouts. Pre-Vote is disabled, so any election attempt would change node 1's vote; retaining
+/// the same committed vote and follower state proves that inbound heartbeats keep renewing its
+/// leader lease.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn inbound_heartbeats_prevent_election_when_outbound_rpcs_fail() -> Result<()> {
+    let config = Config {
+        enable_pre_vote: Some(false),
+        election_timeout_min: ELECTION_TIMEOUT_MIN,
+        election_timeout_max: ELECTION_TIMEOUT_MAX,
+        ..Default::default()
+    }
+    .validate()?;
+    let mut router = RaftRouter::new(Arc::new(config));
+
+    tracing::info!("--- establish node 0 as leader and node 1 as follower in a three-voter cluster");
+    let log_index = { router.new_cluster(btreeset! {0, 1, 2}, btreeset! {}).await? };
+
+    let n0 = router.get_raft_handle(&0)?;
+    let n1 = router.get_raft_handle(&1)?;
+    tracing::info!(
+        log_index,
+        "--- wait until node 1 recognizes node 0 as leader before installing the fault"
+    );
+    let before = {
+        n1.wait(Some(WAIT_TIMEOUT))
+            .metrics(
+                |metrics| metrics.state == ServerState::Follower && metrics.current_leader == Some(0),
+                "node 1 follows node 0",
+            )
+            .await?
+    };
+
+    tracing::info!(
+        log_index,
+        term = before.current_term,
+        vote = %before.vote,
+        "--- block node 1 outbound RPCs and prove it can still receive heartbeats"
+    );
+    {
+        router.set_rpc_failure(1, Direction::NetSend, Some(RpcErrorType::NetworkError));
+
+        let heartbeat_at = TokioInstant::now();
+        n0.trigger().heartbeat().await?;
+
+        let mut heartbeat_received = false;
+        for _ in 0..20 {
+            let last_modified = router.with_raft_state(1, |state| state.vote_last_modified()).await?;
+            if last_modified > Some(heartbeat_at) {
+                heartbeat_received = true;
+                break;
+            }
+
+            TypeConfig::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(heartbeat_received, "node 1 must receive the forced heartbeat");
+    }
+
+    tracing::info!(
+        log_index,
+        "--- let two election timeouts pass while inbound heartbeats renew node 1's lease"
+    );
+    {
+        TypeConfig::sleep(ELECTION_OBSERVATION).await;
+    }
+
+    tracing::info!(
+        log_index,
+        "--- node 1 keeps the same vote and remains a follower of node 0"
+    );
+    {
+        let after = n1.metrics().borrow_watched().clone();
+        assert_eq!(
+            before.current_term, after.current_term,
+            "node 1 must not advance its term"
+        );
+        assert_eq!(before.vote, after.vote, "node 1 must retain its vote");
+        assert_eq!(
+            Some(0),
+            after.current_leader,
+            "node 1 must still recognize node 0 as leader"
+        );
+        assert_eq!(ServerState::Follower, after.state, "node 1 must remain a follower");
+    }
+
+    Ok(())
+}
+
+/// A follower must campaign when it cannot receive heartbeats but can still send outbound RPCs.
+///
+/// `NetRecv` on node 1 blocks `AppendEntries` from node 0 without blocking node 1's own Vote RPCs.
+/// With Pre-Vote disabled, the first expired leader lease starts a real election: node 1 must
+/// enter `Candidate` with a higher-term, uncommitted vote for itself and no known leader.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn missing_inbound_heartbeats_start_election() -> Result<()> {
+    let config = Config {
+        enable_pre_vote: Some(false),
+        election_timeout_min: ELECTION_TIMEOUT_MIN,
+        election_timeout_max: ELECTION_TIMEOUT_MAX,
+        ..Default::default()
+    }
+    .validate()?;
+    let mut router = RaftRouter::new(Arc::new(config));
+
+    tracing::info!("--- establish node 0 as leader and node 1 as follower in a three-voter cluster");
+    let log_index = { router.new_cluster(btreeset! {0, 1, 2}, btreeset! {}).await? };
+
+    let n1 = router.get_raft_handle(&1)?;
+    tracing::info!(
+        log_index,
+        "--- wait until node 1 recognizes node 0 as leader before installing the fault"
+    );
+    let before = {
+        n1.wait(Some(WAIT_TIMEOUT))
+            .metrics(
+                |metrics| metrics.state == ServerState::Follower && metrics.current_leader == Some(0),
+                "node 1 follows node 0",
+            )
+            .await?
+    };
+
+    tracing::info!(
+        log_index,
+        term = before.current_term,
+        vote = %before.vote,
+        "--- block node 1 inbound RPCs while keeping its outbound Vote RPCs available"
+    );
+    {
+        router.set_rpc_failure(1, Direction::NetRecv, Some(RpcErrorType::NetworkError));
+    }
+
+    tracing::info!(log_index, "--- node 1 misses heartbeats and starts a direct election");
+    {
+        let candidate = router
+            .wait(&1, Some(WAIT_TIMEOUT))
+            .state(
+                ServerState::Candidate,
+                "node 1 becomes a candidate after its leader lease expires",
+            )
+            .await?;
+
+        let expected_vote = Vote::new(candidate.current_term, 1);
+        assert!(
+            candidate.current_term > before.current_term,
+            "node 1 must advance its term"
+        );
+        assert_eq!(
+            expected_vote, candidate.vote,
+            "node 1 must install its uncommitted self-vote"
+        );
+        assert_eq!(
+            None, candidate.current_leader,
+            "node 1 must no longer recognize a leader"
+        );
+        assert_eq!(
+            ServerState::Candidate,
+            candidate.state,
+            "node 1 must enter candidate state"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### test: storage: cover vote change during bounded read
# Summary

leader_bounded_stream now has a deterministic regression test for a vote
that changes after entries are read.

# Details

A purpose-built RaftLogReader returns two different votes and records the
read order. The test asserts the exact LeaderChanged result and proves no
loaded entry reaches the stream.


##### test: server-state: cover leader retained as learner
# Summary

test_update_server_state_if_changed now verifies that a committed node-2
leader remains Leader after voter removal when membership retains it as a
learner.

# Details

The case compares the resulting server state, vote, and complete effective
membership so a partial transition cannot satisfy the regression test.


##### refactor: vote-handler: avoid duplicate follower teardown
# Summary

VoteHandler::become_following() now closes replication streams only when
it exits leader, candidate, or pre-candidate state.

# Details

Already-following nodes still reconcile follower versus learner state, but
no longer issue a redundant CloseReplicationStreams command.

Regression coverage verifies each volatile role is cleared, one teardown is
emitted for real transitions, and repeat transitions emit only one close.
Existing engine expectations now omit the redundant close for follower and
learner fixtures.

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1995)
<!-- Reviewable:end -->
