### PR TITLE
docs: cluster-control: state that node IDs must never be reused

### DIFF
--- a/openraft/src/docs/cluster_control/dynamic-membership.md
+++ b/openraft/src/docs/cluster_control/dynamic-membership.md
@@ -85,6 +85,70 @@ need to roll back. For permanent removal in a single call, prefer
 from the cluster without an intermediate learner state.
 
 
+## Node IDs Must Not Be Reused
+
+A node ID identifies one node, holding one log, for the entire lifetime of the
+cluster. Once a node is removed, never assign its ID to a node that starts from
+a different log, typically an empty one. Restarting a node with its data intact
+is not reuse: the ID still designates the same log.
+
+Reusing an ID is equivalent to letting that node revert its log, and it can
+split the cluster into two independent quorums. The reason is that a node
+replaying the log from an empty state passes through every **historical**
+membership config on its way to the current one, and a membership config takes
+effect as soon as it is appended, without waiting to be committed. A historical
+config that contains the reused ID therefore becomes the effective membership
+of the fresh node for a while.
+
+Consider a cluster whose membership was once the single node `{n3}` and is now
+`{n1, n2, n3}` with `n1` as the leader:
+
+1. `n1` calls `change_membership({n1, n2})`, removing `n3`.
+2. `n3` observes its removal and wipes its disk.
+3. `n1` calls `add_learner(n3, ..)` and `change_membership({n1, n2, n3})`,
+   giving the ID `n3` to the wiped node.
+4. The wiped `n3` replays the log from the beginning. Partway through, it
+   appends the historical membership entry `{n3}` and adopts it as its
+   effective membership, in which `n3` alone is a quorum.
+5. If replication to `n3` stalls before it catches up, because the leader
+   crashed or the network partitioned, `n3`'s election timer fires. It elects
+   itself with its own vote under config `{n3}` and commits writes, while
+   `{n1, n2}` is still a quorum under the current config and commits writes of
+   its own. The two quorums are split-brained.
+
+```text
+membership: {n3}      {n1,n2,n3}   {n1,n2}   {n1,n2,n3}
+n1        |  ...  ------------------------------------->  quorum {n1,n2}
+n2        |  ...  ------------------------------------->
+n3        |  ...  --------------------------X  erased
+n3(new)   |                                    {n3} -->   quorum {n3}
+----------+------------------------------------------------------> time
+```
+
+Openraft cannot detect this. Removing a node discards the leader's replication
+progress for it, so the empty log of the re-added `n3` does not look like a
+[log reversion][`Config::allow_log_reversion`]; the caller must guarantee ID
+uniqueness.
+
+**Recommendation:** allocate a fresh, never-before-used ID for every node that
+joins the cluster. A good way to do so is to let the cluster's own log allocate
+it: when a node joins, the leader proposes a blank log entry and uses the index
+of that entry as the new node's ID.
+
+```ignore
+// `Request::blank()` is an application request that changes nothing.
+let resp = raft.client_write(Request::blank()).await?;
+let node_id = resp.log_id.index();
+
+raft.add_learner(node_id, node, true).await?;
+```
+
+Log indices strictly increase and no committed index is ever assigned twice, so
+every ID obtained this way is one that no node has ever held, and no external ID
+service is needed. If the blank write fails, no node has taken that index yet,
+so retrying is safe.
+
+
 ## Updating Node Metadata
 
 To update node metadata (e.g., network address), use `ChangeMembers::SetNodes`.
@@ -143,6 +207,7 @@ Exercise additional care when:
 [`Raft::change_membership()`]: `crate::Raft::change_membership`
 [`ChangeMembers::SetNodes`]: `crate::change_members::ChangeMembers::SetNodes`
 [`ChangeMembers::RemoveNodes`]: `crate::change_members::ChangeMembers::RemoveNodes`
+[`Config::allow_log_reversion`]: `crate::config::Config::allow_log_reversion`
 [`RaftNetworkFactory`]: `crate::network::RaftNetworkFactory`
 [`RaftNetworkV2`]: `crate::network::RaftNetworkV2`
 [`joint_consensus`]: `crate::docs::cluster_control::joint_consensus`

--- a/openraft/src/docs/faq/06-operations/02-remove-node.md
+++ b/openraft/src/docs/faq/06-operations/02-remove-node.md
@@ -3,3 +3,7 @@
 Call `Raft::change_membership(btreeset!{1, 3})` to exclude node-2 from
 the cluster. Then wipe out node-2 data.
 **NEVER** modify/erase the data of any node that is still in a raft cluster, unless you know what you are doing.
+
+Do not give node-2's ID to a different node afterwards: reusing an ID can cause
+split-brain. See:
+[Can I reuse the ID of a removed node for a new node?](#can-i-reuse-the-id-of-a-removed-node-for-a-new-node)

--- a/openraft/src/docs/faq/06-operations/09-reuse-node-id.md
+++ b/openraft/src/docs/faq/06-operations/09-reuse-node-id.md
@@ -1,0 +1,30 @@
+### Can I reuse the ID of a removed node for a new node?
+
+No. A node ID must identify the same node, holding the same log, for the entire
+lifetime of the cluster. Assigning the ID of a removed node to a node that
+starts from an empty log is equivalent to letting that node revert its log, and
+it can split the cluster into two independent quorums. Restarting a node with
+its data intact is not reuse; it keeps the same ID and the same log.
+
+The hazard is that the new node replays the log from the beginning and passes
+through every **historical** membership config on its way to the current one,
+adopting each as its effective membership as soon as it is appended. If a
+historical config contains the reused ID with a small quorum, for example the
+single-node config `{n3}` a cluster started from, the new node becomes a quorum
+of one under that config and can elect itself leader while the rest of the
+cluster still forms a quorum of its own.
+
+Openraft cannot detect this, because removing a node discards the leader's
+replication progress for it: the empty log of the re-added node does not look
+like a [log reversion][`Config::allow_log_reversion`]. Allocate a fresh,
+never-before-used ID for every node that joins the cluster. A good way to do so
+is to let the cluster's own log allocate it: propose a blank log entry with
+[`Raft::client_write()`] and use the index of that entry as the new node's ID.
+Log indices strictly increase and no committed index is ever assigned twice, so
+the ID is one that no node has ever held.
+
+See: [Node IDs Must Not Be Reused][`dynamic_membership`] for the full scenario.
+
+[`Config::allow_log_reversion`]: `crate::config::Config::allow_log_reversion`
+[`Raft::client_write()`]: `crate::Raft::client_write`
+[`dynamic_membership`]: `crate::docs::cluster_control::dynamic_membership#node-ids-must-not-be-reused`

--- a/openraft/src/docs/faq/07-troubleshooting/04-wipe-node-data.md
+++ b/openraft/src/docs/faq/07-troubleshooting/04-wipe-node-data.md
@@ -30,4 +30,8 @@ But for even number nodes cluster, Erasing **exactly one** node won't cause data
 Thus, in a special scenario like this, or for testing purpose, you can use
 [`Config::allow_log_reversion`] to permit erasing a node.
 
+Removing the node from the membership before wiping it does not make the
+sequence safe either, as long as the wiped node rejoins under its old ID. See:
+[Can I reuse the ID of a removed node for a new node?](#can-i-reuse-the-id-of-a-removed-node-for-a-new-node)
+
 [`Config::allow_log_reversion`]: `crate::config::Config::allow_log_reversion`

--- a/openraft/src/docs/faq/faq-toc.md
+++ b/openraft/src/docs/faq/faq-toc.md
@@ -35,6 +35,7 @@
   * [Error logs after `raft.shutdown()` completes](#error-logs-after-raftshutdown-completes)
   * [Why can a Leader reject a client write?](#why-can-a-leader-reject-a-client-write)
   * [How to restore a cluster from a snapshot backup?](#how-to-restore-a-cluster-from-a-snapshot-backup)
+  * [Can I reuse the ID of a removed node for a new node?](#can-i-reuse-the-id-of-a-removed-node-for-a-new-node)
 - [Troubleshooting & Safety](#troubleshooting--safety)
   * [Panic: "assertion failed: self.internal_server_state.is_following()"](#panic-assertion-failed-selfinternal_server_stateis_following)
   * [Holding `Raft::metrics()` reference blocks the Raft node](#holding-raftmetrics-reference-blocks-the-raft-node)

--- a/openraft/src/docs/faq/faq.md
+++ b/openraft/src/docs/faq/faq.md
@@ -710,6 +710,10 @@ Call `Raft::change_membership(btreeset!{1, 3})` to exclude node-2 from
 the cluster. Then wipe out node-2 data.
 **NEVER** modify/erase the data of any node that is still in a raft cluster, unless you know what you are doing.
 
+Do not give node-2's ID to a different node afterwards: reusing an ID can cause
+split-brain. See:
+[Can I reuse the ID of a removed node for a new node?](#can-i-reuse-the-id-of-a-removed-node-for-a-new-node)
+
 
 ### Does OpenRaft support calling `change_membership` in parallel?
 
@@ -932,6 +936,38 @@ Notes:
 [`Config::allow_log_reversion`]: `crate::config::Config::allow_log_reversion`
 
 
+### Can I reuse the ID of a removed node for a new node?
+
+No. A node ID must identify the same node, holding the same log, for the entire
+lifetime of the cluster. Assigning the ID of a removed node to a node that
+starts from an empty log is equivalent to letting that node revert its log, and
+it can split the cluster into two independent quorums. Restarting a node with
+its data intact is not reuse; it keeps the same ID and the same log.
+
+The hazard is that the new node replays the log from the beginning and passes
+through every **historical** membership config on its way to the current one,
+adopting each as its effective membership as soon as it is appended. If a
+historical config contains the reused ID with a small quorum, for example the
+single-node config `{n3}` a cluster started from, the new node becomes a quorum
+of one under that config and can elect itself leader while the rest of the
+cluster still forms a quorum of its own.
+
+Openraft cannot detect this, because removing a node discards the leader's
+replication progress for it: the empty log of the re-added node does not look
+like a [log reversion][`Config::allow_log_reversion`]. Allocate a fresh,
+never-before-used ID for every node that joins the cluster. A good way to do so
+is to let the cluster's own log allocate it: propose a blank log entry with
+[`Raft::client_write()`] and use the index of that entry as the new node's ID.
+Log indices strictly increase and no committed index is ever assigned twice, so
+the ID is one that no node has ever held.
+
+See: [Node IDs Must Not Be Reused][`dynamic_membership`] for the full scenario.
+
+[`Config::allow_log_reversion`]: `crate::config::Config::allow_log_reversion`
+[`Raft::client_write()`]: `crate::Raft::client_write`
+[`dynamic_membership`]: `crate::docs::cluster_control::dynamic_membership#node-ids-must-not-be-reused`
+
+
 ## Troubleshooting & Safety
 
 ### Panic: "assertion failed: self.internal_server_state.is_following()"
@@ -1028,6 +1064,10 @@ N5 |                 elect  L2
 But for even number nodes cluster, Erasing **exactly one** node won't cause data loss.
 Thus, in a special scenario like this, or for testing purpose, you can use
 [`Config::allow_log_reversion`] to permit erasing a node.
+
+Removing the node from the membership before wiping it does not make the
+sequence safe either, as long as the wiped node rejoins under its old ID. See:
+[Can I reuse the ID of a removed node for a new node?](#can-i-reuse-the-id-of-a-removed-node-for-a-new-node)
 
 [`Config::allow_log_reversion`]: `crate::config::Config::allow_log_reversion`
 

--- a/openraft/src/docs/getting_started/getting-started.md
+++ b/openraft/src/docs/getting_started/getting-started.md
@@ -93,7 +93,10 @@ impl openraft::RaftTypeConfig for TypeConfig {
 
 > In the above `TypeConfig` declaration,
 > - `NodeId` is the identifier of a node in the cluster, which implements
->   [`NodeId`] trait.
+>   [`NodeId`] trait. A node ID identifies one node, holding one log, for the
+>   lifetime of the cluster: never give the ID of a removed node to a node that
+>   starts from an empty log, otherwise the cluster may split-brain. See:
+>   [Node IDs must not be reused][`docs::node-id-reuse`].
 > - `Node` is the node type that contains the node's address, etc., which
 >   implements [`Node`] trait.
 > - `Entry` is the log entry type that will be stored in the raft log,
@@ -526,3 +529,4 @@ Additionally, two test scripts for setting up a cluster are available:
 [`Unreachable`]:                        `crate::error::Unreachable`
 
 [`docs::connect-to-correct-node`]:      `crate::docs::cluster_control::dynamic_membership#ensure-connection-to-the-correct-node`
+[`docs::node-id-reuse`]:                `crate::docs::cluster_control::dynamic_membership#node-ids-must-not-be-reused`

--- a/openraft/src/node.rs
+++ b/openraft/src/node.rs
@@ -32,6 +32,14 @@ use crate::base::OptionalFeatures;
 /// A Raft node's ID.
 ///
 /// A `NodeId` uniquely identifies a node in the Raft cluster.
+///
+/// A node ID identifies one node, holding one log, for the entire lifetime of the cluster. Never
+/// give the ID of a removed node to a node that starts from an empty log: such reuse is equivalent
+/// to reverting that node's log and can split the cluster into two independent quorums.
+///
+/// See: [Node IDs must not be reused][node-id-reuse]
+///
+/// [node-id-reuse]: crate::docs::cluster_control::dynamic_membership#node-ids-must-not-be-reused
 pub trait NodeId
 where Self: Sized + OptionalFeatures + Eq + PartialEq + Ord + PartialOrd + Debug + Display + Hash + Clone + 'static
 {


### PR DESCRIPTION

## Changelog

##### docs: cluster-control: state that node IDs must never be reused
# Summary

Document that a node ID identifies one node holding one log for the
lifetime of the cluster, and that giving a removed node's ID to a node
starting from an empty log can split the cluster into two independent
quorums.

# Details

A new "Node IDs Must Not Be Reused" section in the dynamic membership
guide carries the reasoning and the split-brain scenario: the fresh node
replays the log from the beginning and adopts every historical
membership config as it is appended, so a historical config containing
the reused ID makes that node a quorum on its own while the current
members still form a quorum. Openraft cannot guard against this, because
removing a node discards the leader's replication progress for it, so
the re-added node's empty log is not detected as a log reversion.

The rule reaches readers through the entry points that lead them into
the trap: the `NodeId` trait doc, the `NodeId` bullet in the getting
started tutorial, and a new FAQ entry under Operations & Maintenance.
The two FAQ answers that end with "wipe the node data" — removing a node
and wiping one node's data — now link to it, since a reader following
either is one step away from reusing the ID.

- Reported in: https://github.com/databendlabs/openraft/discussions/1998

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2002)
<!-- Reviewable:end -->
