### PR TITLE
fix: progress: ignore stale conflict in update_conflicting()

### DIFF
--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -41,6 +41,8 @@ mod append_membership_test;
 #[cfg(test)]
 mod try_purge_log_test;
 #[cfg(test)]
+mod update_conflicting_test;
+#[cfg(test)]
 mod update_matching_test;
 
 /// Handle replication operations.
@@ -254,8 +256,10 @@ where
     /// Update progress when replicated data(logs or snapshot) does not match the follower/learner
     /// state and is rejected.
     ///
-    /// If `has_payload` is true, the `inflight` state is reset because AppendEntries RPC
-    /// manages the inflight state.
+    /// If `inflight_id` is `Some`, the inflight state is reset because the response corresponds
+    /// to a replication request with log payload; a stale inflight ID leaves the progress entry
+    /// unchanged. If `None`, the response is from an RPC without payload (e.g., heartbeat), and
+    /// inflight state is not modified.
     ///
     /// This method intentionally bypasses `VecProgress::update_entry_with()`: when log
     /// reversion is explicitly allowed, [`Updater::update_conflicting()`] may reset
@@ -269,8 +273,6 @@ where
         conflict: LogIdOf<C>,
         inflight_id: Option<InflightId>,
     ) {
-        // TODO(2): test it?
-
         self.leader.progress.reset_entry_with(&target, |entry| {
             let mut updater = Updater::new(&*self.config, entry);
             updater.update_conflicting(conflict.index(), inflight_id);

--- a/openraft/src/engine/handler/replication_handler/update_conflicting_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_conflicting_test.rs
@@ -1,0 +1,236 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use pretty_assertions::assert_eq;
+
+use crate::Membership;
+use crate::MembershipState;
+use crate::Vote;
+use crate::engine::Engine;
+use crate::engine::testing::UTConfig;
+use crate::engine::testing::log_id;
+use crate::progress::Inflight;
+use crate::progress::entry::ProgressEntry;
+use crate::progress::inflight_id::InflightId;
+use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::StoredMembershipOf;
+use crate::utime::Leased;
+
+fn eng() -> Engine<UTConfig> {
+    let mut eng = Engine::testing_default(1);
+    eng.state.enable_validation(false);
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
+    let membership = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1, 2, 3}], []);
+    let committed = StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 1, 1)), membership.clone());
+    let effective = StoredMembershipOf::<UTConfig>::new(Some(log_id(2, 1, 3)), membership);
+    eng.state.membership_state = MembershipState::new(Arc::new(committed), Arc::new(effective));
+    eng.testing_new_leader();
+    eng.output.clear_commands();
+    eng
+}
+
+fn update_entry<F>(eng: &mut Engine<UTConfig>, target: u64, update: F)
+where F: FnOnce(&mut ProgressEntry<UTConfig>) {
+    let leader = eng.leader.as_mut().unwrap();
+    let result = leader.progress.update_entry_with(&target, update);
+    let found = result.is_ok();
+    assert!(found);
+}
+
+fn entries(eng: &Engine<UTConfig>) -> Vec<ProgressEntry<UTConfig>> {
+    let leader = eng.leader.as_ref().unwrap();
+    leader.progress.iter().cloned().collect()
+}
+
+fn entry(eng: &Engine<UTConfig>, target: u64) -> ProgressEntry<UTConfig> {
+    let leader = eng.leader.as_ref().unwrap();
+    let entry = leader.progress.try_get(&target).unwrap();
+    entry.clone()
+}
+
+fn ordered_matching(eng: &Engine<UTConfig>) -> Vec<(u64, Option<LogIdOf<UTConfig>>)> {
+    let leader = eng.leader.as_ref().unwrap();
+    leader.progress.collect_mapped(|entry| (entry.id, entry.matching))
+}
+
+fn quorum_accepted(eng: &Engine<UTConfig>) -> Option<LogIdOf<UTConfig>> {
+    let leader = eng.leader.as_ref().unwrap();
+    *leader.progress.quorum_accepted()
+}
+
+#[test]
+fn test_update_conflicting_response_identity() -> anyhow::Result<()> {
+    let mut eng = eng();
+    let first_id = InflightId::new(7);
+    let second_id = InflightId::new(8);
+
+    tracing::info!(target = 2, "install the first payload request");
+    {
+        update_entry(&mut eng, 2, |entry| {
+            entry.matching = Some(log_id(2, 1, 3));
+            entry.data.searching_end = 10;
+            entry.data.inflight = Inflight::logs(Some(log_id(2, 1, 7)), Some(log_id(2, 1, 9)), first_id);
+        });
+    }
+
+    tracing::info!(target = 2, inflight_id = 7, "apply the matching conflict response");
+    {
+        let mut expected = entry(&eng, 2);
+        expected.data.inflight = Inflight::None;
+        expected.data.searching_end = 7;
+
+        eng.replication_handler().update_conflicting(2, log_id(2, 1, 7), Some(first_id));
+
+        let actual = entry(&eng, 2);
+        assert_eq!(expected, actual);
+    }
+
+    tracing::info!(target = 2, inflight_id = 8, "replace the completed payload request");
+    {
+        update_entry(&mut eng, 2, |entry| {
+            entry.data.searching_end = 10;
+            entry.data.inflight = Inflight::logs(Some(log_id(2, 1, 3)), Some(log_id(2, 1, 9)), second_id);
+        });
+    }
+
+    tracing::info!(
+        target = 2,
+        inflight_id = 7,
+        "ignore a stale conflict from the first request"
+    );
+    {
+        let expected_entry = entry(&eng, 2);
+        let expected_entries = entries(&eng);
+        let expected_quorum = quorum_accepted(&eng);
+
+        eng.replication_handler().update_conflicting(2, log_id(2, 1, 7), Some(first_id));
+
+        let actual_entry = entry(&eng, 2);
+        let actual_entries = entries(&eng);
+        let actual_quorum = quorum_accepted(&eng);
+        assert_eq!(expected_entry, actual_entry);
+        assert_eq!(expected_entries, actual_entries);
+        assert_eq!(expected_quorum, actual_quorum);
+    }
+
+    tracing::info!(target = 2, "apply a heartbeat conflict without clearing payload state");
+    {
+        let mut expected = entry(&eng, 2);
+        expected.data.searching_end = 6;
+
+        eng.replication_handler().update_conflicting(2, log_id(2, 1, 6), None);
+
+        let actual = entry(&eng, 2);
+        assert_eq!(expected, actual);
+    }
+
+    tracing::info!(target = 99, "ignore a conflict for a removed target");
+    {
+        let expected_entries = entries(&eng);
+        let expected_quorum = quorum_accepted(&eng);
+
+        eng.replication_handler().update_conflicting(99, log_id(2, 1, 0), Some(first_id));
+
+        let actual_entries = entries(&eng);
+        let actual_quorum = quorum_accepted(&eng);
+        assert_eq!(expected_entries, actual_entries);
+        assert_eq!(expected_quorum, actual_quorum);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_update_conflicting_reversion() -> anyhow::Result<()> {
+    let mut eng = eng();
+    let first_id = InflightId::new(1);
+    let third_id = InflightId::new(3);
+
+    tracing::info!("establish ordered voter progress and a quorum watermark");
+    {
+        update_entry(&mut eng, 1, |entry| {
+            entry.matching = Some(log_id(2, 1, 8));
+            entry.data.searching_end = 12;
+            entry.data.inflight = Inflight::logs(Some(log_id(2, 1, 8)), Some(log_id(2, 1, 11)), first_id);
+        });
+        update_entry(&mut eng, 2, |entry| {
+            entry.matching = Some(log_id(2, 1, 7));
+            entry.data.searching_end = 12;
+        });
+        update_entry(&mut eng, 3, |entry| {
+            entry.matching = Some(log_id(2, 1, 6));
+            entry.data.searching_end = 12;
+        });
+
+        let ordered = ordered_matching(&eng);
+        let expected_ordered = vec![
+            (1, Some(log_id(2, 1, 8))),
+            (2, Some(log_id(2, 1, 7))),
+            (3, Some(log_id(2, 1, 6))),
+        ];
+        assert_eq!(expected_ordered, ordered);
+
+        let expected_quorum = Some(log_id(2, 1, 7));
+        let actual_quorum = quorum_accepted(&eng);
+        assert_eq!(expected_quorum, actual_quorum);
+    }
+
+    tracing::info!(target = 1, conflict = 8, "apply globally enabled log reversion");
+    {
+        eng.config.allow_log_reversion = true;
+        let mut expected = entry(&eng, 1);
+        expected.matching = None;
+        expected.data.inflight = Inflight::None;
+        expected.data.searching_end = 8;
+
+        eng.replication_handler().update_conflicting(1, log_id(2, 1, 8), Some(first_id));
+
+        let actual = entry(&eng, 1);
+        assert_eq!(expected, actual);
+
+        let ordered = ordered_matching(&eng);
+        let expected_ordered = vec![(2, Some(log_id(2, 1, 7))), (3, Some(log_id(2, 1, 6))), (1, None)];
+        assert_eq!(expected_ordered, ordered);
+
+        let expected_quorum = Some(log_id(2, 1, 7));
+        let actual_quorum = quorum_accepted(&eng);
+        assert_eq!(expected_quorum, actual_quorum);
+    }
+
+    tracing::info!(target = 3, conflict = 6, "consume one-shot log reversion permission");
+    {
+        eng.config.allow_log_reversion = false;
+        update_entry(&mut eng, 3, |entry| {
+            entry.data.searching_end = 10;
+            entry.data.inflight = Inflight::logs(Some(log_id(2, 1, 6)), Some(log_id(2, 1, 9)), third_id);
+        });
+        eng.replication_handler().allow_next_revert(3, true)?;
+
+        let mut expected = entry(&eng, 3);
+        expected.matching = None;
+        expected.data.inflight = Inflight::None;
+        expected.data.searching_end = 6;
+        expected.data.allow_log_reversion = false;
+
+        eng.replication_handler().update_conflicting(3, log_id(2, 1, 6), Some(third_id));
+
+        let actual = entry(&eng, 3);
+        assert_eq!(expected, actual);
+
+        let ordered = ordered_matching(&eng);
+        let expected_ordered = vec![(2, Some(log_id(2, 1, 7))), (3, None), (1, None)];
+        assert_eq!(expected_ordered, ordered);
+
+        let expected_quorum = Some(log_id(2, 1, 7));
+        let actual_quorum = quorum_accepted(&eng);
+        assert_eq!(expected_quorum, actual_quorum);
+    }
+
+    Ok(())
+}

--- a/openraft/src/progress/entry/update.rs
+++ b/openraft/src/progress/entry/update.rs
@@ -30,7 +30,8 @@ where C: RaftTypeConfig
     ///
     /// If `inflight_id` is `Some`, the inflight state is reset because the response corresponds
     /// to a replication request with log payload. If `None`, the response is from an RPC without
-    /// payload (e.g., heartbeat), and inflight state is not modified.
+    /// payload (e.g., heartbeat), and inflight state is not modified. A payload response with a
+    /// stale inflight ID leaves the entire progress entry unchanged.
     ///
     /// Normally, the `conflict` index should be greater than or equal to the `matching` index
     /// when follower data is intact. However, for testing purposes, a follower may clean its
@@ -54,7 +55,10 @@ where C: RaftTypeConfig
 
         // The inflight may be None if the conflict is caused by a heartbeat response.
         if let Some(inflight_id) = inflight_id {
-            self.entry.data.inflight.conflict(conflict, inflight_id);
+            let applied = self.entry.data.inflight.conflict(conflict, inflight_id);
+            if !applied {
+                return;
+            }
         }
 
         if conflict >= self.entry.data.searching_end {

--- a/openraft/src/progress/inflight/mod.rs
+++ b/openraft/src/progress/inflight/mod.rs
@@ -205,36 +205,36 @@ where C: RaftTypeConfig
 
     /// Update inflight state when a conflicting log id is responded by a follower/learner.
     ///
-    /// If `from_inflight_id` doesn't match the current `InflightId`,
-    /// the conflict is ignored as a stale response.
-    pub(crate) fn conflict(&mut self, _conflict: u64, from_inflight_id: InflightId) {
+    /// Returns `true` if the conflict matched the current inflight request and was applied;
+    /// `false` if it was stale and ignored.
+    pub(crate) fn conflict(&mut self, _conflict: u64, from_inflight_id: InflightId) -> bool {
         match self {
-            Inflight::None => {
-                // with LogsSince, there might be duplicated conflict message received.
-            }
+            Inflight::None => false,
             Inflight::Logs {
                 log_id_range: _,
                 inflight_id,
             } => {
                 if *inflight_id != from_inflight_id {
-                    return;
+                    return false;
                 }
 
-                *self = Inflight::None
+                *self = Inflight::None;
+                true
             }
             Inflight::Snapshot { inflight_id } => {
                 if *inflight_id != from_inflight_id {
-                    return;
+                    return false;
                 }
 
                 unreachable!("sending snapshot should not conflict");
             }
             Inflight::LogsSince { prev: _, inflight_id } => {
                 if *inflight_id != from_inflight_id {
-                    return;
+                    return false;
                 }
 
-                *self = Inflight::None
+                *self = Inflight::None;
+                true
             }
         }
     }

--- a/openraft/src/progress/inflight/tests.rs
+++ b/openraft/src/progress/inflight/tests.rs
@@ -122,7 +122,8 @@ fn test_inflight_ack() -> anyhow::Result<()> {
 fn test_inflight_conflict() -> anyhow::Result<()> {
     {
         let mut f = Inflight::<UTConfig>::logs(Some(log_id(5)), Some(log_id(10)), InflightId::new(1));
-        f.conflict(5, InflightId::new(1));
+        let applied = f.conflict(5, InflightId::new(1));
+        assert!(applied, "matching conflict should be applied");
         assert_eq!(Inflight::<UTConfig>::None, f, "valid conflict");
     }
 
@@ -174,12 +175,22 @@ fn test_inflight_ack_none_is_stale() -> anyhow::Result<()> {
 
 #[test]
 fn test_inflight_conflict_inflight_id_mismatch() -> anyhow::Result<()> {
+    // None: there is no request to match
+    {
+        let mut f = Inflight::<UTConfig>::None;
+
+        let applied = f.conflict(7, InflightId::new(1));
+        assert!(!applied, "conflict without an inflight request is stale");
+        assert_eq!(Inflight::<UTConfig>::None, f);
+    }
+
     // Logs: mismatched inflight_id should be ignored
     {
         let mut f = Inflight::<UTConfig>::logs(Some(log_id(5)), Some(log_id(10)), InflightId::new(1));
         let original = f;
 
-        f.conflict(7, InflightId::new(2));
+        let applied = f.conflict(7, InflightId::new(2));
+        assert!(!applied, "conflict with mismatched inflight_id is stale");
         assert_eq!(original, f, "conflict with mismatched inflight_id should be ignored");
     }
 
@@ -252,7 +263,8 @@ fn test_inflight_logs_since_conflict() -> anyhow::Result<()> {
     {
         let mut f = Inflight::<UTConfig>::logs_since(Some(log_id(5)), InflightId::new(1));
 
-        f.conflict(5, InflightId::new(1));
+        let applied = f.conflict(5, InflightId::new(1));
+        assert!(applied, "matching conflict should be applied");
         assert_eq!(Inflight::<UTConfig>::None, f, "conflict should reset to None");
     }
 
@@ -261,7 +273,8 @@ fn test_inflight_logs_since_conflict() -> anyhow::Result<()> {
         let mut f = Inflight::<UTConfig>::logs_since(Some(log_id(5)), InflightId::new(1));
         let original = f;
 
-        f.conflict(5, InflightId::new(2));
+        let applied = f.conflict(5, InflightId::new(2));
+        assert!(!applied, "conflict with mismatched inflight_id is stale");
         assert_eq!(original, f, "conflict with mismatched inflight_id should be ignored");
     }
 

--- a/tests/tests/client_api/t10_client_writes.rs
+++ b/tests/tests/client_api/t10_client_writes.rs
@@ -44,39 +44,47 @@ async fn client_writes() -> Result<()> {
     tracing::info!("--- initializing cluster");
     let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
 
-    // Write a bunch of data and assert that the cluster stayes stable.
-    let leader = router.leader().expect("leader not found");
-    let mut clients = futures::stream::FuturesUnordered::new();
-    clients.push(router.client_request_many(leader, "0", 100));
-    clients.push(router.client_request_many(leader, "1", 100));
-    clients.push(router.client_request_many(leader, "2", 100));
-    clients.push(router.client_request_many(leader, "3", 100));
-    clients.push(router.client_request_many(leader, "4", 100));
-    clients.push(router.client_request_many(leader, "5", 100));
-    while clients.next().await.is_some() {}
+    tracing::info!(log_index, "--- run concurrent writes while the cluster remains stable");
+    {
+        let leader = router.leader().expect("leader not found");
+        let mut clients = futures::stream::FuturesUnordered::new();
+        clients.push(router.client_request_many(leader, "0", 100));
+        clients.push(router.client_request_many(leader, "1", 100));
+        clients.push(router.client_request_many(leader, "2", 100));
+        clients.push(router.client_request_many(leader, "3", 100));
+        clients.push(router.client_request_many(leader, "4", 100));
+        clients.push(router.client_request_many(leader, "5", 100));
+        while clients.next().await.is_some() {}
 
-    log_index += 100 * 6;
-    for id in [0, 1, 2] {
-        router.wait(&id, None).applied_index(Some(log_index), "sync logs").await?;
+        log_index += 100 * 6;
+        for id in [0, 1, 2] {
+            router.wait(&id, None).applied_index(Some(log_index), "sync logs").await?;
+        }
     }
 
-    for id in [0, 1, 2] {
-        let (mut sto, mut sm) = router.get_storage_handle(&id)?;
+    tracing::info!(
+        log_index,
+        "--- verify every node persisted and applied the complete workload"
+    );
+    {
+        for id in [0, 1, 2] {
+            let (mut sto, mut sm) = router.get_storage_handle(&id)?;
 
-        let last_log_id = sto.get_log_state().await?.last_log_id;
-        assert_eq!(last_log_id, Some(log_id(1, 0, log_index)));
+            let last_log_id = sto.get_log_state().await?.last_log_id;
+            assert_eq!(Some(log_id(1, 0, log_index)), last_log_id);
 
-        let vote = sto.read_vote().await?.unwrap();
-        assert_eq!(vote, Vote::new_committed(1, 0));
+            let vote = sto.read_vote().await?.unwrap();
+            assert_eq!(Vote::new_committed(1, 0), vote);
 
-        let (last_applied, _) = sm.applied_state().await?;
-        assert_eq!(last_applied, Some(log_id(1, 0, log_index)));
+            let (last_applied, _) = sm.applied_state().await?;
+            assert_eq!(Some(log_id(1, 0, log_index)), last_applied);
 
-        let snap = sm.get_current_snapshot().await?.unwrap();
-        let snap_log_id = snap.meta.last_log_id.unwrap();
-        assert!(snap_log_id.index() >= 450);
-        assert!(snap_log_id.index() < 600);
-        assert_eq!(snap_log_id.committed_leader_id().term, 1);
+            let snap = sm.get_current_snapshot().await?.unwrap();
+            let snap_log_id = snap.meta.last_log_id.unwrap();
+            assert!(snap_log_id.index() >= 450);
+            assert!(snap_log_id.index() < 600);
+            assert_eq!(1, snap_log_id.committed_leader_id().term);
+        }
     }
 
     Ok(())
@@ -109,13 +117,15 @@ async fn client_write_ff() -> Result<()> {
     let got: ClientWriteResponse<TypeConfig> = complete_rx.await??;
     assert_eq!(None, got.response().0.as_deref());
 
-    // Deliberately set the responder to None and do not wait for the result.
-    n0.client_write_ff(ClientRequest::make_request("foo", 3), None).await?;
+    tracing::info!("--- omit one responder and observe that write through the next response");
+    {
+        n0.client_write_ff(ClientRequest::make_request("foo", 3), None).await?;
 
-    let (responder, complete_rx) = ProgressResponder::complete_only();
-    n0.client_write_ff(ClientRequest::make_request("foo", 4), Some(responder)).await?;
-    let got: ClientWriteResponse<TypeConfig> = complete_rx.await??;
-    assert_eq!(Some("request-3"), got.response().0.as_deref());
+        let (responder, complete_rx) = ProgressResponder::complete_only();
+        n0.client_write_ff(ClientRequest::make_request("foo", 4), Some(responder)).await?;
+        let got: ClientWriteResponse<TypeConfig> = complete_rx.await??;
+        assert_eq!(Some("request-3"), got.response().0.as_deref());
+    }
 
     Ok(())
 }
@@ -253,37 +263,36 @@ async fn write_blank() -> Result<()> {
 
     let n0 = router.get_raft_handle(&0)?;
 
-    // Write a blank entry
     tracing::info!("--- write blank entry");
-    let resp = n0.write_blank().await?;
-    log_index += 1;
+    {
+        let resp = n0.write_blank().await?;
+        log_index += 1;
+        assert_eq!(&log_id(1, 0, log_index), resp.log_id());
 
-    assert_eq!(&log_id(1, 0, log_index), resp.log_id());
+        for id in [0, 1, 2] {
+            router.wait(&id, None).applied_index(Some(log_index), "blank entry applied").await?;
+        }
 
-    // Wait for all nodes to apply the blank entry
-    for id in [0, 1, 2] {
-        router.wait(&id, None).applied_index(Some(log_index), "blank entry applied").await?;
+        let (mut sto, _sm) = router.get_storage_handle(&0)?;
+        let entries = sto.try_get_log_entries(log_index..=log_index).await?;
+        assert_eq!(1, entries.len());
+
+        let entry = &entries[0];
+        assert!(
+            matches!(entry.payload, openraft::entry::EntryPayload::Blank),
+            "Expected Blank payload, got: {:?}",
+            entry.payload
+        );
     }
 
-    // Verify the log contains a blank entry
-    let (mut sto, _sm) = router.get_storage_handle(&0)?;
-    let entries = sto.try_get_log_entries(log_index..=log_index).await?;
-    assert_eq!(1, entries.len());
-
-    let entry = &entries[0];
-    assert!(
-        matches!(entry.payload, openraft::entry::EntryPayload::Blank),
-        "Expected Blank payload, got: {:?}",
-        entry.payload
-    );
-
-    // Write another normal entry to verify blank didn't break anything
     tracing::info!("--- write normal entry after blank");
-    n0.client_write(ClientRequest::make_request("after_blank", 1)).await?;
-    log_index += 1;
+    {
+        n0.client_write(ClientRequest::make_request("after_blank", 1)).await?;
+        log_index += 1;
 
-    for id in [0, 1, 2] {
-        router.wait(&id, None).applied_index(Some(log_index), "normal entry after blank").await?;
+        for id in [0, 1, 2] {
+            router.wait(&id, None).applied_index(Some(log_index), "normal entry after blank").await?;
+        }
     }
 
     Ok(())

--- a/tests/tests/client_api/t16_with_raft_state.rs
+++ b/tests/tests/client_api/t16_with_raft_state.rs
@@ -28,18 +28,22 @@ async fn with_raft_state() -> Result<()> {
 
     let n0 = router.get_raft_handle(&0)?;
 
-    let committed = n0.with_raft_state(|st| st.local_committed().cloned()).await?;
-    assert_eq!(committed, Some(log_id(1, 0, log_index)));
+    tracing::info!(log_index, "--- inspect the leader's committed log IDs");
+    {
+        let committed = n0.with_raft_state(|st| st.local_committed().cloned()).await?;
+        assert_eq!(Some(log_id(1, 0, log_index)), committed);
 
-    // On the leader, the cluster-committed log id equals the local committed log id.
-    let cluster_committed = n0.with_raft_state(|st| st.cluster_committed().cloned()).await?;
-    assert_eq!(cluster_committed, Some(log_id(1, 0, log_index)));
+        let cluster_committed = n0.with_raft_state(|st| st.cluster_committed().cloned()).await?;
+        assert_eq!(Some(log_id(1, 0, log_index)), cluster_committed);
+    }
 
     tracing::info!("--- shutting down node 0");
-    n0.shutdown().await?;
+    {
+        n0.shutdown().await?;
 
-    let res = n0.with_raft_state(|st| st.local_committed().cloned()).await;
-    assert_eq!(Err(Fatal::Stopped), res);
+        let res = n0.with_raft_state(|st| st.local_committed().cloned()).await;
+        assert_eq!(Err(Fatal::Stopped), res);
+    }
 
     Ok(())
 }

--- a/tests/tests/membership/t30_elect_with_new_config.rs
+++ b/tests/tests/membership/t30_elect_with_new_config.rs
@@ -38,44 +38,51 @@ async fn leader_election_after_changing_0_to_01234() -> Result<()> {
     tracing::info!("--- initializing cluster");
     let mut log_index = router.new_cluster(btreeset! {0,1,2,3,4}, btreeset! {}).await?;
 
-    // Isolate old leader and assert that a new leader takes over.
-    tracing::info!(log_index, "--- isolating leader node 0");
-    router.set_network_error(0, true);
+    tracing::info!(
+        log_index,
+        "--- isolate node 0 and elect node 1 under the new membership"
+    );
+    {
+        router.set_network_error(0, true);
+        TypeConfig::sleep(Duration::from_millis(700)).await;
 
-    // Wait for leader lease to expire
-    TypeConfig::sleep(Duration::from_millis(700)).await;
+        let node_1 = router.get_raft_handle(&1)?;
+        node_1.trigger().elect(false).await?;
+        log_index += 1;
 
-    // Let node-1 become leader.
-    let node_1 = router.get_raft_handle(&1)?;
-    node_1.trigger().elect(false).await?;
-    log_index += 1; // leader initial blank log
+        router.wait(&1, timeout()).metrics(|x| x.current_leader == Some(1), "wait for new leader").await?;
 
-    router.wait(&1, timeout()).metrics(|x| x.current_leader == Some(1), "wait for new leader").await?;
-
-    for node_id in [1, 2, 3, 4] {
-        router
-            .wait(&node_id, timeout())
-            .applied_index(Some(log_index), "replicate and apply log to every node")
-            .await?;
+        for node_id in [1, 2, 3, 4] {
+            router
+                .wait(&node_id, timeout())
+                .applied_index(Some(log_index), "replicate and apply log to every node")
+                .await?;
+        }
     }
 
     let leader_id = 1;
 
-    tracing::info!(log_index, "--- restore node 0, log_index:{}", log_index);
-    router.set_network_error(0, false);
-    router
-        .wait(&0, timeout())
-        .metrics(
-            |x| x.current_leader == Some(leader_id) && x.last_applied.index() == Some(log_index),
-            "wait for restored node-0 to sync",
-        )
-        .await?;
-
-    let current_leader = router.leader().expect("expected to find current leader");
-    assert_eq!(
-        leader_id, current_leader,
-        "expected cluster leadership to stay the same"
+    tracing::info!(
+        log_index,
+        leader_id,
+        "--- restore node 0 and verify leadership stays stable"
     );
+    {
+        router.set_network_error(0, false);
+        router
+            .wait(&0, timeout())
+            .metrics(
+                |x| x.current_leader == Some(leader_id) && x.last_applied.index() == Some(log_index),
+                "wait for restored node-0 to sync",
+            )
+            .await?;
+
+        let current_leader = router.leader().expect("expected to find current leader");
+        assert_eq!(
+            leader_id, current_leader,
+            "expected cluster leadership to stay the same"
+        );
+    }
 
     Ok(())
 }

--- a/tests/tests/snapshot_building/t60_snapshot_policy_never.rs
+++ b/tests/tests/snapshot_building/t60_snapshot_policy_never.rs
@@ -47,33 +47,37 @@ async fn snapshot_policy_never() -> Result<()> {
     tracing::info!("--- initializing cluster");
     let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
-    let mut clients = futures::stream::FuturesUnordered::new();
+    tracing::info!(n_logs, "--- write enough logs to exceed the default snapshot threshold");
+    {
+        let mut clients = futures::stream::FuturesUnordered::new();
+        let n_clients = 20;
+        for i in 0..n_clients {
+            let per_client = n_logs / n_clients;
+            let r = router.clone();
+            clients.push(async move {
+                let client_id = format!("{}", i);
+                r.client_request_many(0, &client_id, per_client as usize).await
+            });
+            log_index += per_client;
+        }
 
-    let n_clients = 20;
-    for i in 0..n_clients {
-        let per_client = n_logs / n_clients;
-        let r = router.clone();
-        clients.push(async move {
-            let client_id = format!("{}", i);
-            r.client_request_many(0, &client_id, per_client as usize).await
-        });
-        log_index += per_client;
+        while clients.next().await.is_some() {}
     }
 
-    while clients.next().await.is_some() {}
+    tracing::info!(log_index, "--- verify all logs apply without building a snapshot");
+    {
+        router
+            .wait(&0, timeout())
+            .applied_index(Some(log_index), format_args!("write log up to {}", log_index))
+            .await?;
 
-    tracing::info!(log_index, "--- log_index: {}", log_index);
-    router
-        .wait(&0, timeout())
-        .applied_index(Some(log_index), format_args!("write log up to {}", log_index))
-        .await?;
+        let wait_snapshot_res = router
+            .wait(&0, Some(Duration::from_millis(3_000)))
+            .metrics(|m| m.snapshot.is_some(), "no snapshot will be built")
+            .await;
 
-    let wait_snapshot_res = router
-        .wait(&0, Some(Duration::from_millis(3_000)))
-        .metrics(|m| m.snapshot.is_some(), "no snapshot will be built")
-        .await;
-
-    assert!(wait_snapshot_res.is_err(), "no snapshot should be built");
+        assert!(wait_snapshot_res.is_err(), "no snapshot should be built");
+    }
 
     Ok(())
 }


### PR DESCRIPTION

## Changelog

##### fix: progress: ignore stale conflict in update_conflicting()
# Summary

`Updater::update_conflicting()` now leaves the whole progress entry
untouched when a conflict response carries an inflight ID that no longer
matches the entry's current inflight request. Previously only
`Inflight::conflict()` skipped the stale response, while `searching_end`
and `matching` were still rewound by it.

# Details

`Inflight::conflict()` returns whether the conflict was applied:
`false` when the inflight ID does not match, and also for
`Inflight::None`, where no outstanding request exists to conflict with.
`Updater::update_conflicting()` returns early on `false`.

Without the early return, a late response from a superseded replication
request could lower `searching_end` back to an already-resolved index,
and with log reversion allowed could reset `matching` to `None`, forcing
the leader to search back from the start and delaying replication to
that follower.

New `update_conflicting_test.rs` covers `ReplicationHandler::
update_conflicting()`: matching, stale, heartbeat (no inflight ID) and
removed-target responses, plus the globally-enabled and one-shot log
reversion paths, checking entry state, progress ordering and
`quorum_accepted()`. It resolves the `TODO(2): test it?` that the method
carried.


##### test: integration: organize tests into logged phases
# Summary

Make multi-step integration tests read as linear, purpose-driven phases.

# Details

Replace action comments with contextual tracing and scoped blocks. Keep
phase-local values local, and make selected-field assertion failures report
the expected and actual values in their conventional order.

---

- Bug Fix
- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2000)
<!-- Reviewable:end -->
