### PR TITLE
fix: rocks: persist state-machine apply writes

### DIFF
--- a/examples/log-rocks/src/lib.rs
+++ b/examples/log-rocks/src/lib.rs
@@ -29,6 +29,7 @@ use openraft::type_config::TypeConfigExt;
 use rocksdb::ColumnFamily;
 use rocksdb::DB;
 use rocksdb::Direction;
+use rocksdb::WriteBatch;
 
 #[derive(Debug, Clone)]
 pub struct RocksLogStore<C>
@@ -168,20 +169,17 @@ where C: RaftTypeConfig
 
     async fn append<I>(&mut self, entries: I, callback: IOFlushed<C>) -> Result<(), io::Error>
     where I: IntoIterator<Item = EntryOf<C>> + Send {
+        let mut batch = WriteBatch::default();
         for entry in entries {
             let id = id_to_bin(entry.index());
-            self.db
-                .put_cf(
-                    self.cf_logs(),
-                    id,
-                    serde_json::to_vec(&entry).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
-                )
-                .map_err(|e| io::Error::other(e.to_string()))?;
+            let value = serde_json::to_vec(&entry).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            batch.put_cf(self.cf_logs(), id, value);
         }
+        self.db.write(batch).map_err(|e| io::Error::other(e.to_string()))?;
 
         // Make sure the logs are persisted to disk before invoking the callback.
         //
-        // But the above `pub_cf()` must be called in this function, not in another task.
+        // But the above `write()` must be called in this function, not in another task.
         // Because when the function returns, it requires the log entries can be read.
         let db = self.db.clone();
         std::thread::spawn(move || {

--- a/examples/sm-rocks/src/state_machine.rs
+++ b/examples/sm-rocks/src/state_machine.rs
@@ -262,10 +262,16 @@ impl RaftStateMachine<TypeConfig> for RocksStateMachine {
             batch.put_cf(cf_meta, "last_membership", serialize(membership)?);
         }
 
-        // Atomic write of all data + metadata - fail fast before sending any responses
-        self.db.write(batch).map_err(|e| io::Error::other(e.to_string()))?;
+        // Persist data and metadata atomically before acknowledging the applied entries.
+        let db = self.db.clone();
+        TypeConfig::spawn_blocking(move || {
+            let mut write_options = rocksdb::WriteOptions::default();
+            write_options.set_sync(true);
+            db.write_opt(batch, &write_options).map_err(io::Error::other)
+        })
+        .await??;
 
-        // Only send responses after successful write
+        // Only send responses after the write is durable.
         for (responder, response) in responses {
             responder.send(response);
         }


### PR DESCRIPTION

## Changelog

##### fix: rocks: persist state-machine apply writes
# Summary

RocksDB state-machine writes now reach durable storage before client
responses, and batched log appends keep their existing asynchronous
flush contract.

# Details

`RocksStateMachine::apply()` performs its atomic WriteBatch with
synchronous WriteOptions on a blocking worker, preventing acknowledged
state changes from being lost after a power failure.

`RocksLogStore::append()` commits its entries as one WriteBatch before
the existing WAL-flush callback, reducing write-path overhead while
preserving read visibility and deferred durability notification.

---

- Bug Fix

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/1999)
<!-- Reviewable:end -->
