### PR TITLE
test: jepsen: enforce error-handling semantics

### DIFF
--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -186,6 +186,165 @@ shared readiness check. Client operations continue while faults are active and
 during recovery. Final recovery performs one write and one read per register;
 every operation must succeed.
 
+### Outcome Semantics and Evidence
+
+[Jepsen error-handling semantics](error-handling-semantics.md) defines the
+agreed target contract. It is authoritative where the implementation notes
+below differ.
+
+An unsuccessful operation is often a correct and necessary Jepsen observation,
+not a failure of the test itself. This document uses *outcome* for the result of
+a Client or Nemesis operation, *SUT failure* for an OpenRaft property violation
+established by a checker, and *Harness failure* for a defect in the test code,
+configuration, or execution environment. An `:error` field in an EDN record is
+diagnostic data; its presence alone does not decide which category applies. The
+classification depends on whether the condition is a modeled external result,
+not on whether it occurred before, during, or after a Client or Nemesis call.
+There is no separate generic "Client error" category.
+
+#### Workload Outcomes
+
+Every Client invocation and completion belongs in `history.edn`:
+
+- `:ok` means the operation completed successfully.
+- `:fail` means the operation did not take effect.
+- `:info` means a mutating operation may or may not have taken effect, so its
+  result is indeterminate.
+
+Connection failures, request timeouts, and version mismatches can therefore be
+valid workload outcomes. Even when a Nemesis caused them, they remain workload
+outcomes because they describe what the Client observed from the SUT. Workload
+checkers interpret these outcomes together rather than treating every
+unsuccessful request as a broken test. The Client converts only recognized
+transport, HTTP, and OpenRaft API conditions into workload outcomes. A recognized
+protocol violation, such as invalid JSON, is recorded as an unexpected outcome
+for the workload checker. An exception that the Client does not recognize is a
+Harness failure, not a catch-all `:client-error` outcome.
+
+The current workload still has a catch-all `:client-error` fallback for unknown
+exceptions. Its unexpected-error checker prevents such a run from passing, but
+the fallback must be removed to enforce the boundary described above.
+
+#### Nemesis Outcomes
+
+Nemesis invocations and completions also belong in `history.edn`. Their outcomes
+describe whether a requested fault was installed, skipped, failed, or became
+indeterminate. For example, `:no-supported-leader` and
+`:no-reachable-pause-target` mean that no fault was installed and must not count
+toward fault coverage. A partial or uncertain fault leaves the affected cluster
+state unknown until a later cleanup or recovery operation proves otherwise.
+
+Nemesis operations use informational history events by convention, so their
+`:type` alone does not establish success. The OpenRaft Nemesis checkers inspect
+their structured values, errors, observed modes, and final recovery state. An
+expected operational problem must be converted into a structured Nemesis
+outcome. An unexpected implementation exception, such as a null dereference, is
+a Harness failure even when it occurs while a Nemesis operation is running.
+
+The partition, process, and pause wrappers treat exceptions from delegated fault
+injection as Harness failures. Only explicitly modeled conditions, such as a
+missing supported leader, become Nemesis outcomes. A new expected failure mode
+requires a narrow classifier; delegate exceptions must not be caught by a
+generic fallback.
+
+#### Checker Verdicts
+
+Checkers turn the collected evidence into separate verdicts. Property checkers
+decide whether OpenRaft satisfies a property: for example, the linearizability
+checker may prove that no legal sequential execution explains the Client
+history, or the crash checker may find the stable panic marker in an OpenRaft
+node log. Coverage checkers instead decide whether the run produced enough
+evidence that required scenarios were successfully exercised, such as all
+required Nemesis modes and successful main-phase operations. Nemesis checkers
+also verify a separate lifecycle postcondition: after fault cleanup, the cluster
+must return to the required state within the recovery deadline.
+
+A coverage failure rejects the run but does not by itself identify an OpenRaft
+failure or its root cause. For example, `:missing-modes` is written to
+`results.edn`; the mode may be absent from `history.edn`, skipped by an outcome
+such as `:no-supported-leader`, or blocked by a Harness failure recorded in
+`jepsen.log`. Start with the nested checker result, inspect the corresponding
+operations in `history.edn`, and then use `jepsen.log` for Harness diagnostics.
+
+The top-level `:valid?` combines these independent verdicts and answers only
+whether the entire run can be accepted. It does not by itself identify an
+OpenRaft property violation or the state of the Harness.
+
+#### Harness Failures
+
+Harness failures include Client or Nemesis implementation bugs, invalid test
+configuration, missing runtime dependencies, and unexpected failures in setup,
+teardown, artifact storage, or checker execution. They make the run unacceptable
+and must not be reclassified as ordinary workload or Nemesis outcomes. They do
+not automatically erase a conclusion already established by a nested checker.
+`jepsen.log` is the primary diagnostic record for these failures. Jepsen may also
+attach a worker exception to the operation being executed in `history.edn`; that
+association is diagnostic evidence, not a successful or expected outcome.
+
+Best-effort teardown is different from formal fault cleanup. When cleanup and
+recovery completions exist in `history.edn`, they determine the checker verdict;
+teardown must not manufacture a successful outcome. An expected teardown
+cleanup failure should be logged as a warning and must not prevent analysis of
+the recorded history. An unexpected teardown implementation failure remains a
+Harness failure.
+
+The current partition and pause teardown implementations do not yet enforce
+this boundary: they log every non-interruption exception as a cleanup warning.
+They must be narrowed so unexpected implementation exceptions remain Harness
+failures.
+
+The required Harness policy is controlled fail-fast. The first unhandled
+exception should be retained as the run-level cause, stop new Client and Nemesis
+operations, run best-effort fault cleanup, preserve the available artifacts,
+and exit nonzero. The run cannot pass, although individual property and coverage
+checkers may still produce independent verdicts. A Harness failure does not by
+itself prove an SUT failure.
+
+Interruption is a cancellation mechanism, not an operation outcome or a
+standalone failure category. Client and Nemesis code must restore the thread's
+interrupt flag and rethrow instead of converting interruption into `:fail`,
+`:info`, or a cleanup warning. Normal Jepsen completion does not use
+interruption: after the generator is exhausted, the interpreter drains
+outstanding operations and stops its workers. If the interpreter exits
+abnormally, worker interruption is a secondary cleanup signal rather than the
+original failure. Client and Nemesis code must therefore propagate interruption
+without trying to infer its cause. Controlled fail-fast instead needs a
+run-level channel for the first unhandled exception, not cancellation-origin or
+Harness fields in `history.edn`.
+
+The current implementation does not yet have this run-level failure channel or
+stop the schedule immediately. Jepsen catches a worker exception, records an
+`:info` completion with `:exception`, and continues running. The strict
+unhandled-exception checker reports `:unknown`, so such a run cannot pass;
+another nested checker may still make the composed top-level result `false`.
+Controlled fail-fast remains necessary to report the Harness failure at the
+point where it occurs.
+
+#### Stored Evidence
+
+A run normally stores its artifacts under
+`jepsen/store/<test-name>/<timestamp>/`:
+
+- `history.edn` is the structured Client and Nemesis history used by the
+  workload, Nemesis, statistics, and unhandled-exception checkers. `history.txt`
+  is a human-readable rendering of the same history.
+- `jepsen.log` records Harness activity and diagnostics from setup, workers,
+  fault injection, teardown, and analysis. Checkers do not use it as an
+  observation source.
+- `<node>/openraft.log` is the collected runtime log of the OpenRaft test
+  application on that node. The crash checker scans it for the test
+  application's stable panic marker.
+- `results.edn` contains the composed checker results and top-level verdict. It
+  is a summary, not the raw execution record.
+- `test.jepsen` contains the original test map, including run options and the
+  random seed. It remains useful when a Harness failure prevents `results.edn`
+  from being written.
+
+Use `history.edn` to reconstruct requests and the fault schedule, `jepsen.log`
+to diagnose the Harness, and each node's `openraft.log` to investigate the
+OpenRaft process. Start with `results.edn` when the run reached analysis and a
+checker verdict is available.
+
 ### Interpreting Results
 
 Each run writes its checker output to

--- a/jepsen/error-handling-semantics.md
+++ b/jepsen/error-handling-semantics.md
@@ -1,0 +1,162 @@
+# Jepsen Error-Handling Semantics
+
+This document defines the agreed error-handling contract for OpenRaft Jepsen
+runs. It specifies the target behavior. Current implementation notes may
+describe gaps, but Client, Nemesis, lifecycle, and checker code must preserve
+these boundaries.
+
+## Classification Model
+
+OpenRaft Jepsen recognizes only two runtime event classes:
+
+- An **Outcome** is a result or observation recorded at a Workload or Nemesis
+  boundary.
+- A **Harness failure** is a failure in the test code, controller, configuration,
+  dependencies, or execution environment.
+
+Checker verdicts are derived from the recorded history and outcomes. They are
+analysis results, not a third event class alongside Outcomes and Harness
+failures. A checker can reject a run because it found a system under test (SUT)
+property violation, insufficient coverage, or another failed postcondition.
+
+Interruption is not a runtime event class. It is a lifecycle signal that must
+propagate to the caller.
+
+## Workload Outcomes
+
+Workload outcomes include successful operations, modeled failures, and
+ambiguous observations. Request timeouts and connection failures are valid
+outcomes when they describe what a Client observed through the SUT API. For a
+mutating request, such an observation may leave the operation's effect unknown.
+
+`:unexpected-sut-response?` is an attribute on a Workload outcome, not a new
+outcome class. Set it only when a valid request receives a SUT response outside
+the modeled API contract, such as an unexpected HTTP response or invalid
+response shape. Keep that outcome in the history so the
+`unexpected-sut-responses` checker can report it and reject the run.
+
+Do not set `:unexpected-sut-response?` on modeled failures or ambiguous
+observations, including timeouts, connection failures, or quorum-related
+rejections. Unknown Client, Nemesis, or other Harness exceptions must not
+receive the marker. They are Harness failures.
+
+## Nemesis Outcomes
+
+A Nemesis operation has only three modeled outcomes:
+
+- `installed` means the requested fault is known to have been installed, or the
+  requested restoration is known to have completed.
+- `skipped` means the action is known not to have been installed. Reasons
+  include no safe target, no reachable leader, or a membership change already
+  in progress.
+- `indeterminate` means the action was attempted, but the available evidence
+  cannot establish whether its side effect occurred.
+
+There is no generic `failed` Nemesis outcome. A condition belongs in `skipped`
+or `indeterminate` only when its meaning is explicitly modeled. An unclassified
+exception or execution failure is a Harness failure.
+
+The modeled `skipped` reasons assume a functioning control plane. Failure to
+find or control a target because SSH failed is a Harness failure.
+
+## Harness Failures
+
+Harness failures include:
+
+- configuration, dependency, and environment failures;
+- every SSH and other control-plane failure;
+- unknown exceptions from Client, Nemesis, or checker code;
+- command construction, permission, and environment-execution failures; and
+- unexpected teardown or recovery failures.
+
+SSH carries controller-to-node management traffic for setup, fault control,
+recovery, and artifact collection. It is separate from Client traffic through
+the SUT API and from node-to-node Raft traffic. An SSH authentication,
+connection, session, or remote-execution failure is therefore always a Harness
+failure, including when it occurs during a Nemesis operation. Uncertainty after
+an SSH command was dispatched does not turn that failure into a Nemesis
+`indeterminate` outcome.
+
+## Controlled Stop After the First Harness Failure
+
+The first Harness failure starts a controlled stop:
+
+1. Record the first failure as run-level state, including its source and
+   original exception. Later failures must not replace it.
+2. A gate around the ordinary runtime generator returns `nil` whenever Jepsen
+   asks for another operation. This stops new ordinary Client and Nemesis
+   operations from being scheduled.
+3. Preserve completions from operations already in flight.
+4. Run the final Nemesis recovery generator so installed faults can be removed
+   and the cluster can recover.
+5. Skip final Workload reads and writes. They cannot make a compromised run
+   acceptable and would add new Workload history after the experiment stopped.
+6. Run applicable analysis and retain its checker outputs.
+7. Finish with a nonzero exit status.
+
+The generator gate does not throw and does not perform cleanup. Returning `nil`
+means normal generator exhaustion. It is neither an exception nor an
+interruption. Existing lifecycle handling drains in-flight operations and then
+runs final recovery, teardown, artifact collection, and applicable analysis.
+
+## Teardown, Recovery, and Interruption
+
+Membership and Recovery Nemeses have empty `teardown!` methods. Their formal
+recovery belongs in final Nemesis operations.
+
+Other Nemeses may perform cleanup during teardown. A failure in a non-empty
+teardown is a Harness failure. Record it, then continue independent cleanup,
+artifact collection, and applicable analysis. Teardown must not exit early
+because one cleanup failed, and the failure must not be reduced to a warning.
+
+A modeled final-recovery outcome remains a Nemesis outcome, and a failed
+recovery postcondition remains a checker verdict. An unexpected execution
+failure while recovery is running is a Harness failure.
+
+Interruption must propagate through Client, Nemesis, teardown, and recovery
+code. Restore the thread's interruption state when required by the runtime and
+rethrow the interruption. Do not convert it into an Outcome or Harness failure.
+
+## `strict-unhandled-exceptions`
+
+`strict-unhandled-exceptions` is a fallback diagnostic checker. An exception
+that escapes a Client or Nemesis worker shows that the Harness missed a
+classification boundary. The exception is a Harness failure.
+
+The run-level first-failure state remains authoritative for runtime control.
+This checker runs after teardown, when it cannot retroactively stop work or
+recover the original `Throwable`. If it finds an escaped worker exception that
+the run-level path missed, it emits structured post-hoc Harness evidence and
+rejects the final verdict. It does not synthesize or mutate runtime failure
+state from history.
+
+Interruption is excluded from this rule and continues to propagate as a
+lifecycle signal.
+
+## Checker Exceptions
+
+A non-interruption, non-fatal exception from checker implementation code is a
+post-hoc Harness failure. The checker records serializable exception evidence
+on its own result and returns a `false` verdict. This rule applies equally to a
+checker run alone, a checker used as a composed child, and the composition
+itself. Other independent checkers may still run and retain their results.
+
+Checker exceptions do not mutate run-level failure state: analysis happens
+after execution, so they cannot retroactively control scheduling or recover the
+original runtime context.
+
+## Run Acceptance
+
+Any Harness failure makes the whole run unacceptable and requires a nonzero
+exit. It does not erase recorded history, logs, nested checker results, or an
+existing counterexample. A Harness failure does not by itself prove a SUT
+property violation, and it does not invalidate a property violation that a
+checker already established from retained evidence.
+
+## Jepsen Core Artifact Lifecycle
+
+Jepsen core owns test-store creation, history and result persistence, Harness
+log persistence, and remote artifact download. This suite declares OpenRaft
+artifacts but does not wrap or replace that lifecycle. Consequently, artifact
+persistence failures are not suite-level Harness failures specified here;
+their handling belongs to Jepsen core.

--- a/jepsen/src/jepsen/openraft/await.clj
+++ b/jepsen/src/jepsen/openraft/await.clj
@@ -1,0 +1,67 @@
+(ns jepsen.openraft.await
+  (:require [jepsen.openraft.interruption :as interruption]
+            [jepsen.util :as util]))
+
+(def ^:private retry-kind ::retry)
+(def ^:private condition-timeout-kind ::condition-timeout)
+(def ^:private escaped-exception (Object.))
+
+(defn retry!
+  "Signals that an owned SUT condition is not satisfied yet."
+  [condition details]
+  (throw (ex-info "OpenRaft SUT condition is not satisfied yet"
+                  (assoc details
+                         :kind retry-kind
+                         :condition condition))))
+
+(defn condition-timeout?
+  "True when e is a timeout produced while waiting for condition."
+  [e condition]
+  (let [data (ex-data e)]
+    (and (= condition-timeout-kind (:kind data))
+         (= condition (:condition data)))))
+
+(defn- retry-exception? [e condition]
+  (let [data (ex-data e)]
+    (and (= retry-kind (:kind data))
+         (= condition (:condition data)))))
+
+(defn- propagate! [e]
+  (when (interruption/interruption? e)
+    (.interrupt (Thread/currentThread)))
+  (throw e))
+
+(defn until!
+  "Polls until f returns, retrying only retry! for the owned condition.
+
+  Unknown exceptions return through an opaque value so Jepsen's broad
+  await-fn catch cannot retry them."
+  [condition f opts]
+  (let [result
+        (try
+          (util/await-fn
+           #(try
+              (f)
+              (catch Exception e
+                (if (retry-exception? e condition)
+                  (throw e)
+                  [escaped-exception e])))
+           opts)
+          (catch Exception e
+            (cond
+              (interruption/interruption? e)
+              (propagate! e)
+
+              (and (= :timeout (:type (ex-data e)))
+                   (retry-exception? (ex-cause e) condition))
+              (throw (ex-info "Timed out waiting for an OpenRaft SUT condition"
+                              {:kind condition-timeout-kind
+                               :condition condition}
+                              e))
+
+              :else
+              (throw e))))]
+    (if (and (vector? result)
+             (identical? escaped-exception (first result)))
+      (propagate! (second result))
+      result)))

--- a/jepsen/src/jepsen/openraft/checker.clj
+++ b/jepsen/src/jepsen/openraft/checker.clj
@@ -1,6 +1,7 @@
 (ns jepsen.openraft.checker
   (:require [clojure.java.io :as io]
             [jepsen.checker :as checker]
+            [jepsen.openraft.harness :as harness]
             [jepsen.store :as store]))
 
 ;; Emitted by openraft-test-app's panic hook.
@@ -13,14 +14,62 @@
       {:valid? true
        :seed (:seed test)})))
 
+(defn- escaped-worker-evidence [exceptions]
+  (mapv (fn [exception]
+          (update exception :example #(when % (into {} %))))
+        exceptions))
+
 (defn strict-unhandled-exceptions []
   (let [delegate (checker/unhandled-exceptions)]
     (reify checker/Checker
       (check [_ test history opts]
         (let [result (checker/check delegate test history opts)]
           (if (seq (:exceptions result))
-            (assoc result :valid? :unknown)
+            (assoc result
+                   :valid? false
+                   :escaped-worker-exceptions
+                   (escaped-worker-evidence (:exceptions result)))
             result))))))
+
+(defn- failure-evidence [{:keys [source context throwable]}]
+  {:source source
+   :context context
+   :exception {:class (.getName (class throwable))
+               :message (ex-message throwable)}})
+
+(defrecord HarnessFailureChecker [failure-state delegate strict-checker-key]
+  checker/Checker
+  (check [_ test history opts]
+    (let [{:keys [primary secondary]}
+          (harness/failure-snapshot failure-state)
+          result (checker/check delegate test history opts)
+          strict-evidence
+          (when strict-checker-key
+            (get-in result
+                    [strict-checker-key :escaped-worker-exceptions]))]
+      (if (or primary (seq strict-evidence))
+        (assoc result
+               :valid? false
+               :harness-failure
+               (cond-> {:valid? false}
+                 primary
+                 (assoc :primary (failure-evidence primary)
+                        :secondary (mapv failure-evidence secondary))
+
+                 (seq strict-evidence)
+                 (assoc :strict-fallback
+                        {:escaped-worker-exceptions strict-evidence})))
+        result))))
+
+(defn reject-harness-failures
+  "Rejects recorded Harness failures after retaining aggregate analysis.
+
+  When strict-checker-key is supplied, escaped-worker evidence from that
+  composed child also rejects the final verdict as a post-hoc fallback."
+  ([failure-state delegate]
+   (HarnessFailureChecker. failure-state delegate nil))
+  ([failure-state delegate strict-checker-key]
+   (HarnessFailureChecker. failure-state delegate strict-checker-key)))
 
 (defn- log-matches [pattern node file]
   (with-open [reader (io/reader file)]

--- a/jepsen/src/jepsen/openraft/checker.clj
+++ b/jepsen/src/jepsen/openraft/checker.clj
@@ -2,17 +2,57 @@
   (:require [clojure.java.io :as io]
             [jepsen.checker :as checker]
             [jepsen.openraft.harness :as harness]
+            [jepsen.openraft.interruption :as interruption]
             [jepsen.store :as store]))
 
 ;; Emitted by openraft-test-app's panic hook.
 (def node-panic-pattern
   #"OPENRAFT_JEPSEN_PANIC")
 
+(defn- fatal-throwable? [throwable]
+  (or (instance? ThreadDeath throwable)
+      (instance? VirtualMachineError throwable)))
+
+(defn- checker-exception-evidence [throwable]
+  {:class (.getName (class throwable))
+   :message (ex-message throwable)})
+
+(defn reject-checker-exceptions
+  "Turns non-interruption checker exceptions into Harness evidence.
+
+  The wrapper is suitable for both standalone and composed checkers."
+  [delegate]
+  (reify
+    clojure.lang.ILookup
+    (valAt [_ key]
+      (get delegate key))
+    (valAt [_ key not-found]
+      (get delegate key not-found))
+
+    checker/Checker
+    (check [_ test history opts]
+      (try
+        (checker/check delegate test history opts)
+        (catch Throwable throwable
+          (cond
+            (interruption/interruption? throwable)
+            (do
+              (.interrupt (Thread/currentThread))
+              (throw throwable))
+
+            (fatal-throwable? throwable)
+            (throw throwable)
+
+            :else
+            {:valid? false
+             :checker-exception (checker-exception-evidence throwable)}))))))
+
 (defn random-seed-checker []
-  (reify checker/Checker
-    (check [_ test _history _opts]
-      {:valid? true
-       :seed (:seed test)})))
+  (reject-checker-exceptions
+   (reify checker/Checker
+     (check [_ test _history _opts]
+       {:valid? true
+        :seed (:seed test)}))))
 
 (defn- escaped-worker-evidence [exceptions]
   (mapv (fn [exception]
@@ -21,15 +61,16 @@
 
 (defn strict-unhandled-exceptions []
   (let [delegate (checker/unhandled-exceptions)]
-    (reify checker/Checker
-      (check [_ test history opts]
-        (let [result (checker/check delegate test history opts)]
-          (if (seq (:exceptions result))
-            (assoc result
-                   :valid? false
-                   :escaped-worker-exceptions
-                   (escaped-worker-evidence (:exceptions result)))
-            result))))))
+    (reject-checker-exceptions
+     (reify checker/Checker
+       (check [_ test history opts]
+         (let [result (checker/check delegate test history opts)]
+           (if (seq (:exceptions result))
+             (assoc result
+                    :valid? false
+                    :escaped-worker-exceptions
+                    (escaped-worker-evidence (:exceptions result)))
+             result)))))))
 
 (defn- failure-evidence [{:keys [source context throwable]}]
   {:source source
@@ -81,27 +122,28 @@
           (line-seq reader))))
 
 (defn required-log-file-pattern [pattern filename]
-  (reify checker/Checker
-    (check [_ test _history _opts]
-      (let [node-files (mapv (fn [node]
-                               [node (store/path test node filename)])
-                             (:nodes test))
-            missing-nodes (->> node-files
-                               (remove (fn [[_ file]]
-                                         (.isFile ^java.io.File file)))
-                               (mapv first))
-            matches (->> node-files
-                         (filter (fn [[_ file]]
-                                   (.isFile ^java.io.File file)))
-                         (mapcat (fn [[node file]]
-                                   (log-matches pattern node file)))
-                         vec)
-            valid? (cond
-                     (seq matches) false
-                     (seq missing-nodes) :unknown
-                     :else true)]
-        {:valid? valid?
-         :filename filename
-         :missing-nodes missing-nodes
-         :count (count matches)
-         :matches matches}))))
+  (reject-checker-exceptions
+   (reify checker/Checker
+     (check [_ test _history _opts]
+       (let [node-files (mapv (fn [node]
+                                [node (store/path test node filename)])
+                              (:nodes test))
+             missing-nodes (->> node-files
+                                (remove (fn [[_ file]]
+                                          (.isFile ^java.io.File file)))
+                                (mapv first))
+             matches (->> node-files
+                          (filter (fn [[_ file]]
+                                    (.isFile ^java.io.File file)))
+                          (mapcat (fn [[node file]]
+                                    (log-matches pattern node file)))
+                          vec)
+             valid? (cond
+                      (seq matches) false
+                      (seq missing-nodes) :unknown
+                      :else true)]
+         {:valid? valid?
+          :filename filename
+          :missing-nodes missing-nodes
+          :count (count matches)
+          :matches matches})))))

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -105,6 +105,7 @@
         nemesis-types (normalize-nemeses (:nemesis opts))
         nemesis-package
         (openraft-nemesis/compose-packages
+         failure-state
          (mapv (fn [nemesis-type]
                  (case nemesis-type
                    :partition
@@ -131,15 +132,18 @@
                                             (:time-limit opts)
                                             workload
                                             nemesis-package)
-            :checker (checker/compose
-                      {:seed (openraft-checker/random-seed-checker)
-                       :stats (checker/stats)
-                       :exceptions (openraft-checker/strict-unhandled-exceptions)
-                       :crash (openraft-checker/required-log-file-pattern
-                               openraft-checker/node-panic-pattern
-                               "openraft.log")
-                       :nemesis (:checker nemesis-package)
-                       :workload (:checker workload)})})))
+            :checker (openraft-checker/reject-harness-failures
+                      failure-state
+                      (checker/compose
+                       {:seed (openraft-checker/random-seed-checker)
+                        :stats (checker/stats)
+                        :exceptions (openraft-checker/strict-unhandled-exceptions)
+                        :crash (openraft-checker/required-log-file-pattern
+                                openraft-checker/node-panic-pattern
+                                "openraft.log")
+                        :nemesis (:checker nemesis-package)
+                        :workload (:checker workload)})
+                      :exceptions)})))
 
 (defn -main [& args]
   (cli/run! (cli/single-test-cmd {:test-fn openraft-test

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -132,18 +132,22 @@
                                             (:time-limit opts)
                                             workload
                                             nemesis-package)
-            :checker (openraft-checker/reject-harness-failures
-                      failure-state
-                      (checker/compose
-                       {:seed (openraft-checker/random-seed-checker)
-                        :stats (checker/stats)
-                        :exceptions (openraft-checker/strict-unhandled-exceptions)
-                        :crash (openraft-checker/required-log-file-pattern
-                                openraft-checker/node-panic-pattern
-                                "openraft.log")
-                        :nemesis (:checker nemesis-package)
-                        :workload (:checker workload)})
-                      :exceptions)})))
+            :checker (openraft-checker/reject-checker-exceptions
+                      (openraft-checker/reject-harness-failures
+                       failure-state
+                       (openraft-checker/reject-checker-exceptions
+                        (checker/compose
+                         {:seed (openraft-checker/random-seed-checker)
+                          :stats (openraft-checker/reject-checker-exceptions
+                                  (checker/stats))
+                          :exceptions
+                          (openraft-checker/strict-unhandled-exceptions)
+                          :crash (openraft-checker/required-log-file-pattern
+                                  openraft-checker/node-panic-pattern
+                                  "openraft.log")
+                          :nemesis (:checker nemesis-package)
+                          :workload (:checker workload)}))
+                       :exceptions))})))
 
 (defn -main [& args]
   (cli/run! (cli/single-test-cmd {:test-fn openraft-test

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -8,7 +8,10 @@
              [tests :as tests]]
             [jepsen.openraft [checker :as openraft-checker]
              [db :as openraft-db]
+             [generator :as openraft-generator]
+             [harness :as harness]
              [nemesis :as openraft-nemesis]
+             [worker :as worker]
              [workload :as workload]]
             [jepsen.openraft.nemesis [membership :as membership]
              [partition :as partition]
@@ -79,8 +82,25 @@
               (random/set-seed! seed)
               (assoc options :seed seed)))))
 
+(defn- lifecycle-generator
+  [failure-state time-limit workload nemesis-package]
+  (gen/phases
+   (openraft-generator/stop-on-harness-failure
+    failure-state
+    (gen/shortest-any
+     (gen/nemesis
+      (gen/time-limit time-limit (:generator nemesis-package)))
+     (:generator workload)))
+   (gen/nemesis (:final-generator nemesis-package))
+   (delay
+     (when-not (harness/primary-failure failure-state)
+       (openraft-generator/stop-on-harness-failure
+        failure-state
+        (:final-generator workload))))))
+
 (defn openraft-test [opts]
-  (let [database (openraft-db/db opts)
+  (let [failure-state (harness/failure-state)
+        database (openraft-db/db opts)
         workload (workload/workload opts)
         nemesis-types (normalize-nemeses (:nemesis opts))
         nemesis-package
@@ -104,18 +124,13 @@
            {:name (str "openraft linearizable registers "
                        (str/join "," (map name nemesis-types)))
             :db database
-            :client (:client workload)
-            :nemesis (:nemesis nemesis-package)
-            :generator (gen/phases
-                        (gen/shortest-any
-                         (gen/nemesis
-                          (gen/phases
-                           (gen/time-limit
-                            (:time-limit opts)
-                            (:generator nemesis-package))
-                           (:final-generator nemesis-package)))
-                         (:generator workload))
-                        (:final-generator workload))
+            :client (worker/wrap-client failure-state (:client workload))
+            :nemesis (worker/wrap-nemesis failure-state
+                                          (:nemesis nemesis-package))
+            :generator (lifecycle-generator failure-state
+                                            (:time-limit opts)
+                                            workload
+                                            nemesis-package)
             :checker (checker/compose
                       {:seed (openraft-checker/random-seed-checker)
                        :stats (checker/stats)

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -124,7 +124,7 @@
            opts
            {:name (str "openraft linearizable registers "
                        (str/join "," (map name nemesis-types)))
-            :db database
+            :db (worker/wrap-db failure-state database)
             :client (worker/wrap-client failure-state (:client workload))
             :nemesis (worker/wrap-nemesis failure-state
                                           (:nemesis nemesis-package))

--- a/jepsen/src/jepsen/openraft/client.clj
+++ b/jepsen/src/jepsen/openraft/client.clj
@@ -1,7 +1,14 @@
 (ns jepsen.openraft.client
   (:require [cheshire.core :as json]
-            [clojure.string :as str])
-  (:import (java.net ConnectException URI)
+            [cheshire.factory :as json-factory]
+            [cheshire.parse :as json-parse]
+            [clojure.string :as str]
+            [jepsen.openraft.interruption :as interruption])
+  (:import (com.fasterxml.jackson.core JsonFactory
+                                       JsonParseException
+                                       JsonParser$Feature
+                                       JsonToken)
+           (java.net ConnectException URI)
            (java.net.http HttpClient
                           HttpConnectTimeoutException
                           HttpRequest
@@ -12,6 +19,18 @@
 
 (def default-api-port 21001)
 (def default-raft-port 22001)
+
+(def ^:private max-u64 18446744073709551615N)
+(def ^:private response-body-preview-limit 1024)
+(def ^:private modeled-error-variants
+  #{:ForwardToLeader :QuorumNotEnough})
+
+(def ^:private ^JsonFactory preflight-json-factory
+  (json-factory/make-json-factory {}))
+
+(def ^:private ^JsonFactory strict-json-factory
+  (doto (json-factory/make-json-factory {})
+    (.enable JsonParser$Feature/STRICT_DUPLICATE_DETECTION)))
 
 (def ^:private http-client
   (-> (HttpClient/newBuilder)
@@ -42,6 +61,11 @@
   (doto (HttpRequest/newBuilder (URI/create (node-url endpoint path)))
     (.timeout (Duration/ofSeconds 5))))
 
+(defn- propagate-interruption! [e]
+  (when (interruption/interruption? e)
+    (.interrupt (Thread/currentThread))
+    (throw e)))
+
 (defn- send! [request]
   (let [request-info {:method (.method request)
                       :uri (str (.uri request))}
@@ -60,14 +84,12 @@
                                      (assoc request-info :kind :request-timeout)
                                      e)))
                    (catch java.io.IOException e
+                     (propagate-interruption! e)
                      (throw (ex-info "HTTP request failed"
                                      (assoc request-info :kind :transport-error)
                                      e)))
                    (catch InterruptedException e
-                     (.interrupt (Thread/currentThread))
-                     (throw (ex-info "HTTP request interrupted"
-                                     (assoc request-info :kind :interrupted)
-                                     e))))
+                     (propagate-interruption! e)))
         status (.statusCode response)
         body (.body response)
         result (assoc request-info
@@ -78,24 +100,149 @@
                       (assoc result :kind :http-error))))
     result))
 
+(defn- response-evidence [response]
+  (let [body (:body response)]
+    (cond-> (select-keys response [:method :uri :status])
+      (string? body)
+      (assoc :body-character-count (count body)
+             :body-preview (subs body
+                                 0
+                                 (min response-body-preview-limit
+                                      (count body)))))))
+
+(defn- invalid-response! [response reason details]
+  (throw (ex-info "OpenRaft API returned an invalid response"
+                  (merge {:kind :invalid-response
+                          :reason reason
+                          :response (response-evidence response)}
+                         details))))
+
 (defn- parse-body [response]
   (try
-    (json/parse-string (:body response) true)
-    (catch Exception e
+    (with-open [parser (.createParser preflight-json-factory
+                                      ^String (:body response))]
+      (let [token (.nextToken parser)]
+        (when (nil? token)
+          (throw (JsonParseException.
+                  parser
+                  "OpenRaft API response has no JSON document")))
+        (when-not (= JsonToken/START_OBJECT token)
+          (.skipChildren parser)
+          (when (.nextToken parser)
+            (throw (JsonParseException.
+                    parser
+                    "Trailing content after OpenRaft API response")))
+          (invalid-response! response
+                             :response-union-not-map
+                             {:response-arm-count nil}))))
+    (with-open [parser (.createParser strict-json-factory
+                                      ^String (:body response))]
+      (let [body (json-parse/parse-strict parser
+                                          true
+                                          ::missing-json-root
+                                          nil)]
+        (when (= ::missing-json-root body)
+          (throw (JsonParseException.
+                  parser
+                  "OpenRaft API response has no JSON document")))
+        (when (.nextToken parser)
+          (throw (JsonParseException.
+                  parser
+                  "Trailing content after OpenRaft API response")))
+        body))
+    (catch JsonParseException e
       (throw (ex-info "Failed to parse OpenRaft API response"
                       {:kind :invalid-json
-                       :response response}
+                       :response (response-evidence response)}
                       e)))))
 
+(defn- invalid-union-reason [body]
+  (cond
+    (not (map? body)) :response-union-not-map
+    (empty? body) :missing-response-arm
+    (and (contains? body :Ok)
+         (contains? body :Err)) :ambiguous-response-arms
+    (not-any? #{:Ok :Err} (keys body)) :unknown-response-arm
+    :else :invalid-response-union))
+
 (defn- ok-value [response]
-  (let [body (parse-body response)]
+  (let [body (parse-body response)
+        arms (when (map? body)
+               (set (filter #{:Ok :Err} (keys body))))]
     (cond
-      (contains? body :Ok) (:Ok body)
-      (contains? body :Err) (throw (ex-info "OpenRaft API returned Err"
-                                            {:kind :openraft-error
-                                             :error (:Err body)
-                                             :response response}))
-      :else body)))
+      (= #{:Ok} arms)
+      (:Ok body)
+
+      (= #{:Err} arms)
+      (let [error (:Err body)]
+        (if (and (map? error) (= 1 (count error)))
+          (let [[variant payload] (first error)]
+            (if (and (modeled-error-variants variant)
+                     (not (map? payload)))
+              (invalid-response! response
+                                 :invalid-error-payload
+                                 {:error-variant variant})
+              (throw (ex-info "OpenRaft API returned Err"
+                              {:kind :openraft-error
+                               :error error
+                               :response response}))))
+          (invalid-response! response
+                             :invalid-error-union
+                             {:error-arm-count (when (map? error)
+                                                 (count error))})))
+
+      :else
+      (invalid-response! response
+                         (invalid-union-reason body)
+                         {:response-arm-count (when arms
+                                                (count arms))}))))
+
+(defn- versioned-value? [value]
+  (and (map? value)
+       (contains? value :value)
+       (string? (:value value))
+       (contains? value :version)
+       (integer? (:version value))
+       (<= 0 (:version value) max-u64)))
+
+(defn- response-value [response payload path allow-nil?]
+  (let [value (get-in payload path ::missing)]
+    (cond
+      (= ::missing value)
+      (invalid-response! response
+                         :missing-payload-field
+                         {:payload-path path})
+
+      (nil? value)
+      (if allow-nil?
+        nil
+        (invalid-response! response
+                           :nil-payload-field
+                           {:payload-path path}))
+
+      (versioned-value? value)
+      value
+
+      :else
+      (invalid-response! response
+                         :invalid-versioned-value
+                         {:payload-path path}))))
+
+(defn- require-echoed-value [response versioned-value expected]
+  (when (and versioned-value
+             (not= expected (:value versioned-value)))
+    (invalid-response! response
+                       :unexpected-payload-value
+                       {:payload-path [:data :value :value]}))
+  versioned-value)
+
+(defn- require-newer-cas-version [response versioned-value expected-version]
+  (when (and versioned-value
+             (<= (:version versioned-value) expected-version))
+    (invalid-response! response
+                       :non-increasing-cas-version
+                       {:payload-path [:data :value :version]}))
+  versioned-value)
 
 (defn- forward-to-leader? [e]
   ;; contains? returns false for a nil map, so no nil guard is needed.
@@ -195,23 +342,34 @@
 ;; These functions make one HTTP attempt. KVClient performs leader routing and
 ;; classifies errors based on whether the operation may have taken effect.
 (defn write! [endpoint key value]
-  (-> (post! endpoint "/write"
-             {:Set {:key key
-                    :value value}})
-      ok-value
-      :data
-      :value))
+  (let [response (post! endpoint "/write"
+                        {:Set {:key key
+                               :value value}})
+        payload (ok-value response)
+        versioned-value (response-value response
+                                        payload
+                                        [:data :value]
+                                        false)]
+    (require-echoed-value response versioned-value value)))
 
 (defn cas! [endpoint key expected-version value]
-  (-> (post! endpoint "/write"
-             {:CompareAndSet {:key key
-                              :expected_version expected-version
-                              :value value}})
-      ok-value
-      :data
-      :value))
+  (let [response (post! endpoint "/write"
+                        {:CompareAndSet {:key key
+                                         :expected_version expected-version
+                                         :value value}})
+        payload (ok-value response)
+        versioned-value (response-value response
+                                        payload
+                                        [:data :value]
+                                        true)
+        versioned-value (require-echoed-value response
+                                              versioned-value
+                                              value)]
+    (require-newer-cas-version response
+                               versioned-value
+                               expected-version)))
 
 (defn linearizable-read! [endpoint key]
-  (-> (post! endpoint "/linearizable_read" key)
-      ok-value
-      :value))
+  (let [response (post! endpoint "/linearizable_read" key)
+        payload (ok-value response)]
+    (response-value response payload [:value] true)))

--- a/jepsen/src/jepsen/openraft/cluster.clj
+++ b/jepsen/src/jepsen/openraft/cluster.clj
@@ -2,10 +2,10 @@
   (:require [clojure.set :as set]
             [clojure.tools.logging :refer [info]]
             [jepsen.core :as jepsen]
+            [jepsen.openraft.await :as await]
             [jepsen.openraft.client :as client]
             [jepsen.openraft.interruption :as interruption]
-            [jepsen.openraft.quorum :as quorum]
-            [jepsen.util :as util]))
+            [jepsen.openraft.quorum :as quorum]))
 
 (defn node-info [test node]
   {:node-id (client/node-host node)
@@ -67,14 +67,22 @@
     (client/metrics! (client/api-endpoint test node))
     (catch Exception e
       (if (interruption/interruption? e)
-        (let [interrupted-exception
-              (if (instance? InterruptedException e)
-                e
-                (doto (InterruptedException. (ex-message e))
-                  (.initCause e)))]
+        (do
           (.interrupt (Thread/currentThread))
-          (throw interrupted-exception))
+          (throw e))
         (throw e)))))
+
+(def ^:private modeled-metrics-failure-kinds
+  #{:http-error
+    :invalid-json
+    :invalid-response
+    :openraft-error
+    :request-timeout
+    :transport-error
+    :unreachable})
+
+(defn- modeled-metrics-failure? [e]
+  (contains? modeled-metrics-failure-kinds (:kind (ex-data e))))
 
 (defn- collect-reachable-metrics-from [test nodes]
   (into {}
@@ -84,8 +92,10 @@
              [node (node-metrics! test node)]
              (catch InterruptedException e
                (throw e))
-             (catch Exception _
-               nil)))
+             (catch Exception e
+               (if (modeled-metrics-failure? e)
+                 nil
+                 (throw e)))))
          nodes)))
 
 (defn- collect-reachable-metrics [test]
@@ -179,14 +189,14 @@
 (defn await-committed-membership!
   "Waits for a committed membership view from a quorum-supported leader."
   [test]
-  (util/await-fn
+  (await/until!
+   :committed-membership
    #(let [status (membership-status test)]
       (if (and status
                (= (:effective-log-id status)
                   (:committed-log-id status)))
         status
-        (throw (ex-info "OpenRaft membership is not committed yet"
-                        {:status status}))))
+        (await/retry! :committed-membership {:status status})))
    {:log-message "Waiting for a committed OpenRaft membership"
     :timeout 60000}))
 
@@ -196,24 +206,58 @@
    (await-stable-membership! test nil))
   ([test expected-voters]
    (let [expected-voters (some-> expected-voters set)]
-     (util/await-fn
+     (await/until!
+      :stable-membership
       #(let [status (membership-status test)]
          (if (and (:stable? status)
                   (or (nil? expected-voters)
                       (= expected-voters (:voters status))))
            status
-           (throw (ex-info "OpenRaft membership is not stable yet"
-                           {:expected-voters expected-voters
-                            :status status}))))
+           (await/retry! :stable-membership
+                         {:expected-voters expected-voters
+                          :status status})))
       {:log-message "Waiting for OpenRaft membership to become stable"
        :timeout 60000}))))
 
 (defn await-ready! [test]
-  (util/await-fn
+  (await/until!
+   :cluster-ready
    #(or (cluster-status test)
-        (throw (ex-info "OpenRaft cluster is not ready yet" {})))
+        (await/retry! :cluster-ready {}))
    {:log-message "Waiting for every OpenRaft node to agree on a leader"
     :timeout 60000}))
+
+(defn await-node-metrics!
+  "Waits for modeled SUT availability while preserving Harness exceptions."
+  [test node timeout-ms]
+  (await/until!
+   :node-metrics
+   #(try
+      (node-metrics! test node)
+      (catch Exception e
+        (if (modeled-metrics-failure? e)
+          (await/retry! :node-metrics
+                        {:node node
+                         :failure-kind (:kind (ex-data e))})
+          (throw e))))
+   {:log-message (str "Waiting for OpenRaft node " node " metrics")
+    :timeout timeout-ms}))
+
+(defn await-observed-learner!
+  "Waits for a learner in committed membership without retrying Harness errors."
+  [test node timeout-ms]
+  (await/until!
+   :learner-observed
+   #(let [status (membership-status test)]
+      (if (and (:stable? status)
+               (contains? (:learners status) node))
+        status
+        (await/retry! :learner-observed
+                      {:node node
+                       :status status})))
+   {:log-message (str "Waiting for OpenRaft learner " node
+                      " to appear in membership")
+    :timeout timeout-ms}))
 
 (defn voter-configs
   "Maps the effective OpenRaft voter configs to Jepsen node names."
@@ -243,13 +287,19 @@
     ;; which is still before that entry commits. Waiting for the leader alone
     ;; therefore races with the first add-learner, which fails with
     ;; `ChangeMembershipError::InProgress`.
-    (util/await-fn
-     #(let [metrics (client/metrics! leader-endpoint)]
-        (if (and (= leader-id (:current_leader metrics))
-                 (membership-committed? metrics))
-          metrics
-          (throw (ex-info "Initial OpenRaft leader is not ready yet"
-                          {:metrics metrics}))))
+    (await/until!
+     :bootstrap-membership
+     #(try
+        (let [metrics (client/metrics! leader-endpoint)]
+          (if (and (= leader-id (:current_leader metrics))
+                   (membership-committed? metrics))
+            metrics
+            (await/retry! :bootstrap-membership {:metrics metrics})))
+        (catch Exception e
+          (if (modeled-metrics-failure? e)
+            (await/retry! :bootstrap-membership
+                          {:failure-kind (:kind (ex-data e))})
+            (throw e))))
      {:log-message "Waiting for initial OpenRaft leader to commit its membership"
       :timeout 60000})
 

--- a/jepsen/src/jepsen/openraft/db.clj
+++ b/jepsen/src/jepsen/openraft/db.clj
@@ -5,7 +5,8 @@
              [db :as db]]
             [jepsen.control.util :as cu]
             [jepsen.openraft.client :as client]
-            [jepsen.openraft.cluster :as cluster]))
+            [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.interruption :as interruption]))
 
 (def binary "/usr/local/bin/openraft-jepsen-app")
 (def process-name "openraft-jepsen-app")
@@ -15,19 +16,193 @@
 (def pid-file (str data-dir "/openraft.pid"))
 (def default-snapshot-threshold 100)
 
+(def ^:private process-confirm-timeout-ms 30000)
+(def ^:private process-confirm-interval-ms 100)
+
+(def ^:private process-probe-script
+  (str "pids=$(pgrep -u root -f --ignore-ancestors -- \"$1\"); "
+       "rc=$?; case \"$rc\" in "
+       "0) ;; "
+       "1) printf 'absent\\n'; exit 0 ;; "
+       "*) exit \"$rc\" ;; esac; "
+       "seen=0; paused=0; running=0; other=0; "
+       "for pid in $pids; do "
+       "stat_file=\"/proc/$pid/stat\"; "
+       "if IFS= read -r stat < \"$stat_file\"; then "
+       "rest=${stat##*) }; state=${rest%% *}; "
+       "seen=$((seen + 1)); "
+       "case \"$state\" in "
+       "T|t) paused=$((paused + 1)) ;; "
+       "Z|X|x|'') other=$((other + 1)) ;; "
+       "*) running=$((running + 1)) ;; esac; "
+       "elif [ ! -e \"/proc/$pid\" ]; then :; "
+       "else printf 'unable to read %s\\n' \"$stat_file\" >&2; "
+       "exit 74; fi; "
+       "done; "
+       "if [ \"$seen\" -eq 0 ]; then printf 'absent\\n'; "
+       "elif [ \"$other\" -ne 0 ]; then printf 'mixed\\n'; "
+       "elif [ \"$paused\" -eq \"$seen\" ]; then printf 'paused\\n'; "
+       "elif [ \"$running\" -eq \"$seen\" ]; then printf 'running\\n'; "
+       "else printf 'mixed\\n'; fi"))
+
+(defn- process-pattern []
+  (str "^" binary "([[:space:]].*)?$"))
+
+(defn- rethrow-control! [e]
+  (when (interruption/interruption? e)
+    (.interrupt (Thread/currentThread)))
+  (throw e))
+
+(defn- control-exec! [& command]
+  (try
+    (apply c/exec command)
+    (catch Exception e
+      (rethrow-control! e))))
+
+(defn- probe-process! []
+  (let [result (control-exec! :bash
+                              :-c
+                              process-probe-script
+                              "openraft-process-probe"
+                              (process-pattern))]
+    (case result
+      "absent" :absent
+      "running" :running
+      "paused" :paused
+      "mixed" :mixed
+      (throw (ex-info "Unexpected OpenRaft process probe result"
+                      {:kind :unexpected-process-probe-result
+                       :result result})))))
+
+(defn- await-process-state! [expected-state]
+  (let [deadline (+ (System/nanoTime)
+                    (* 1000000 process-confirm-timeout-ms))]
+    (loop []
+      (let [state (probe-process!)]
+        (cond
+          (= expected-state state)
+          state
+
+          (>= (System/nanoTime) deadline)
+          (throw (ex-info "Timed out confirming OpenRaft process state"
+                          {:kind :process-confirmation-timeout
+                           :expected-state expected-state
+                           :observed-state state
+                           :timeout-ms process-confirm-timeout-ms}))
+
+          :else
+          (do
+            (try
+              (Thread/sleep process-confirm-interval-ms)
+              (catch InterruptedException e
+                (rethrow-control! e)))
+            (recur)))))))
+
+(defn- remove-pid-file! []
+  (control-exec! :rm :-f pid-file))
+
+(defn- no-such-process-race? [e]
+  (let [{:keys [type exit err]} (ex-data e)
+        binary-name-pattern (str "(?:"
+                                 (java.util.regex.Pattern/quote binary)
+                                 "|"
+                                 (java.util.regex.Pattern/quote process-name)
+                                 ")")]
+    (and (not (interruption/interruption? e))
+         (= :jepsen.control/nonzero-exit type)
+         (= 1 exit)
+         (re-matches (re-pattern
+                      (str "(?is)\\s*"
+                           binary-name-pattern
+                           ":\\s*no process found\\s*"))
+                     (or err "")))))
+
+(defn- signal-process! [signal confirmed-result]
+  (try
+    (control-exec! :killall :-s signal binary)
+    confirmed-result
+    (catch Exception e
+      (if (no-such-process-race? e)
+        :target-already-exited
+        (rethrow-control! e)))))
+
+(defn- signal-and-confirm! [signal expected-state confirmed-result]
+  (if (= :absent (probe-process!))
+    :target-absent
+    (let [result (signal-process! signal confirmed-result)]
+      (if (= :target-already-exited result)
+        result
+        (do
+          (await-process-state! expected-state)
+          result)))))
+
+(defn- stop-process! []
+  (let [result (signal-and-confirm! 9 :absent :killed)]
+    (remove-pid-file!)
+    result))
+
+(defn- pause-process! []
+  (signal-and-confirm! "STOP" :paused :paused))
+
+(defn- resume-process! []
+  (signal-and-confirm! "CONT" :running :resumed))
+
+(defn- start-command!
+  [node-id api-addr raft-addr snapshot-threshold]
+  (control-exec!
+   (c/env {:RUST_BACKTRACE "1"
+           :RUST_LOG "info"})
+   :start-stop-daemon
+   :--start
+   :--oknodo
+   :--background
+   :--no-close
+   :--make-pidfile
+   :--exec binary
+   :--pidfile pid-file
+   :--chdir data-dir
+   :--startas binary
+   :--
+   :--id node-id
+   :--api-addr api-addr
+   :--raft-addr raft-addr
+   :--snapshot-threshold snapshot-threshold
+   :>> log-file
+   (c/lit "2>&1")))
+
+(defn- start-process!
+  [node-id api-addr raft-addr snapshot-threshold]
+  (let [state (probe-process!)]
+    (case state
+      :running
+      :already-running
+
+      :absent
+      (do
+        (remove-pid-file!)
+        ;; --oknodo makes a start race succeed without broadly suppressing exit
+        ;; status 1, which may instead mean a control or permission failure.
+        (start-command! node-id api-addr raft-addr snapshot-threshold)
+        (await-process-state! :running)
+        :start-confirmed)
+
+      (throw (ex-info "OpenRaft process exists in an unexpected state"
+                      {:kind :unexpected-existing-process-state
+                       :state state})))))
+
 (defn- prepare-dirs! []
   (c/su
-   (c/exec :mkdir :-p data-dir log-dir)))
+   (control-exec! :mkdir :-p data-dir log-dir)))
 
 (defn- wipe-data! []
   (c/su
-   (c/exec :rm :-rf data-dir)
-   (c/exec :mkdir :-p data-dir log-dir)))
+   (control-exec! :rm :-rf data-dir)
+   (control-exec! :mkdir :-p data-dir log-dir)))
 
 (defn- wipe! []
   (wipe-data!)
   (c/su
-   (c/exec :rm :-f log-file)))
+   (control-exec! :rm :-f log-file)))
 
 (defn db [_opts]
   (reify
@@ -62,30 +237,23 @@
                                         :api-addr api-addr
                                         :raft-addr raft-addr})
         (c/su
-         (cu/start-daemon!
-          {:chdir data-dir
-           :env {:RUST_BACKTRACE "1"
-                 :RUST_LOG "info"}
-           :logfile log-file
-           :pidfile pid-file}
-          binary
-          :--id node-id
-          :--api-addr api-addr
-          :--raft-addr raft-addr
-          :--snapshot-threshold (:snapshot-threshold test)))))
+         (start-process! node-id
+                         api-addr
+                         raft-addr
+                         (:snapshot-threshold test)))))
 
     (kill! [_ _ _node]
       (c/su
-       (cu/stop-daemon! process-name pid-file)))
+       (stop-process!)))
 
     db/Pause
     (pause! [_ _ _node]
       (c/su
-       (cu/grepkill! :stop process-name)))
+       (pause-process!)))
 
     (resume! [_ _ _node]
       (c/su
-       (cu/grepkill! :cont process-name)))))
+       (resume-process!)))))
 
 (defn- start-empty-node-on-current-node! [database test node]
   (info node "starting an empty OpenRaft node")

--- a/jepsen/src/jepsen/openraft/generator.clj
+++ b/jepsen/src/jepsen/openraft/generator.clj
@@ -1,0 +1,21 @@
+(ns jepsen.openraft.generator
+  (:require [jepsen.generator :as gen]
+            [jepsen.openraft.harness :as harness]))
+
+(defrecord StopOnHarnessFailure [failure-state generator]
+  gen/Generator
+  (op [_ test context]
+    (when-not (harness/primary-failure failure-state)
+      (when-let [[operation generator'] (gen/op generator test context)]
+        (when-not (harness/primary-failure failure-state)
+          [operation (StopOnHarnessFailure. failure-state generator')]))))
+
+  (update [_ test context event]
+    (when-let [generator' (gen/update generator test context event)]
+      (StopOnHarnessFailure. failure-state generator'))))
+
+(defn stop-on-harness-failure
+  "Stops new operations after a Harness failure while forwarding updates."
+  [failure-state generator]
+  (when generator
+    (StopOnHarnessFailure. failure-state generator)))

--- a/jepsen/src/jepsen/openraft/harness.clj
+++ b/jepsen/src/jepsen/openraft/harness.clj
@@ -1,0 +1,22 @@
+(ns jepsen.openraft.harness
+  (:require [jepsen.openraft.interruption :as interruption]))
+
+(defn failure-state
+  "Creates run-scoped state for the primary Harness failure."
+  []
+  (atom nil))
+
+(defn primary-failure
+  "Returns the first recorded Harness failure, or nil."
+  [state]
+  @state)
+
+(defn record-failure!
+  "Atomically records the first non-interruption Harness failure."
+  [state source context throwable]
+  (and (not (interruption/interruption? throwable))
+       (compare-and-set! state
+                         nil
+                         {:source source
+                          :context context
+                          :throwable throwable})))

--- a/jepsen/src/jepsen/openraft/harness.clj
+++ b/jepsen/src/jepsen/openraft/harness.clj
@@ -2,21 +2,41 @@
   (:require [jepsen.openraft.interruption :as interruption]))
 
 (defn failure-state
-  "Creates run-scoped state for the primary Harness failure."
+  "Creates run-scoped state for Harness failures."
   []
-  (atom nil))
+  (atom {:primary nil
+         :secondary []}))
 
 (defn primary-failure
   "Returns the first recorded Harness failure, or nil."
   [state]
+  (:primary @state))
+
+(defn secondary-failures
+  "Returns Harness failures recorded after the primary failure."
+  [state]
+  (:secondary @state))
+
+(defn failure-snapshot
+  "Returns an immutable snapshot of all recorded Harness failures."
+  [state]
   @state)
 
 (defn record-failure!
-  "Atomically records the first non-interruption Harness failure."
+  "Atomically records a non-interruption Harness failure.
+
+  Returns true only when this call records the primary failure. Later failures
+  are retained as secondary diagnostic evidence."
   [state source context throwable]
-  (and (not (interruption/interruption? throwable))
-       (compare-and-set! state
-                         nil
-                         {:source source
-                          :context context
-                          :throwable throwable})))
+  (if (interruption/interruption? throwable)
+    false
+    (let [failure {:source source
+                   :context context
+                   :throwable throwable}
+          [before _]
+          (swap-vals! state
+                      (fn [{:keys [primary] :as failures}]
+                        (if primary
+                          (update failures :secondary conj failure)
+                          (assoc failures :primary failure))))]
+      (nil? (:primary before)))))

--- a/jepsen/src/jepsen/openraft/nemesis.clj
+++ b/jepsen/src/jepsen/openraft/nemesis.clj
@@ -5,12 +5,18 @@
              [nemesis :as nemesis]
              [random :as random]]
             [jepsen.nemesis.combined :as combined]
-            [jepsen.openraft.cluster :as cluster]))
+            [jepsen.openraft.await :as await]
+            [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.interruption :as interruption]
+            [jepsen.openraft.nemesis.outcome :as outcome]))
 
 (def ^:private initial-healthy-seconds 5)
 (def ^:private retry-interval-seconds 1)
-(def ^:private retryable-skip-results
-  #{:no-reachable-pause-target :no-supported-leader})
+(def ^:private retryable-skip-reasons
+  #{:no-quorum-safe-process-target
+    :no-reachable-pause-target
+    :no-safe-partition-target
+    :no-supported-leader})
 
 (defn- jittered-interval [interval]
   (long (random/double (* 0.5 interval)
@@ -45,10 +51,17 @@
           retry-generator' (some-> retry-generator
                                    (gen/update test context event))
           completion-value (:value event)
-          retry-result (if (map? completion-value)
+          retry-reason (cond
+                         (= :skipped (:status completion-value))
+                         (:reason completion-value)
+
+                         (and (map? completion-value)
+                              (contains? completion-value :status))
                          (:status completion-value)
+
+                         :else
                          completion-value)
-          retry? (contains? retryable-skip-results retry-result)
+          retry? (contains? retryable-skip-reasons retry-reason)
           operation-event? (and stage
                                 (= :nemesis (:process event))
                                 (= operation-f (:f event)))]
@@ -102,9 +115,28 @@
     this)
 
   (invoke! [_ test op]
-    (let [{:keys [leader]} (cluster/await-ready! test)]
-      (info "OpenRaft cluster recovered with leader" leader)
-      (assoc op :value {:leader leader})))
+    (try
+      (let [{:keys [leader]} (cluster/await-ready! test)]
+        (info "OpenRaft cluster recovered with leader" leader)
+        (assoc op :value (outcome/installed {:leader leader})))
+      (catch Exception e
+        (cond
+          (interruption/interruption? e)
+          (do
+            (.interrupt (Thread/currentThread))
+            (throw e))
+
+          (await/condition-timeout? e :cluster-ready)
+          (do
+            (info "OpenRaft cluster recovery is indeterminate"
+                  {:error (ex-message e)})
+            (assoc op
+                   :value (outcome/indeterminate
+                           :recovery-timeout
+                           {:message (ex-message e)})))
+
+          :else
+          (throw e)))))
 
   (teardown! [this _test]
     this)

--- a/jepsen/src/jepsen/openraft/nemesis.clj
+++ b/jepsen/src/jepsen/openraft/nemesis.clj
@@ -8,7 +8,8 @@
             [jepsen.openraft.await :as await]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.interruption :as interruption]
-            [jepsen.openraft.nemesis.outcome :as outcome]))
+            [jepsen.openraft.nemesis.outcome :as outcome]
+            [jepsen.openraft.worker :as worker]))
 
 (def ^:private initial-healthy-seconds 5)
 (def ^:private retry-interval-seconds 1)
@@ -190,21 +191,32 @@
 
 (defn compose-packages
   "Composes interval-bearing fault packages and confirms final recovery."
-  [packages]
-  (when-not (seq packages)
-    (throw (ex-info "At least one nemesis package is required" {})))
-  (let [packages (->> packages
-                      (mapv #(assoc % :perf (or (:perf %) #{})))
-                      cleanup-order
-                      (mapv schedule-package))
-        composed (combined/compose-packages
-                  (conj packages (recovery-package)))
-        checkers (into {}
-                       (map (fn [{:keys [name checker]}]
-                              [name (fault-class-checker checker)])
-                            packages))]
-    (assoc composed
-           :nemesis (nemesis/validate (:nemesis composed))
-           :checker (if (= 1 (count packages))
-                      (:checker (first packages))
-                      (checker/compose checkers)))))
+  ([packages]
+   (compose-packages nil packages))
+  ([failure-state packages]
+   (when-not (seq packages)
+     (throw (ex-info "At least one nemesis package is required" {})))
+   (let [packages (->> packages
+                       (mapv (fn [{:keys [name] :as package}]
+                               (cond-> (assoc package
+                                              :perf
+                                              (or (:perf package) #{}))
+                                 failure-state
+                                 (update :nemesis
+                                         #(worker/wrap-nemesis-teardown
+                                           failure-state
+                                           name
+                                           %)))))
+                       cleanup-order
+                       (mapv schedule-package))
+         composed (combined/compose-packages
+                   (conj packages (recovery-package)))
+         checkers (into {}
+                        (map (fn [{:keys [name checker]}]
+                               [name (fault-class-checker checker)])
+                             packages))]
+     (assoc composed
+            :nemesis (nemesis/validate (:nemesis composed))
+            :checker (if (= 1 (count packages))
+                       (:checker (first packages))
+                       (checker/compose checkers))))))

--- a/jepsen/src/jepsen/openraft/nemesis.clj
+++ b/jepsen/src/jepsen/openraft/nemesis.clj
@@ -6,6 +6,7 @@
              [random :as random]]
             [jepsen.nemesis.combined :as combined]
             [jepsen.openraft.await :as await]
+            [jepsen.openraft.checker :as openraft-checker]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.interruption :as interruption]
             [jepsen.openraft.nemesis.outcome :as outcome]
@@ -153,26 +154,27 @@
    :perf #{}})
 
 (defn- fault-class-checker [fault-checker]
-  (reify checker/Checker
-    (check [_ test history opts]
-      (let [result (checker/check fault-checker test history opts)
-            observed (or (:observed-modes result)
-                         (:observed-changes result))
-            executed? (boolean (seq observed))
-            cluster-state (:cluster-state result)
-            valid? (cond
-                     (not executed?) false
-                     (pos? (or (:error-count result) 0)) false
-                     (contains? result :restored?)
-                     (and (:restored? result)
-                          (:recovered? result))
-                     (= :intact cluster-state) true
-                     (= :unknown cluster-state) :unknown
-                     :else false)]
-        (-> result
-            (dissoc :missing-modes :missing-changes)
-            (assoc :valid? valid?
-                   :fault-class-executed? executed?))))))
+  (openraft-checker/reject-checker-exceptions
+   (reify checker/Checker
+     (check [_ test history opts]
+       (let [result (checker/check fault-checker test history opts)
+             observed (or (:observed-modes result)
+                          (:observed-changes result))
+             executed? (boolean (seq observed))
+             cluster-state (:cluster-state result)
+             valid? (cond
+                      (not executed?) false
+                      (pos? (or (:error-count result) 0)) false
+                      (contains? result :restored?)
+                      (and (:restored? result)
+                           (:recovered? result))
+                      (= :intact cluster-state) true
+                      (= :unknown cluster-state) :unknown
+                      :else false)]
+         (-> result
+             (dissoc :missing-modes :missing-changes)
+             (assoc :valid? valid?
+                    :fault-class-executed? executed?)))))))
 
 (defn- cleanup-order [packages]
   (let [membership? #(= :membership (:name %))]
@@ -219,4 +221,5 @@
             :nemesis (nemesis/validate (:nemesis composed))
             :checker (if (= 1 (count packages))
                        (:checker (first packages))
-                       (checker/compose checkers))))))
+                       (openraft-checker/reject-checker-exceptions
+                        (checker/compose checkers)))))))

--- a/jepsen/src/jepsen/openraft/nemesis/membership.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/membership.clj
@@ -3,16 +3,20 @@
             [jepsen [checker :as checker]
              [generator :as gen]
              [nemesis :as nemesis]
-             [random :as random]
-             [util :as util]]
+             [random :as random]]
+            [jepsen.openraft.await :as await]
             [jepsen.openraft [client :as client]
              [cluster :as cluster]
              [db :as openraft-db]]
+            [jepsen.openraft.nemesis.outcome :as outcome]
             [jepsen.openraft.quorum :as quorum]))
 
 (def change-seconds 10)
 (def minimum-voters 3)
 (def learner-wait-timeout-ms 60000)
+
+(def ^:private membership-error-arm-limit 8)
+(def ^:private membership-error-arm-name-limit 128)
 
 (defn- select-node [test candidates]
   (->> (:nodes test)
@@ -33,7 +37,10 @@
 
 (defn- ambiguous-request-error? [e]
   (let [{:keys [kind status]} (ex-data e)]
-    (or (#{:request-timeout :transport-error :invalid-json} kind)
+    (or (#{:request-timeout
+           :transport-error
+           :invalid-json
+           :invalid-response} kind)
         (and (= :http-error kind)
              (or (nil? status)
                  (<= 500 status 599))))))
@@ -43,25 +50,44 @@
     (or (= :unreachable kind)
         (contains? error :ForwardToLeader))))
 
+(defn- change-membership-error [e]
+  (let [error (:error (ex-data e))]
+    (when (and (map? error)
+               (contains? error :ChangeMembershipError))
+      {:payload (:ChangeMembershipError error)})))
+
+(defn- bounded-arm-name [arm]
+  (let [arm-name (if (keyword? arm) (name arm) (str arm))]
+    (subs arm-name 0 (min membership-error-arm-name-limit
+                          (count arm-name)))))
+
+(defn- malformed-membership-error-evidence [e]
+  (when-let [{:keys [payload]} (change-membership-error e)]
+    (when-not (and (map? payload) (= 1 (count payload)))
+      {:error-shape (if (map? payload) :map :not-map)
+       :error-arm-count (when (map? payload) (count payload))
+       :error-arm-names (if (map? payload)
+                          (->> (keys payload)
+                               (take membership-error-arm-limit)
+                               (map bounded-arm-name)
+                               sort
+                               vec)
+                          [])})))
+
+(defn- membership-error-variant [e]
+  (let [payload (:payload (change-membership-error e))]
+    (when (and (map? payload) (= 1 (count payload)))
+      (ffirst payload))))
+
 (defn- membership-change-in-progress? [e]
-  (contains? (get-in (ex-data e)
-                     [:error :ChangeMembershipError])
-             :InProgress))
+  (= :InProgress (membership-error-variant e)))
+
+(defn- unexpected-membership-error-outcome [e]
+  (when-let [evidence (malformed-membership-error-evidence e)]
+    (outcome/indeterminate :unexpected-sut-response evidence)))
 
 (defn- await-reachable-learner! [test node]
-  (try
-    (util/await-fn
-     #(cluster/node-metrics! test node)
-     {:log-message (str "Waiting for OpenRaft learner " node)
-      :timeout learner-wait-timeout-ms})
-    (catch InterruptedException e
-      (.interrupt (Thread/currentThread))
-      (throw e))
-    (catch Exception e
-      (throw (ex-info "Existing OpenRaft learner is unreachable"
-                      {:kind :learner-unreachable
-                       :node node}
-                      e)))))
+  (cluster/await-node-metrics! test node learner-wait-timeout-ms))
 
 (defn- request-membership-change!
   [test leader-endpoint target-voters]
@@ -72,79 +98,232 @@
      #(client/change-membership! % (voter-ids test target-voters)))
     :completed
     (catch Exception e
-      (cond
-        (leader-routing-error? e)
-        :no-supported-leader
+      (let [unexpected (unexpected-membership-error-outcome e)]
+        (cond
+          (leader-routing-error? e)
+          :no-supported-leader
 
-        (ambiguous-request-error? e)
-        (do
-          (info "OpenRaft membership change result is indeterminate"
-                {:target-voters target-voters
-                 :error (ex-message e)})
-          :indeterminate)
+          unexpected
+          unexpected
 
-        (membership-change-in-progress? e)
-        (do
-          (info "OpenRaft membership change is already in progress"
-                {:target-voters target-voters
-                 :error (ex-message e)})
-          :in-progress)
+          (ambiguous-request-error? e)
+          (do
+            (info "OpenRaft membership change result is indeterminate"
+                  {:target-voters target-voters
+                   :error (ex-message e)})
+            :indeterminate)
 
-        :else
-        (throw e)))))
+          (membership-change-in-progress? e)
+          (do
+            (info "OpenRaft membership change is already in progress"
+                  {:target-voters target-voters
+                   :error (ex-message e)})
+            :in-progress)
+
+          :else
+          (throw e))))))
+
+(def ^:private restoration-outcome-kind ::restoration-outcome)
+
+(defn- closed-outcome? [value]
+  (contains? #{:installed :skipped :indeterminate} (:status value)))
+
+(defn- restoration-context [pending]
+  (atom
+   (cond-> (merge {:attempted? (= :indeterminate (:status pending))}
+                  (select-keys pending
+                               [:stage
+                                :error-variant
+                                :error-shape
+                                :error-arm-count
+                                :error-arm-names]))
+     (= :indeterminate (:status pending))
+     (assoc :reason (or (:reason pending) :request-result-unknown))
+     (= :in-progress (:status pending))
+     (assoc :skip-reason :membership-change-in-progress)
+     (#{:learner-unreachable :no-supported-leader :node-starting}
+      (:status pending))
+     (assoc :skip-reason (:status pending)))))
+
+(defn- return-restoration-outcome! [value]
+  (throw (ex-info "OpenRaft membership restoration has a modeled outcome"
+                  {:kind restoration-outcome-kind
+                   :outcome value})))
+
+(defn- note-restoration-request!
+  [context stage result details]
+  (let [status (if (map? result) (:status result) result)
+        evidence (when (map? result)
+                   (select-keys result
+                                [:reason
+                                 :error-variant
+                                 :error-shape
+                                 :error-arm-count
+                                 :error-arm-names]))]
+    (case status
+      :completed
+      (swap! context assoc
+             :attempted? true
+             :stage stage)
+
+      :indeterminate
+      (swap! context
+             #(merge %
+                     evidence
+                     {:attempted? true
+                      :reason (or (:reason evidence)
+                                  :request-result-unknown)
+                      :stage stage}))
+
+      :in-progress
+      (swap! context assoc
+             :skip-reason :membership-change-in-progress
+             :stage stage)
+
+      :no-supported-leader
+      (let [{:keys [attempted? reason]
+             prior-stage :stage} @context
+            details (assoc details :stage (or prior-stage stage))]
+        (return-restoration-outcome!
+         (if attempted?
+           (outcome/indeterminate
+            (or reason :membership-recovery-unconfirmed)
+            details)
+           (outcome/skipped :no-supported-leader details))))
+
+      nil))
+  result)
+
+(defn- restoration-timeout-outcome [context e]
+  (let [{:keys [attempted? reason skip-reason] :as state} @context
+        details (merge {:condition (:condition (ex-data e))
+                        :message (ex-message e)}
+                       (select-keys state
+                                    [:stage
+                                     :error-variant
+                                     :error-shape
+                                     :error-arm-count
+                                     :error-arm-names]))]
+    (if attempted?
+      (outcome/indeterminate
+       (or reason :membership-recovery-unconfirmed)
+       details)
+      (outcome/skipped (or skip-reason :membership-not-ready)
+                       details))))
+
+(defn- request-membership-change-when-ready!
+  [test leader-endpoint target-voters context]
+  (let [waiting-for-stable? (atom false)]
+    (await/until!
+     :membership-change-request-ready
+     #(let [waiting? @waiting-for-stable?
+            status (when waiting? (cluster/membership-status test))]
+        (cond
+          (and waiting? (not (:stable? status)))
+          (await/retry! :membership-change-request-ready
+                        {:target-voters target-voters
+                         :status status})
+
+          (and waiting? (= target-voters (:voters status)))
+          status
+
+          :else
+          (do
+            (reset! waiting-for-stable? false)
+            (let [result (request-membership-change! test
+                                                     leader-endpoint
+                                                     target-voters)]
+              (note-restoration-request! context
+                                         :change-membership
+                                         result
+                                         {:target-voters target-voters})
+              (cond
+                (closed-outcome? result)
+                (return-restoration-outcome!
+                 (assoc result :stage :change-membership))
+
+                (= :in-progress result)
+                (do
+                  (reset! waiting-for-stable? true)
+                  (await/retry! :membership-change-request-ready
+                                {:target-voters target-voters}))
+
+                :else
+                result)))))
+     {:log-message "Waiting to retry an OpenRaft membership change"
+      :timeout learner-wait-timeout-ms})))
 
 (defn- complete-joint-membership!
-  [test {:keys [leader effective-voter-configs]}]
+  [test {:keys [leader effective-voter-configs]} context]
   (let [target-voters (peek effective-voter-configs)
-        leader-endpoint (atom (client/api-endpoint test leader))]
+        leader-endpoint (atom (client/api-endpoint test leader))
+        result (request-membership-change-when-ready! test
+                                                      leader-endpoint
+                                                      target-voters
+                                                      context)]
     (info "Completing an existing joint OpenRaft membership"
           {:configs effective-voter-configs
            :target-voters target-voters})
-    (request-membership-change! test leader-endpoint target-voters)
-    (cluster/await-stable-membership! test target-voters)))
+    (if (map? result)
+      result
+      (cluster/await-stable-membership! test target-voters))))
 
-(defn- stable-membership! [test]
-  (let [{:keys [stable?] :as status}
-        (cluster/await-committed-membership! test)]
-    (if stable?
-      status
-      (complete-joint-membership! test status))))
+(defn- stable-membership!
+  ([test]
+   (stable-membership! test (restoration-context nil)))
+  ([test context]
+   (let [{:keys [stable?] :as status}
+         (cluster/await-committed-membership! test)]
+     (if stable?
+       status
+       (complete-joint-membership! test status context)))))
 
 (defn- change-membership-and-await!
-  [test leader-endpoint target-voters]
-  (when (= :in-progress
-           (request-membership-change! test leader-endpoint target-voters))
-    (let [status (stable-membership! test)]
-      (when-not (= target-voters (:voters status))
-        (request-membership-change!
-         test
-         leader-endpoint
-         target-voters))))
-  (try
-    (cluster/await-stable-membership! test target-voters)
-    (catch Exception e
-      (when-not (= :timeout (:type (ex-data e)))
-        (throw e))
-      (let [status (stable-membership! test)]
-        (if (= target-voters (:voters status))
-          status
-          (throw e))))))
+  [test leader-endpoint target-voters context]
+  (let [result (request-membership-change-when-ready! test
+                                                      leader-endpoint
+                                                      target-voters
+                                                      context)]
+    (if (map? result)
+      result
+      (try
+        (cluster/await-stable-membership! test target-voters)
+        (catch Exception e
+          (when-not (await/condition-timeout? e :stable-membership)
+            (throw e))
+          (let [status (stable-membership! test context)]
+            (if (= target-voters (:voters status))
+              status
+              (throw e))))))))
 
 (defn- await-observed-learner! [test node]
-  (util/await-fn
-   #(let [status (cluster/membership-status test)]
-      (if (and (:stable? status)
-               (contains? (:learners status) node))
-        status
-        (throw (ex-info "OpenRaft learner is not committed yet"
-                        {:node node
-                         :status status}))))
-   {:log-message (str "Waiting for OpenRaft learner " node
-                      " to appear in membership")
-    :timeout learner-wait-timeout-ms}))
+  (cluster/await-observed-learner! test node learner-wait-timeout-ms))
+
+(defn- validate-add-learner-request!
+  [test node node-id api-addr raft-addr]
+  (let [configured? (contains? (set (:nodes test)) node)
+        expected {:node-id (client/node-host node)
+                  :api-addr (client/api-endpoint test node)
+                  :raft-addr (client/raft-addr test node)}
+        actual {:node-id node-id
+                :api-addr api-addr
+                :raft-addr raft-addr}]
+    (when-not (and configured? (= expected actual))
+      (throw (ex-info "Invalid OpenRaft add-learner request"
+                      {:kind :invalid-add-learner-request
+                       :node node
+                       :configured? configured?
+                       :expected expected
+                       :actual actual})))))
+
+(defn- unexpected-add-learner-error-variant [e]
+  (let [variant (membership-error-variant e)]
+    (when (#{:LearnerNotFound :EmptyMembership} variant)
+      variant)))
 
 (defn- request-add-learner!
   [test leader-endpoint node node-id api-addr raft-addr]
+  (validate-add-learner-request! test node node-id api-addr raft-addr)
   (try
     (request-leader!
      test
@@ -152,35 +331,102 @@
      #(client/add-learner! % node-id api-addr raft-addr))
     :completed
     (catch Exception e
-      (cond
-        (leader-routing-error? e)
-        :no-supported-leader
+      (let [unexpected (unexpected-membership-error-outcome e)]
+        (cond
+          (leader-routing-error? e)
+          :no-supported-leader
 
-        (ambiguous-request-error? e)
-        (do
-          (info "OpenRaft learner addition result is indeterminate"
-                {:node node
-                 :error (ex-message e)})
-          :indeterminate)
+          unexpected
+          unexpected
 
-        :else
-        (throw e)))))
+          (ambiguous-request-error? e)
+          (do
+            (info "OpenRaft learner addition result is indeterminate"
+                  {:node node
+                   :error (ex-message e)})
+            :indeterminate)
+
+          (membership-change-in-progress? e)
+          (do
+            (info "OpenRaft learner addition found a membership change in progress"
+                  {:node node
+                   :error (ex-message e)})
+            :in-progress)
+
+          (unexpected-add-learner-error-variant e)
+          (let [variant (unexpected-add-learner-error-variant e)]
+            (info "OpenRaft learner addition returned an unexpected error"
+                  {:node node
+                   :error-variant variant})
+            (outcome/indeterminate :unexpected-sut-response
+                                   {:error-variant variant}))
+
+          :else
+          (throw e))))))
+
+(defn- request-add-learner-when-ready!
+  [test leader-endpoint node node-id api-addr raft-addr context]
+  (let [waiting-for-stable? (atom false)]
+    (await/until!
+     :add-learner-request-ready
+     #(let [waiting? @waiting-for-stable?
+            status (when waiting? (cluster/membership-status test))]
+        (cond
+          (and waiting? (not (:stable? status)))
+          (await/retry! :add-learner-request-ready
+                        {:node node
+                         :status status})
+
+          (and waiting?
+               (or (contains? (:learners status) node)
+                   (contains? (:voters status) node)))
+          status
+
+          :else
+          (do
+            (reset! waiting-for-stable? false)
+            (let [result (request-add-learner! test
+                                               leader-endpoint
+                                               node
+                                               node-id
+                                               api-addr
+                                               raft-addr)]
+              (note-restoration-request! context
+                                         :add-learner
+                                         result
+                                         {:node node})
+              (cond
+                (closed-outcome? result)
+                (return-restoration-outcome! (assoc result
+                                                    :stage
+                                                    :add-learner))
+
+                (= :in-progress result)
+                (do
+                  (reset! waiting-for-stable? true)
+                  (await/retry! :add-learner-request-ready {:node node}))
+
+                :else
+                result)))))
+     {:log-message (str "Waiting to retry adding OpenRaft learner " node)
+      :timeout learner-wait-timeout-ms})))
 
 (defn- add-learner-and-confirm!
-  [test leader-endpoint node node-id api-addr raft-addr]
-  (let [result (request-add-learner! test
-                                     leader-endpoint
-                                     node
-                                     node-id
-                                     api-addr
-                                     raft-addr)]
-    (when (= :indeterminate result)
-      (await-observed-learner! test node))
-    result))
+  [test leader-endpoint node node-id api-addr raft-addr context]
+  (let [result (request-add-learner-when-ready! test
+                                                leader-endpoint
+                                                node
+                                                node-id
+                                                api-addr
+                                                raft-addr
+                                                context)]
+    (if (= :indeterminate result)
+      (await-observed-learner! test node)
+      result)))
 
-(defn- grow! [database test]
+(defn- grow! [database test context]
   (let [{:keys [leader voters learners non-members metrics]}
-        (stable-membership! test)
+        (stable-membership! test context)
         source (if (seq learners) :learner :non-member)
         node (select-node test
                           (if (= :learner source)
@@ -202,29 +448,35 @@
               {:node node
                :source source
                :leader leader})
-        (add-learner-and-confirm!
-         test
-         leader-endpoint
-         node
-         node-id
-         api-addr
-         raft-addr)
-
-        (info "Growing OpenRaft membership"
-              {:node node
-               :before voters
-               :after target-voters})
-
-        (let [final-status
-              (change-membership-and-await!
+        (let [learner-status
+              (add-learner-and-confirm!
                test
                leader-endpoint
-               target-voters)]
-          {:node node
-           :source source
-           :leader (:leader final-status)
-           :before voters
-           :after (:voters final-status)})))))
+               node
+               node-id
+               api-addr
+               raft-addr
+               context)]
+
+          (info "Growing OpenRaft membership"
+                {:node node
+                 :before voters
+                 :after target-voters})
+
+          (let [final-status
+                (if (and (map? learner-status)
+                         (= target-voters (:voters learner-status)))
+                  learner-status
+                  (change-membership-and-await!
+                   test
+                   leader-endpoint
+                   target-voters
+                   context))]
+            {:node node
+             :source source
+             :leader (:leader final-status)
+             :before voters
+             :after (:voters final-status)}))))))
 
 (defn- shrink-candidates [{:keys [voters metrics]}]
   (let [reachable (set (keys metrics))]
@@ -238,14 +490,45 @@
   [pending-change pending leader]
   (reset! pending-change nil)
   (-> pending
-      (dissoc :target)
+      (dissoc :target
+              :status
+              :reason
+              :stage
+              :error-variant
+              :error-shape
+              :error-arm-count
+              :error-arm-names)
       (assoc :leader leader
              :after (:target pending))))
 
+(defn- retained-status-reason [status]
+  (case status
+    :indeterminate :request-result-unknown
+    :in-progress :membership-change-in-progress
+    :learner-unreachable :learner-unreachable
+    :no-supported-leader :no-supported-leader
+    :node-starting :node-starting
+    nil))
+
 (defn- retain-pending-change!
-  [pending-change pending status]
-  (reset! pending-change pending)
-  (assoc pending :status status))
+  [pending-change pending result]
+  (let [current @pending-change
+        status (if (map? result) (:status result) result)
+        reason (if (map? result)
+                 (:reason result)
+                 (retained-status-reason status))
+        evidence (when (map? result)
+                   (select-keys result
+                                [:error-variant
+                                 :error-shape
+                                 :error-arm-count
+                                 :error-arm-names]))
+        retained (if (= :indeterminate (:status current))
+                   current
+                   (cond-> (merge pending evidence {:status status})
+                     reason (assoc :reason reason)))]
+    (reset! pending-change retained)
+    retained))
 
 (defn- request-pending-membership-change!
   [pending-change test status pending]
@@ -274,8 +557,22 @@
                           api-addr
                           raft-addr)]
       (if-not (= :completed learner-result)
-        (retain-pending-change! pending-change pending learner-result)
-        (do
+        (retain-pending-change! pending-change
+                                (assoc pending :stage :add-learner)
+                                learner-result)
+        (let [current @pending-change
+              pending (cond-> (assoc pending
+                                     :stage :change-membership)
+                        (and (= :indeterminate (:status current))
+                             (= :add-learner (:stage current)))
+                        (dissoc :status
+                                :reason
+                                :error-variant
+                                :error-shape
+                                :error-arm-count
+                                :error-arm-names))]
+          (when current
+            (reset! pending-change pending))
           (info "Growing OpenRaft membership"
                 {:node node
                  :before (:before pending)
@@ -384,7 +681,10 @@
                 (-> pending
                     (dissoc :target)
                     (assoc :after target-voters)))
-              (retain-pending-change! pending-change pending result))))
+              (retain-pending-change! pending-change
+                                      (assoc pending
+                                             :stage :change-membership)
+                                      result))))
         :no-quorum-safe-shrink))))
 
 (defn- resolve-pending-removal!
@@ -413,9 +713,9 @@
                 test
                 (atom (client/api-endpoint test (:leader status)))
                 target-voters)]
-    {:status result
-     :target target-voters
-     :voter-configs (:effective-voter-configs status)}))
+    (merge (if (map? result) result {:status result})
+           {:target target-voters
+            :voter-configs (:effective-voter-configs status)})))
 
 (defn- request-membership-operation!
   [database pending-change test operation]
@@ -440,16 +740,103 @@
       (request-shrink! database pending-change test status))
     :no-supported-leader))
 
+(def ^:private skipped-results
+  #{:learner-pending
+    :membership-full
+    :minimum-membership
+    :no-quorum-safe-shrink
+    :no-supported-leader})
+
+(def ^:private skipped-status-reasons
+  {:in-progress :membership-change-in-progress
+   :learner-unreachable :learner-unreachable
+   :no-supported-leader :no-supported-leader
+   :node-starting :node-starting})
+
+(defn- normalize-membership-result [result]
+  (cond
+    (= :indeterminate result)
+    (outcome/indeterminate :request-result-unknown {})
+
+    (contains? skipped-results result)
+    (outcome/skipped result {})
+
+    (map? result)
+    (let [status (:status result)
+          details (dissoc result :status :reason)]
+      (cond
+        (= :completed status)
+        (outcome/installed details)
+
+        (= :indeterminate status)
+        (outcome/indeterminate (or (:reason result)
+                                   :request-result-unknown)
+                               details)
+
+        (contains? skipped-status-reasons status)
+        (outcome/skipped (get skipped-status-reasons status) details)
+
+        (contains? result :after)
+        (outcome/installed (dissoc result :reason))
+
+        :else
+        (throw (ex-info "Unknown membership Nemesis result"
+                        {:result result}))))
+
+    :else
+    (throw (ex-info "Unknown membership Nemesis result"
+                    {:result result}))))
+
+(defn- membership-operation-outcome [operation result]
+  (let [normalized (normalize-membership-result result)
+        actual-change (when (map? result) (:change result))
+        indeterminate? (= :indeterminate (:status normalized))]
+    (cond
+      (and indeterminate?
+           actual-change
+           (not= operation actual-change))
+      (outcome/indeterminate (:reason normalized)
+                             {:pending-change normalized})
+
+      (and indeterminate?
+           (map? result)
+           (contains? result :voter-configs))
+      (outcome/indeterminate (:reason normalized)
+                             {:existing-change normalized})
+
+      (and actual-change (not= operation actual-change))
+      (outcome/skipped
+       :pending-membership-change
+       {(if (= :installed (:status normalized))
+          :resolved-change
+          :pending-change) normalized})
+
+      (and (map? result) (contains? result :voter-configs))
+      (outcome/skipped :membership-change-in-progress
+                       {:existing-change normalized})
+
+      :else
+      normalized)))
+
+(defn- restoration-outcome [result]
+  (if (closed-outcome? result)
+    result
+    (outcome/installed
+     (cond-> result
+       (:resolved-change result)
+       (update :resolved-change outcome/installed)))))
+
 (defn- complete-pending-removal-and-await!
-  [database pending-change test]
+  [database pending-change test context]
   (when-let [{:keys [node target] :as pending} @pending-change]
-    (let [status (stable-membership! test)
+    (let [status (stable-membership! test context)
           final-status (if (= target (:voters status))
                          status
                          (change-membership-and-await!
                           test
                           (atom (client/api-endpoint test (:leader status)))
-                          target))]
+                          target
+                          context))]
       (openraft-db/stop-and-wipe-node! database test node)
       (reset! pending-change nil)
       (-> pending
@@ -457,46 +844,87 @@
           (assoc :leader (:leader final-status)
                  :after target)))))
 
-(defn- confirm-pending-grow!
-  [pending-change test]
-  (let [{:keys [target] :as pending} @pending-change
-        status (stable-membership! test)]
-    (reset! pending-change nil)
-    (when (= target (:voters status))
+(defn- confirm-pending-grow-status!
+  [pending-change status]
+  (when-let [{:keys [change target] :as pending} @pending-change]
+    (when (and (= :grow change)
+               (= target (:voters status)))
+      (reset! pending-change nil)
       (-> pending
-          (dissoc :target)
+          (dissoc :target
+                  :status
+                  :reason
+                  :stage
+                  :error-variant
+                  :error-shape
+                  :error-arm-count
+                  :error-arm-names)
           (assoc :leader (:leader status)
                  :after target)))))
 
+(defn- confirm-pending-grow!
+  [pending-change test context]
+  (let [status (stable-membership! test context)]
+    (confirm-pending-grow-status! pending-change status)))
+
 (defn- complete-pending-change-and-await!
-  [database pending-change test]
+  [database pending-change test context]
   (case (:change @pending-change)
-    :grow (confirm-pending-grow! pending-change test)
+    :grow (confirm-pending-grow! pending-change test context)
     :shrink (complete-pending-removal-and-await!
              database
              pending-change
-             test)
+             test
+             context)
     nil nil))
 
-(defn- restore-membership! [database pending-change test]
+(defn- restore-membership! [database pending-change test context]
   (let [resolved-change (complete-pending-change-and-await!
                          database
                          pending-change
-                         test)
+                         test
+                         context)
         target-voters (set (:nodes test))]
-    (loop [status (stable-membership! test)]
+    (loop [status (stable-membership! test context)]
       (if (= target-voters (:voters status))
-        (cond-> {:leader (:leader status)
-                 :voters (:voters status)}
-          resolved-change
-          (assoc :resolved-change resolved-change))
-        (let [result (grow! database test)]
+        (let [resolved-change (or resolved-change
+                                  (confirm-pending-grow-status!
+                                   pending-change
+                                   status))]
+          (cond-> {:leader (:leader status)
+                   :voters (:voters status)}
+            resolved-change
+            (assoc :resolved-change resolved-change)))
+        (let [result (grow! database test context)]
           (when (keyword? result)
-            (throw (ex-info "Unable to restore OpenRaft membership"
-                            {:result result
-                             :status status
-                             :target-voters target-voters})))
-          (recur (stable-membership! test)))))))
+            (return-restoration-outcome!
+             (outcome/skipped result
+                              {:status status
+                               :target-voters target-voters})))
+          (recur (stable-membership! test context)))))))
+
+(defn- restore-membership-outcome!
+  [database pending-change test]
+  (let [context (restoration-context @pending-change)]
+    (try
+      (restoration-outcome
+       (restore-membership! database pending-change test context))
+      (catch Exception e
+        (cond
+          (= restoration-outcome-kind (:kind (ex-data e)))
+          (:outcome (ex-data e))
+
+          (some #(await/condition-timeout? e %)
+                [:add-learner-request-ready
+                 :committed-membership
+                 :learner-observed
+                 :membership-change-request-ready
+                 :node-metrics
+                 :stable-membership])
+          (restoration-timeout-outcome context e)
+
+          :else
+          (throw e))))))
 
 (defrecord MembershipNemesis [database pending-change]
   nemesis/Nemesis
@@ -506,24 +934,27 @@
   (invoke! [_ test op]
     (case (:f op)
       :grow
-      (assoc op :value (request-membership-operation!
-                        database
-                        pending-change
-                        test
-                        :grow))
+      (let [result (request-membership-operation!
+                    database
+                    pending-change
+                    test
+                    :grow)]
+        (assoc op :value (membership-operation-outcome :grow result)))
 
       :shrink
-      (assoc op :value (request-membership-operation!
-                        database
-                        pending-change
-                        test
-                        :shrink))
+      (let [result (request-membership-operation!
+                    database
+                    pending-change
+                    test
+                    :shrink)]
+        (assoc op :value (membership-operation-outcome :shrink result)))
 
       :restore-membership
-      (assoc op :value (restore-membership!
-                        database
-                        pending-change
-                        test))))
+      (assoc op
+             :value (restore-membership-outcome!
+                     database
+                     pending-change
+                     test))))
 
   (teardown! [_ _test])
 
@@ -544,6 +975,38 @@
                       :f :grow})
              (repeat {:type :info
                       :f :shrink})])))
+
+(defn- membership-change-installed? [required-changes change]
+  (and (outcome/installed-or-legacy?
+        change
+        #(and (map? %)
+              (required-changes (:change %))
+              (:node %)
+              (:leader %)
+              (coll? (:before %))
+              (coll? (:after %))
+              (not= (:before %) (:after %))))
+       (required-changes (:change change))
+       (:node change)
+       (:leader change)
+       (coll? (:before change))
+       (coll? (:after change))
+       (not= (:before change) (:after change))))
+
+(defn- membership-restored? [expected-voters value]
+  (and (outcome/installed-or-legacy?
+        value
+        #(and (map? %)
+              (:leader %)
+              (= expected-voters (:voters %))))
+       (:leader value)
+       (= expected-voters (:voters value))))
+
+(defn- recovery-installed? [value]
+  (and (outcome/installed-or-legacy?
+        value
+        #(and (map? %) (:leader %)))
+       (:leader value)))
 
 (defn- coverage-checker []
   (reify checker/Checker
@@ -568,27 +1031,23 @@
                                         (:resolved-change value)])))
                                   (keep
                                    (fn [change]
-                                     (when (and (map? change)
-                                                (required-changes
-                                                 (:change change))
-                                                (contains? change :before)
-                                                (contains? change :after)
-                                                (not= (:before change)
-                                                      (:after change)))
+                                     (when (membership-change-installed?
+                                            required-changes
+                                            change)
                                        (:change change))))
                                   set)
             missing-changes (remove observed-changes
                                     required-changes)
             final-operation (peek membership-history)
             restored? (and (= :restore-membership (:f final-operation))
-                           (= expected-voters
-                              (get-in final-operation
-                                      [:value :voters])))
+                           (membership-restored?
+                            expected-voters
+                            (:value final-operation)))
             final-recovery (->> history
                                 (filter #(= :await-recovery (:f %)))
                                 last)
-            recovered? (boolean (get-in final-recovery
-                                        [:value :leader]))]
+            recovered? (boolean
+                        (recovery-installed? (:value final-recovery)))]
         {:valid? (and (empty? errors)
                       (empty? missing-changes)
                       restored?

--- a/jepsen/src/jepsen/openraft/nemesis/membership.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/membership.clj
@@ -6,6 +6,7 @@
              [random :as random]]
             [jepsen.openraft.await :as await]
             [jepsen.openraft [client :as client]
+             [checker :as openraft-checker]
              [cluster :as cluster]
              [db :as openraft-db]]
             [jepsen.openraft.nemesis.outcome :as outcome]
@@ -1070,4 +1071,5 @@
    :generator (membership-generator)
    :final-generator {:type :info
                      :f :restore-membership}
-   :checker (coverage-checker)})
+   :checker (openraft-checker/reject-checker-exceptions
+             (coverage-checker))})

--- a/jepsen/src/jepsen/openraft/nemesis/outcome.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/outcome.clj
@@ -1,0 +1,27 @@
+(ns jepsen.openraft.nemesis.outcome)
+
+(defn installed
+  "Returns a confirmed Nemesis outcome with structured details."
+  [details]
+  (assoc details :status :installed))
+
+(defn skipped
+  "Returns a known non-installation with a structured reason."
+  [reason details]
+  (assoc details
+         :status :skipped
+         :reason reason))
+
+(defn indeterminate
+  "Returns an attempted action whose side effect cannot be confirmed."
+  [reason details]
+  (assoc details
+         :status :indeterminate
+         :reason reason))
+
+(defn installed-or-legacy?
+  "Checks an installed outcome, or an exact legacy success without status."
+  [value legacy-installed?]
+  (if (and (map? value) (contains? value :status))
+    (= :installed (:status value))
+    (boolean (legacy-installed? value))))

--- a/jepsen/src/jepsen/openraft/nemesis/partition.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/partition.clj
@@ -5,6 +5,7 @@
              [nemesis :as nemesis]
              [random :as random]]
             [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.checker :as openraft-checker]
             [jepsen.openraft.interruption :as interruption]
             [jepsen.openraft.nemesis.outcome :as outcome]
             [jepsen.openraft.quorum :as quorum]))
@@ -221,4 +222,5 @@
    :generator (partition-generator)
    :final-generator {:type :info
                      :f :stop-partition}
-   :checker (coverage-checker)})
+   :checker (openraft-checker/reject-checker-exceptions
+             (coverage-checker))})

--- a/jepsen/src/jepsen/openraft/nemesis/partition.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/partition.clj
@@ -1,5 +1,5 @@
 (ns jepsen.openraft.nemesis.partition
-  (:require [clojure.tools.logging :refer [info warn]]
+  (:require [clojure.tools.logging :refer [info]]
             [jepsen [checker :as checker]
              [generator :as gen]
              [nemesis :as nemesis]
@@ -107,13 +107,9 @@
     (try
       (nemesis/teardown! partitioner test)
       (catch Exception e
-        (if (interruption/interruption? e)
-          (do
-            (.interrupt (Thread/currentThread))
-            (throw e))
-          (warn e
-                "Failed to heal network partition during teardown"
-                {:nodes (:nodes test)})))))
+        (when (interruption/interruption? e)
+          (.interrupt (Thread/currentThread)))
+        (throw e))))
 
   nemesis/Reflection
   (fs [_]

--- a/jepsen/src/jepsen/openraft/nemesis/partition.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/partition.clj
@@ -6,6 +6,7 @@
              [random :as random]]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.interruption :as interruption]
+            [jepsen.openraft.nemesis.outcome :as outcome]
             [jepsen.openraft.quorum :as quorum]))
 
 (def partition-seconds 10)
@@ -30,15 +31,21 @@
                        (throw (ex-info "Unknown partition mode"
                                        {:mode mode})))
           quorum-side (first (random/shuffle candidates))]
-      (when-not quorum-side
-        (throw (ex-info "Membership has no partition for the requested mode"
-                        {:leader leader
-                         :mode mode
-                         :configs configs})))
-      (let [other-side (remove quorum-side nodes)]
-        (if (contains? quorum-side leader)
-          [(vec (filter quorum-side nodes)) (vec other-side)]
-          [(vec other-side) (vec (filter quorum-side nodes))])))))
+      (when quorum-side
+        (let [other-side (remove quorum-side nodes)]
+          (if (contains? quorum-side leader)
+            [(vec (filter quorum-side nodes)) (vec other-side)]
+            [(vec other-side) (vec (filter quorum-side nodes))]))))))
+
+(defn- invoke-delegate! [delegate test op]
+  (try
+    (nemesis/invoke! delegate test op)
+    (catch Exception e
+      ;; Partition control runs multi-node operations on real-pmap workers.
+      ;; Restore the interrupt flag on the receiving Nemesis thread too.
+      (when (interruption/interruption? e)
+        (.interrupt (Thread/currentThread)))
+      (throw e))))
 
 (defrecord PartitionNemesis [partitioner]
   nemesis/Nemesis
@@ -51,37 +58,50 @@
       (if-let [{:keys [leader] :as status}
                (cluster/membership-status test)]
         (let [configs (cluster/voter-configs test status)
-              mode (:value op)
-              components (partition-components (:nodes test)
-                                               configs
-                                               leader
-                                               mode)
-              grudge (nemesis/complete-grudge components)]
-          (info "Partitioning OpenRaft nodes"
-                {:mode mode
-                 :leader leader
-                 :components components})
-          (nemesis/invoke! partitioner test
-                           (assoc op
-                                  :f :start
-                                  :value grudge))
-          (assoc op
-                 :value {:mode mode
-                         :leader leader
-                         :voter-configs configs
-                         :components components}))
+              mode (:value op)]
+          (if-let [components (partition-components (:nodes test)
+                                                    configs
+                                                    leader
+                                                    mode)]
+            (let [grudge (nemesis/complete-grudge components)]
+              (info "Partitioning OpenRaft nodes"
+                    {:mode mode
+                     :leader leader
+                     :components components})
+              (invoke-delegate! partitioner test
+                                (assoc op
+                                       :f :start
+                                       :value grudge))
+              (assoc op
+                     :value (outcome/installed
+                             {:mode mode
+                              :leader leader
+                              :voter-configs configs
+                              :components components})))
+            (do
+              (info "Skipping partition without a safe target"
+                    {:mode mode
+                     :leader leader
+                     :voter-configs configs})
+              (assoc op
+                     :value (outcome/skipped
+                             :no-safe-partition-target
+                             {:mode mode
+                              :leader leader
+                              :voter-configs configs})))))
         (do
           (info "Skipping partition without a quorum-supported leader")
-          (assoc op :value :no-supported-leader)))
+          (assoc op
+                 :value (outcome/skipped :no-supported-leader {}))))
 
       :stop-partition
       (do
         (info "Healing OpenRaft network partition")
-        (nemesis/invoke! partitioner test
-                         (assoc op
-                                :f :stop
-                                :value nil))
-        (assoc op :value :network-healed))))
+        (invoke-delegate! partitioner test
+                          (assoc op
+                                 :f :stop
+                                 :value nil))
+        (assoc op :value (outcome/installed {})))))
 
   (teardown! [_ test]
     (try
@@ -101,6 +121,27 @@
 
 (defn partition-nemesis []
   (PartitionNemesis. (nemesis/partitioner)))
+
+(defn- legacy-partition-start-installed? [value]
+  (and (map? value)
+       (required-partition-modes (:mode value))
+       (:leader value)
+       (coll? (:voter-configs value))
+       (coll? (:components value))))
+
+(defn- partition-start-installed? [value]
+  (and (outcome/installed-or-legacy? value
+                                     legacy-partition-start-installed?)
+       (required-partition-modes (:mode value))))
+
+(defn- partition-stop-installed? [value]
+  (outcome/installed-or-legacy? value #{:network-healed}))
+
+(defn- recovery-installed? [value]
+  (and (outcome/installed-or-legacy?
+        value
+        #(and (map? %) (:leader %)))
+       (:leader value)))
 
 (defn- partition-generator []
   (gen/cycle
@@ -128,25 +169,30 @@
   that every node follows one leader, while leftover rules from an
   indeterminate heal may still cut follower-to-follower links."
   [state op]
-  (let [operation-error? (boolean (or (:error op)
-                                      (:exception op)))]
+  (let [status (get-in op [:value :status])
+        operation-error? (boolean (or (:error op)
+                                      (:exception op)
+                                      (= :indeterminate status)))]
     (case (:f op)
       :start-partition
       (cond
         operation-error? :unknown
-        (get-in op [:value :mode]) :recovery-pending
+        (partition-start-installed? (:value op)) :recovery-pending
         :else state)
 
       :stop-partition
       (cond
         operation-error? :unknown
-        (= :network-healed (:value op)) :recovery-pending
+        (partition-stop-installed? (:value op)) :recovery-pending
         :else state)
 
       :await-recovery
       (cond
+        operation-error? (if (= :recovery-pending state)
+                           :recovery-pending
+                           :unknown)
         (= :unknown state) :unknown
-        (get-in op [:value :leader]) :intact
+        (recovery-installed? (:value op)) :intact
         :else state)
 
       state)))
@@ -156,6 +202,8 @@
     (check [_ _test history _opts]
       (let [observed-modes (->> history
                                 (filter #(= :start-partition (:f %)))
+                                (filter #(partition-start-installed?
+                                          (:value %)))
                                 (keep #(get-in % [:value :mode]))
                                 set)
             missing-modes (remove observed-modes required-partition-modes)

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -1,5 +1,5 @@
 (ns jepsen.openraft.nemesis.process
-  (:require [clojure.tools.logging :refer [info warn]]
+  (:require [clojure.tools.logging :refer [info]]
             [jepsen [checker :as checker]
              [generator :as gen]
              [nemesis :as nemesis]
@@ -8,7 +8,8 @@
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.interruption :as interruption]
             [jepsen.openraft.nemesis.outcome :as outcome]
-            [jepsen.openraft.quorum :as quorum]))
+            [jepsen.openraft.quorum :as quorum]
+            [jepsen.openraft.worker :as worker]))
 
 (def downtime-seconds 10)
 (def required-process-modes
@@ -299,16 +300,16 @@
                        {:type :info
                         :f :resume
                         :value (:nodes test)})
-      (catch Exception e
-        (if (interruption/interruption? e)
-          (do
-            (.interrupt (Thread/currentThread))
-            (throw e))
-          (warn e
-                "Failed to resume OpenRaft processes during teardown"
-                {:nodes (:nodes test)})))
-      (finally
-        (nemesis/teardown! delegate test))))
+      (catch Throwable throwable
+        (worker/handle-teardown-failure!
+         {:action :resume-processes}
+         throwable)))
+    (try
+      (nemesis/teardown! delegate test)
+      (catch Throwable throwable
+        (worker/handle-teardown-failure!
+         {:action :delegate-teardown}
+         throwable))))
 
   nemesis/Reflection
   (fs [_]

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -7,6 +7,7 @@
             [jepsen.nemesis.combined :as combined]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.interruption :as interruption]
+            [jepsen.openraft.nemesis.outcome :as outcome]
             [jepsen.openraft.quorum :as quorum]))
 
 (def downtime-seconds 10)
@@ -60,12 +61,14 @@
 (def ^:private disruption-start-specs
   {:process {:delegate-f :kill
              :active-key :killed
+             :active-reason :processes-already-killed
              :active-message "Processes are already stopped"
              :start-message "Killing OpenRaft processes"
              :skip-message
              "Skipping process kill without a quorum-supported leader"}
    :pause {:delegate-f :pause
            :active-key :paused
+           :active-reason :processes-already-paused
            :active-message "Processes are already paused"
            :start-message "Pausing OpenRaft processes"
            :skip-message
@@ -76,51 +79,157 @@
       (throw (ex-info "Unknown process disruption kind"
                       {:kind kind}))))
 
+(def ^:private stop-results
+  #{:killed :target-absent :target-already-exited})
+
+(def ^:private start-results
+  #{:already-running :start-confirmed})
+
+(def ^:private pause-results
+  #{:paused :target-absent :target-already-exited})
+
+(def ^:private resume-results
+  #{:resumed :target-absent :target-already-exited})
+
+(defn- invoke-delegate! [delegate test op]
+  (try
+    (nemesis/invoke! delegate test op)
+    (catch Exception e
+      ;; c/on-nodes runs multi-node control operations on worker threads.
+      ;; Restore the interrupt flag on the receiving Nemesis thread too.
+      (when (interruption/interruption? e)
+        (.interrupt (Thread/currentThread)))
+      (throw e))))
+
+(defn- delegate-results!
+  [completion targets allowed-results operation]
+  (let [results (:value completion)
+        expected-targets (set targets)]
+    (when-not (and (map? results)
+                   (= expected-targets (set (keys results)))
+                   (= (count expected-targets) (count results))
+                   (every? allowed-results (vals results)))
+      (throw (ex-info "Unexpected process control result"
+                      {:kind :unexpected-process-control-result
+                       :operation operation
+                       :expected-targets expected-targets
+                       :allowed-results allowed-results
+                       :result results})))
+    results))
+
+(defn- control-outcome
+  [details completion targets allowed-results operation result-key
+   confirmed-result]
+  (let [results (delegate-results! completion
+                                   targets
+                                   allowed-results
+                                   operation)
+        details (assoc details result-key results)]
+    [details
+     (cond
+       (some #{confirmed-result} (vals results))
+       (outcome/installed details)
+
+       (every? #{:target-absent} (vals results))
+       (outcome/skipped :target-absent details)
+
+       :else
+       (outcome/skipped :target-already-exited details))]))
+
+(defn- stop-outcome [disruption completion]
+  (control-outcome disruption
+                   completion
+                   (:nodes disruption)
+                   stop-results
+                   :kill
+                   :stop-results
+                   :killed))
+
+(defn- pause-outcome [disruption completion]
+  (control-outcome disruption
+                   completion
+                   (:nodes disruption)
+                   pause-results
+                   :pause
+                   :pause-results
+                   :paused))
+
+(defn- resume-outcome [disruption completion targets]
+  (control-outcome {:paused disruption
+                    :resumed targets}
+                   completion
+                   targets
+                   resume-results
+                   :resume
+                   :resume-results
+                   :resumed))
+
 (defn- start-disruption! [delegate active kind test op]
-  (let [{:keys [delegate-f active-key active-message
+  (let [{:keys [delegate-f active-key active-reason active-message
                 start-message skip-message]}
         (disruption-spec kind)]
-    (when @active
-      (throw (ex-info active-message
-                      {active-key @active})))
-    (if-let [status (cluster/membership-status test)]
-      (let [mode (:value op)
-            eligible-nodes (if (= :pause kind)
-                             (->> (:nodes test)
-                                  (filter (set (keys (:metrics status))))
-                                  vec)
-                             (:nodes test))]
-        (if-let [disruption (process-disruption test
-                                                status
-                                                mode
-                                                eligible-nodes)]
-          (let [targets (:nodes disruption)]
-            (info start-message disruption)
-            ;; A multi-node disruption may partially succeed before the delegate
-            ;; reports an error, so retain every node that may need recovering.
-            (reset! active disruption)
-            (nemesis/invoke! delegate test
-                             (assoc op
-                                    :f delegate-f
-                                    :value targets))
-            (assoc op :value disruption))
-          (case kind
-            :process
-            (throw (ex-info "Membership has no quorum-safe process targets"
-                            {:leader (:leader status)
+    (if-let [active-disruption @active]
+      (do
+        (info active-message {active-key active-disruption})
+        (assoc op
+               :value (outcome/skipped
+                       active-reason
+                       {:kind kind
+                        active-key active-disruption})))
+      (if-let [status (cluster/membership-status test)]
+        (let [mode (:value op)
+              eligible-nodes (if (= :pause kind)
+                               (->> (:nodes test)
+                                    (filter (set (keys (:metrics status))))
+                                    vec)
+                               (:nodes test))]
+          (if-let [disruption (process-disruption test
+                                                  status
+                                                  mode
+                                                  eligible-nodes)]
+            (let [targets (:nodes disruption)]
+              (info start-message disruption)
+              ;; A multi-node disruption may partially succeed before the
+              ;; delegate reports an error, so retain every node that may need
+              ;; recovering.
+              (reset! active disruption)
+              (let [completion (invoke-delegate! delegate
+                                                 test
+                                                 (assoc op
+                                                        :f delegate-f
+                                                        :value targets))
+                    [active-disruption value]
+                    (case kind
+                      :process (stop-outcome disruption completion)
+                      :pause (pause-outcome disruption completion))]
+                (reset! active active-disruption)
+                (assoc op :value value)))
+            (case kind
+              :process
+              (let [details {:leader (:leader status)
                              :mode mode
                              :voter-configs (cluster/voter-configs test
-                                                                   status)}))
+                                                                   status)}]
+                (info "Skipping process kill without a quorum-safe target"
+                      details)
+                (assoc op
+                       :value (outcome/skipped
+                               :no-quorum-safe-process-target
+                               details)))
 
-            :pause
-            (do
-              (info "Skipping process pause without a reachable target"
-                    {:mode mode
-                     :reachable-nodes eligible-nodes})
-              (assoc op :value :no-reachable-pause-target)))))
-      (do
-        (info skip-message)
-        (assoc op :value :no-supported-leader)))))
+              :pause
+              (let [details {:mode mode
+                             :reachable-nodes eligible-nodes}]
+                (info "Skipping process pause without a reachable target"
+                      details)
+                (assoc op
+                       :value (outcome/skipped
+                               :no-reachable-pause-target
+                               details))))))
+        (do
+          (info skip-message)
+          (assoc op
+                 :value (outcome/skipped :no-supported-leader {})))))))
 
 (defrecord ProcessNemesis [delegate killed]
   nemesis/Nemesis
@@ -134,15 +243,23 @@
 
       :restart-process
       (if-let [{:keys [nodes] :as disruption} @killed]
-        (do
-          (info "Restarting OpenRaft processes" {:nodes nodes})
-          (nemesis/invoke! delegate test
-                           (assoc op
-                                  :f :start
-                                  :value nodes))
+        (let [_ (info "Restarting OpenRaft processes" {:nodes nodes})
+              completion
+              (invoke-delegate! delegate
+                                test
+                                (assoc op
+                                       :f :start
+                                       :value nodes))
+              results (delegate-results! completion
+                                         nodes
+                                         start-results
+                                         :start)
+              value (outcome/installed
+                     (assoc disruption :start-results results))]
           (reset! killed nil)
-          (assoc op :value disruption))
-        (assoc op :value :no-processes-killed))))
+          (assoc op :value value))
+        (assoc op
+               :value (outcome/skipped :no-processes-killed {})))))
 
   (teardown! [_ test]
     (nemesis/teardown! delegate test))
@@ -165,15 +282,16 @@
       (start-disruption! delegate paused :pause test op)
 
       :resume-process
-      (let [disruption @paused]
+      (let [disruption @paused
+            targets (:nodes test)]
         (info "Resuming all OpenRaft processes" {:nodes (:nodes test)})
-        (nemesis/invoke! delegate test
-                         (assoc op
-                                :f :resume
-                                :value (:nodes test)))
-        (reset! paused nil)
-        (assoc op :value {:paused disruption
-                          :resumed (:nodes test)}))))
+        (let [completion (invoke-delegate! delegate test
+                                           (assoc op
+                                                  :f :resume
+                                                  :value targets))
+              [_ value] (resume-outcome disruption completion targets)]
+          (reset! paused nil)
+          (assoc op :value value)))))
 
   (teardown! [_ test]
     (try
@@ -198,6 +316,80 @@
 
 (defn pause-nemesis [db]
   (PauseNemesis. (combined/db-nemesis db) (atom nil)))
+
+(defn- legacy-disruption-installed? [required-modes value]
+  (and (map? value)
+       (required-modes (:mode value))
+       (:leader value)
+       (coll? (:nodes value))
+       (coll? (:voter-configs value))
+       (coll? (:survivors value))))
+
+(defn- disruption-installed? [required-modes value]
+  (and (outcome/installed-or-legacy?
+        value
+        (partial legacy-disruption-installed? required-modes))
+       (required-modes (:mode value))))
+
+(defn- pause-installed? [value]
+  (if (and (map? value) (contains? value :status))
+    (let [targets (:nodes value)
+          target-set (set targets)
+          results (:pause-results value)
+          mode (:mode value)
+          leader (:leader value)]
+      (and (= :installed (:status value))
+           (required-pause-modes mode)
+           (seq targets)
+           (map? results)
+           (= (set targets) (set (keys results)))
+           (case mode
+             :leader-paused
+             (and (contains? target-set leader)
+                  (= :paused (get results leader)))
+
+             :leader-unpaused
+             (and (not (contains? target-set leader))
+                  (some #{:paused} (vals results)))
+
+             false)))
+    (legacy-disruption-installed? required-pause-modes value)))
+
+(defn- actual-pause-installed? [value]
+  (if (and (map? value) (contains? value :status))
+    (let [targets (:nodes value)
+          results (:pause-results value)]
+      (and (= :installed (:status value))
+           (seq targets)
+           (map? results)
+           (= (set targets) (set (keys results)))
+           (every? pause-results (vals results))
+           (some #{:paused} (vals results))))
+    (legacy-disruption-installed? required-pause-modes value)))
+
+(defn- legacy-resume-installed? [expected-nodes value]
+  (and (map? value)
+       (contains? value :paused)
+       (coll? (:resumed value))
+       (= expected-nodes (set (:resumed value)))))
+
+(defn- resume-installed? [expected-nodes value]
+  (if (and (map? value) (contains? value :status))
+    (let [results (:resume-results value)]
+      (and (= :installed (:status value))
+           (contains? value :paused)
+           (coll? (:resumed value))
+           (= expected-nodes (set (:resumed value)))
+           (map? results)
+           (= expected-nodes (set (keys results)))
+           (every? #(= :resumed (get results %)) expected-nodes)))
+    (legacy-resume-installed? expected-nodes value)))
+
+(defn- recovery-installed? [value]
+  (and (outcome/installed-or-legacy?
+        value
+        #(and (map? %) (:leader %)))
+       (:leader value)))
 
 (defn- process-generator []
   (gen/cycle
@@ -229,12 +421,14 @@
 
 (defn- operation-error? [op]
   (boolean (or (:error op)
-               (:exception op))))
+               (:exception op)
+               (= :indeterminate (get-in op [:value :status])))))
 
 (defn- coverage-result
-  [required-modes operation-f invalid-states history cluster-state]
+  [required-modes operation-f installed? invalid-states history cluster-state]
   (let [observed-modes (->> history
                             (filter #(= operation-f (:f %)))
+                            (filter #(installed? (:value %)))
                             (keep #(get-in % [:value :mode]))
                             set)
         missing-modes (remove observed-modes required-modes)
@@ -260,7 +454,9 @@
                                  :unknown
 
                                  (and (= :kill-process (:f op))
-                                      (get-in op [:value :mode]))
+                                      (disruption-installed?
+                                       required-process-modes
+                                       (:value op)))
                                  :degraded
 
                                  (and (= :restart-process (:f op))
@@ -268,7 +464,7 @@
                                  :unknown
 
                                  (and (= :await-recovery (:f op))
-                                      (get-in op [:value :leader]))
+                                      (recovery-installed? (:value op)))
                                  :intact
 
                                  (and (= :await-recovery (:f op))
@@ -282,6 +478,8 @@
                            history)]
         (coverage-result required-process-modes
                          :kill-process
+                         (partial disruption-installed?
+                                  required-process-modes)
                          #{:degraded}
                          history
                          cluster-state)))))
@@ -297,29 +495,30 @@
 
 (defn- next-pause-state [expected-nodes state op]
   (let [error? (operation-error? op)
-        resumed-nodes (get-in op [:value :resumed])]
+        status (get-in op [:value :status])]
     (case (:f op)
       :pause-process
       (cond
         error? :unknown
-        (get-in op [:value :mode]) :paused
+        (actual-pause-installed? (:value op)) :paused
         :else state)
 
       :resume-process
       (cond
         error? :unknown
-        (and (coll? resumed-nodes)
-             (= expected-nodes (set resumed-nodes))) :recovery-pending
+        (resume-installed? expected-nodes (:value op)) :recovery-pending
+        (= :skipped status) state
         :else :unknown)
 
       :await-recovery
       (cond
-        (get-in op [:value :leader]) (if (= :recovery-pending state)
-                                       :intact
-                                       :unknown)
         error? (if (#{:paused :recovery-pending} state)
                  state
                  :unknown)
+        (recovery-installed? (:value op)) (if (#{:intact
+                                                 :recovery-pending} state)
+                                            :intact
+                                            :unknown)
         :else state)
 
       state)))
@@ -333,6 +532,7 @@
                                   history)]
         (coverage-result required-pause-modes
                          :pause-process
+                         pause-installed?
                          #{:paused :recovery-pending}
                          history
                          cluster-state)))))

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -6,6 +6,7 @@
              [random :as random]]
             [jepsen.nemesis.combined :as combined]
             [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.checker :as openraft-checker]
             [jepsen.openraft.interruption :as interruption]
             [jepsen.openraft.nemesis.outcome :as outcome]
             [jepsen.openraft.quorum :as quorum]
@@ -492,7 +493,8 @@
    :generator (process-generator)
    :final-generator {:type :info
                      :f :restart-process}
-   :checker (coverage-checker)})
+   :checker (openraft-checker/reject-checker-exceptions
+             (coverage-checker))})
 
 (defn- next-pause-state [expected-nodes state op]
   (let [error? (operation-error? op)
@@ -545,4 +547,5 @@
    :generator (pause-generator)
    :final-generator {:type :info
                      :f :resume-process}
-   :checker (pause-coverage-checker)})
+   :checker (openraft-checker/reject-checker-exceptions
+             (pause-coverage-checker))})

--- a/jepsen/src/jepsen/openraft/worker.clj
+++ b/jepsen/src/jepsen/openraft/worker.clj
@@ -1,6 +1,7 @@
 (ns jepsen.openraft.worker
   (:require [clojure.tools.logging :refer [error]]
             [jepsen [client :as client]
+             [db :as db]
              [nemesis :as nemesis]]
             [jepsen.openraft.harness :as harness]
             [jepsen.openraft.interruption :as interruption]))
@@ -10,7 +11,9 @@
   (try
     (f)
     (catch Throwable throwable
-      (harness/record-failure! failure-state source context throwable)
+      (if (interruption/interruption? throwable)
+        (.interrupt (Thread/currentThread))
+        (harness/record-failure! failure-state source context throwable))
       (throw throwable))))
 
 (def ^:dynamic ^:private *teardown-failure-handler* nil)
@@ -81,7 +84,12 @@
                                #(client/open! delegate test node))))
 
     (setup! [_ test]
-      (wrap-client failure-state (client/setup! delegate test)))
+      (wrap-client
+       failure-state
+       (call-recording-failure failure-state
+                               :client
+                               {:phase :setup}
+                               #(client/setup! delegate test))))
 
     (invoke! [_ test op]
       (call-recording-failure failure-state
@@ -108,7 +116,12 @@
   [failure-state delegate]
   (reify nemesis/Nemesis
     (setup! [_ test]
-      (wrap-nemesis failure-state (nemesis/setup! delegate test)))
+      (wrap-nemesis
+       failure-state
+       (call-recording-failure failure-state
+                               :nemesis
+                               {:phase :setup}
+                               #(nemesis/setup! delegate test))))
 
     (invoke! [_ test op]
       (call-recording-failure failure-state
@@ -123,6 +136,42 @@
                                 :component :composed-nemesis
                                 :nodes (:nodes test)}
                                #(nemesis/teardown! delegate test)))))
+
+(defn wrap-db
+  "Records failures from the OpenRaft DB lifecycle and control boundaries."
+  [failure-state delegate]
+  (reify db/DB
+    (setup! [_ test node]
+      (call-recording-failure failure-state
+                              :db
+                              {:phase :setup
+                               :node node}
+                              #(db/setup! delegate test node)))
+
+    (teardown! [_ test node]
+      (call-recording-failure failure-state
+                              :db
+                              {:phase :teardown
+                               :node node}
+                              #(db/teardown! delegate test node)))
+
+    db/Kill
+    (kill! [_ test node]
+      (db/kill! delegate test node))
+
+    (start! [_ test node]
+      (db/start! delegate test node))
+
+    db/Pause
+    (pause! [_ test node]
+      (db/pause! delegate test node))
+
+    (resume! [_ test node]
+      (db/resume! delegate test node))
+
+    db/LogFiles
+    (log-files [_ test node]
+      (db/log-files delegate test node))))
 
 (defn wrap-nemesis-teardown
   "Records and contains a package's non-interruption teardown failures."

--- a/jepsen/src/jepsen/openraft/worker.clj
+++ b/jepsen/src/jepsen/openraft/worker.clj
@@ -1,0 +1,65 @@
+(ns jepsen.openraft.worker
+  (:require [jepsen [client :as client]
+             [nemesis :as nemesis]]
+            [jepsen.openraft.harness :as harness]))
+
+(defn- call-recording-failure
+  [failure-state source context f]
+  (try
+    (f)
+    (catch Throwable throwable
+      (harness/record-failure! failure-state source context throwable)
+      (throw throwable))))
+
+(defn wrap-client
+  "Records failures from Client worker lifecycle and invocation boundaries."
+  [failure-state delegate]
+  (reify client/Client
+    (open! [_ test node]
+      (wrap-client
+       failure-state
+       (call-recording-failure failure-state
+                               :client
+                               {:phase :open
+                                :node node}
+                               #(client/open! delegate test node))))
+
+    (setup! [_ test]
+      (wrap-client failure-state (client/setup! delegate test)))
+
+    (invoke! [_ test op]
+      (call-recording-failure failure-state
+                              :client
+                              {:phase :invoke
+                               :operation op}
+                              #(client/invoke! delegate test op)))
+
+    (teardown! [_ test]
+      (client/teardown! delegate test))
+
+    (close! [_ test]
+      (call-recording-failure failure-state
+                              :client
+                              {:phase :close}
+                              #(client/close! delegate test)))
+
+    client/Reusable
+    (reusable? [_ test]
+      (client/is-reusable? delegate test))))
+
+(defn wrap-nemesis
+  "Records failures from the Nemesis worker invocation boundary."
+  [failure-state delegate]
+  (reify nemesis/Nemesis
+    (setup! [_ test]
+      (wrap-nemesis failure-state (nemesis/setup! delegate test)))
+
+    (invoke! [_ test op]
+      (call-recording-failure failure-state
+                              :nemesis
+                              {:phase :invoke
+                               :operation op}
+                              #(nemesis/invoke! delegate test op)))
+
+    (teardown! [_ test]
+      (nemesis/teardown! delegate test))))

--- a/jepsen/src/jepsen/openraft/worker.clj
+++ b/jepsen/src/jepsen/openraft/worker.clj
@@ -1,7 +1,9 @@
 (ns jepsen.openraft.worker
-  (:require [jepsen [client :as client]
+  (:require [clojure.tools.logging :refer [error]]
+            [jepsen [client :as client]
              [nemesis :as nemesis]]
-            [jepsen.openraft.harness :as harness]))
+            [jepsen.openraft.harness :as harness]
+            [jepsen.openraft.interruption :as interruption]))
 
 (defn- call-recording-failure
   [failure-state source context f]
@@ -10,6 +12,60 @@
     (catch Throwable throwable
       (harness/record-failure! failure-state source context throwable)
       (throw throwable))))
+
+(def ^:dynamic ^:private *teardown-failure-handler* nil)
+
+(defn- fatal-throwable? [throwable]
+  (or (instance? ThreadDeath throwable)
+      (instance? VirtualMachineError throwable)))
+
+(defn handle-teardown-failure!
+  "Records a teardown stage failure when a package guard is active.
+
+  Outside guarded package teardown, the original Throwable is rethrown."
+  [context throwable]
+  (cond
+    (interruption/interruption? throwable)
+    (do
+      (.interrupt (Thread/currentThread))
+      (throw throwable))
+
+    (fatal-throwable? throwable)
+    (throw throwable)
+
+    *teardown-failure-handler*
+    (*teardown-failure-handler* context throwable)
+
+    :else
+    (throw throwable)))
+
+(defn- log-teardown-failure [context throwable]
+  (error throwable "OpenRaft Nemesis teardown failed" context))
+
+(defn- call-recording-teardown
+  [failure-state context f]
+  (binding [*teardown-failure-handler*
+            (fn [stage-context throwable]
+              (let [context (merge context stage-context)]
+                (harness/record-failure! failure-state
+                                         :nemesis
+                                         context
+                                         throwable)
+                (try
+                  (log-teardown-failure context throwable)
+                  (catch Throwable logging-failure
+                    (if (or (interruption/interruption? logging-failure)
+                            (fatal-throwable? logging-failure))
+                      (handle-teardown-failure! {} logging-failure)
+                      (harness/record-failure!
+                       failure-state
+                       :nemesis
+                       (assoc context :diagnostic :failure-log)
+                       logging-failure))))))]
+    (try
+      (f)
+      (catch Throwable throwable
+        (handle-teardown-failure! {} throwable)))))
 
 (defn wrap-client
   "Records failures from Client worker lifecycle and invocation boundaries."
@@ -48,7 +104,7 @@
       (client/is-reusable? delegate test))))
 
 (defn wrap-nemesis
-  "Records failures from the Nemesis worker invocation boundary."
+  "Records failures from Nemesis worker and teardown boundaries."
   [failure-state delegate]
   (reify nemesis/Nemesis
     (setup! [_ test]
@@ -62,4 +118,31 @@
                               #(nemesis/invoke! delegate test op)))
 
     (teardown! [_ test]
-      (nemesis/teardown! delegate test))))
+      (call-recording-teardown failure-state
+                               {:phase :teardown
+                                :component :composed-nemesis
+                                :nodes (:nodes test)}
+                               #(nemesis/teardown! delegate test)))))
+
+(defn wrap-nemesis-teardown
+  "Records and contains a package's non-interruption teardown failures."
+  [failure-state component delegate]
+  (reify nemesis/Nemesis
+    (setup! [_ test]
+      (wrap-nemesis-teardown failure-state
+                             component
+                             (nemesis/setup! delegate test)))
+
+    (invoke! [_ test op]
+      (nemesis/invoke! delegate test op))
+
+    (teardown! [_ test]
+      (call-recording-teardown failure-state
+                               {:phase :teardown
+                                :component component
+                                :nodes (:nodes test)}
+                               #(nemesis/teardown! delegate test)))
+
+    nemesis/Reflection
+    (fs [_]
+      (nemesis/fs delegate))))

--- a/jepsen/src/jepsen/openraft/workload.clj
+++ b/jepsen/src/jepsen/openraft/workload.clj
@@ -6,6 +6,7 @@
              [independent :as independent]
              [random :as random]]
             [jepsen.openraft.client :as http]
+            [jepsen.openraft.interruption :as interruption]
             [knossos.model :as model]))
 
 (def ^:private key-names
@@ -108,81 +109,87 @@
 (defn- mutation? [op]
   (#{:write :cas} (:f op)))
 
-(defn- complete-with-error [op type error unexpected?]
+(defn- complete-with-error [op type error unexpected-sut-response?]
   (cond-> (assoc op
                  :type type
                  :error error)
-    unexpected? (assoc :unexpected? true)))
+    unexpected-sut-response? (assoc :unexpected-sut-response? true)))
 
 (defn- complete-with-ambiguous-outcome
   "Marks an ambiguous mutation as info and a read as failed."
-  [op error unexpected?]
+  [op error unexpected-sut-response?]
   (complete-with-error op
                        (if (mutation? op) :info :fail)
                        error
-                       unexpected?))
+                       unexpected-sut-response?))
 
 (defn- handle-operation-exception
   "Classifies a client exception and returns a completed Jepsen operation.
   Thread interruptions are rethrown so Jepsen's control signals survive."
   [op e]
-  ;; A raw InterruptedException (thrown outside send!, which clears the interrupt
-  ;; flag) would otherwise fall through to the :client-error default and be
-  ;; swallowed. Restore the flag and rethrow so the interrupt is not lost.
-  (when (instance? InterruptedException e)
+  (when (interruption/interruption? e)
     (.interrupt (Thread/currentThread))
     (throw e))
-  (let [{:keys [kind status error]} (ex-data e)]
-    ;; send! already re-interrupted the thread for wrapped interruptions.
-    (if (= :interrupted kind)
-      (throw e)
-      (let [result
-            (case kind
-              :unreachable
-              (complete-with-error op :fail :unreachable false)
+  (let [{:keys [kind status error]} (ex-data e)
+        result
+        (case kind
+          :unreachable
+          (complete-with-error op :fail :unreachable false)
 
-              :request-timeout
-              (complete-with-ambiguous-outcome op :timeout false)
+          :request-timeout
+          (complete-with-ambiguous-outcome op :timeout false)
 
-              :transport-error
-              (complete-with-ambiguous-outcome op :transport-error false)
+          :transport-error
+          (complete-with-ambiguous-outcome op :transport-error false)
 
-              :http-error
-              ;; app-http returns 4xx before invoking a handler, while a 5xx
-              ;; may occur while serializing a response after a mutation has
-              ;; completed.
-              (if (and status (<= 400 status 499))
-                (complete-with-error op :fail [:http status] true)
-                (complete-with-ambiguous-outcome op [:http status] true))
+          :http-error
+            ;; app-http returns 4xx before invoking a handler, while a 5xx
+            ;; may occur while serializing a response after a mutation has
+            ;; completed.
+          (if (and status (<= 400 status 499))
+            (complete-with-error op :fail [:http status] true)
+            (complete-with-ambiguous-outcome op [:http status] true))
 
-              :invalid-json
-              (complete-with-ambiguous-outcome op :invalid-json true)
+          :invalid-json
+          (complete-with-ambiguous-outcome op :invalid-json true)
 
-              :openraft-error
-              (cond
-                (contains? error :ForwardToLeader)
-                (complete-with-error op :fail :not-leader false)
+          :invalid-response
+          (complete-with-ambiguous-outcome op :invalid-response true)
 
-                (contains? error :QuorumNotEnough)
-                (complete-with-error op :fail :quorum-not-enough false)
+          :openraft-error
+          (cond
+            (contains? error :ForwardToLeader)
+            (complete-with-error op :fail :not-leader false)
 
-                :else
-                (complete-with-ambiguous-outcome op :openraft-error true))
+            (contains? error :QuorumNotEnough)
+            (complete-with-error op :fail :quorum-not-enough false)
 
-              (throw e))]
-        (cond-> result
-          (or (:unexpected? result) (:final? op))
-          (assoc :exception-message (ex-message e)
-                 :exception-data (ex-data e)
-                 :unexpected? true))))))
+            :else
+            (complete-with-ambiguous-outcome op :openraft-error true))
 
-(defn- unexpected-errors-checker []
+          (throw e))]
+    (cond-> result
+      (or (:unexpected-sut-response? result) (:final? op))
+      (assoc :exception-message (ex-message e)
+             :exception-data (ex-data e)))))
+
+(defn- unexpected-sut-responses-checker []
   (reify checker/Checker
     (check [_ _test history _opts]
-      (let [errors (filter :unexpected? history)]
-        {:valid? (empty? errors)
-         :count (count errors)
-         :errors (vec (take 10 errors))}))))
+      (let [responses (filter :unexpected-sut-response? history)]
+        {:valid? (empty? responses)
+         :count (count responses)
+         :responses (vec (take 10 responses))}))))
+
+(defn- final-workload-checker []
+  (reify checker/Checker
+    (check [_ _test history _opts]
+      (let [failures (filter #(and (:final? %)
+                                   (#{:fail :info} (:type %)))
+                             history)]
+        {:valid? (empty? failures)
+         :count (count failures)
+         :failures (vec (take 10 failures))}))))
 
 (defn- empty-operation-counts []
   (into {}
@@ -302,4 +309,6 @@
                                (checker/linearizable
                                 {:model (model/cas-register)}))
                 :meaningful-operations (meaningful-operations-checker)
-                :unexpected-errors (unexpected-errors-checker)})}))
+                :final-workload (final-workload-checker)
+                :unexpected-sut-responses
+                (unexpected-sut-responses-checker)})}))

--- a/jepsen/src/jepsen/openraft/workload.clj
+++ b/jepsen/src/jepsen/openraft/workload.clj
@@ -6,6 +6,7 @@
              [independent :as independent]
              [random :as random]]
             [jepsen.openraft.client :as http]
+            [jepsen.openraft.checker :as openraft-checker]
             [jepsen.openraft.interruption :as interruption]
             [knossos.model :as model]))
 
@@ -304,11 +305,19 @@
                   bootstrap
                   (gen/stagger 0.1 operations)))
      :final-generator (gen/clients final)
-     :checker (checker/compose
-               {:linearizable (independent/checker
-                               (checker/linearizable
-                                {:model (model/cas-register)}))
-                :meaningful-operations (meaningful-operations-checker)
-                :final-workload (final-workload-checker)
-                :unexpected-sut-responses
-                (unexpected-sut-responses-checker)})}))
+     :checker (openraft-checker/reject-checker-exceptions
+               (checker/compose
+                {:linearizable
+                 (openraft-checker/reject-checker-exceptions
+                  (independent/checker
+                   (checker/linearizable
+                    {:model (model/cas-register)})))
+                 :meaningful-operations
+                 (openraft-checker/reject-checker-exceptions
+                  (meaningful-operations-checker))
+                 :final-workload
+                 (openraft-checker/reject-checker-exceptions
+                  (final-workload-checker))
+                 :unexpected-sut-responses
+                 (openraft-checker/reject-checker-exceptions
+                  (unexpected-sut-responses-checker))}))}))

--- a/jepsen/src/jepsen/openraft/workload.clj
+++ b/jepsen/src/jepsen/openraft/workload.clj
@@ -169,7 +169,7 @@
                 :else
                 (complete-with-ambiguous-outcome op :openraft-error true))
 
-              (complete-with-ambiguous-outcome op :client-error true))]
+              (throw e))]
         (cond-> result
           (or (:unexpected? result) (:final? op))
           (assoc :exception-message (ex-message e)

--- a/jepsen/test/jepsen/openraft/await_test.clj
+++ b/jepsen/test/jepsen/openraft/await_test.clj
@@ -1,0 +1,70 @@
+(ns jepsen.openraft.await-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen.openraft.await :as await]))
+
+(deftest retries-only-owned-unsatisfied-conditions
+  (testing "an owned retry can later succeed"
+    (let [attempts (atom 0)
+          result (await/until!
+                  :test-condition
+                  #(if (= 1 (swap! attempts inc))
+                     (await/retry! :test-condition {})
+                     :ready)
+                  {:retry-interval 0
+                   :timeout 100})]
+      (is (= :ready result))
+      (is (= 2 @attempts))))
+
+  (testing "an unknown exception escapes immediately by identity"
+    (let [attempts (atom 0)
+          error (RuntimeException. "wait bug")
+          thrown (try
+                   (await/until! :test-condition
+                                 #(do
+                                    (swap! attempts inc)
+                                    (throw error))
+                                 {:retry-interval 0
+                                  :timeout 100})
+                   nil
+                   (catch Exception e
+                     e))]
+      (is (identical? error thrown))
+      (is (= 1 @attempts))))
+
+  (testing "only the owned condition matches a modeled timeout"
+    (let [error (try
+                  (await/until! :test-condition
+                                #(await/retry! :test-condition {})
+                                {:retry-interval 0
+                                 :timeout 0})
+                  nil
+                  (catch Exception e
+                    e))]
+      (is (await/condition-timeout? error :test-condition))
+      (is (false? (await/condition-timeout? error :other-condition))))))
+
+(deftest preserves-wait-interruptions
+  (doseq [[label make-error]
+          [[:interrupted #(InterruptedException. "interrupted")]
+           [:interrupted-io
+            #(java.io.InterruptedIOException. "interrupted")]
+           [:closed-by-interrupt
+            #(java.nio.channels.ClosedByInterruptException.)]
+           [:wrapped #(ex-info "interrupted" {:kind :interrupted})]]]
+    (testing (name label)
+      (Thread/interrupted)
+      (try
+        (let [error (make-error)
+              [thrown interrupted?]
+              (try
+                (await/until! :test-condition
+                              #(throw error)
+                              {:retry-interval 0
+                               :timeout 100})
+                [nil (.isInterrupted (Thread/currentThread))]
+                (catch Exception e
+                  [e (.isInterrupted (Thread/currentThread))]))]
+          (is (identical? error thrown))
+          (is interrupted?))
+        (finally
+          (Thread/interrupted))))))

--- a/jepsen/test/jepsen/openraft/checker_test.clj
+++ b/jepsen/test/jepsen/openraft/checker_test.clj
@@ -14,6 +14,11 @@
       (swap! calls inc)
       result)))
 
+(defn- throwing-checker [throwable]
+  (reify checker/Checker
+    (check [_ _test _history _opts]
+      (throw throwable))))
+
 (def ^:private escaped-worker-op
   {:type :info
    :f :read
@@ -26,6 +31,37 @@
                         {:seed 41}
                         (history/history [])
                         {}))))
+
+(deftest checker-exceptions-reject-standalone-and-composed-checkers
+  (let [throwable (RuntimeException. "checker failed")
+        subject (openraft-checker/reject-checker-exceptions
+                 (throwing-checker throwable))
+        expected {:valid? false
+                  :checker-exception
+                  {:class "java.lang.RuntimeException"
+                   :message "checker failed"}}
+        standalone (checker/check subject {} (history/history []) {})
+        composed (checker/check (checker/compose {:subject subject})
+                                {}
+                                (history/history [])
+                                {})]
+    (is (= expected standalone))
+    (is (= expected (:subject composed)))
+    (is (false? (:valid? composed)))))
+
+(deftest checker-interruptions-propagate
+  (let [throwable (InterruptedException. "cancelled")
+        subject (openraft-checker/reject-checker-exceptions
+                 (throwing-checker throwable))]
+    (try
+      (let [thrown (try
+                     (checker/check subject {} (history/history []) {})
+                     nil
+                     (catch Throwable throwable
+                       throwable))]
+        (is (identical? throwable thrown)))
+      (finally
+        (Thread/interrupted)))))
 
 (deftest reports-unhandled-worker-exceptions
   (let [subject (openraft-checker/strict-unhandled-exceptions)

--- a/jepsen/test/jepsen/openraft/checker_test.clj
+++ b/jepsen/test/jepsen/openraft/checker_test.clj
@@ -1,10 +1,23 @@
 (ns jepsen.openraft.checker-test
-  (:require [clojure.java.io :as io]
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing]]
             [jepsen.checker :as checker]
             [jepsen.history :as history]
             [jepsen.openraft.checker :as openraft-checker]
+            [jepsen.openraft.harness :as harness]
             [jepsen.store :as store]))
+
+(defn- result-checker [calls result]
+  (reify checker/Checker
+    (check [_ _test _history _opts]
+      (swap! calls inc)
+      result)))
+
+(def ^:private escaped-worker-op
+  {:type :info
+   :f :read
+   :exception {:via [{:type 'java.lang.IllegalStateException}]}})
 
 (deftest records-the-random-seed
   (is (= {:valid? true
@@ -16,19 +29,183 @@
 
 (deftest reports-unhandled-worker-exceptions
   (let [subject (openraft-checker/strict-unhandled-exceptions)
-        op {:type :info
-            :f :read
-            :exception {:via [{:type 'java.lang.IllegalStateException}]}}
-        result (checker/check subject {} (history/history [op]) {})
+        result (checker/check subject
+                              {}
+                              (history/history [escaped-worker-op])
+                              {})
         exception (first (:exceptions result))]
-    (is (= :unknown (:valid? result)))
+    (is (false? (:valid? result)))
     (is (= {:count 1
             :class 'java.lang.IllegalStateException}
            (select-keys exception [:count :class])))
-    (is (true? (:valid? (checker/check subject
-                                       {}
-                                       (history/history [])
-                                       {}))))))
+    (let [escaped (:escaped-worker-exceptions result)]
+      (is (= (select-keys exception [:count :class])
+             (select-keys (first escaped) [:count :class])))
+      (is (= escaped (edn/read-string (pr-str escaped)))))
+    (let [clean-result (checker/check subject
+                                      {}
+                                      (history/history [])
+                                      {})]
+      (is (true? (:valid? clean-result)))
+      (is (not (contains? clean-result :escaped-worker-exceptions))))))
+
+(deftest preserves-results-without-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        calls (atom 0)
+        expected {:valid? :unknown
+                  :workload {:valid? true}
+                  :nemesis {:valid? :unknown}}
+        subject (openraft-checker/reject-harness-failures
+                 failure-state
+                 (result-checker calls expected))
+        result (checker/check subject {} (history/history []) {})]
+    (is (identical? expected result))
+    (is (= 1 @calls))
+    (is (not (contains? result :harness-failure)))))
+
+(deftest rejects-recorded-harness-failures-after-analysis
+  (doseq [delegate-verdict [true :unknown]]
+    (testing (str "delegate verdict " delegate-verdict)
+      (let [failure-state (harness/failure-state)
+            primary (ex-info "teardown failed" {:unsafe (Object.)})
+            secondary (RuntimeException. "logging failed")
+            calls (atom 0)
+            nested {:workload {:valid? false
+                               :counterexample [{:f :write}]}
+                    :nemesis {:valid? true
+                              :observed-modes [:partition]}}
+            delegate-result (assoc nested :valid? delegate-verdict)
+            _ (harness/record-failure!
+               failure-state
+               :nemesis
+               {:phase :teardown
+                :component :partition}
+               primary)
+            _ (harness/record-failure!
+               failure-state
+               :nemesis
+               {:phase :teardown
+                :diagnostic :failure-log}
+               secondary)
+            result (checker/check
+                    (openraft-checker/reject-harness-failures
+                     failure-state
+                     (result-checker calls delegate-result))
+                    {}
+                    (history/history [])
+                    {})
+            evidence (:harness-failure result)]
+        (is (false? (:valid? result)))
+        (is (= nested (select-keys result [:workload :nemesis])))
+        (is (= 1 @calls))
+        (is (= {:valid? false
+                :primary
+                {:source :nemesis
+                 :context {:phase :teardown
+                           :component :partition}
+                 :exception
+                 {:class "clojure.lang.ExceptionInfo"
+                  :message "teardown failed"}}
+                :secondary
+                [{:source :nemesis
+                  :context {:phase :teardown
+                            :diagnostic :failure-log}
+                  :exception
+                  {:class "java.lang.RuntimeException"
+                   :message "logging failed"}}]}
+               evidence))
+        (is (= evidence (edn/read-string (pr-str evidence))))))))
+
+(deftest rejects-strict-fallback-without-mutating-runtime-state
+  (let [failure-state (harness/failure-state)
+        workload-result {:valid? true
+                         :details {:reads 4}}
+        aggregate (checker/compose
+                   {:exceptions
+                    (openraft-checker/strict-unhandled-exceptions)
+                    :workload (result-checker (atom 0) workload-result)})
+        result (checker/check
+                (openraft-checker/reject-harness-failures
+                 failure-state
+                 aggregate
+                 :exceptions)
+                {}
+                (history/history [escaped-worker-op])
+                {})
+        strict-result (:exceptions result)
+        escaped (:escaped-worker-exceptions strict-result)]
+    (is (false? (:valid? result)))
+    (is (= workload-result (:workload result)))
+    (is (false? (:valid? strict-result)))
+    (is (seq escaped))
+    (is (= {:valid? false
+            :strict-fallback {:escaped-worker-exceptions escaped}}
+           (:harness-failure result)))
+    (is (nil? (harness/primary-failure failure-state)))
+    (is (empty? (harness/secondary-failures failure-state)))))
+
+(deftest preserves-direct-and-strict-harness-diagnostics
+  (let [failure-state (harness/failure-state)
+        primary (RuntimeException. "client failed")
+        secondary (RuntimeException. "cleanup failed")
+        workload-result {:valid? false
+                         :counterexample [{:f :write :value 1}]}
+        aggregate (checker/compose
+                   {:exceptions
+                    (openraft-checker/strict-unhandled-exceptions)
+                    :workload (result-checker (atom 0) workload-result)})
+        _ (harness/record-failure!
+           failure-state :client {:operation :write} primary)
+        _ (harness/record-failure!
+           failure-state :nemesis {:phase :teardown} secondary)
+        result (checker/check
+                (openraft-checker/reject-harness-failures
+                 failure-state
+                 aggregate
+                 :exceptions)
+                {}
+                (history/history [escaped-worker-op])
+                {})
+        strict-result (:exceptions result)
+        evidence (:harness-failure result)]
+    (is (false? (:valid? result)))
+    (is (= workload-result (:workload result)))
+    (is (= {:source :client
+            :context {:operation :write}
+            :exception {:class "java.lang.RuntimeException"
+                        :message "client failed"}}
+           (:primary evidence)))
+    (is (= [{:source :nemesis
+             :context {:phase :teardown}
+             :exception {:class "java.lang.RuntimeException"
+                         :message "cleanup failed"}}]
+           (:secondary evidence)))
+    (is (= {:escaped-worker-exceptions
+            (:escaped-worker-exceptions strict-result)}
+           (:strict-fallback evidence)))
+    (is (false? (:valid? strict-result)))
+    (is (= (select-keys (first (:exceptions strict-result)) [:count :class])
+           (select-keys
+            (first (:escaped-worker-exceptions strict-result))
+            [:count :class])))
+    (is (= evidence (edn/read-string (pr-str evidence))))))
+
+(deftest does-not-reject-interruption
+  (let [failure-state (harness/failure-state)
+        expected {:valid? true}]
+    (is (false? (harness/record-failure!
+                 failure-state
+                 :nemesis
+                 {:phase :teardown}
+                 (InterruptedException. "cancelled"))))
+    (is (= expected
+           (checker/check
+            (openraft-checker/reject-harness-failures
+             failure-state
+             (result-checker (atom 0) expected))
+            {}
+            (history/history [])
+            {})))))
 
 (deftest checks-downloaded-logs-for-node-panics
   (let [^java.io.File temp-dir

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -1,8 +1,13 @@
 (ns jepsen.openraft.cli-test
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.tools.cli :as tools-cli]
+            [jepsen.generator :as gen]
+            [jepsen.generator.test :as gen-test]
             [jepsen.openraft.cli :as cli]
             [jepsen.openraft.db :as openraft-db]
+            [jepsen.openraft.generator :as openraft-generator]
+            [jepsen.openraft.harness :as harness]
+            [jepsen.openraft.worker :as worker]
             [jepsen.random :as random]))
 
 (deftest records-and-applies-the-random-seed
@@ -75,3 +80,109 @@
            (set (keys checkers))))
     (is (= #{:partition :membership}
            (set (keys nemesis-checkers))))))
+
+(deftest shares-one-harness-state-across-workers-and-generators
+  (let [failure-state (harness/failure-state)
+        wrapped-states (atom [])
+        generator-states (atom [])
+        wrap (fn [source]
+               (fn [state delegate]
+                 (swap! wrapped-states conj [source state])
+                 delegate))
+        stop (fn [state generator]
+               (swap! generator-states conj state)
+               generator)]
+    (with-redefs [harness/failure-state (constantly failure-state)
+                  worker/wrap-client (wrap :client)
+                  worker/wrap-nemesis (wrap :nemesis)
+                  openraft-generator/stop-on-harness-failure stop]
+      (cli/openraft-test {:nemesis :partition
+                          :nodes ["n1" "n2" "n3"]
+                          :time-limit 10}))
+    (is (= [:client :nemesis] (mapv first @wrapped-states)))
+    (is (every? #(identical? failure-state (second %))
+                @wrapped-states))
+    (is (= 1 (count @generator-states)))
+    (is (identical? failure-state (first @generator-states)))))
+
+(defn- lifecycle-test-generator [failure-state]
+  (#'cli/lifecycle-generator
+   failure-state
+   0.3
+   {:generator (gen/clients
+                (gen/delay 0.1 (repeat {:f :ordinary-workload})))
+    :final-generator (gen/clients [{:f :final-workload-1}
+                                   {:f :final-workload-2}])}
+   {:generator (gen/delay
+                 0.1
+                 (repeat {:type :info :f :ordinary-nemesis}))
+    :final-generator {:type :info :f :final-nemesis}}))
+
+(defn- simulate-lifecycle [failure-state failure-operation]
+  (let [operations (atom [])
+        failure-recorded? (atom false)
+        history (gen-test/simulate
+                 (lifecycle-test-generator failure-state)
+                 (fn [_context operation]
+                   (swap! operations conj (:f operation))
+                   (when (and (= failure-operation (:f operation))
+                              (compare-and-set! failure-recorded? false true))
+                     (harness/record-failure!
+                      failure-state
+                      :client
+                      {:operation operation}
+                      (RuntimeException. "client failed")))
+                   (-> operation
+                       (assoc :type (if (= :nemesis (:process operation))
+                                      :info
+                                      :ok))
+                       (update :time + 10))))]
+    {:history history
+     :operations @operations}))
+
+(deftest runs-the-full-lifecycle-without-a-harness-failure
+  (let [{:keys [operations]}
+        (simulate-lifecycle (harness/failure-state) nil)]
+    (is (some #{:ordinary-workload} operations))
+    (is (some #{:ordinary-nemesis} operations))
+    (is (= [:final-nemesis :final-workload-1 :final-workload-2]
+           (filter #{:final-nemesis
+                     :final-workload-1
+                     :final-workload-2}
+                   operations)))))
+
+(deftest recovers-and-skips-final-workload-after-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        {:keys [history operations]}
+        (simulate-lifecycle failure-state :ordinary-workload)
+        workload-completion-index
+        (first (keep-indexed (fn [index operation]
+                               (when (and (= :ordinary-workload
+                                             (:f operation))
+                                          (= :ok (:type operation)))
+                                 index))
+                             history))
+        recovery-index
+        (first (keep-indexed (fn [index operation]
+                               (when (= :final-nemesis (:f operation))
+                                 index))
+                             history))]
+    (is (some? (harness/primary-failure failure-state)))
+    (is (< workload-completion-index recovery-index))
+    (is (= 1 (count (filter #{:ordinary-workload} operations))))
+    (is (= [:final-nemesis]
+           (filter #{:final-nemesis
+                     :final-workload-1
+                     :final-workload-2}
+                   operations)))))
+
+(deftest stops-final-workload-after-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        {:keys [operations]}
+        (simulate-lifecycle failure-state :final-workload-1)]
+    (is (some? (harness/primary-failure failure-state)))
+    (is (= [:final-nemesis :final-workload-1]
+           (filter #{:final-nemesis
+                     :final-workload-1
+                     :final-workload-2}
+                   operations)))))

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -3,10 +3,12 @@
             [clojure.tools.cli :as tools-cli]
             [jepsen.generator :as gen]
             [jepsen.generator.test :as gen-test]
+            [jepsen.openraft.checker :as openraft-checker]
             [jepsen.openraft.cli :as cli]
             [jepsen.openraft.db :as openraft-db]
             [jepsen.openraft.generator :as openraft-generator]
             [jepsen.openraft.harness :as harness]
+            [jepsen.openraft.nemesis :as openraft-nemesis]
             [jepsen.openraft.worker :as worker]
             [jepsen.random :as random]))
 
@@ -74,7 +76,7 @@
   (let [test (cli/openraft-test {:nemesis [:membership :partition]
                                  :nodes ["n1" "n2" "n3" "n4" "n5"]
                                  :time-limit 10})
-        checkers (get-in test [:checker :checkers])
+        checkers (get-in test [:checker :delegate :checkers])
         nemesis-checkers (get-in checkers [:nemesis :checkers])]
     (is (= #{:seed :stats :exceptions :crash :nemesis :workload}
            (set (keys checkers))))
@@ -85,6 +87,9 @@
   (let [failure-state (harness/failure-state)
         wrapped-states (atom [])
         generator-states (atom [])
+        composition-states (atom [])
+        checker-states (atom [])
+        compose-packages openraft-nemesis/compose-packages
         wrap (fn [source]
                (fn [state delegate]
                  (swap! wrapped-states conj [source state])
@@ -93,8 +98,17 @@
                (swap! generator-states conj state)
                generator)]
     (with-redefs [harness/failure-state (constantly failure-state)
+                  openraft-nemesis/compose-packages
+                  (fn [state packages]
+                    (swap! composition-states conj state)
+                    (compose-packages state packages))
                   worker/wrap-client (wrap :client)
                   worker/wrap-nemesis (wrap :nemesis)
+                  openraft-checker/reject-harness-failures
+                  (fn [state delegate strict-checker-key]
+                    (swap! checker-states conj
+                           [state strict-checker-key])
+                    delegate)
                   openraft-generator/stop-on-harness-failure stop]
       (cli/openraft-test {:nemesis :partition
                           :nodes ["n1" "n2" "n3"]
@@ -103,7 +117,12 @@
     (is (every? #(identical? failure-state (second %))
                 @wrapped-states))
     (is (= 1 (count @generator-states)))
-    (is (identical? failure-state (first @generator-states)))))
+    (is (identical? failure-state (first @generator-states)))
+    (is (= 1 (count @composition-states)))
+    (is (identical? failure-state (first @composition-states)))
+    (is (= 1 (count @checker-states)))
+    (is (identical? failure-state (ffirst @checker-states)))
+    (is (= :exceptions (second (first @checker-states))))))
 
 (defn- lifecycle-test-generator [failure-state]
   (#'cli/lifecycle-generator

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -102,6 +102,7 @@
                   (fn [state packages]
                     (swap! composition-states conj state)
                     (compose-packages state packages))
+                  worker/wrap-db (wrap :db)
                   worker/wrap-client (wrap :client)
                   worker/wrap-nemesis (wrap :nemesis)
                   openraft-checker/reject-harness-failures
@@ -113,7 +114,7 @@
       (cli/openraft-test {:nemesis :partition
                           :nodes ["n1" "n2" "n3"]
                           :time-limit 10}))
-    (is (= [:client :nemesis] (mapv first @wrapped-states)))
+    (is (= [:db :client :nemesis] (mapv first @wrapped-states)))
     (is (every? #(identical? failure-state (second %))
                 @wrapped-states))
     (is (= 1 (count @generator-states)))

--- a/jepsen/test/jepsen/openraft/client_test.clj
+++ b/jepsen/test/jepsen/openraft/client_test.clj
@@ -1,6 +1,29 @@
 (ns jepsen.openraft.client-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cheshire.core :as json]
+            [cheshire.parse :as json-parse]
+            [clojure.test :refer [deftest is testing]]
             [jepsen.openraft.client :as client]))
+
+(defn- raw-http-response [body]
+  {:method "POST"
+   :uri "http://n1:21001/write"
+   :status 200
+   :body body})
+
+(defn- http-response [body]
+  (raw-http-response (json/generate-string body)))
+
+(defn- caught [f]
+  (try
+    (f)
+    nil
+    (catch Throwable throwable
+      throwable)))
+
+(defn- throwing-http-client [throwable]
+  (proxy [java.net.http.HttpClient] []
+    (send [_request _handler]
+      (throw throwable))))
 
 (defn- forward-error
   ([]
@@ -130,3 +153,294 @@
     (is (= ["n1:21001" "n2:21001" "n3:21001"] @attempts))
     (is (= "n1:21001" @leader)
         "a retry candidate becomes the cached leader only after it succeeds")))
+
+(deftest accepts-valid-workload-responses
+  (testing "write returns a versioned value, including an empty string"
+    (let [versioned {:value "" :version 0}]
+      (with-redefs [client/post! (fn [& _]
+                                   (http-response
+                                    {:Ok {:data {:value versioned}}}))]
+        (is (= versioned (client/write! "n1:21001" "key" ""))))))
+
+  (testing "write accepts the largest u64 version"
+    (let [versioned {:value "value" :version 18446744073709551615N}]
+      (with-redefs [client/post! (fn [& _]
+                                   (http-response
+                                    {:Ok {:data {:value versioned}}}))]
+        (is (= versioned
+               (client/write! "n1:21001" "key" "value"))))))
+
+  (testing "CAS accepts an explicit nil value as a version mismatch"
+    (with-redefs [client/post! (fn [& _]
+                                 (http-response
+                                  {:Ok {:data {:value nil}}}))]
+      (is (nil? (client/cas! "n1:21001" "key" 1 "value")))))
+
+  (testing "CAS accepts a matching non-nil value"
+    (let [versioned {:value "new" :version 2}]
+      (with-redefs [client/post! (fn [& _]
+                                   (http-response
+                                    {:Ok {:data {:value versioned}}}))]
+        (is (= versioned
+               (client/cas! "n1:21001" "key" 1 "new"))))))
+
+  (testing "read accepts an explicit nil value for a missing key"
+    (with-redefs [client/post! (fn [& _]
+                                 (http-response {:Ok {:value nil}}))]
+      (is (nil? (client/linearizable-read! "n1:21001" "key")))))
+
+  (testing "additive response fields do not invalidate the Ok arm"
+    (let [versioned {:value "value" :version 1}]
+      (with-redefs [client/post! (fn [& _]
+                                   (http-response
+                                    {:Ok {:data {:value versioned}}
+                                     :trace "diagnostic"}))]
+        (is (= versioned
+               (client/write! "n1:21001" "key" "value")))))))
+
+(deftest preserves-known-application-errors
+  (let [error {:QuorumNotEnough {:cluster "n1,n2,n3"
+                                 :got ["n1"]}}
+        response (http-response {:Err error})
+        thrown (with-redefs [client/post! (fn [& _] response)]
+                 (caught #(client/linearizable-read! "n1:21001" "key")))]
+    (is (= :openraft-error (:kind (ex-data thrown))))
+    (is (= error (:error (ex-data thrown))))
+    (is (= response (:response (ex-data thrown))))))
+
+(deftest rejects-invalid-application-response-unions
+  (doseq [[label body reason]
+          [["missing arm" {} :missing-response-arm]
+           ["ambiguous arms"
+            {:Ok {:data {:value {:value "value" :version 1}}}
+             :Err {:ForwardToLeader {}}}
+            :ambiguous-response-arms]
+           ["unknown arm" {:Result {}} :unknown-response-arm]
+           ["non-object union" [] :response-union-not-map]]]
+    (testing label
+      (let [response (http-response body)
+            thrown (with-redefs [client/post! (fn [& _] response)]
+                     (caught #(client/write! "n1:21001" "key" "value")))
+            data (ex-data thrown)]
+        (is (= :invalid-response (:kind data)))
+        (is (= reason (:reason data)))
+        (is (= (when (map? body)
+                 (count (filter #{:Ok :Err} (keys body))))
+               (:response-arm-count data)))
+        (is (= (select-keys response [:method :uri :status])
+               (select-keys (:response data) [:method :uri :status])))
+        (is (= (count (:body response))
+               (get-in data [:response :body-character-count])))
+        (is (= (:body response)
+               (get-in data [:response :body-preview])))
+        (is (not (contains? data :decoded-response))))))
+
+  (testing "Err contains exactly one error variant"
+    (let [body {:Err {:ForwardToLeader {}
+                      :QuorumNotEnough {}}}
+          response (http-response body)
+          thrown (with-redefs [client/post! (fn [& _] response)]
+                   (caught #(client/write! "n1:21001" "key" "value")))
+          data (ex-data thrown)]
+      (is (= :invalid-response (:kind data)))
+      (is (= :invalid-error-union (:reason data)))
+      (is (= 2 (:error-arm-count data)))
+      (is (= (:body response)
+             (get-in data [:response :body-preview])))))
+
+  (testing "a non-object root is rejected without materializing it"
+    (let [decoded? (atom false)
+          response (http-response [])
+          thrown (with-redefs [client/post! (fn [& _] response)
+                               json-parse/parse-strict
+                               (fn [& _]
+                                 (reset! decoded? true)
+                                 (throw (RuntimeException.
+                                         "unexpected full decode")))]
+                   (caught #(client/write! "n1:21001" "key" "value")))]
+      (is (= :invalid-response (:kind (ex-data thrown))))
+      (is (= :response-union-not-map (:reason (ex-data thrown))))
+      (is (false? @decoded?)))))
+
+(deftest rejects-incomplete-or-ambiguous-json-documents
+  (let [valid-ok
+        "{\"Ok\":{\"data\":{\"value\":{\"value\":\"value\",\"version\":1}}}}"]
+    (doseq [[label body]
+            [["duplicate top-level key"
+              (str "{\"Ok\":{\"data\":{\"value\":"
+                   "{\"value\":\"value\",\"version\":1}}},"
+                   "\"Ok\":{\"data\":{\"value\":"
+                   "{\"value\":\"value\",\"version\":2}}}}")]
+             ["duplicate nested key"
+              "{\"Err\":{\"ForwardToLeader\":{},\"ForwardToLeader\":[]}}"]
+             ["second root document"
+              (str valid-ok " {\"Err\":{\"ForwardToLeader\":{}}}")]
+             ["trailing garbage" (str valid-ok " garbage")]
+             ["empty body" ""]
+             ["whitespace-only body" " \n\t"]]]
+      (testing label
+        (let [response (raw-http-response body)
+              thrown (with-redefs [client/post! (fn [& _] response)]
+                       (caught #(client/write! "n1:21001" "key" "value")))]
+          (is (= :invalid-json (:kind (ex-data thrown))))
+          (is (= (select-keys response [:method :uri :status])
+                 (select-keys (:response (ex-data thrown))
+                              [:method :uri :status])))
+          (is (= (count body)
+                 (get-in (ex-data thrown)
+                         [:response :body-character-count]))))))
+
+    (testing "trailing whitespace is part of one complete document"
+      (let [response (raw-http-response (str valid-ok " \n\t"))]
+        (with-redefs [client/post! (fn [& _] response)]
+          (is (= {:value "value" :version 1}
+                 (client/write! "n1:21001" "key" "value"))))))))
+
+(deftest validates-modeled-error-payload-containers
+  (testing "an empty ForwardToLeader object remains modeled"
+    (let [error {:ForwardToLeader {}}
+          thrown (with-redefs [client/post! (fn [& _]
+                                              (http-response {:Err error}))]
+                   (caught #(client/write! "n1:21001" "key" "value")))]
+      (is (= :openraft-error (:kind (ex-data thrown))))
+      (is (= error (:error (ex-data thrown))))))
+
+  (doseq [[variant payload]
+          [[:ForwardToLeader "not-an-object"]
+           [:QuorumNotEnough ["not" "an" "object"]]]]
+    (testing (name variant)
+      (let [thrown (with-redefs [client/post! (fn [& _]
+                                                (http-response
+                                                 {:Err {variant payload}}))]
+                     (caught #(client/write! "n1:21001" "key" "value")))
+            data (ex-data thrown)]
+        (is (= :invalid-response (:kind data)))
+        (is (= :invalid-error-payload (:reason data)))
+        (is (= variant (:error-variant data)))))))
+
+(deftest bounds-invalid-response-evidence
+  (let [body {:Unknown (apply str (repeat 2048 "x"))}
+        response (http-response body)
+        thrown (with-redefs [client/post! (fn [& _] response)]
+                 (caught #(client/write! "n1:21001" "key" "value")))
+        data (ex-data thrown)
+        evidence (:response data)]
+    (is (= :invalid-response (:kind data)))
+    (is (= :unknown-response-arm (:reason data)))
+    (is (= (count (:body response)) (:body-character-count evidence)))
+    (is (= 1024 (count (:body-preview evidence))))
+    (is (not (contains? data :decoded-response)))
+    (is (not (contains? data :payload)))))
+
+(deftest rejects-malformed-workload-payloads
+  (doseq [[label invoke body reason path]
+          [["write nil"
+            #(client/write! "n1:21001" "key" "value")
+            {:Ok {:data {:value nil}}}
+            :nil-payload-field
+            [:data :value]]
+           ["write missing data"
+            #(client/write! "n1:21001" "key" "value")
+            {:Ok {}}
+            :missing-payload-field
+            [:data :value]]
+           ["CAS missing value"
+            #(client/cas! "n1:21001" "key" 1 "value")
+            {:Ok {:data {}}}
+            :missing-payload-field
+            [:data :value]]
+           ["read malformed value"
+            #(client/linearizable-read! "n1:21001" "key")
+            {:Ok {:value {:value 1 :version 2}}}
+            :invalid-versioned-value
+            [:value]]
+           ["write version exceeds u64"
+            #(client/write! "n1:21001" "key" "value")
+            {:Ok {:data {:value {:value "value"
+                                 :version 18446744073709551616N}}}}
+            :invalid-versioned-value
+            [:data :value]]
+           ["write returns a different logical value"
+            #(client/write! "n1:21001" "key" "value")
+            {:Ok {:data {:value {:value "other" :version 1}}}}
+            :unexpected-payload-value
+            [:data :value :value]]
+           ["CAS returns a different logical value"
+            #(client/cas! "n1:21001" "key" 1 "new")
+            {:Ok {:data {:value {:value "other" :version 2}}}}
+            :unexpected-payload-value
+            [:data :value :value]]
+           ["CAS returns a non-increasing version"
+            #(client/cas! "n1:21001" "key" 2 "new")
+            {:Ok {:data {:value {:value "new" :version 2}}}}
+            :non-increasing-cas-version
+            [:data :value :version]]]]
+    (testing label
+      (let [response (http-response body)
+            thrown (with-redefs [client/post! (fn [& _] response)]
+                     (caught invoke))
+            data (ex-data thrown)]
+        (is (= :invalid-response (:kind data)))
+        (is (= reason (:reason data)))
+        (is (= path (:payload-path data)))
+        (is (= (count (:body response))
+               (get-in data [:response :body-character-count])))
+        (is (= (:body response)
+               (get-in data [:response :body-preview])))
+        (is (not (contains? data :payload)))))))
+
+(deftest distinguishes-invalid-json-from-parser-failures
+  (testing "malformed JSON is a SUT response error"
+    (let [response (assoc (http-response {}) :body "{")
+          thrown (with-redefs [client/post! (fn [& _] response)]
+                   (caught #(client/write! "n1:21001" "key" "value")))]
+      (is (= :invalid-json (:kind (ex-data thrown))))
+      (is (= (select-keys response [:method :uri :status])
+             (select-keys (:response (ex-data thrown))
+                          [:method :uri :status])))
+      (is (= 1 (get-in (ex-data thrown)
+                       [:response :body-character-count])))
+      (is (= "{" (get-in (ex-data thrown)
+                         [:response :body-preview])))))
+
+  (testing "an unknown parser exception escapes unchanged"
+    (let [throwable (RuntimeException. "parser bug")
+          response (http-response
+                    {:Ok {:data {:value {:value "value" :version 1}}}})
+          thrown (with-redefs [client/post! (fn [& _] response)
+                               json-parse/parse-strict (fn [& _]
+                                                         (throw throwable))]
+                   (caught #(client/write! "n1:21001" "key" "value")))]
+      (is (identical? throwable thrown)))))
+
+(deftest propagates-http-client-interruptions
+  (doseq [[label throwable]
+          [["InterruptedException" (InterruptedException. "interrupted")]
+           ["InterruptedIOException"
+            (java.io.InterruptedIOException. "interrupted")]
+           ["ClosedByInterruptException"
+            (java.nio.channels.ClosedByInterruptException.)]]]
+    (testing label
+      (Thread/interrupted)
+      (let [fake-client (throwing-http-client throwable)
+            thrown (with-redefs-fn
+                     {(ns-resolve 'jepsen.openraft.client 'http-client)
+                      fake-client}
+                     #(caught
+                       (fn []
+                         (client/post! "n1:21001" "/write" {}))))
+            interrupted (Thread/interrupted)]
+        (is (identical? throwable thrown))
+        (is interrupted))))
+
+  (testing "ordinary I/O remains a transport error"
+    (let [throwable (java.io.IOException. "broken pipe")
+          fake-client (throwing-http-client throwable)
+          thrown (with-redefs-fn
+                   {(ns-resolve 'jepsen.openraft.client 'http-client)
+                    fake-client}
+                   #(caught
+                     (fn []
+                       (client/post! "n1:21001" "/write" {}))))]
+      (is (= :transport-error (:kind (ex-data thrown))))
+      (is (identical? throwable (ex-cause thrown))))))

--- a/jepsen/test/jepsen/openraft/cluster_test.clj
+++ b/jepsen/test/jepsen/openraft/cluster_test.clj
@@ -1,5 +1,5 @@
 (ns jepsen.openraft.cluster-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [jepsen.openraft.client :as client]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.util :as util]))
@@ -68,8 +68,44 @@
                                         {:kind :unreachable}))))]
       (is (nil? (#'cluster/cluster-status test-config))))))
 
+(deftest distinguishes-modeled-metrics-failures-from-harness-errors
+  (testing "recognized SUT observations make a node unavailable"
+    (doseq [kind [:http-error
+                  :invalid-json
+                  :invalid-response
+                  :openraft-error
+                  :request-timeout
+                  :transport-error
+                  :unreachable]]
+      (with-redefs [client/metrics!
+                    (fn [_endpoint]
+                      (throw (ex-info "unavailable" {:kind kind})))]
+        (is (nil? (#'cluster/cluster-status test-config)) (name kind)))))
+
+  (testing "unknown implementation exceptions propagate"
+    (let [error (RuntimeException. "metrics bug")
+          thrown (with-redefs [client/metrics! (fn [_endpoint]
+                                                 (throw error))]
+                   (try
+                     (#'cluster/cluster-status test-config)
+                     nil
+                     (catch Exception e
+                       e)))]
+      (is (identical? error thrown))))
+
+  (testing "the readiness wait preserves the unknown exception"
+    (let [error (RuntimeException. "readiness bug")
+          thrown (with-redefs [client/metrics! (fn [_endpoint]
+                                                 (throw error))]
+                   (try
+                     (cluster/await-ready! test-config)
+                     nil
+                     (catch Exception e
+                       e)))]
+      (is (identical? error thrown)))))
+
 (deftest preserves-metrics-request-interruption
-  (doseq [[label error]
+  (doseq [[label make-error]
           [[:interrupted-exception
             #(InterruptedException. "interrupted")]
            [:interrupted-io
@@ -78,19 +114,20 @@
             #(java.nio.channels.ClosedByInterruptException.)]
            [:wrapped
             #(ex-info "interrupted" {:kind :interrupted})]]]
-    (let [interrupted?
+    (let [error (make-error)
+          [thrown interrupted?]
           @(future
-             (with-redefs [client/metrics!
-                           (fn [_endpoint]
-                             (throw (error)))]
-               (try
+             (try
+               (with-redefs [client/metrics!
+                             (fn [_endpoint]
+                               (throw error))]
                  (#'cluster/cluster-status test-config)
-                 false
-                 (catch InterruptedException _
-                   (let [interrupted? (.isInterrupted
-                                       (Thread/currentThread))]
-                     (Thread/interrupted)
-                     interrupted?)))))]
+                 [nil (.isInterrupted (Thread/currentThread))])
+               (catch Exception e
+                 [e (.isInterrupted (Thread/currentThread))])
+               (finally
+                 (Thread/interrupted))))]
+      (is (identical? error thrown) (name label))
       (is interrupted? (name label)))))
 
 (defn- membership [configs]
@@ -316,6 +353,44 @@
       (is (= committed
              (cluster/await-committed-membership! test-config)))
       (is (= [:retry] @attempts)))))
+
+(deftest membership-waits-do-not-retry-harness-exceptions
+  (doseq [[label wait!]
+          [[:committed #(cluster/await-committed-membership! test-config)]
+           [:stable #(cluster/await-stable-membership! test-config)]
+           [:learner #(cluster/await-observed-learner!
+                       test-config
+                       "n4"
+                       100)]]]
+    (testing (name label)
+      (let [attempts (atom 0)
+            error (RuntimeException. "membership wait bug")
+            thrown (with-redefs [cluster/membership-status
+                                 (fn [_test]
+                                   (swap! attempts inc)
+                                   (throw error))]
+                     (try
+                       (wait!)
+                       nil
+                       (catch Exception e
+                         e)))]
+        (is (identical? error thrown))
+        (is (= 1 @attempts)))))
+
+  (testing "node metrics retries only modeled SUT availability"
+    (let [attempts (atom 0)
+          error (RuntimeException. "node metrics bug")
+          thrown (with-redefs [cluster/node-metrics!
+                               (fn [_test _node]
+                                 (swap! attempts inc)
+                                 (throw error))]
+                   (try
+                     (cluster/await-node-metrics! test-config "n4" 100)
+                     nil
+                     (catch Exception e
+                       e)))]
+      (is (identical? error thrown))
+      (is (= 1 @attempts)))))
 
 (deftest rejects-support-from-an-older-leader-term
   (let [membership (stored-membership

--- a/jepsen/test/jepsen/openraft/db_test.clj
+++ b/jepsen/test/jepsen/openraft/db_test.clj
@@ -1,22 +1,418 @@
 (ns jepsen.openraft.db-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [jepsen.control :as c]
-            [jepsen.control.util :as cu]
             [jepsen.db :as db]
             [jepsen.openraft.db :as openraft-db]))
 
-(deftest builds-test-app-start-arguments
-  (let [started-args (atom nil)
-        database (openraft-db/db {})
-        test {:api-port 21001
-              :raft-port 22001
-              :snapshot-threshold 250}]
-    (with-redefs [c/exec (fn [& _args])
-                  cu/start-daemon! (fn [_opts _binary & args]
-                                     (reset! started-args args))]
-      (db/start! database test "n1"))
-    (is (= {:--id "n1"
-            :--api-addr "n1:21001"
-            :--raft-addr "n1:22001"
-            :--snapshot-threshold 250}
-           (apply hash-map @started-args)))))
+(def test-config
+  {:api-port 21001
+   :raft-port 22001
+   :snapshot-threshold 250})
+
+(defn- command-kind [command]
+  (cond
+    (= :bash (first command)) :probe
+    (= :killall (first command)) (case (nth command 2)
+                                   9 :kill
+                                   "STOP" :pause
+                                   "CONT" :resume)
+    (= :rm (first command)) :remove
+    (= :mkdir (first command)) :mkdir
+    (some #{:start-stop-daemon} command) :start))
+
+(defn- argument-after [command argument]
+  (let [index (.indexOf command argument)]
+    (when-not (neg? index)
+      (nth command (inc index)))))
+
+(deftest starts-and-confirms-the-test-app
+  (let [calls (atom [])
+        running? (atom false)
+        database (openraft-db/db {})]
+    (with-redefs [c/exec
+                  (fn [& command]
+                    (swap! calls conj command)
+                    (case (command-kind command)
+                      :probe (if @running? "running" "absent")
+                      :start (do (reset! running? true) "")
+                      ""))]
+      (is (= :start-confirmed (db/start! database test-config "n1"))))
+    (let [start-command (first (filter #(= :start (command-kind %)) @calls))]
+      (is (some #{:--oknodo} start-command))
+      (is (= "n1" (argument-after start-command :--id)))
+      (is (= "n1:21001" (argument-after start-command :--api-addr)))
+      (is (= "n1:22001" (argument-after start-command :--raft-addr)))
+      (is (= 250 (argument-after start-command :--snapshot-threshold))))))
+
+(deftest uses-explicit-process-evidence-when-starting
+  (let [database (openraft-db/db {})]
+    (testing "an already running process is not started again"
+      (let [starts (atom 0)]
+        (with-redefs [c/exec
+                      (fn [& command]
+                        (case (command-kind command)
+                          :probe "running"
+                          :start (do (swap! starts inc) "")
+                          ""))]
+          (is (= :already-running
+                 (db/start! database test-config "n1"))))
+        (is (zero? @starts))))
+
+    (testing "a paused process is not treated as already running"
+      (let [starts (atom 0)
+            error (with-redefs [c/exec
+                                (fn [& command]
+                                  (case (command-kind command)
+                                    :probe "paused"
+                                    :start (do (swap! starts inc) "")
+                                    ""))]
+                    (try
+                      (db/start! database test-config "n1")
+                      nil
+                      (catch Exception e
+                        e)))]
+        (is (= :unexpected-existing-process-state
+               (:kind (ex-data error))))
+        (is (= :paused (:state (ex-data error))))
+        (is (zero? @starts))))
+
+    (testing "an exit-one start failure propagates unchanged"
+      (let [error (ex-info "permission denied"
+                           {:type :jepsen.control/nonzero-exit
+                            :exit 1})
+            thrown (with-redefs [c/exec
+                                 (fn [& command]
+                                   (case (command-kind command)
+                                     :probe "absent"
+                                     :start (throw error)
+                                     ""))]
+                     (try
+                       (db/start! database test-config "n1")
+                       nil
+                       (catch Exception e
+                         e)))]
+        (is (identical? error thrown))))
+
+    (testing "a background start that never appears times out"
+      (let [error
+            (with-redefs-fn
+              {#'c/exec
+               (fn [& command]
+                 (case (command-kind command)
+                   :probe "absent"
+                   ""))
+               #'openraft-db/process-confirm-timeout-ms 0}
+              #(try
+                 (db/start! database test-config "n1")
+                 nil
+                 (catch Exception e
+                   e)))]
+        (is (= :process-confirmation-timeout
+               (:kind (ex-data error))))))))
+
+(deftest pauses-and-resumes-processes-with-strict-evidence
+  (let [database (openraft-db/db {})]
+    (testing "a pause signal is confirmed"
+      (let [state (atom :running)
+            calls (atom [])]
+        (with-redefs [c/exec
+                      (fn [& command]
+                        (swap! calls conj command)
+                        (case (command-kind command)
+                          :probe (name @state)
+                          :pause (do (reset! state :paused) "")
+                          ""))]
+          (is (= :paused (db/pause! database {} "n1"))))
+        (is (= [:probe :pause :probe]
+               (mapv command-kind @calls)))))
+
+    (testing "a resume signal is confirmed"
+      (let [state (atom :paused)
+            calls (atom [])]
+        (with-redefs [c/exec
+                      (fn [& command]
+                        (swap! calls conj command)
+                        (case (command-kind command)
+                          :probe (name @state)
+                          :resume (do (reset! state :running) "")
+                          ""))]
+          (is (= :resumed (db/resume! database {} "n1"))))
+        (is (= [:probe :resume :probe]
+               (mapv command-kind @calls)))))
+
+    (doseq [[label operation]
+            [[:pause #(db/pause! database {} "n1")]
+             [:resume #(db/resume! database {} "n1")]]]
+      (testing (str (name label) " records a pre-probe absence")
+        (let [calls (atom [])]
+          (with-redefs [c/exec
+                        (fn [& command]
+                          (swap! calls conj command)
+                          (case (command-kind command)
+                            :probe "absent"
+                            ""))]
+            (is (= :target-absent (operation))))
+          (is (= [:probe] (mapv command-kind @calls))))))
+
+    (doseq [[label process-state operation]
+            [[:pause :running #(db/pause! database {} "n1")]
+             [:resume :paused #(db/resume! database {} "n1")]]]
+      (testing (str (name label) " records an explicit exit race")
+        (let [race (ex-info "no process found"
+                            {:type :jepsen.control/nonzero-exit
+                             :exit 1
+                             :err (str openraft-db/process-name
+                                       ": no process found")})]
+          (with-redefs [c/exec
+                        (fn [& command]
+                          (case (command-kind command)
+                            :probe (name process-state)
+                            (:pause :resume) (throw race)
+                            ""))]
+            (is (= :target-already-exited (operation)))))))
+
+    (doseq [[label process-state operation]
+            [[:pause :running #(db/pause! database {} "n1")]
+             [:resume :paused #(db/resume! database {} "n1")]]]
+      (testing (str (name label) " propagates control failures")
+        (let [error (ex-info "permission denied"
+                             {:type :jepsen.control/nonzero-exit
+                              :exit 1
+                              :err "permission denied"})
+              thrown (with-redefs [c/exec
+                                   (fn [& command]
+                                     (case (command-kind command)
+                                       :probe (name process-state)
+                                       (:pause :resume) (throw error)
+                                       ""))]
+                       (try
+                         (operation)
+                         nil
+                         (catch Exception e
+                           e)))]
+          (is (identical? error thrown)))))
+
+    (doseq [[label process-state operation]
+            [[:pause :running #(db/pause! database {} "n1")]
+             [:resume :paused #(db/resume! database {} "n1")]]]
+      (testing (str (name label) " has bounded confirmation")
+        (let [error
+              (with-redefs-fn
+                {#'c/exec
+                 (fn [& command]
+                   (case (command-kind command)
+                     :probe (name process-state)
+                     ""))
+                 #'openraft-db/process-confirm-timeout-ms 0}
+                #(try
+                   (operation)
+                   nil
+                   (catch Exception e
+                     e)))]
+          (is (= :process-confirmation-timeout
+                 (:kind (ex-data error)))))))))
+
+(deftest stops-processes-with-strict-evidence
+  (let [database (openraft-db/db {})]
+    (testing "a pre-probe absence is a structured no-op"
+      (let [calls (atom [])]
+        (with-redefs [c/exec
+                      (fn [& command]
+                        (swap! calls conj command)
+                        (case (command-kind command)
+                          :probe "absent"
+                          ""))]
+          (is (= :target-absent (db/kill! database {} "n1"))))
+        (is (= [:probe :remove]
+               (mapv command-kind @calls)))))
+
+    (testing "a successful kill is confirmed absent"
+      (let [running? (atom true)
+            calls (atom [])]
+        (with-redefs [c/exec
+                      (fn [& command]
+                        (swap! calls conj command)
+                        (case (command-kind command)
+                          :probe (if @running? "running" "absent")
+                          :kill (do (reset! running? false) "")
+                          ""))]
+          (is (= :killed (db/kill! database {} "n1"))))
+        (is (= [:probe :kill :probe :remove]
+               (mapv command-kind @calls)))))
+
+    (testing "an explicit exit race is skipped without polling"
+      (let [calls (atom [])
+            race (ex-info "no process found"
+                          {:type :jepsen.control/nonzero-exit
+                           :exit 1
+                           :err "openraft-jepsen-app: no process found"})]
+        (with-redefs [c/exec
+                      (fn [& command]
+                        (swap! calls conj command)
+                        (case (command-kind command)
+                          :probe "running"
+                          :kill (throw race)
+                          ""))]
+          (is (= :target-already-exited
+                 (db/kill! database {} "n1"))))
+        (is (= [:probe :kill :remove]
+               (mapv command-kind @calls)))))
+
+    (testing "permission failures are never treated as absence"
+      (let [removed? (atom false)
+            error (ex-info "permission denied"
+                           {:type :jepsen.control/nonzero-exit
+                            :exit 1
+                            :err "permission denied"})
+            thrown (with-redefs [c/exec
+                                 (fn [& command]
+                                   (case (command-kind command)
+                                     :probe "running"
+                                     :kill (throw error)
+                                     :remove (do (reset! removed? true) "")))]
+                     (try
+                       (db/kill! database {} "n1")
+                       nil
+                       (catch Exception e
+                         e)))]
+        (is (identical? error thrown))
+        (is (false? @removed?))))
+
+    (testing "mixed control diagnostics are not an explicit exit race"
+      (let [error (ex-info "kill failed"
+                           {:type :jepsen.control/nonzero-exit
+                            :exit 1
+                            :err (str "permission denied\n"
+                                      openraft-db/process-name
+                                      ": no process found")})
+            thrown (with-redefs [c/exec
+                                 (fn [& command]
+                                   (case (command-kind command)
+                                     :probe "running"
+                                     :kill (throw error)
+                                     ""))]
+                     (try
+                       (db/kill! database {} "n1")
+                       nil
+                       (catch Exception e
+                         e)))]
+        (is (identical? error thrown))))
+
+    (testing "a process that remains running fails bounded confirmation"
+      (let [error
+            (with-redefs-fn
+              {#'c/exec
+               (fn [& command]
+                 (case (command-kind command)
+                   :probe "running"
+                   ""))
+               #'openraft-db/process-confirm-timeout-ms 0}
+              #(try
+                 (db/kill! database {} "n1")
+                 nil
+                 (catch Exception e
+                   e)))]
+        (is (= :process-confirmation-timeout
+               (:kind (ex-data error))))))))
+
+(deftest process-control-preserves-interruptions
+  (doseq [[label make-error]
+          [[:interrupted #(InterruptedException. "interrupted")]
+           [:interrupted-io
+            #(java.io.InterruptedIOException. "interrupted")]
+           [:closed-by-interrupt
+            #(java.nio.channels.ClosedByInterruptException.)]
+           [:wrapped
+            #(ex-info "interrupted"
+                      {:kind :interrupted
+                       :type :jepsen.control/nonzero-exit
+                       :exit 1
+                       :err "no process found"})]]]
+    (testing (name label)
+      (Thread/interrupted)
+      (try
+        (let [error (make-error)
+              database (openraft-db/db {})
+              [thrown interrupted?]
+              (with-redefs [c/exec (fn [& _] (throw error))]
+                (try
+                  (db/kill! database {} "n1")
+                  [nil (.isInterrupted (Thread/currentThread))]
+                  (catch Exception e
+                    [e (.isInterrupted (Thread/currentThread))])))]
+          (is (identical? error thrown))
+          (is interrupted?))
+        (finally
+          (Thread/interrupted))))))
+
+(deftest every-process-control-stage-preserves-interruptions
+  (let [database (openraft-db/db {})
+        stages
+        [{:label :remove-pid
+          :operation #(db/kill! database {} "n1")
+          :exec (fn [error command]
+                  (case (command-kind command)
+                    :probe "absent"
+                    :remove (throw error)
+                    ""))}
+         {:label :kill-signal
+          :operation #(db/kill! database {} "n1")
+          :exec (fn [error command]
+                  (case (command-kind command)
+                    :probe "running"
+                    :kill (throw error)
+                    ""))}
+         {:label :pause-signal
+          :operation #(db/pause! database {} "n1")
+          :exec (fn [error command]
+                  (case (command-kind command)
+                    :probe "running"
+                    :pause (throw error)
+                    ""))}
+         {:label :resume-signal
+          :operation #(db/resume! database {} "n1")
+          :exec (fn [error command]
+                  (case (command-kind command)
+                    :probe "paused"
+                    :resume (throw error)
+                    ""))}
+         {:label :start-command
+          :operation #(db/start! database test-config "n1")
+          :exec (fn [error command]
+                  (case (command-kind command)
+                    :probe "absent"
+                    :start (throw error)
+                    ""))}]]
+    (doseq [{:keys [label operation exec]} stages]
+      (testing (name label)
+        (Thread/interrupted)
+        (try
+          (let [error (InterruptedException. "interrupted")
+                [thrown interrupted?]
+                (with-redefs [c/exec (fn [& command]
+                                       (exec error command))]
+                  (try
+                    (operation)
+                    [nil (.isInterrupted (Thread/currentThread))]
+                    (catch Exception e
+                      [e (.isInterrupted (Thread/currentThread))])))]
+            (is (identical? error thrown))
+            (is interrupted?))
+          (finally
+            (Thread/interrupted)))))))
+
+(deftest passes-the-process-pattern-as-a-separate-argument
+  (let [calls (atom [])
+        adversarial "/tmp/openraft app; touch /tmp/not-run"
+        database (openraft-db/db {})]
+    (with-redefs [openraft-db/binary adversarial
+                  c/exec (fn [& command]
+                           (swap! calls conj command)
+                           (if (= :probe (command-kind command))
+                             "absent"
+                             ""))]
+      (is (= :target-absent (db/kill! database {} "n1"))))
+    (let [probe (first @calls)]
+      (is (not (.contains ^String (nth probe 2) adversarial)))
+      (is (= (str "^" adversarial "([[:space:]].*)?$")
+             (last probe))))))

--- a/jepsen/test/jepsen/openraft/generator_test.clj
+++ b/jepsen/test/jepsen/openraft/generator_test.clj
@@ -1,0 +1,55 @@
+(ns jepsen.openraft.generator-test
+  (:require [clojure.test :refer [deftest is]]
+            [jepsen.generator :as gen]
+            [jepsen.generator.test :as gen-test]
+            [jepsen.openraft.generator :as openraft-generator]
+            [jepsen.openraft.harness :as harness]))
+
+(deftest stops-new-operations-after-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        generator (openraft-generator/stop-on-harness-failure
+                   failure-state
+                   [{:f :first} {:f :second}])
+        [operation generator'] (gen/op generator
+                                       gen-test/default-test
+                                       gen-test/default-context)]
+    (is (= :first (:f operation)))
+    (harness/record-failure! failure-state
+                             :client
+                             {:operation operation}
+                             (RuntimeException. "client failed"))
+    (is (nil? (gen/op generator'
+                      gen-test/default-test
+                      gen-test/default-context)))))
+
+(deftest forwards-in-flight-updates-after-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        events (atom [])
+        delegate (gen/on-update
+                  (fn [generator _test _context event]
+                    (swap! events conj event)
+                    generator)
+                  (repeat {:f :ordinary-workload}))
+        generator (openraft-generator/stop-on-harness-failure
+                   failure-state
+                   delegate)
+        [operation generator'] (gen/op generator
+                                       gen-test/default-test
+                                       gen-test/default-context)
+        completion (assoc operation :type :ok)]
+    (harness/record-failure! failure-state
+                             :client
+                             {:operation operation}
+                             (RuntimeException. "client failed"))
+    (let [after-invocation (gen/update generator'
+                                       gen-test/default-test
+                                       gen-test/default-context
+                                       operation)
+          after-completion (gen/update after-invocation
+                                       gen-test/default-test
+                                       gen-test/default-context
+                                       completion)]
+      (is (= [operation completion] @events))
+      (is (nil? (gen/op after-completion
+                        gen-test/default-test
+                        gen-test/default-context))))))

--- a/jepsen/test/jepsen/openraft/harness_test.clj
+++ b/jepsen/test/jepsen/openraft/harness_test.clj
@@ -1,0 +1,51 @@
+(ns jepsen.openraft.harness-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen.openraft.harness :as harness]))
+
+(deftest starts-without-a-primary-failure
+  (is (nil? (harness/primary-failure (harness/failure-state)))))
+
+(deftest records-the-first-failure
+  (let [state (harness/failure-state)
+        context {:operation :write
+                 :node :n1}
+        throwable (ex-info "Client failed" {:kind :client-error})]
+    (harness/record-failure! state :client context throwable)
+    (let [failure (harness/primary-failure state)]
+      (is (= :client (:source failure)))
+      (is (= context (:context failure)))
+      (is (identical? throwable (:throwable failure))))))
+
+(deftest retains-the-first-failure
+  (let [state (harness/failure-state)
+        first-throwable (RuntimeException. "first")
+        later-throwable (RuntimeException. "later")]
+    (harness/record-failure! state
+                             :nemesis
+                             {:operation :partition}
+                             first-throwable)
+    (harness/record-failure! state
+                             :teardown
+                             {:operation :heal}
+                             later-throwable)
+    (let [failure (harness/primary-failure state)]
+      (is (= :nemesis (:source failure)))
+      (is (= {:operation :partition} (:context failure)))
+      (is (identical? first-throwable (:throwable failure))))))
+
+(deftest ignores-interruptions
+  (doseq [[description throwable]
+          [["InterruptedException" (InterruptedException. "interrupted")]
+           ["InterruptedIOException"
+            (java.io.InterruptedIOException. "interrupted")]
+           ["ClosedByInterruptException"
+            (java.nio.channels.ClosedByInterruptException.)]
+           ["interrupted ex-info"
+            (ex-info "interrupted" {:kind :interrupted})]]]
+    (testing description
+      (let [state (harness/failure-state)]
+        (harness/record-failure! state
+                                 :client
+                                 {:operation :read}
+                                 throwable)
+        (is (nil? (harness/primary-failure state)))))))

--- a/jepsen/test/jepsen/openraft/harness_test.clj
+++ b/jepsen/test/jepsen/openraft/harness_test.clj
@@ -3,14 +3,20 @@
             [jepsen.openraft.harness :as harness]))
 
 (deftest starts-without-a-primary-failure
-  (is (nil? (harness/primary-failure (harness/failure-state)))))
+  (let [state (harness/failure-state)]
+    (is (nil? (harness/primary-failure state)))
+    (is (empty? (harness/secondary-failures state)))))
 
 (deftest records-the-first-failure
   (let [state (harness/failure-state)
         context {:operation :write
                  :node :n1}
         throwable (ex-info "Client failed" {:kind :client-error})]
-    (harness/record-failure! state :client context throwable)
+    (is (true? (harness/record-failure!
+                state
+                :client
+                context
+                throwable)))
     (let [failure (harness/primary-failure state)]
       (is (= :client (:source failure)))
       (is (= context (:context failure)))
@@ -19,19 +25,59 @@
 (deftest retains-the-first-failure
   (let [state (harness/failure-state)
         first-throwable (RuntimeException. "first")
-        later-throwable (RuntimeException. "later")]
+        later-throwable (RuntimeException. "later")
+        last-throwable (RuntimeException. "last")]
     (harness/record-failure! state
                              :nemesis
                              {:operation :partition}
                              first-throwable)
-    (harness/record-failure! state
-                             :teardown
-                             {:operation :heal}
-                             later-throwable)
+    (is (false? (harness/record-failure!
+                 state
+                 :nemesis
+                 {:phase :teardown
+                  :operation :heal}
+                 later-throwable)))
+    (is (false? (harness/record-failure!
+                 state
+                 :nemesis
+                 {:phase :teardown
+                  :operation :resume}
+                 last-throwable)))
     (let [failure (harness/primary-failure state)]
       (is (= :nemesis (:source failure)))
       (is (= {:operation :partition} (:context failure)))
-      (is (identical? first-throwable (:throwable failure))))))
+      (is (identical? first-throwable (:throwable failure))))
+    (let [[later last] (harness/secondary-failures state)]
+      (is (= {:phase :teardown
+              :operation :heal}
+             (:context later)))
+      (is (identical? later-throwable (:throwable later)))
+      (is (= {:phase :teardown
+              :operation :resume}
+             (:context last)))
+      (is (identical? last-throwable (:throwable last))))))
+
+(deftest records-concurrent-failures-once
+  (let [state (harness/failure-state)
+        start (promise)
+        errors (mapv #(RuntimeException. (str "failure " %)) (range 16))
+        workers (mapv (fn [id throwable]
+                        (future
+                          @start
+                          (harness/record-failure! state
+                                                   :nemesis
+                                                   {:id id}
+                                                   throwable)))
+                      (range 16)
+                      errors)]
+    (deliver start true)
+    (let [results (mapv deref workers)
+          primary (harness/primary-failure state)
+          recorded (cons primary (harness/secondary-failures state))]
+      (is (= 1 (count (filter true? results))))
+      (is (= (count errors) (count recorded)))
+      (is (= (set (range 16)) (set (map (comp :id :context) recorded))))
+      (is (= (set errors) (set (map :throwable recorded)))))))
 
 (deftest ignores-interruptions
   (doseq [[description throwable]
@@ -43,9 +89,21 @@
            ["interrupted ex-info"
             (ex-info "interrupted" {:kind :interrupted})]]]
     (testing description
-      (let [state (harness/failure-state)]
-        (harness/record-failure! state
-                                 :client
-                                 {:operation :read}
-                                 throwable)
-        (is (nil? (harness/primary-failure state)))))))
+      (let [state (harness/failure-state)
+            primary (RuntimeException. "primary")]
+        (is (false? (harness/record-failure!
+                     state
+                     :client
+                     {:operation :read}
+                     throwable)))
+        (is (nil? (harness/primary-failure state)))
+        (is (empty? (harness/secondary-failures state)))
+        (harness/record-failure! state :client {:operation :write} primary)
+        (is (false? (harness/record-failure!
+                     state
+                     :nemesis
+                     {:phase :teardown}
+                     throwable)))
+        (is (identical? primary
+                        (:throwable (harness/primary-failure state))))
+        (is (empty? (harness/secondary-failures state)))))))

--- a/jepsen/test/jepsen/openraft/nemesis/membership_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/membership_test.clj
@@ -2,9 +2,12 @@
   (:require [clojure.test :refer [deftest is testing]]
             [jepsen [checker :as checker]
              [nemesis :as nemesis]]
-            [jepsen.openraft [client :as client]
+            [jepsen.openraft [await :as await]
+             [client :as client]
              [cluster :as cluster]
-             [db :as openraft-db]]
+             [db :as openraft-db]
+             [harness :as harness]
+             [worker :as worker]]
             [jepsen.openraft.nemesis.membership :as membership]
             [jepsen.random :as random]))
 
@@ -14,6 +17,25 @@
   {:nodes nodes
    :api-port 21001
    :raft-port 22001})
+
+(defn- installed [details]
+  (assoc details :status :installed))
+
+(defn- skipped [reason details]
+  (assoc details :status :skipped :reason reason))
+
+(defn- indeterminate [reason details]
+  (assoc details :status :indeterminate :reason reason))
+
+(defn- condition-timeout [condition]
+  (try
+    (await/until! condition
+                  #(await/retry! condition {})
+                  {:timeout 0
+                   :retry-interval 0})
+    nil
+    (catch Exception e
+      e)))
 
 (defn- membership-nemesis []
   (membership/->MembershipNemesis :database (atom nil)))
@@ -64,7 +86,8 @@
                                     test-config
                                     {:type :info
                                      :f :grow})]
-        (is (= :node-starting (get-in starting [:value :status])))
+        (is (= :skipped (get-in starting [:value :status])))
+        (is (= :node-starting (get-in starting [:value :reason])))
         (is (= [[:start-empty :database "n5"]
                 [:add-learner
                  "n1:21001"
@@ -81,7 +104,8 @@
                 :before before
                 :after after}
                (select-keys (:value result)
-                            [:change :node :source :before :after])))))))
+                            [:change :node :source :before :after])))
+        (is (= :installed (get-in result [:value :status])))))))
 
 (deftest handles-an-existing-learner
   (let [before #{"n1" "n2" "n3" "n4"}
@@ -109,7 +133,8 @@
                                       {:type :info
                                        :f :grow})]
           (is (= [:add-learner :change-membership] @calls))
-          (is (= after (get-in result [:value :after]))))))
+          (is (= after (get-in result [:value :after])))
+          (is (= :installed (get-in result [:value :status]))))))
 
     (testing "an unreachable learner is reported without blocking"
       (reset! calls [])
@@ -121,8 +146,9 @@
                                       test-config
                                       {:type :info
                                        :f :grow})]
+          (is (= :skipped (get-in result [:value :status])))
           (is (= :learner-unreachable
-                 (get-in result [:value :status])))
+                 (get-in result [:value :reason])))
           (is (empty? @calls)))))))
 
 (deftest defers-an-indeterminate-learner-addition
@@ -147,7 +173,230 @@
                                     {:type :info
                                      :f :grow})]
         (is (= :indeterminate (get-in result [:value :status])))
+        (is (= :request-result-unknown
+               (get-in result [:value :reason])))
         (is (false? @changed?))))))
+
+(deftest skips-an-add-learner-during-an-existing-membership-change
+  (let [before #{"n1" "n2" "n3" "n4"}
+        status (update (stable-status before) :metrics assoc "n5" {})
+        changed? (atom false)
+        pending (atom nil)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database pending))]
+    (with-redefs [cluster/membership-status (constantly status)
+                  client/add-learner!
+                  (fn [& _]
+                    (throw (ex-info
+                            "membership change in progress"
+                            {:kind :openraft-error
+                             :error {:ChangeMembershipError
+                                     {:InProgress {}}}})))
+                  client/change-membership!
+                  (fn [& _] (reset! changed? true))]
+      (let [value (:value
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info :f :grow}))]
+        (is (= :skipped (:status value)))
+        (is (= :membership-change-in-progress (:reason value)))
+        (is (= :add-learner (:stage value)))
+        (is (= {:status :in-progress
+                :reason :membership-change-in-progress
+                :stage :add-learner}
+               (select-keys @pending [:status :reason :stage])))
+        (is (false? @changed?))
+        (is (nil? (harness/primary-failure failure-state)))))))
+
+(deftest classifies-invalid-membership-responses-after-the-attempt
+  (testing "an invalid add-learner response is indeterminate"
+    (let [before #{"n1" "n2" "n3" "n4"}
+          status (update (stable-status before) :metrics assoc "n5" {})
+          failure-state (harness/failure-state)
+          changed? (atom false)
+          subject (worker/wrap-nemesis failure-state
+                                       (membership-nemesis))]
+      (with-redefs [cluster/membership-status (constantly status)
+                    client/add-learner!
+                    (fn [& _]
+                      (throw (ex-info "invalid response"
+                                      {:kind :invalid-response})))
+                    client/change-membership!
+                    (fn [& _]
+                      (reset! changed? true))]
+        (let [setup-subject (nemesis/setup! subject test-config)
+              value (:value (nemesis/invoke! setup-subject
+                                             test-config
+                                             {:type :info :f :grow}))]
+          (is (= :indeterminate (:status value)))
+          (is (= :request-result-unknown (:reason value)))
+          (is (= :add-learner (:stage value)))
+          (is (false? @changed?))
+          (is (nil? (harness/primary-failure failure-state)))))))
+
+  (testing "an invalid change-membership response is indeterminate"
+    (let [failure-state (harness/failure-state)
+          cleaned? (atom false)
+          subject (worker/wrap-nemesis failure-state
+                                       (membership-nemesis))]
+      (with-redefs [cluster/membership-status
+                    (constantly (stable-status (set nodes)))
+                    random/shuffle reverse
+                    client/change-membership!
+                    (fn [& _]
+                      (throw (ex-info "invalid response"
+                                      {:kind :invalid-response})))
+                    openraft-db/stop-and-wipe-node!
+                    (fn [& _]
+                      (reset! cleaned? true))]
+        (let [setup-subject (nemesis/setup! subject test-config)
+              value (:value (nemesis/invoke! setup-subject
+                                             test-config
+                                             {:type :info :f :shrink}))]
+          (is (= :indeterminate (:status value)))
+          (is (= :request-result-unknown (:reason value)))
+          (is (= :change-membership (:stage value)))
+          (is (false? @cleaned?))
+          (is (nil? (harness/primary-failure failure-state)))))))
+
+  (testing "an unknown request exception still records Harness failure"
+    (let [before #{"n1" "n2" "n3" "n4"}
+          status (update (stable-status before) :metrics assoc "n5" {})
+          failure-state (harness/failure-state)
+          error (RuntimeException. "request bug")
+          subject (worker/wrap-nemesis failure-state
+                                       (membership-nemesis))]
+      (with-redefs [cluster/membership-status (constantly status)
+                    client/add-learner! (fn [& _] (throw error))]
+        (let [setup-subject (nemesis/setup! subject test-config)
+              thrown (try
+                       (nemesis/invoke! setup-subject
+                                        test-config
+                                        {:type :info :f :grow})
+                       nil
+                       (catch Exception e
+                         e))]
+          (is (identical? error thrown))
+          (is (identical? error
+                          (:throwable
+                           (harness/primary-failure failure-state)))))))))
+
+(deftest malformed-membership-error-unions-are-unexpected-sut-responses
+  (doseq [[description payload expected-shape expected-count expected-names]
+          [["scalar payload" "not-a-union" :not-map nil []]
+           ["multiple variants"
+            {:InProgress {}
+             :LearnerNotFound {:node_id "n5"}}
+            :map
+            2
+            ["InProgress" "LearnerNotFound"]]]]
+    (testing (str description " from add-learner")
+      (let [before #{"n1" "n2" "n3" "n4"}
+            status (update (stable-status before) :metrics assoc "n5" {})
+            failure-state (harness/failure-state)
+            subject (worker/wrap-nemesis failure-state
+                                         (membership-nemesis))]
+        (with-redefs [cluster/membership-status (constantly status)
+                      client/add-learner!
+                      (fn [& _]
+                        (throw
+                         (ex-info
+                          "malformed membership error"
+                          {:kind :openraft-error
+                           :error {:ChangeMembershipError payload}
+                           :response {:body (apply str (repeat 2048 "x"))}})))]
+          (let [value (:value
+                       (nemesis/invoke! subject
+                                        test-config
+                                        {:type :info :f :grow}))]
+            (is (= :indeterminate (:status value)))
+            (is (= :unexpected-sut-response (:reason value)))
+            (is (= :add-learner (:stage value)))
+            (is (= expected-shape (:error-shape value)))
+            (is (= expected-count (:error-arm-count value)))
+            (is (= expected-names (:error-arm-names value)))
+            (is (not (contains? value :error)))
+            (is (not (contains? value :response)))
+            (is (nil? (harness/primary-failure failure-state)))))))
+
+    (testing (str description " from change-membership")
+      (let [failure-state (harness/failure-state)
+            cleaned? (atom false)
+            subject (worker/wrap-nemesis failure-state
+                                         (membership-nemesis))]
+        (with-redefs [cluster/membership-status
+                      (constantly (stable-status (set nodes)))
+                      random/shuffle reverse
+                      client/change-membership!
+                      (fn [& _]
+                        (throw
+                         (ex-info
+                          "malformed membership error"
+                          {:kind :openraft-error
+                           :error {:ChangeMembershipError payload}
+                           :response {:body (apply str (repeat 2048 "x"))}})))
+                      openraft-db/stop-and-wipe-node!
+                      (fn [& _] (reset! cleaned? true))]
+          (let [value (:value
+                       (nemesis/invoke! subject
+                                        test-config
+                                        {:type :info :f :shrink}))]
+            (is (= :indeterminate (:status value)))
+            (is (= :unexpected-sut-response (:reason value)))
+            (is (= :change-membership (:stage value)))
+            (is (= expected-shape (:error-shape value)))
+            (is (= expected-count (:error-arm-count value)))
+            (is (= expected-names (:error-arm-names value)))
+            (is (not (contains? value :error)))
+            (is (not (contains? value :response)))
+            (is (false? @cleaned?))
+            (is (nil? (harness/primary-failure failure-state)))))))))
+
+(deftest ordinary-grow-classifies-impossible-add-learner-errors
+  (doseq [[variant payload]
+          [[:LearnerNotFound {:node_id "n5"}]
+           [:EmptyMembership {}]]]
+    (testing (name variant)
+      (let [before #{"n1" "n2" "n3" "n4"}
+            status (update (stable-status before) :metrics assoc "n5" {})
+            pending (atom nil)
+            changed? (atom false)
+            failure-state (harness/failure-state)
+            subject (worker/wrap-nemesis
+                     failure-state
+                     (membership/->MembershipNemesis :database pending))]
+        (with-redefs [cluster/membership-status (constantly status)
+                      client/add-learner!
+                      (fn [& _]
+                        (throw
+                         (ex-info
+                          "unexpected add-learner response"
+                          {:kind :openraft-error
+                           :error {:ChangeMembershipError
+                                   {variant payload}}})))
+                      client/change-membership!
+                      (fn [& _]
+                        (reset! changed? true))]
+          (let [value (:value
+                       (nemesis/invoke! subject
+                                        test-config
+                                        {:type :info :f :grow}))]
+            (is (= {:status :indeterminate
+                    :reason :unexpected-sut-response
+                    :stage :add-learner
+                    :error-variant variant}
+                   (select-keys value
+                                [:status :reason :stage :error-variant])))
+            (is (= {:status :indeterminate
+                    :reason :unexpected-sut-response
+                    :stage :add-learner
+                    :error-variant variant}
+                   (select-keys @pending
+                                [:status :reason :stage :error-variant])))
+            (is (false? @changed?))
+            (is (nil? (harness/primary-failure failure-state)))))))))
 
 (deftest defers-a-grow-when-leader-routing-is-exhausted
   (let [before #{"n1" "n2" "n3" "n4"}
@@ -170,16 +419,18 @@
                      ["n1:21001" "n2:21001" "n3:21001"
                       "n4:21001" "n5:21001"])
                @attempts))
-        (is (= {:type :info
-                :f :grow
-                :value {:change :grow
-                        :node "n5"
-                        :source :non-member
-                        :leader "n1"
-                        :before before
-                        :target (conj before "n5")
-                        :status :no-supported-leader}}
-               result))))))
+        (is (= :skipped (get-in result [:value :status])))
+        (is (= :no-supported-leader
+               (get-in result [:value :reason])))
+        (is (= :add-learner (get-in result [:value :stage])))
+        (is (= {:change :grow
+                :node "n5"
+                :source :non-member
+                :leader "n1"
+                :before before
+                :target (conj before "n5")}
+               (select-keys (:value result)
+                            [:change :node :source :leader :before :target])))))))
 
 (deftest confirms-an-indeterminate-grow-from-membership-state
   (let [before #{"n1" "n2" "n3" "n4"}
@@ -214,11 +465,48 @@
                                       {:type :info
                                        :f :shrink})]
         (is (= 1 @change-attempts))
+        (is (= :skipped (get-in resolved [:value :status])))
+        (is (= :pending-membership-change
+               (get-in resolved [:value :reason])))
         (is (= {:change :grow
                 :before before
                 :after after}
-               (select-keys (:value resolved)
+               (select-keys (get-in resolved
+                                    [:value :resolved-change])
                             [:change :before :after])))))))
+
+(deftest opposite-operation-preserves-an-indeterminate-pending-retry
+  (let [before (set nodes)
+        after (disj before "n5")
+        pending (atom {:change :shrink
+                       :node "n5"
+                       :leader "n1"
+                       :before before
+                       :target after
+                       :stage :change-membership})
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database pending))]
+    (with-redefs [cluster/membership-status
+                  (constantly (stable-status before))
+                  client/change-membership!
+                  (fn [& _]
+                    (throw (ex-info "timeout" {:kind :request-timeout})))
+                  openraft-db/stop-and-wipe-node!
+                  (fn [& _]
+                    (throw (ex-info "MUST NOT clean up" {})))]
+      (let [value (:value
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info :f :grow}))]
+        (is (= :indeterminate (:status value)))
+        (is (= :request-result-unknown (:reason value)))
+        (is (= :indeterminate
+               (get-in value [:pending-change :status])))
+        (is (= :shrink (get-in value [:pending-change :change])))
+        (is (= :indeterminate (:status @pending)))
+        (is (nil? (harness/primary-failure failure-state)))))))
 
 (deftest shrinks-without-waiting-before-cleanup
   (let [calls (atom [])
@@ -251,7 +539,8 @@
                 :before before
                 :after after}
                (select-keys (:value result)
-                            [:change :node :before :after])))))))
+                            [:change :node :before :after])))
+        (is (= :installed (get-in result [:value :status])))))))
 
 (deftest defers-cleanup-after-an-indeterminate-shrink
   (let [calls (atom [])
@@ -286,10 +575,14 @@
                                       {:type :info
                                        :f :grow})]
         (is (= [:change-membership [:stop-and-wipe "n5"]] @calls))
+        (is (= :skipped (get-in resolved [:value :status])))
+        (is (= :pending-membership-change
+               (get-in resolved [:value :reason])))
         (is (= {:change :shrink
                 :before before
                 :after after}
-               (select-keys (:value resolved)
+               (select-keys (get-in resolved
+                                    [:value :resolved-change])
                             [:change :before :after])))))))
 
 (deftest defers-a-shrink-when-leader-routing-is-exhausted
@@ -319,15 +612,41 @@
                      ["n1:21001" "n2:21001" "n3:21001"
                       "n4:21001" "n5:21001"])
                @attempts))
-        (is (= {:type :info
-                :f :shrink
-                :value {:change :shrink
-                        :node "n5"
-                        :leader "n1"
-                        :before before
-                        :target after
-                        :status :no-supported-leader}}
-               result))))))
+        (is (= :skipped (get-in result [:value :status])))
+        (is (= :no-supported-leader
+               (get-in result [:value :reason])))
+        (is (= :change-membership (get-in result [:value :stage])))
+        (is (= {:change :shrink
+                :node "n5"
+                :leader "n1"
+                :before before
+                :target after}
+               (select-keys (:value result)
+                            [:change :node :leader :before :target])))))))
+
+(deftest skips-a-membership-change-that-is-already-in-progress
+  (let [cleaned? (atom false)]
+    (with-redefs [cluster/membership-status
+                  (constantly (stable-status (set nodes)))
+                  random/shuffle reverse
+                  client/change-membership!
+                  (fn [& _]
+                    (throw (ex-info
+                            "membership change in progress"
+                            {:kind :openraft-error
+                             :error {:ChangeMembershipError
+                                     {:InProgress {}}}})))
+                  openraft-db/stop-and-wipe-node!
+                  (fn [& _]
+                    (reset! cleaned? true))]
+      (let [value (:value
+                   (nemesis/invoke! (membership-nemesis)
+                                    test-config
+                                    {:type :info :f :shrink}))]
+        (is (= :skipped (:status value)))
+        (is (= :membership-change-in-progress (:reason value)))
+        (is (= :change-membership (:stage value)))
+        (is (false? @cleaned?))))))
 
 (deftest advances-a-joint-membership-without-waiting
   (let [before #{"n1" "n2" "n3"}
@@ -353,9 +672,39 @@
                  "n1:21001"
                  ["n1" "n2" "n3" "n4"]]]
                @calls))
-        (is (= {:status :completed
-                :target target}
-               (select-keys (:value result) [:status :target])))))))
+        (is (= :skipped (get-in result [:value :status])))
+        (is (= :membership-change-in-progress
+               (get-in result [:value :reason])))
+        (is (= :installed
+               (get-in result [:value :existing-change :status])))
+        (is (= target
+               (get-in result [:value :existing-change :target])))))))
+
+(deftest joint-membership-ambiguity-remains-indeterminate
+  (let [before #{"n1" "n2" "n3"}
+        target (conj before "n4")
+        joint {:leader "n1"
+               :stable? false
+               :effective-voter-configs [before target]}
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis failure-state
+                                     (membership-nemesis))]
+    (with-redefs [cluster/membership-status (constantly joint)
+                  client/change-membership!
+                  (fn [& _]
+                    (throw (ex-info "timeout" {:kind :request-timeout})))]
+      (let [value (:value
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info :f :grow}))]
+        (is (= :indeterminate (:status value)))
+        (is (= :request-result-unknown (:reason value)))
+        (is (= :indeterminate
+               (get-in value [:existing-change :status])))
+        (is (= target (get-in value [:existing-change :target])))
+        (is (= [before target]
+               (get-in value [:existing-change :voter-configs])))
+        (is (nil? (harness/primary-failure failure-state)))))))
 
 (deftest final-restoration-resolves-a-pending-removal
   (let [before (set nodes)
@@ -372,16 +721,16 @@
         calls (atom [])]
     (with-redefs-fn
       {#'membership/stable-membership!
-       (fn [_test]
+       (fn [_test _context]
          (let [status (first @statuses)]
            (swap! statuses subvec 1)
            status))
        #'membership/change-membership-and-await!
-       (fn [_test _leader-endpoint target]
+       (fn [_test _leader-endpoint target _context]
          (swap! calls conj [:complete-removal target])
          (stable-status after))
        #'membership/grow!
-       (fn [_database _test]
+       (fn [_database _test _context]
          (swap! calls conj :grow))
        #'openraft-db/stop-and-wipe-node!
        (fn [_database _test node]
@@ -397,12 +746,16 @@
                  @calls))
           (is (= {:leader "n1"
                   :voters before
-                  :resolved-change {:change :shrink
-                                    :node "n5"
-                                    :before before
-                                    :leader "n1"
-                                    :after after}}
-                 (:value result)))
+                  :status :installed}
+                 (select-keys (:value result)
+                              [:leader :voters :status])))
+          (is (= {:change :shrink
+                  :node "n5"
+                  :before before
+                  :leader "n1"
+                  :after after
+                  :status :installed}
+                 (get-in result [:value :resolved-change])))
           (is (nil? @pending)))))))
 
 (deftest final-restoration-confirms-a-completed-grow
@@ -415,7 +768,7 @@
                        :target after})
         subject (membership/->MembershipNemesis :database pending)]
     (with-redefs-fn
-      {#'membership/stable-membership! (fn [_test]
+      {#'membership/stable-membership! (fn [_test _context]
                                          (stable-status after))
        #'membership/grow! (fn [& _]
                             (throw (ex-info "MUST NOT grow again" {})))}
@@ -429,9 +782,383 @@
                   :source :non-member
                   :before before
                   :leader "n1"
-                  :after after}
+                  :after after
+                  :status :installed}
                  (get-in result [:value :resolved-change])))
+          (is (= :installed (get-in result [:value :status])))
           (is (nil? @pending)))))))
+
+(deftest final-restoration-waits-for-an-in-progress-learner-add
+  (let [before #{"n1" "n2" "n3" "n4"}
+        after (conj before "n5")
+        initial-status (update (stable-status before)
+                               :metrics
+                               assoc
+                               "n5"
+                               {})
+        learner-status (assoc initial-status
+                              :learners #{"n5"}
+                              :non-members #{})
+        original-until! await/until!]
+    (doseq [{:keys [description observed-status expected-calls]}
+            [{:description "continues when the learner is already present"
+              :observed-status learner-status
+              :expected-calls [:start-empty
+                               [:add-learner 1]
+                               :membership-status
+                               :change-membership
+                               :await-stable]}
+             {:description "retries add-learner when the node is still absent"
+              :observed-status initial-status
+              :expected-calls [:start-empty
+                               [:add-learner 1]
+                               :membership-status
+                               [:add-learner 2]
+                               :change-membership
+                               :await-stable]}]]
+      (testing description
+        (let [calls (atom [])
+              statuses (atom [initial-status
+                              initial-status
+                              (stable-status after)])
+              add-attempts (atom 0)
+              failure-state (harness/failure-state)
+              subject (worker/wrap-nemesis
+                       failure-state
+                       (membership/->MembershipNemesis :database (atom nil)))]
+          (with-redefs [await/until!
+                        (fn [condition f opts]
+                          (original-until!
+                           condition
+                           f
+                           (assoc opts :retry-interval 0)))
+                        cluster/await-committed-membership!
+                        (fn [_test]
+                          (let [status (first @statuses)]
+                            (swap! statuses subvec 1)
+                            status))
+                        cluster/membership-status
+                        (fn [_test]
+                          (swap! calls conj :membership-status)
+                          observed-status)
+                        cluster/await-stable-membership!
+                        (fn [_test target]
+                          (swap! calls conj :await-stable)
+                          (is (= after target))
+                          (stable-status after))
+                        openraft-db/start-empty-node!
+                        (fn [& _]
+                          (swap! calls conj :start-empty))
+                        client/add-learner!
+                        (fn [& _]
+                          (let [attempt (swap! add-attempts inc)]
+                            (swap! calls conj [:add-learner attempt])
+                            (when (= 1 attempt)
+                              (throw
+                               (ex-info
+                                "membership change in progress"
+                                {:kind :openraft-error
+                                 :error {:ChangeMembershipError
+                                         {:InProgress {}}}})))))
+                        client/change-membership!
+                        (fn [& _]
+                          (swap! calls conj :change-membership))]
+            (let [value (:value
+                         (nemesis/invoke! subject
+                                          test-config
+                                          {:type :info
+                                           :f :restore-membership}))]
+              (is (= :installed (:status value)))
+              (is (= after (:voters value)))
+              (is (= expected-calls @calls))
+              (is (empty? @statuses))
+              (is (nil? (harness/primary-failure failure-state))))))))))
+
+(deftest final-restoration-bounds-an-in-progress-learner-add
+  (let [before #{"n1" "n2" "n3" "n4"}
+        status (update (stable-status before) :metrics assoc "n5" {})
+        add-attempts (atom 0)
+        changed? (atom false)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database (atom nil)))]
+    (with-redefs [membership/learner-wait-timeout-ms 0
+                  cluster/await-committed-membership! (constantly status)
+                  openraft-db/start-empty-node! (fn [& _])
+                  client/add-learner!
+                  (fn [& _]
+                    (swap! add-attempts inc)
+                    (throw
+                     (ex-info
+                      "membership change in progress"
+                      {:kind :openraft-error
+                       :error {:ChangeMembershipError {:InProgress {}}}})))
+                  client/change-membership!
+                  (fn [& _]
+                    (reset! changed? true))]
+      (let [value (:value
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info
+                                     :f :restore-membership}))]
+        (is (= :skipped (:status value)))
+        (is (= :membership-change-in-progress (:reason value)))
+        (is (= :add-learner (:stage value)))
+        (is (= :add-learner-request-ready (:condition value)))
+        (is (= 1 @add-attempts))
+        (is (false? @changed?))
+        (is (nil? (harness/primary-failure failure-state)))))))
+
+(deftest final-restoration-classifies-impossible-add-learner-errors
+  (doseq [[variant payload]
+          [[:LearnerNotFound {:node_id "n5"}]
+           [:EmptyMembership {}]]]
+    (testing (name variant)
+      (let [before #{"n1" "n2" "n3" "n4"}
+            status (update (stable-status before) :metrics assoc "n5" {})
+            calls (atom [])
+            failure-state (harness/failure-state)
+            subject (worker/wrap-nemesis
+                     failure-state
+                     (membership/->MembershipNemesis :database (atom nil)))]
+        (with-redefs [cluster/await-committed-membership!
+                      (constantly status)
+                      openraft-db/start-empty-node!
+                      (fn [& _]
+                        (swap! calls conj :start-empty))
+                      client/add-learner!
+                      (fn [endpoint node-id api-addr raft-addr]
+                        (swap! calls conj :add-learner)
+                        (is (= ["n1:21001"
+                                "n5"
+                                "n5:21001"
+                                "n5:22001"]
+                               [endpoint node-id api-addr raft-addr]))
+                        (throw
+                         (ex-info
+                          "unexpected add-learner response"
+                          {:kind :openraft-error
+                           :error {:ChangeMembershipError
+                                   {variant payload}}
+                           :response {:body (apply str (repeat 2048 "x"))}})))
+                      client/change-membership!
+                      (fn [& _]
+                        (swap! calls conj :change-membership))]
+          (let [value (:value
+                       (nemesis/invoke! subject
+                                        test-config
+                                        {:type :info
+                                         :f :restore-membership}))]
+            (is (= {:status :indeterminate
+                    :reason :unexpected-sut-response
+                    :stage :add-learner
+                    :error-variant variant}
+                   value))
+            (is (= [:start-empty :add-learner] @calls))
+            (is (not (contains? value :response)))
+            (is (not (contains? value :error)))
+            (is (nil? (harness/primary-failure failure-state)))))))))
+
+(deftest rejects-a-noncanonical-add-learner-request-before-http
+  (let [before #{"n1" "n2" "n3" "n4"}
+        status (update (stable-status before) :metrics assoc "n5" {})
+        http-called? (atom false)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database (atom nil)))
+        thrown (with-redefs [cluster/await-committed-membership!
+                             (constantly status)
+                             cluster/node-info
+                             (fn [_test _node]
+                               {:node-id "n5"
+                                :api-addr "wrong:21001"
+                                :raft-addr "n5:22001"})
+                             openraft-db/start-empty-node! (fn [& _])
+                             client/add-learner!
+                             (fn [& _]
+                               (reset! http-called? true))]
+                 (try
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info
+                                     :f :restore-membership})
+                   nil
+                   (catch Exception e
+                     e)))]
+    (is (= :invalid-add-learner-request (:kind (ex-data thrown))))
+    (is (= {:node-id "n5"
+            :api-addr "n5:21001"
+            :raft-addr "n5:22001"}
+           (:expected (ex-data thrown))))
+    (is (false? @http-called?))
+    (is (identical? thrown
+                    (:throwable (harness/primary-failure failure-state))))))
+
+(deftest final-restoration-keeps-a-prior-indeterminate-add-sticky
+  (let [before #{"n1" "n2" "n3" "n4"}
+        status (update (stable-status before) :metrics assoc "n5" {})
+        pending (atom nil)
+        add-attempts (atom 0)
+        changed? (atom false)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database pending))]
+    (with-redefs [membership/learner-wait-timeout-ms 0
+                  cluster/membership-status (constantly status)
+                  cluster/await-committed-membership! (constantly status)
+                  openraft-db/start-empty-node! (fn [& _])
+                  client/add-learner!
+                  (fn [& _]
+                    (case (swap! add-attempts inc)
+                      1 (throw (ex-info "invalid response"
+                                        {:kind :invalid-response}))
+                      (throw
+                       (ex-info
+                        "membership change in progress"
+                        {:kind :openraft-error
+                         :error {:ChangeMembershipError
+                                 {:InProgress {}}}}))))
+                  client/change-membership!
+                  (fn [& _]
+                    (reset! changed? true))]
+      (let [runtime-value (:value
+                           (nemesis/invoke! subject
+                                            test-config
+                                            {:type :info :f :grow}))
+            retained @pending
+            final-value (:value
+                         (nemesis/invoke! subject
+                                          test-config
+                                          {:type :info
+                                           :f :restore-membership}))]
+        (is (= :indeterminate (:status runtime-value)))
+        (is (= :request-result-unknown (:reason runtime-value)))
+        (is (= :add-learner (:stage runtime-value)))
+        (is (= :indeterminate (:status retained)))
+        (is (= :request-result-unknown (:reason retained)))
+        (is (= :add-learner (:stage retained)))
+        (is (= :indeterminate (:status final-value)))
+        (is (= :request-result-unknown (:reason final-value)))
+        (is (= :add-learner (:stage final-value)))
+        (is (= retained @pending))
+        (is (= 2 @add-attempts))
+        (is (false? @changed?))
+        (is (nil? (harness/primary-failure failure-state)))))))
+
+(deftest final-restoration-preserves-an-indeterminate-request
+  (let [before (set nodes)
+        after (disj before "n5")
+        pending-value {:change :shrink
+                       :node "n5"
+                       :leader "n1"
+                       :before before
+                       :target after
+                       :stage :change-membership}
+        pending (atom pending-value)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database pending))
+        cleaned? (atom false)
+        timeout (condition-timeout :stable-membership)]
+    (with-redefs [cluster/await-committed-membership!
+                  (constantly (stable-status before))
+                  cluster/await-stable-membership!
+                  (fn [& _] (throw timeout))
+                  client/change-membership!
+                  (fn [& _]
+                    (throw (ex-info "invalid application response"
+                                    {:kind :invalid-response})))
+                  openraft-db/stop-and-wipe-node!
+                  (fn [& _] (reset! cleaned? true))]
+      (let [value (:value
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info
+                                     :f :restore-membership}))]
+        (is (= :indeterminate (:status value)))
+        (is (= :request-result-unknown (:reason value)))
+        (is (= :change-membership (:stage value)))
+        (is (= pending-value @pending))
+        (is (false? @cleaned?))
+        (is (nil? (harness/primary-failure failure-state)))))))
+
+(deftest final-restoration-does-not-demote-earlier-ambiguity
+  (let [before (set nodes)
+        after (disj before "n5")
+        pending-value {:change :shrink
+                       :node "n5"
+                       :leader "n1"
+                       :before before
+                       :target after
+                       :stage :change-membership
+                       :status :indeterminate}
+        pending (atom pending-value)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database pending))
+        cleaned? (atom false)]
+    (with-redefs [cluster/await-committed-membership!
+                  (constantly (stable-status before))
+                  client/change-membership!
+                  (fn [& _]
+                    (throw (ex-info "no leader" {:kind :unreachable})))
+                  openraft-db/stop-and-wipe-node!
+                  (fn [& _] (reset! cleaned? true))]
+      (let [value (:value
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info
+                                     :f :restore-membership}))]
+        (is (= :indeterminate (:status value)))
+        (is (= :request-result-unknown (:reason value)))
+        (is (= :change-membership (:stage value)))
+        (is (= pending-value @pending))
+        (is (false? @cleaned?))
+        (is (nil? (harness/primary-failure failure-state)))))))
+
+(deftest final-restoration-distinguishes-pre-attempt-and-harness-failures
+  (testing "a modeled wait expiry before a request is skipped"
+    (let [failure-state (harness/failure-state)
+          subject (worker/wrap-nemesis
+                   failure-state
+                   (membership/->MembershipNemesis :database (atom nil)))
+          timeout (condition-timeout :committed-membership)]
+      (with-redefs [cluster/await-committed-membership!
+                    (fn [_test] (throw timeout))]
+        (let [value (:value
+                     (nemesis/invoke! subject
+                                      test-config
+                                      {:type :info
+                                       :f :restore-membership}))]
+          (is (= :skipped (:status value)))
+          (is (= :membership-not-ready (:reason value)))
+          (is (nil? (harness/primary-failure failure-state)))))))
+
+  (testing "an unknown wait exception takes the direct Harness path"
+    (let [failure-state (harness/failure-state)
+          error (RuntimeException. "membership wait bug")
+          subject (worker/wrap-nemesis
+                   failure-state
+                   (membership/->MembershipNemesis :database (atom nil)))
+          thrown (with-redefs [cluster/await-committed-membership!
+                               (fn [_test] (throw error))]
+                   (try
+                     (nemesis/invoke! subject
+                                      test-config
+                                      {:type :info
+                                       :f :restore-membership})
+                     nil
+                     (catch Exception e
+                       e)))]
+      (is (identical? error thrown))
+      (is (identical? error
+                      (:throwable
+                       (harness/primary-failure failure-state)))))))
 
 (deftest preserves-the-minimum-membership
   (let [changed? (atom false)
@@ -444,7 +1171,7 @@
                                     test-config
                                     {:type :info
                                      :f :shrink})]
-        (is (= :minimum-membership (:value result)))
+        (is (= (skipped :minimum-membership {}) (:value result)))
         (is (false? @changed?))))))
 
 (deftest membership-package-requires-room-to-change
@@ -468,21 +1195,25 @@
         four-voters (disj all-voters "n5")
         shrink {:type :info
                 :f :grow
-                :value {:change :shrink
-                        :before all-voters
-                        :after four-voters}}
+                :value (installed {:change :shrink
+                                   :node "n5"
+                                   :leader "n1"
+                                   :before all-voters
+                                   :after four-voters})}
         grow {:type :info
               :f :grow
-              :value {:change :grow
-                      :before four-voters
-                      :after all-voters}}
+              :value (installed {:change :grow
+                                 :node "n5"
+                                 :leader "n1"
+                                 :before four-voters
+                                 :after all-voters})}
         restore {:type :info
                  :f :restore-membership
-                 :value {:leader "n1"
-                         :voters all-voters}}
+                 :value (installed {:leader "n1"
+                                    :voters all-voters})}
         recovery {:type :info
                   :f :await-recovery
-                  :value {:leader "n1"}}]
+                  :value (installed {:leader "n1"})}]
     (testing "a resolved change is attributed to its actual fault class"
       (is (:valid? (checker/check subject
                                   test-config
@@ -494,10 +1225,11 @@
                     subject
                     test-config
                     [(assoc shrink
-                            :value {:change :shrink
-                                    :status :indeterminate
-                                    :before all-voters
-                                    :target four-voters})
+                            :value (indeterminate
+                                    :request-result-unknown
+                                    {:change :shrink
+                                     :before all-voters
+                                     :target four-voters}))
                      grow
                      restore
                      recovery]
@@ -510,10 +1242,11 @@
                     subject
                     test-config
                     [(assoc shrink
-                            :value {:change :shrink
-                                    :status :indeterminate
-                                    :before all-voters
-                                    :target four-voters})
+                            :value (indeterminate
+                                    :request-result-unknown
+                                    {:change :shrink
+                                     :before all-voters
+                                     :target four-voters}))
                      grow
                      (assoc-in restore
                                [:value :resolved-change]
@@ -539,8 +1272,9 @@
                                    restore
                                    recovery
                                    (assoc recovery
-                                          :value nil
-                                          :error :timeout)]
+                                          :value (indeterminate
+                                                  :recovery-timeout
+                                                  {}))]
                                   {})]
         (is (false? (:valid? result)))
         (is (false? (:recovered? result)))))
@@ -552,3 +1286,54 @@
                                   {})]
         (is (false? (:valid? result)))
         (is (false? (:restored? result)))))))
+
+(deftest reanalyzes-exact-legacy-membership-history
+  (let [subject (:checker (membership/membership-package
+                           :database
+                           test-config))
+        all-voters (set nodes)
+        four-voters (disj all-voters "n5")
+        shrink {:change :shrink
+                :node "n5"
+                :leader "n1"
+                :before all-voters
+                :after four-voters}
+        grow {:change :grow
+              :node "n5"
+              :leader "n1"
+              :before four-voters
+              :after all-voters}
+        history [{:f :shrink :value shrink}
+                 {:f :restore-membership
+                  :value {:leader "n1"
+                          :voters all-voters
+                          :resolved-change grow}}
+                 {:f :await-recovery :value {:leader "n1"}}]
+        check #(checker/check subject test-config % {})]
+    (testing "exact pre-status change, restore, and recovery shapes remain valid"
+      (is (true? (:valid? (check history)))))
+
+    (testing "explicit status overrides direct legacy-looking change evidence"
+      (doseq [status [:skipped :indeterminate]]
+        (let [result (check (assoc-in history [0 :value :status] status))]
+          (is (false? (:valid? result)) (name status))
+          (is (= [:shrink] (:missing-changes result)) (name status)))))
+
+    (testing "explicit status overrides nested resolved-change evidence"
+      (doseq [status [:skipped :indeterminate]]
+        (let [result (check (assoc-in history
+                                      [1 :value :resolved-change :status]
+                                      status))]
+          (is (false? (:valid? result)) (name status))
+          (is (= [:grow] (:missing-changes result)) (name status)))))
+
+    (testing "explicit restore and recovery status remain authoritative"
+      (doseq [status [:skipped :indeterminate]]
+        (let [restore-result (check (assoc-in history
+                                              [1 :value :status]
+                                              status))
+              recovery-result (check (assoc-in history
+                                               [2 :value :status]
+                                               status))]
+          (is (false? (:restored? restore-result)) (name status))
+          (is (false? (:recovered? recovery-result)) (name status)))))))

--- a/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
@@ -2,12 +2,24 @@
   (:require [clojure.set :as set]
             [clojure.test :refer [deftest is testing]]
             [jepsen [checker :as checker]
+             [control :as c]
              [nemesis :as nemesis]]
-            [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft [cluster :as cluster]
+             [harness :as harness]
+             [worker :as worker]]
             [jepsen.openraft.nemesis.partition :as partition]
             [jepsen.openraft.quorum :as quorum]))
 
 (def nodes ["n1" "n2" "n3"])
+
+(defn- installed [details]
+  (assoc details :status :installed))
+
+(defn- skipped [reason details]
+  (assoc details :status :skipped :reason reason))
+
+(defn- indeterminate [reason details]
+  (assoc details :status :indeterminate :reason reason))
 
 (defn- teardown-partitioner [teardown]
   (reify nemesis/Nemesis
@@ -70,14 +82,30 @@
           (is (= :leader-in-minority
                  (-> result :value :mode)))
           (is (= "n2"
-                 (-> result :value :leader))))))
+                 (-> result :value :leader)))
+          (is (= :installed (get-in result [:value :status]))))))
 
     (testing "no partition is installed without a supported leader"
       (reset! invocations [])
       (with-redefs [cluster/membership-status (constantly nil)]
-        (is (= :no-supported-leader
+        (is (= (skipped :no-supported-leader {})
                (:value (nemesis/invoke! subject {:nodes nodes} op))))
-        (is (empty? @invocations))))))
+        (is (empty? @invocations))))
+
+    (testing "no partition is installed without a safe target"
+      (reset! invocations [])
+      (with-redefs [cluster/membership-status
+                    (constantly {:leader "n1"})
+                    cluster/voter-configs
+                    (fn [_test _status] [#{"n1"}])]
+        (let [value (:value (nemesis/invoke! subject
+                                             {:nodes ["n1"]}
+                                             (assoc op
+                                                    :value
+                                                    :leader-in-majority)))]
+          (is (= :skipped (:status value)))
+          (is (= :no-safe-partition-target (:reason value)))
+          (is (empty? @invocations)))))))
 
 (deftest partition-cleanup-failure-does-not-mask-analysis
   (let [attempted? (atom false)
@@ -89,6 +117,96 @@
     (nemesis/teardown! (partition/->PartitionNemesis partitioner)
                        {:nodes nodes})
     (is @attempted?)))
+
+(deftest partition-control-failures-take-the-harness-path
+  (let [error (ex-info "SSH failed" {:kind :ssh})
+        partitioner (reify nemesis/Nemesis
+                      (setup! [this _test]
+                        this)
+                      (invoke! [_ _test _op]
+                        (throw error))
+                      (teardown! [this _test]
+                        this))
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (partition/->PartitionNemesis partitioner))
+        setup-subject (nemesis/setup! subject {:nodes nodes})
+        op {:type :info
+            :process :nemesis
+            :f :start-partition
+            :value :leader-in-minority}
+        thrown (with-redefs [cluster/membership-status
+                             (constantly {:leader "n1"})
+                             cluster/voter-configs
+                             (fn [_test _status] [(set nodes)])]
+                 (try
+                   (nemesis/invoke! setup-subject {:nodes nodes} op)
+                   nil
+                   (catch Exception e
+                     e)))]
+    (is (identical? error thrown))
+    (is (identical? error
+                    (:throwable (harness/primary-failure failure-state))))))
+
+(deftest runtime-partition-control-restores-receiving-thread-interruption
+  (let [test {:nodes nodes
+              :sessions (zipmap nodes (repeat :unused-session))}
+        cases [[:interrupted-exception
+                #(InterruptedException. "interrupted")]
+               [:interrupted-io
+                #(java.io.InterruptedIOException. "interrupted")]
+               [:closed-by-interrupt
+                #(java.nio.channels.ClosedByInterruptException.)]
+               [:wrapped
+                #(ex-info "interrupted" {:kind :interrupted})]]
+        operations [[:start
+                     {:type :info
+                      :process :nemesis
+                      :f :start-partition
+                      :value :leader-in-minority}]
+                    [:stop
+                     {:type :info
+                      :process :nemesis
+                      :f :stop-partition}]]]
+    (doseq [[operation op] operations
+            [interruption make-error] cases]
+      (testing (str (name operation) " " (name interruption))
+        (Thread/interrupted)
+        (try
+          (let [error (make-error)
+                partitioner
+                (reify nemesis/Nemesis
+                  (setup! [this _test]
+                    this)
+                  (invoke! [_ test _op]
+                    (c/on-nodes test
+                                (fn [_test node]
+                                  (if (= "n2" node)
+                                    (throw error)
+                                    :ok))))
+                  (teardown! [this _test]
+                    this))
+                failure-state (harness/failure-state)
+                subject (->> partitioner
+                             partition/->PartitionNemesis
+                             (worker/wrap-nemesis failure-state))
+                setup-subject (nemesis/setup! subject test)
+                [thrown interrupted?]
+                (with-redefs [cluster/membership-status
+                              (constantly {:leader "n1"})
+                              cluster/voter-configs
+                              (fn [_test _status] [(set nodes)])]
+                  (try
+                    (nemesis/invoke! setup-subject test op)
+                    [nil (.isInterrupted (Thread/currentThread))]
+                    (catch Exception e
+                      [e (.isInterrupted (Thread/currentThread))])))]
+            (is (identical? error thrown))
+            (is interrupted?)
+            (is (nil? (harness/primary-failure failure-state))))
+          (finally
+            (Thread/interrupted)))))))
 
 (deftest partition-cleanup-preserves-interruptions
   (doseq [[label error]
@@ -119,35 +237,40 @@
 (deftest requires-both-partitions-and-an-intact-cluster
   (let [subject (#'partition/coverage-checker)
         complete-history [{:f :start-partition
-                           :value {:mode :leader-in-majority}}
+                           :value (installed {:mode :leader-in-majority})}
                           {:f :stop-partition
-                           :value :network-healed}
+                           :value (installed {})}
                           {:f :start-partition
-                           :value {:mode :leader-in-minority}}
+                           :value (installed {:mode :leader-in-minority})}
                           {:f :stop-partition
-                           :value :network-healed}
+                           :value (installed {})}
                           {:f :await-recovery
-                           :value {:leader "n2"}}]
+                           :value (installed {:leader "n2"})}]
         missing-mode-history [{:f :start-partition
-                               :value {:mode :leader-in-majority}}
+                               :value (installed
+                                       {:mode :leader-in-majority})}
                               {:f :stop-partition
-                               :value :network-healed}
+                               :value (installed {})}
                               {:f :start-partition
-                               :value :no-supported-leader}
+                               :value (skipped :no-supported-leader {})}
                               {:f :stop-partition
-                               :value :network-healed}
+                               :value (installed {})}
                               {:f :await-recovery
-                               :value {:leader "n2"}}]
+                               :value (installed {:leader "n2"})}]
         unrecovered-history [{:f :start-partition
-                              :value {:mode :leader-in-majority}}
+                              :value (installed
+                                      {:mode :leader-in-majority})}
                              {:f :stop-partition
-                              :value :network-healed}
+                              :value (installed {})}
                              {:f :start-partition
-                              :value {:mode :leader-in-minority}}
+                              :value (installed
+                                      {:mode :leader-in-minority})}
                              {:f :stop-partition
-                              :value :network-healed}
+                              :value (installed {})}
                              {:f :await-recovery
-                              :error :timeout}]]
+                              :value (indeterminate
+                                      :recovery-timeout
+                                      {})}]]
     (testing "both modes complete and the cluster recovers"
       (let [result (checker/check subject {} complete-history {})]
         (is (:valid? result))
@@ -172,8 +295,8 @@
                  {:type :info
                   :process :nemesis
                   :f :start-partition
-                  :value {:mode :leader-in-majority
-                          :leader "n1"}}
+                  :value (installed {:mode :leader-in-majority
+                                     :leader "n1"})}
                  {:type :info
                   :process :nemesis
                   :f :stop-partition
@@ -181,7 +304,7 @@
                  {:type :info
                   :process :nemesis
                   :f :stop-partition
-                  :value :network-healed}
+                  :value (installed {})}
                  {:type :info
                   :process :nemesis
                   :f :start-partition
@@ -189,8 +312,8 @@
                  {:type :info
                   :process :nemesis
                   :f :start-partition
-                  :value {:mode :leader-in-minority
-                          :leader "n1"}}
+                  :value (installed {:mode :leader-in-minority
+                                     :leader "n1"})}
                  {:type :info
                   :process :nemesis
                   :f :stop-partition
@@ -198,7 +321,7 @@
                  {:type :info
                   :process :nemesis
                   :f :stop-partition
-                  :value :network-healed}
+                  :value (installed {})}
                  {:type :info
                   :process :nemesis
                   :f :await-recovery
@@ -206,7 +329,7 @@
                  {:type :info
                   :process :nemesis
                   :f :await-recovery
-                  :value {:leader "n2"}}
+                  :value (installed {:leader "n2"})}
                  {:type :info
                   :process :nemesis
                   :f :await-recovery
@@ -214,33 +337,65 @@
                  {:type :info
                   :process :nemesis
                   :f :await-recovery
-                  :value {:leader "n2"}}]
+                  :value (installed {:leader "n2"})}]
         result (checker/check subject {} history {})]
     (is (:valid? result))
     (is (= [:leader-in-majority :leader-in-minority]
            (:observed-modes result)))
     (is (= :intact (:cluster-state result)))))
 
+(deftest reanalyzes-exact-legacy-partition-history
+  (let [subject (#'partition/coverage-checker)
+        start (fn [mode]
+                {:f :start-partition
+                 :value {:mode mode
+                         :leader "n1"
+                         :voter-configs [(set nodes)]
+                         :components [["n1" "n2"] ["n3"]]}})
+        history [(start :leader-in-majority)
+                 {:f :stop-partition :value :network-healed}
+                 (start :leader-in-minority)
+                 {:f :stop-partition :value :network-healed}
+                 {:f :await-recovery :value {:leader "n2"}}]]
+    (testing "the exact pre-status success shapes remain valid"
+      (let [result (checker/check subject {} history {})]
+        (is (true? (:valid? result)))
+        (is (= :intact (:cluster-state result)))))
+
+    (testing "an explicit status is authoritative over legacy-looking fields"
+      (doseq [status [:skipped :indeterminate]]
+        (let [changed (assoc-in history [0 :value :status] status)
+              result (checker/check subject {} changed {})]
+          (is (false? (:valid? result)) (name status))
+          (is (= [:leader-in-majority]
+                 (:missing-modes result)) (name status))))
+
+      (doseq [status [:skipped :indeterminate]]
+        (let [changed (assoc-in history [4 :value :status] status)
+              result (checker/check subject {} changed {})]
+          (is (false? (:valid? result)) (name status))
+          (is (= :recovery-pending
+                 (:cluster-state result)) (name status)))))))
+
 (deftest reports-an-indeterminate-partition-state
   (let [subject (#'partition/coverage-checker)
         covered-history [{:f :start-partition
-                          :value {:mode :leader-in-majority}}
+                          :value (installed {:mode :leader-in-majority})}
                          {:f :stop-partition
-                          :value :network-healed}
+                          :value (installed {})}
                          {:f :start-partition
-                          :value {:mode :leader-in-minority}}
+                          :value (installed {:mode :leader-in-minority})}
                          {:f :stop-partition
-                          :value :network-healed}
+                          :value (installed {})}
                          {:f :await-recovery
-                          :value {:leader "n2"}}]
+                          :value (installed {:leader "n2"})}]
         indeterminate-history
         (conj covered-history
               {:type :info
                :process :nemesis
                :f :start-partition
-               :value :leader-in-majority
-               :error "indeterminate: partition failed"
-               :exception (ex-info "partition failed" {})})
+               :value (indeterminate :effect-unknown
+                                     {:mode :leader-in-majority})})
         result (checker/check subject {} indeterminate-history {})]
     (is (= :unknown (:valid? result)))
     (is (= :unknown (:cluster-state result)))))
@@ -248,21 +403,25 @@
 (deftest reports-an-indeterminate-heal-state
   (let [subject (#'partition/coverage-checker)
         history-before-heal [{:f :start-partition
-                              :value {:mode :leader-in-majority}}
+                              :value (installed
+                                      {:mode :leader-in-majority})}
                              {:f :stop-partition
-                              :value :network-healed}
+                              :value (installed {})}
                              {:f :start-partition
-                              :value {:mode :leader-in-minority}}
+                              :value (installed
+                                      {:mode :leader-in-minority})}
                              {:f :stop-partition
-                              :error :heal-failed}]
+                              :value (indeterminate
+                                      :effect-unknown
+                                      {})}]
         indeterminate-history (conj history-before-heal
                                     {:f :await-recovery
-                                     :value {:leader "n2"}})
+                                     :value (installed {:leader "n2"})})
         recovered-history (into history-before-heal
                                 [{:f :stop-partition
-                                  :value :network-healed}
+                                  :value (installed {})}
                                  {:f :await-recovery
-                                  :value {:leader "n2"}}])]
+                                  :value (installed {:leader "n2"})}])]
     (testing "a successful readiness check cannot prove that a failed heal completed"
       (let [result (checker/check subject {} indeterminate-history {})]
         (is (= :unknown (:valid? result)))

--- a/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
@@ -107,16 +107,28 @@
           (is (= :no-safe-partition-target (:reason value)))
           (is (empty? @invocations)))))))
 
-(deftest partition-cleanup-failure-does-not-mask-analysis
-  (let [attempted? (atom false)
+(deftest partition-cleanup-failure-records-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        error (ex-info "unreachable" {:kind :unreachable})
+        attempted? (atom false)
         partitioner (teardown-partitioner
                      #(do
                         (reset! attempted? true)
-                        (throw (ex-info "unreachable"
-                                        {:kind :unreachable}))))]
-    (nemesis/teardown! (partition/->PartitionNemesis partitioner)
+                        (throw error)))
+        subject (worker/wrap-nemesis-teardown
+                 failure-state
+                 :partition
+                 (partition/->PartitionNemesis partitioner))]
+    (nemesis/teardown! subject
                        {:nodes nodes})
-    (is @attempted?)))
+    (is @attempted?)
+    (let [failure (harness/primary-failure failure-state)]
+      (is (= :nemesis (:source failure)))
+      (is (= {:phase :teardown
+              :component :partition
+              :nodes nodes}
+             (:context failure)))
+      (is (identical? error (:throwable failure))))))
 
 (deftest partition-control-failures-take-the-harness-path
   (let [error (ex-info "SSH failed" {:kind :ssh})

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -1,6 +1,7 @@
 (ns jepsen.openraft.nemesis.process-test
   (:require [clojure.test :refer [deftest is testing]]
             [jepsen [checker :as checker]
+             [db :as db]
              [nemesis :as nemesis]
              [random :as random]]
             [jepsen.openraft.cluster :as cluster]
@@ -10,13 +11,31 @@
 
 (def voters ["n1" "n2" "n3" "n4" "n5"])
 
+(defn- installed [details]
+  (assoc details :status :installed))
+
+(defn- skipped [reason details]
+  (assoc details :status :skipped :reason reason))
+
+(defn- indeterminate [reason details]
+  (assoc details :status :indeterminate :reason reason))
+
+(defn- delegate-completion [op]
+  (case (:f op)
+    :kill (assoc op :value (zipmap (:value op) (repeat :killed)))
+    :start (assoc op :value (zipmap (:value op)
+                                    (repeat :start-confirmed)))
+    :pause (assoc op :value (zipmap (:value op) (repeat :paused)))
+    :resume (assoc op :value (zipmap (:value op) (repeat :resumed)))
+    op))
+
 (defn- recording-nemesis [invocations]
   (reify nemesis/Nemesis
     (setup! [this _test]
       this)
     (invoke! [_ _test op]
       (swap! invocations conj op)
-      op)
+      (delegate-completion op))
     (teardown! [this _test]
       this)))
 
@@ -28,7 +47,7 @@
       (swap! invocations conj op)
       (when (= failing-f (:f op))
         (throw error))
-      op)
+      (delegate-completion op))
     (teardown! [this _test]
       this)))
 
@@ -82,9 +101,316 @@
                         :f :restart-process})]
         (is (= ["n1"] (get-in killed [:value :nodes])))
         (is (= ["n1"] (get-in restarted [:value :nodes])))
+        (is (= :installed (get-in killed [:value :status])))
+        (is (= :installed (get-in restarted [:value :status])))
+        (is (= {"n1" :killed}
+               (get-in killed [:value :stop-results])))
+        (is (= {"n1" :start-confirmed}
+               (get-in restarted [:value :start-results])))
         (is (= [[:kill ["n1"]]
                 [:start ["n1"]]]
                (mapv (juxt :f :value) @invocations)))))))
+
+(deftest derives-process-outcomes-from-confirmed-node-results
+  (let [test {:nodes ["n1" "n2" "n3"]}
+        status {:leader "n1"}
+        invoke-with-results
+        (fn [results]
+          (let [delegate (reify nemesis/Nemesis
+                           (setup! [this _test] this)
+                           (invoke! [_ _test op]
+                             (assoc op :value results))
+                           (teardown! [this _test] this))
+                subject (process/->ProcessNemesis delegate (atom nil))]
+            (with-redefs [cluster/membership-status (constantly status)
+                          cluster/voter-configs
+                          (fn [_test _status] [(set (:nodes test))])]
+              (nemesis/invoke! subject
+                               test
+                               {:type :info
+                                :f :kill-process
+                                :value :leader-killed}))))]
+    (testing "every pre-probe absence skips the kill"
+      (let [value (:value (invoke-with-results {"n1" :target-absent}))]
+        (is (= :skipped (:status value)))
+        (is (= :target-absent (:reason value)))))
+
+    (testing "an explicit exit race skips the kill"
+      (let [value (:value
+                   (invoke-with-results {"n1" :target-already-exited}))]
+        (is (= :skipped (:status value)))
+        (is (= :target-already-exited (:reason value)))))
+
+    (testing "any confirmed kill installs a multi-node disruption"
+      (let [five-node-test {:nodes voters}
+            results {"n2" :killed
+                     "n3" :target-absent}
+            delegate (reify nemesis/Nemesis
+                       (setup! [this _test] this)
+                       (invoke! [_ _test op]
+                         (assoc op :value results))
+                       (teardown! [this _test] this))
+            subject (process/->ProcessNemesis delegate (atom nil))
+            prefer-targets (fn [candidates]
+                             (cons #{"n2" "n3"}
+                                   (remove #{#{"n2" "n3"}} candidates)))]
+        (with-redefs [cluster/membership-status
+                      (constantly {:leader "n1"})
+                      cluster/voter-configs
+                      (fn [_test _status] [(set voters)])
+                      random/shuffle prefer-targets]
+          (let [value (:value
+                       (nemesis/invoke! subject
+                                        five-node-test
+                                        {:type :info
+                                         :f :kill-process
+                                         :value :leader-survives}))]
+            (is (= :installed (:status value)))
+            (is (= results (:stop-results value)))))))))
+
+(deftest derives-pause-outcomes-from-confirmed-node-results
+  (let [test {:nodes ["n1" "n2" "n3"]}
+        status {:leader "n1"
+                :metrics (zipmap (:nodes test) (repeat {}))}
+        invoke-with-result
+        (fn [result]
+          (let [delegate (reify nemesis/Nemesis
+                           (setup! [this _test] this)
+                           (invoke! [_ _test op]
+                             (assoc op
+                                    :value (zipmap (:value op)
+                                                   (repeat result))))
+                           (teardown! [this _test] this))
+                subject (process/->PauseNemesis delegate (atom nil))]
+            (with-redefs [cluster/membership-status (constantly status)
+                          cluster/voter-configs
+                          (fn [_test _status] [(set (:nodes test))])]
+              (nemesis/invoke! subject
+                               test
+                               {:type :info
+                                :f :pause-process
+                                :value :leader-paused}))))]
+    (testing "every pre-probe absence skips the pause"
+      (let [value (:value (invoke-with-result :target-absent))]
+        (is (= :skipped (:status value)))
+        (is (= :target-absent (:reason value)))
+        (is (= {"n1" :target-absent} (:pause-results value)))))
+
+    (testing "an explicit exit race skips the pause"
+      (let [value (:value (invoke-with-result :target-already-exited))]
+        (is (= :skipped (:status value)))
+        (is (= :target-already-exited (:reason value)))
+        (is (= {"n1" :target-already-exited}
+               (:pause-results value)))))
+
+    (testing "a confirmed pause installs the disruption"
+      (let [value (:value (invoke-with-result :paused))]
+        (is (= :installed (:status value)))
+        (is (= {"n1" :paused} (:pause-results value)))))))
+
+(deftest derives-resume-outcomes-from-confirmed-node-results
+  (let [test {:nodes ["n1" "n2" "n3"]}
+        disruption {:mode :leader-paused
+                    :leader "n1"
+                    :nodes ["n1"]
+                    :voter-configs [(set (:nodes test))]
+                    :survivors ["n2" "n3"]
+                    :pause-results {"n1" :paused}}
+        invoke-with-results
+        (fn [results]
+          (let [delegate (reify nemesis/Nemesis
+                           (setup! [this _test] this)
+                           (invoke! [_ _test op]
+                             (assoc op :value results))
+                           (teardown! [this _test] this))
+                active (atom disruption)
+                subject (process/->PauseNemesis delegate active)
+                completion (nemesis/invoke! subject
+                                            test
+                                            {:type :info
+                                             :f :resume-process})]
+            [completion @active]))]
+    (testing "every absent target skips the resume"
+      (let [results (zipmap (:nodes test) (repeat :target-absent))
+            [completion active] (invoke-with-results results)
+            value (:value completion)]
+        (is (= :skipped (:status value)))
+        (is (= :target-absent (:reason value)))
+        (is (= results (:resume-results value)))
+        (is (nil? active))))
+
+    (testing "an explicit exit race skips the resume"
+      (let [results {"n1" :target-absent
+                     "n2" :target-already-exited
+                     "n3" :target-absent}
+            [completion active] (invoke-with-results results)
+            value (:value completion)]
+        (is (= :skipped (:status value)))
+        (is (= :target-already-exited (:reason value)))
+        (is (= results (:resume-results value)))
+        (is (nil? active))))
+
+    (testing "any confirmed resume installs multi-node recovery"
+      (let [results {"n1" :resumed
+                     "n2" :target-absent
+                     "n3" :target-already-exited}
+            [completion active] (invoke-with-results results)
+            value (:value completion)]
+        (is (= :installed (:status value)))
+        (is (= results (:resume-results value)))
+        (is (= disruption (:paused value)))
+        (is (nil? active))))))
+
+(deftest rejects-malformed-process-control-results-and-retains-recovery-state
+  (let [test {:nodes ["n1" "n2" "n3"]}
+        invocations (atom 0)
+        delegate (reify nemesis/Nemesis
+                   (setup! [this _test] this)
+                   (invoke! [_ _test op]
+                     (swap! invocations inc)
+                     (assoc op :value {}))
+                   (teardown! [this _test] this))
+        active (atom nil)
+        subject (process/->ProcessNemesis delegate active)]
+    (with-redefs [cluster/membership-status (constantly {:leader "n1"})
+                  cluster/voter-configs
+                  (fn [_test _status] [(set (:nodes test))])]
+      (let [error (try
+                    (nemesis/invoke! subject
+                                     test
+                                     {:type :info
+                                      :f :kill-process
+                                      :value :leader-killed})
+                    nil
+                    (catch Exception e
+                      e))]
+        (is (= :unexpected-process-control-result
+               (:kind (ex-data error))))
+        (is (= ["n1"] (:nodes @active))))
+
+      (let [error (try
+                    (nemesis/invoke! subject
+                                     test
+                                     {:type :info
+                                      :f :restart-process})
+                    nil
+                    (catch Exception e
+                      e))]
+        (is (= :unexpected-process-control-result
+               (:kind (ex-data error))))
+        (is (= ["n1"] (:nodes @active)))
+        (is (= 2 @invocations))))))
+
+(deftest rejects-malformed-pause-control-results-and-retains-recovery-state
+  (let [test {:nodes ["n1" "n2" "n3"]}
+        status {:leader "n1"
+                :metrics (zipmap (:nodes test) (repeat {}))}
+        delegate (reify nemesis/Nemesis
+                   (setup! [this _test] this)
+                   (invoke! [_ _test op]
+                     (assoc op :value {}))
+                   (teardown! [this _test] this))
+        active (atom nil)
+        subject (process/->PauseNemesis delegate active)]
+    (with-redefs [cluster/membership-status (constantly status)
+                  cluster/voter-configs
+                  (fn [_test _status] [(set (:nodes test))])]
+      (let [error (try
+                    (nemesis/invoke! subject
+                                     test
+                                     {:type :info
+                                      :f :pause-process
+                                      :value :leader-paused})
+                    nil
+                    (catch Exception e
+                      e))]
+        (is (= :unexpected-process-control-result
+               (:kind (ex-data error))))
+        (is (= ["n1"] (:nodes @active))))
+
+      (let [active-before-resume @active
+            error (try
+                    (nemesis/invoke! subject
+                                     test
+                                     {:type :info
+                                      :f :resume-process})
+                    nil
+                    (catch Exception e
+                      e))]
+        (is (= :unexpected-process-control-result
+               (:kind (ex-data error))))
+        (is (= active-before-resume @active))))))
+
+(deftest multi-node-control-restores-the-receiving-thread-interrupt-flag
+  (let [test {:nodes voters
+              :sessions (zipmap voters (repeat :unused-session))}
+        planned #{"n2" "n3"}
+        disruption {:mode :leader-unpaused
+                    :leader "n1"
+                    :nodes ["n2" "n3"]
+                    :voter-configs [(set voters)]
+                    :survivors ["n1" "n4" "n5"]
+                    :pause-results {"n2" :paused "n3" :paused}}
+        prefer-planned (fn [candidates]
+                         (cons planned (remove #{planned} candidates)))
+        cases
+        [[:kill
+          #(InterruptedException. "interrupted")
+          process/process-nemesis
+          nil
+          {:type :info :f :kill-process :value :leader-survives}]
+         [:start
+          #(java.io.InterruptedIOException. "interrupted")
+          process/process-nemesis
+          :killed
+          {:type :info :f :restart-process}]
+         [:pause
+          #(java.nio.channels.ClosedByInterruptException.)
+          process/pause-nemesis
+          nil
+          {:type :info :f :pause-process :value :leader-unpaused}]
+         [:resume
+          #(ex-info "interrupted" {:kind :interrupted})
+          process/pause-nemesis
+          :paused
+          {:type :info :f :resume-process}]]]
+    (doseq [[label make-error make-subject active-key op] cases]
+      (testing (name label)
+        (Thread/interrupted)
+        (try
+          (let [error (make-error)
+                database (reify
+                           db/Process
+                           (kill! [_ _test _node]
+                             (throw error))
+                           (start! [_ _test _node]
+                             (throw error))
+
+                           db/Pause
+                           (pause! [_ _test _node]
+                             (throw error))
+                           (resume! [_ _test _node]
+                             (throw error)))
+                subject (make-subject database)
+                _ (when active-key
+                    (reset! (get subject active-key) disruption))
+                [thrown interrupted?]
+                (with-redefs [cluster/membership-status
+                              (constantly
+                               {:leader "n1"
+                                :metrics (zipmap voters (repeat {}))})
+                              cluster/voter-configs
+                              (fn [_test _status] [(set voters)])
+                              random/shuffle prefer-planned]
+                  (try
+                    (nemesis/invoke! subject test op)
+                    [nil (.isInterrupted (Thread/currentThread))]
+                    (catch Exception e
+                      [e (.isInterrupted (Thread/currentThread))])))]
+            (is (identical? error thrown))
+            (is interrupted?))
+          (finally
+            (Thread/interrupted)))))))
 
 (deftest restarts-all-planned-processes-after-a-kill-error
   (let [invocations (atom [])
@@ -116,7 +442,7 @@
                 [:start ["n2" "n3"]]]
                (mapv (juxt :f :value) @invocations)))))))
 
-(deftest rejects-a-pause-after-a-pause-error
+(deftest skips-a-pause-after-a-pause-error
   (let [invocations (atom [])
         delegate (failing-nemesis invocations
                                   :pause
@@ -134,12 +460,12 @@
            (nemesis/invoke! subject test {:type :info
                                           :f :pause-process
                                           :value :leader-paused})))
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #"Processes are already paused"
-           (nemesis/invoke! subject test {:type :info
-                                          :f :pause-process
-                                          :value :leader-unpaused})))
+      (let [skipped-value
+            (:value (nemesis/invoke! subject test {:type :info
+                                                   :f :pause-process
+                                                   :value :leader-unpaused}))]
+        (is (= :skipped (:status skipped-value)))
+        (is (= :processes-already-paused (:reason skipped-value))))
       (is (= [[:pause ["n1"]]]
              (mapv (juxt :f :value) @invocations)))
       (let [resumed (nemesis/invoke! subject
@@ -177,10 +503,7 @@
                   cluster/voter-configs
                   (fn [_test _status] [(set (:nodes test))])]
       (let [leader-pause (invoke! :pause-process :leader-paused)
-            _ (is (thrown-with-msg?
-                   clojure.lang.ExceptionInfo
-                   #"Processes are already paused"
-                   (invoke! :pause-process :leader-unpaused)))
+            duplicate-pause (invoke! :pause-process :leader-unpaused)
             leader-resume (invoke! :resume-process)
             leader-recovery (recover!)
             follower-pause (invoke! :pause-process :leader-unpaused)
@@ -197,14 +520,23 @@
                      cleanup-resume
                      cleanup-recovery]
             result (checker/check coverage-checker test history {})]
-        (is (= {:paused (:value leader-pause)
-                :resumed (:nodes test)}
+        (is (= :skipped (get-in duplicate-pause [:value :status])))
+        (is (= :processes-already-paused
+               (get-in duplicate-pause [:value :reason])))
+        (is (= {:paused (dissoc (:value leader-pause) :status)
+                :resumed (:nodes test)
+                :resume-results (zipmap (:nodes test) (repeat :resumed))
+                :status :installed}
                (:value leader-resume)))
-        (is (= {:paused (:value follower-pause)
-                :resumed (:nodes test)}
+        (is (= {:paused (dissoc (:value follower-pause) :status)
+                :resumed (:nodes test)
+                :resume-results (zipmap (:nodes test) (repeat :resumed))
+                :status :installed}
                (:value follower-resume)))
         (is (= {:paused nil
-                :resumed (:nodes test)}
+                :resumed (:nodes test)
+                :resume-results (zipmap (:nodes test) (repeat :resumed))
+                :status :installed}
                (:value cleanup-resume)))
         (is (= [[:pause (get-in leader-pause [:value :nodes])]
                 [:resume (:nodes test)]
@@ -275,7 +607,9 @@
                                   test
                                   [completion]
                                   {})]
-        (is (= :no-reachable-pause-target (:value completion)))
+        (is (= :skipped (get-in completion [:value :status])))
+        (is (= :no-reachable-pause-target
+               (get-in completion [:value :reason])))
         (is (empty? @invocations))
         (is (empty? (:observed-modes result)))))))
 
@@ -334,32 +668,79 @@
                       :value :leader-paused}]]]
     (with-redefs [cluster/membership-status (constantly nil)]
       (doseq [[subject op] operations]
-        (is (= :no-supported-leader
+        (is (= (skipped :no-supported-leader {})
                (:value (nemesis/invoke! subject test op))))))
+    (is (empty? @invocations))))
+
+(deftest skips-known-process-precondition-misses
+  (let [invocations (atom [])
+        delegate (recording-nemesis invocations)
+        test {:nodes ["n1"]}
+        subject (process/->ProcessNemesis delegate (atom nil))]
+    (testing "there is no quorum-safe kill target"
+      (with-redefs [cluster/membership-status
+                    (constantly {:leader "n1"})
+                    cluster/voter-configs
+                    (fn [_test _status] [#{"n1"}])]
+        (let [value (:value
+                     (nemesis/invoke! subject
+                                      test
+                                      {:type :info
+                                       :f :kill-process
+                                       :value :leader-survives}))]
+          (is (= :skipped (:status value)))
+          (is (= :no-quorum-safe-process-target (:reason value))))))
+
+    (testing "there are no killed processes to restart"
+      (is (= (skipped :no-processes-killed {})
+             (:value (nemesis/invoke! subject
+                                      test
+                                      {:type :info
+                                       :f :restart-process})))))
+
+    (testing "a tracked disruption is already active"
+      (let [active {:mode :leader-killed
+                    :nodes ["n1"]}
+            active-subject (process/->ProcessNemesis delegate
+                                                     (atom active))
+            value (:value
+                   (nemesis/invoke! active-subject
+                                    test
+                                    {:type :info
+                                     :f :kill-process
+                                     :value :leader-killed}))]
+        (is (= :skipped (:status value)))
+        (is (= :processes-already-killed (:reason value)))
+        (is (= active (:killed value)))))
+
     (is (empty? @invocations))))
 
 (deftest requires-both-process-modes-and-an-intact-cluster
   (let [subject (#'process/coverage-checker)
         complete-history [{:f :kill-process
-                           :value {:mode :leader-survives}}
+                           :value (installed {:mode :leader-survives})}
                           {:f :await-recovery
-                           :value {:leader "n1"}}
+                           :value (installed {:leader "n1"})}
                           {:f :kill-process
-                           :value {:mode :leader-killed}}
+                           :value (installed {:mode :leader-killed})}
                           {:f :await-recovery
-                           :value {:leader "n2"}}]
+                           :value (installed {:leader "n2"})}]
         missing-mode-history [{:f :kill-process
-                               :value {:mode :leader-survives}}
+                               :value (installed {:mode :leader-survives})}
                               {:f :kill-process
-                               :value :no-supported-leader}]
+                               :value (skipped
+                                       :no-supported-leader
+                                       {})}]
         unrecovered-history [{:f :kill-process
-                              :value {:mode :leader-survives}}
+                              :value (installed {:mode :leader-survives})}
                              {:f :await-recovery
-                              :value {:leader "n1"}}
+                              :value (installed {:leader "n1"})}
                              {:f :kill-process
-                              :value {:mode :leader-killed}}
+                              :value (installed {:mode :leader-killed})}
                              {:f :await-recovery
-                              :error :timeout}]]
+                              :value (indeterminate
+                                      :recovery-timeout
+                                      {})}]]
     (let [result (checker/check subject {} complete-history {})]
       (is (:valid? result))
       (is (= :intact (:cluster-state result))))
@@ -375,20 +756,21 @@
 (deftest reports-an-indeterminate-process-state
   (let [subject (#'process/coverage-checker)
         covered-history [{:f :kill-process
-                          :value {:mode :leader-survives}}
+                          :value (installed {:mode :leader-survives})}
                          {:f :await-recovery
-                          :value {:leader "n1"}}
+                          :value (installed {:leader "n1"})}
                          {:f :kill-process
-                          :value {:mode :leader-killed}}
+                          :value (installed {:mode :leader-killed})}
                          {:f :await-recovery
-                          :value {:leader "n2"}}]
+                          :value (installed {:leader "n2"})}]
         indeterminate-history (conj covered-history
                                     {:f :kill-process
-                                     :value :leader-killed
-                                     :error :kill-failed})
+                                     :value (indeterminate
+                                             :effect-unknown
+                                             {:mode :leader-killed})})
         recovered-history (conj indeterminate-history
                                 {:f :await-recovery
-                                 :value {:leader "n2"}})]
+                                 :value (installed {:leader "n2"})})]
     (let [result (checker/check subject {} indeterminate-history {})]
       (is (= :unknown (:valid? result)))
       (is (= :unknown (:cluster-state result))))
@@ -396,43 +778,122 @@
       (is (:valid? result))
       (is (= :intact (:cluster-state result))))))
 
+(deftest reanalyzes-exact-legacy-process-history
+  (let [process-checker (#'process/coverage-checker)
+        disruption (fn [mode nodes]
+                     {:mode mode
+                      :leader "n1"
+                      :nodes nodes
+                      :voter-configs [(set voters)]
+                      :survivors (vec (remove (set nodes) voters))})
+        process-history [{:f :kill-process
+                          :value (disruption :leader-survives ["n2" "n3"])}
+                         {:f :await-recovery :value {:leader "n1"}}
+                         {:f :kill-process
+                          :value (disruption :leader-killed ["n1" "n2"])}
+                         {:f :await-recovery :value {:leader "n3"}}]
+        pause-checker (#'process/pause-coverage-checker)
+        resumed {:paused nil :resumed voters}
+        pause-history [{:f :pause-process
+                        :value (disruption :leader-unpaused ["n2" "n3"])}
+                       {:f :resume-process :value resumed}
+                       {:f :await-recovery :value {:leader "n1"}}
+                       {:f :pause-process
+                        :value (disruption :leader-paused ["n1" "n2"])}
+                       {:f :resume-process :value resumed}
+                       {:f :await-recovery :value {:leader "n3"}}]
+        process-check #(checker/check process-checker {} % {})
+        pause-check #(checker/check pause-checker {:nodes voters} % {})]
+    (testing "exact pre-status process and pause shapes remain valid"
+      (is (true? (:valid? (process-check process-history))))
+      (is (true? (:valid? (pause-check pause-history)))))
+
+    (testing "explicit disruption status overrides legacy-looking evidence"
+      (doseq [status [:skipped :indeterminate]]
+        (let [process-result
+              (process-check (assoc-in process-history
+                                       [0 :value :status]
+                                       status))
+              pause-result
+              (pause-check (assoc-in pause-history
+                                     [0 :value :status]
+                                     status))]
+          (is (false? (:valid? process-result)) (name status))
+          (is (= [:leader-survives]
+                 (:missing-modes process-result)) (name status))
+          (is (false? (:valid? pause-result)) (name status))
+          (is (= [:leader-unpaused]
+                 (:missing-modes pause-result)) (name status)))))
+
+    (testing "explicit recovery and resume statuses are authoritative"
+      (doseq [status [:skipped :indeterminate]]
+        (is (false?
+             (:valid? (process-check
+                       (assoc-in process-history
+                                 [3 :value :status]
+                                 status))))
+            (name status))
+        (is (not (true?
+                  (:valid? (pause-check
+                            (assoc-in pause-history
+                                      [4 :value :status]
+                                      status)))))
+            (name status))))))
+
 (deftest checks-pause-coverage-and-recovery-state
   (let [subject (#'process/pause-coverage-checker)
         test {:nodes voters}
         check #(checker/check subject test % {})
-        resumed-all {:paused nil
-                     :resumed voters}
+        pause-value (fn [mode nodes]
+                      (installed
+                       {:mode mode
+                        :leader "n1"
+                        :nodes nodes
+                        :voter-configs [(set voters)]
+                        :survivors (vec (remove (set nodes) voters))
+                        :pause-results (zipmap nodes (repeat :paused))}))
+        leader-unpaused (pause-value :leader-unpaused ["n2" "n3"])
+        leader-paused (pause-value :leader-paused ["n1" "n2"])
+        resumed-all (installed
+                     {:paused nil
+                      :resumed voters
+                      :resume-results (zipmap voters (repeat :resumed))})
         complete-history [{:f :pause-process
-                           :value {:mode :leader-unpaused}}
+                           :value leader-unpaused}
                           {:f :resume-process
                            :value resumed-all}
                           {:f :await-recovery
-                           :value {:leader "n1"}}
+                           :value (installed {:leader "n1"})}
                           {:f :pause-process
-                           :value {:mode :leader-paused}}
+                           :value leader-paused}
                           {:f :resume-process
                            :value resumed-all}
                           {:f :await-recovery
-                           :value {:leader "n2"}}]
+                           :value (installed {:leader "n2"})}]
         missing-mode-history [{:f :pause-process
-                               :value {:mode :leader-unpaused}}
+                               :value leader-unpaused}
                               {:f :resume-process
                                :value resumed-all}
                               {:f :await-recovery
-                               :value {:leader "n1"}}
+                               :value (installed {:leader "n1"})}
                               {:f :pause-process
-                               :value :no-supported-leader}]
+                               :value (skipped
+                                       :no-supported-leader
+                                       {})}]
         unrecovered-history (-> complete-history
                                 pop
                                 (conj {:f :await-recovery
-                                       :error :timeout}))
+                                       :value (indeterminate
+                                               :recovery-timeout
+                                               {})}))
         indeterminate-history (conj complete-history
                                     {:f :pause-process
-                                     :value :leader-paused
-                                     :error :pause-failed})
+                                     :value (indeterminate
+                                             :effect-unknown
+                                             {:mode :leader-paused})})
         paused-history (conj complete-history
                              {:f :pause-process
-                              :value {:mode :leader-paused}})
+                              :value leader-paused})
         resuming-history (conj paused-history
                                {:type :info
                                 :f :resume-process})
@@ -440,10 +901,23 @@
                                 [{:f :resume-process
                                   :value resumed-all}
                                  {:f :await-recovery
-                                  :value {:leader "n2"}}])
+                                  :value (installed {:leader "n2"})}])
         partial-resume-history (assoc-in complete-history
                                          [4 :value :resumed]
-                                         ["n1"])]
+                                         ["n1"])
+        mixed-leader-pause (assoc-in leader-paused
+                                     [:pause-results "n1"]
+                                     :target-absent)
+        mixed-pause-history (conj (subvec complete-history 0 3)
+                                  {:f :pause-process
+                                   :value mixed-leader-pause})
+        covered-then-mixed-pause-history
+        (conj complete-history
+              {:f :pause-process
+               :value mixed-leader-pause})
+        mixed-resume-history (assoc-in complete-history
+                                       [4 :value :resume-results "n5"]
+                                       :target-absent)]
     (testing "both pause modes complete and recover"
       (is (= {:valid? true
               :cluster-state :intact}
@@ -480,6 +954,26 @@
       (is (= {:valid? :unknown
               :cluster-state :unknown}
              (select-keys (check partial-resume-history)
+                          [:valid? :cluster-state]))))
+
+    (testing "mixed pause evidence does not credit the planned leader mode"
+      (is (= {:valid? false
+              :missing-modes [:leader-paused]
+              :cluster-state :paused}
+             (select-keys (check mixed-pause-history)
+                          [:valid? :missing-modes :cluster-state]))))
+
+    (testing "a terminal mixed pause invalidates prior complete coverage"
+      (is (= {:valid? false
+              :missing-modes []
+              :cluster-state :paused}
+             (select-keys (check covered-then-mixed-pause-history)
+                          [:valid? :missing-modes :cluster-state]))))
+
+    (testing "mixed resume evidence does not confirm recovery"
+      (is (= {:valid? :unknown
+              :cluster-state :unknown}
+             (select-keys (check mixed-resume-history)
                           [:valid? :cluster-state]))))
 
     (testing "resume completion and recovery resolve an in-flight resume"

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -5,9 +5,11 @@
              [nemesis :as nemesis]
              [random :as random]]
             [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.harness :as harness]
             [jepsen.openraft.nemesis :as openraft-nemesis]
             [jepsen.openraft.nemesis.process :as process]
-            [jepsen.openraft.quorum :as quorum]))
+            [jepsen.openraft.quorum :as quorum]
+            [jepsen.openraft.worker :as worker]))
 
 (def voters ["n1" "n2" "n3" "n4" "n5"])
 
@@ -51,16 +53,32 @@
     (teardown! [this _test]
       this)))
 
-(defn- failing-resume-nemesis [events error]
+(defn- failing-resume-nemesis
+  ([events resume-error]
+   (failing-resume-nemesis events resume-error nil))
+  ([events resume-error teardown-error]
+   (reify nemesis/Nemesis
+     (setup! [this _test]
+       this)
+     (invoke! [_ _test op]
+       (swap! events conj [(:f op) (:value op)])
+       (throw resume-error))
+     (teardown! [this _test]
+       (swap! events conj :teardown)
+       (when teardown-error
+         (throw teardown-error))
+       this))))
+
+(defn- failing-teardown-nemesis [events error]
   (reify nemesis/Nemesis
     (setup! [this _test]
       this)
     (invoke! [_ _test op]
       (swap! events conj [(:f op) (:value op)])
-      (throw error))
-    (teardown! [this _test]
+      (delegate-completion op))
+    (teardown! [_ _test]
       (swap! events conj :teardown)
-      this)))
+      (throw error))))
 
 (deftest selects-fault-set-for-leader-mode
   (let [configs [(set voters)]
@@ -613,16 +631,52 @@
         (is (empty? @invocations))
         (is (empty? (:observed-modes result)))))))
 
-(deftest teardown-cleanup-failure-does-not-mask-analysis
-  (let [events (atom [])
+(deftest teardown-cleanup-failure-records-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        events (atom [])
+        error (ex-info "unreachable" {:kind :unreachable})
         delegate (failing-resume-nemesis
                   events
-                  (ex-info "unreachable" {:kind :unreachable}))
-        subject (process/->PauseNemesis delegate (atom nil))
+                  error)
+        subject (worker/wrap-nemesis-teardown
+                 failure-state
+                 :pause
+                 (process/->PauseNemesis delegate (atom nil)))
         test {:nodes ["n1" "n2" "n3"]}]
     (nemesis/teardown! subject test)
     (is (= [[:resume (:nodes test)] :teardown]
-           @events))))
+           @events))
+    (let [failure (harness/primary-failure failure-state)]
+      (is (= :nemesis (:source failure)))
+      (is (= {:phase :teardown
+              :component :pause
+              :action :resume-processes
+              :nodes (:nodes test)}
+             (:context failure)))
+      (is (identical? error (:throwable failure))))))
+
+(deftest teardown-retains-each-stage-failure
+  (let [failure-state (harness/failure-state)
+        events (atom [])
+        resume-error (RuntimeException. "resume failed")
+        teardown-error (RuntimeException. "delegate teardown failed")
+        delegate (failing-resume-nemesis
+                  events
+                  resume-error
+                  teardown-error)
+        subject (worker/wrap-nemesis-teardown
+                 failure-state
+                 :pause
+                 (process/->PauseNemesis delegate (atom nil)))
+        test {:nodes ["n1" "n2" "n3"]}]
+    (nemesis/teardown! subject test)
+    (is (= [[:resume (:nodes test)] :teardown] @events))
+    (let [primary (harness/primary-failure failure-state)
+          [secondary] (harness/secondary-failures failure-state)]
+      (is (= :resume-processes (get-in primary [:context :action])))
+      (is (identical? resume-error (:throwable primary)))
+      (is (= :delegate-teardown (get-in secondary [:context :action])))
+      (is (identical? teardown-error (:throwable secondary))))))
 
 (deftest teardown-preserves-interruptions
   (doseq [[label error]
@@ -649,8 +703,42 @@
                 interrupted? (.isInterrupted (Thread/currentThread))]
             (is (identical? error thrown))
             (is interrupted?)
-            (is (= [[:resume (:nodes test)] :teardown]
+            (is (= [[:resume (:nodes test)]]
                    @events)))
+          (finally
+            (Thread/interrupted)))))))
+
+(deftest delegate-teardown-preserves-interruptions
+  (doseq [[label error]
+          [[:interrupted-exception
+            (InterruptedException. "interrupted")]
+           [:interrupted-io
+            (java.io.InterruptedIOException. "interrupted")]
+           [:closed-by-interrupt
+            (java.nio.channels.ClosedByInterruptException.)]
+           [:wrapped
+            (ex-info "interrupted" {:kind :interrupted})]]]
+    (testing (name label)
+      (Thread/interrupted)
+      (let [failure-state (harness/failure-state)
+            events (atom [])
+            delegate (failing-teardown-nemesis events error)
+            subject (worker/wrap-nemesis-teardown
+                     failure-state
+                     :pause
+                     (process/->PauseNemesis delegate (atom nil)))
+            test {:nodes ["n1" "n2" "n3"]}]
+        (try
+          (let [[thrown interrupted?]
+                (try
+                  (nemesis/teardown! subject test)
+                  [nil (.isInterrupted (Thread/currentThread))]
+                  (catch Throwable throwable
+                    [throwable (.isInterrupted (Thread/currentThread))]))]
+            (is (identical? error thrown))
+            (is interrupted?)
+            (is (= [[:resume (:nodes test)] :teardown] @events))
+            (is (nil? (harness/primary-failure failure-state))))
           (finally
             (Thread/interrupted)))))))
 

--- a/jepsen/test/jepsen/openraft/nemesis_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis_test.clj
@@ -65,8 +65,10 @@
                 (+ (:time retry) (gen/secs->nanos 15))))))))
 
 (deftest cleans-up-all-faults-before-confirming-recovery
-  (let [database (db/db {})
+  (let [failure-state (harness/failure-state)
+        database (db/db {})
         package (openraft-nemesis/compose-packages
+                 failure-state
                  [(membership/membership-package
                    database
                    test-config)
@@ -81,10 +83,12 @@
            (mapv :f (:final-generator package))))))
 
 (deftest requires-each-composed-fault-class-to-execute
-  (let [database (db/db {})
+  (let [failure-state (harness/failure-state)
+        database (db/db {})
         all-voters (set (:nodes test-config))
         fewer-voters (disj all-voters "n5")
         package (openraft-nemesis/compose-packages
+                 failure-state
                  [(partition/partition-package)
                   (process/pause-package database)
                   (membership/membership-package database test-config)])
@@ -143,6 +147,115 @@
                                 history))]
         (is (false? (:valid? result)))
         (is (false? (get-in result [:pause :fault-class-executed?])))))))
+
+(defn- teardown-package [package-name events throwable]
+  {:name package-name
+   :interval 1
+   :nemesis
+   (reify nemesis/Nemesis
+     (setup! [this _test]
+       this)
+
+     (invoke! [_ _test op]
+       op)
+
+     (teardown! [this _test]
+       (swap! events conj package-name)
+       (when throwable
+         (throw throwable))
+       this)
+
+     nemesis/Reflection
+     (fs [_]
+       #{package-name}))
+   :generator {:type :info
+               :f package-name}
+   :final-generator nil
+   :checker (reify checker/Checker
+              (check [_ _test _history _opts]
+                {:valid? true}))
+   :perf #{}})
+
+(deftest composed-teardown-records-failures-and-continues
+  (let [failure-state (harness/failure-state)
+        events (atom [])
+        first-error (RuntimeException. "partition cleanup failed")
+        second-error (RuntimeException. "pause cleanup failed")
+        package (openraft-nemesis/compose-packages
+                 failure-state
+                 [(teardown-package :partition events first-error)
+                  (teardown-package :pause events second-error)
+                  (teardown-package :process events nil)])
+        subject (nemesis/setup! (:nemesis package) test-config)]
+    (nemesis/teardown! subject test-config)
+    (swap! events conj :analysis)
+    (is (= [:partition :pause :process :analysis] @events))
+    (let [primary (harness/primary-failure failure-state)
+          [secondary] (harness/secondary-failures failure-state)]
+      (is (= :nemesis (:source primary)))
+      (is (= {:phase :teardown
+              :component :partition
+              :nodes (:nodes test-config)}
+             (:context primary)))
+      (is (identical? first-error (:throwable primary)))
+      (is (= :nemesis (:source secondary)))
+      (is (= {:phase :teardown
+              :component :pause
+              :nodes (:nodes test-config)}
+             (:context secondary)))
+      (is (identical? second-error (:throwable secondary))))))
+
+(deftest retains-legacy-compose-packages-arity
+  (let [events (atom [])
+        failure (RuntimeException. "legacy teardown failure")
+        package (openraft-nemesis/compose-packages
+                 [(teardown-package :partition events failure)])
+        subject (nemesis/setup! (:nemesis package) test-config)
+        thrown (try
+                 (nemesis/teardown! subject test-config)
+                 nil
+                 (catch Throwable throwable
+                   throwable))]
+    (is (identical? failure thrown))
+    (is (= [:partition] @events))))
+
+(deftest composed-teardown-preserves-clean-behavior
+  (let [failure-state (harness/failure-state)
+        events (atom [])
+        package (openraft-nemesis/compose-packages
+                 failure-state
+                 [(teardown-package :partition events nil)
+                  (teardown-package :process events nil)])
+        subject (nemesis/setup! (:nemesis package) test-config)]
+    (nemesis/teardown! subject test-config)
+    (is (= [:partition :process] @events))
+    (is (nil? (harness/primary-failure failure-state)))
+    (is (empty? (harness/secondary-failures failure-state)))))
+
+(deftest composed-teardown-propagates-interruption
+  (Thread/interrupted)
+  (let [failure-state (harness/failure-state)
+        events (atom [])
+        interruption (InterruptedException. "stop teardown")
+        package (openraft-nemesis/compose-packages
+                 failure-state
+                 [(teardown-package :partition events interruption)
+                  (teardown-package :process events nil)])
+        subject (nemesis/setup! (:nemesis package) test-config)]
+    (try
+      (let [[thrown interrupted?]
+            (try
+              (nemesis/teardown! subject test-config)
+              [nil (.isInterrupted (Thread/currentThread))]
+              (catch Throwable throwable
+                [throwable (.isInterrupted (Thread/currentThread))]))]
+        (is (identical? interruption thrown))
+        (is interrupted?)
+        (is (= [:partition] @events))
+        (is (nil? (harness/primary-failure failure-state)))
+        (is (empty? (harness/secondary-failures failure-state))))
+      (finally
+        (Thread/interrupted)))))
 
 (defn- condition-timeout [condition]
   (try

--- a/jepsen/test/jepsen/openraft/nemesis_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis_test.clj
@@ -3,8 +3,13 @@
             [jepsen.checker :as checker]
             [jepsen.generator :as gen]
             [jepsen.generator.test :as gen-test]
-            [jepsen.openraft.db :as db]
-            [jepsen.openraft.nemesis :as openraft-nemesis]
+            [jepsen.nemesis :as nemesis]
+            [jepsen.openraft [await :as await]
+             [cluster :as cluster]
+             [db :as db]
+             [harness :as harness]
+             [nemesis :as openraft-nemesis]
+             [worker :as worker]]
             [jepsen.openraft.nemesis.membership :as membership]
             [jepsen.openraft.nemesis.partition :as partition]
             [jepsen.openraft.nemesis.process :as process]))
@@ -13,9 +18,16 @@
   {:nodes ["n1" "n2" "n3" "n4" "n5"]})
 
 (deftest schedules-and-retries-skipped-faults
-  (doseq [skip-result [:no-supported-leader
-                       :no-reachable-pause-target
-                       {:status :no-supported-leader}]]
+  (doseq [skip-result (concat
+                       (map (fn [reason]
+                              {:status :skipped
+                               :reason reason})
+                            [:no-quorum-safe-process-target
+                             :no-reachable-pause-target
+                             :no-safe-partition-target
+                             :no-supported-leader])
+                       [{:status :no-supported-leader}
+                        :no-supported-leader])]
     (testing (str skip-result)
       (let [faults (#'openraft-nemesis/interval-schedule
                     10
@@ -82,21 +94,38 @@
                                history
                                {}))
         history [{:f :start-partition
-                  :value {:mode :leader-in-majority}}
+                  :value {:status :installed
+                          :mode :leader-in-majority}}
                  {:f :stop-partition
-                  :value :network-healed}
+                  :value {:status :installed}}
                  {:f :pause-process
-                  :value {:mode :leader-unpaused}}
+                  :value {:status :installed
+                          :mode :leader-unpaused
+                          :leader "n1"
+                          :nodes ["n2"]
+                          :voter-configs [all-voters]
+                          :survivors (vec (disj all-voters "n2"))
+                          :pause-results {"n2" :paused}}}
                  {:f :resume-process
-                  :value {:mode :leader-unpaused}}
+                  :value {:status :installed
+                          :paused nil
+                          :resumed (:nodes test-config)
+                          :resume-results
+                          (zipmap (:nodes test-config) (repeat :resumed))}}
                  {:f :shrink
-                  :value {:change :shrink
+                  :value {:status :installed
+                          :change :shrink
+                          :node "n5"
+                          :leader "n1"
                           :before all-voters
                           :after fewer-voters}}
                  {:f :restore-membership
-                  :value {:voters all-voters}}
+                  :value {:status :installed
+                          :leader "n1"
+                          :voters all-voters}}
                  {:f :await-recovery
-                  :value {:leader "n1"}}]]
+                  :value {:status :installed
+                          :leader "n1"}}]]
     (testing "one successful mode covers each fault class in chaos"
       (let [result (check history)]
         (is (:valid? result))
@@ -107,8 +136,103 @@
 
     (testing "a skipped fault does not count as execution"
       (let [result (check (mapv #(if (= :pause-process (:f %))
-                                   (assoc % :value :no-supported-leader)
+                                   (assoc % :value
+                                          {:status :skipped
+                                           :reason :no-supported-leader})
                                    %)
                                 history))]
         (is (false? (:valid? result)))
         (is (false? (get-in result [:pause :fault-class-executed?])))))))
+
+(defn- condition-timeout [condition]
+  (try
+    (await/until! condition
+                  #(await/retry! condition {})
+                  {:timeout 0
+                   :retry-interval 0})
+    nil
+    (catch Exception e
+      e)))
+
+(deftest classifies-recovery-outcomes
+  (let [op {:type :info
+            :process :nemesis
+            :f :await-recovery}
+        subject (openraft-nemesis/->RecoveryNemesis)]
+    (testing "confirmed recovery is installed"
+      (with-redefs [cluster/await-ready! (constantly {:leader "n2"})]
+        (is (= {:status :installed
+                :leader "n2"}
+               (:value (nemesis/invoke! subject test-config op))))))
+
+    (testing "a modeled readiness timeout is indeterminate"
+      (let [error (condition-timeout :cluster-ready)]
+        (with-redefs [cluster/await-ready! (fn [_test] (throw error))]
+          (let [value (:value (nemesis/invoke! subject test-config op))]
+            (is (= :indeterminate (:status value)))
+            (is (= :recovery-timeout (:reason value)))))))
+
+    (testing "an unexpected recovery exception takes the Harness path"
+      (let [failure-state (harness/failure-state)
+            error (RuntimeException. "recovery bug")
+            wrapped (worker/wrap-nemesis failure-state subject)
+            setup-subject (nemesis/setup! wrapped test-config)
+            thrown (with-redefs [cluster/await-ready! (fn [_test]
+                                                        (throw error))]
+                     (try
+                       (nemesis/invoke! setup-subject test-config op)
+                       nil
+                       (catch Exception e
+                         e)))]
+        (is (identical? error thrown))
+        (is (identical? error
+                        (:throwable
+                         (harness/primary-failure failure-state))))))
+
+    (testing "an unrelated timeout tag takes the Harness path"
+      (let [failure-state (harness/failure-state)
+            error (ex-info "unknown timeout" {:type :timeout})
+            wrapped (worker/wrap-nemesis failure-state subject)
+            setup-subject (nemesis/setup! wrapped test-config)
+            thrown (with-redefs [cluster/await-ready! (fn [_test]
+                                                        (throw error))]
+                     (try
+                       (nemesis/invoke! setup-subject test-config op)
+                       nil
+                       (catch Exception e
+                         e)))]
+        (is (identical? error thrown))
+        (is (identical? error
+                        (:throwable
+                         (harness/primary-failure failure-state))))))
+
+    (testing "interruption takes priority over timeout classification"
+      (doseq [[label make-error]
+              [[:interrupted #(InterruptedException. "interrupted")]
+               [:interrupted-io
+                #(java.io.InterruptedIOException. "interrupted")]
+               [:closed-by-interrupt
+                #(java.nio.channels.ClosedByInterruptException.)]
+               [:wrapped
+                #(ex-info "interrupted"
+                          {:kind :interrupted
+                           :type :timeout})]]]
+        (Thread/interrupted)
+        (try
+          (let [failure-state (harness/failure-state)
+                error (make-error)
+                wrapped (worker/wrap-nemesis failure-state subject)
+                setup-subject (nemesis/setup! wrapped test-config)
+                [thrown interrupted?]
+                (with-redefs [cluster/await-ready!
+                              (fn [_test] (throw error))]
+                  (try
+                    (nemesis/invoke! setup-subject test-config op)
+                    [nil (.isInterrupted (Thread/currentThread))]
+                    (catch Exception e
+                      [e (.isInterrupted (Thread/currentThread))])))]
+            (is (identical? error thrown) (name label))
+            (is interrupted? (name label))
+            (is (nil? (harness/primary-failure failure-state)) (name label)))
+          (finally
+            (Thread/interrupted)))))))

--- a/jepsen/test/jepsen/openraft/worker_test.clj
+++ b/jepsen/test/jepsen/openraft/worker_test.clj
@@ -1,21 +1,23 @@
 (ns jepsen.openraft.worker-test
   (:require [clojure.test :refer [deftest is testing]]
             [jepsen [client :as client]
+             [db :as db]
              [nemesis :as nemesis]]
             [jepsen.openraft [harness :as harness]
              [worker :as worker]]))
 
 (defn- test-client
-  [{:keys [open-f invoke-f close-f]
+  [{:keys [open-f setup-f invoke-f close-f]
     :or {open-f (fn [this _test _node] this)
+         setup-f (fn [this _test] this)
          invoke-f (fn [_test op] (assoc op :type :ok))
          close-f (fn [_test])}}]
   (reify client/Client
     (open! [this test node]
       (open-f this test node))
 
-    (setup! [this _test]
-      this)
+    (setup! [this test]
+      (setup-f this test))
 
     (invoke! [_ test op]
       (invoke-f test op))
@@ -27,17 +29,39 @@
 
 (defn- test-nemesis
   ([invoke-f]
-   (test-nemesis invoke-f (fn [_test])))
+   (test-nemesis invoke-f (fn [this _test] this) (fn [_test])))
   ([invoke-f teardown-f]
+   (test-nemesis invoke-f (fn [this _test] this) teardown-f))
+  ([invoke-f setup-f teardown-f]
    (reify nemesis/Nemesis
-     (setup! [this _test]
-       this)
+     (setup! [this test]
+       (setup-f this test))
 
      (invoke! [_ test op]
        (invoke-f test op))
 
      (teardown! [_ test]
        (teardown-f test)))))
+
+(defn- test-db
+  [setup-f]
+  (reify db/DB
+    (setup! [_ test node]
+      (setup-f test node))
+
+    (teardown! [_ _test _node])
+
+    db/Kill
+    (kill! [_ _test _node])
+    (start! [_ _test _node])
+
+    db/Pause
+    (pause! [_ _test _node])
+    (resume! [_ _test _node])
+
+    db/LogFiles
+    (log-files [_ _test _node]
+      {})))
 
 (defn- thrown-by [f]
   (try
@@ -54,6 +78,19 @@
     (is (identical? throwable (:throwable failure)))))
 
 (deftest records-client-worker-failures
+  (testing "setup"
+    (let [failure-state (harness/failure-state)
+          throwable (RuntimeException. "setup failed")
+          subject (worker/wrap-client
+                   failure-state
+                   (test-client {:setup-f (fn [& _] (throw throwable))}))
+          thrown (thrown-by #(client/setup! subject {}))]
+      (is (identical? throwable thrown))
+      (assert-primary-failure failure-state
+                              :client
+                              {:phase :setup}
+                              throwable)))
+
   (testing "open"
     (let [failure-state (harness/failure-state)
           throwable (RuntimeException. "open failed")
@@ -100,6 +137,21 @@
                               throwable))))
 
 (deftest records-nemesis-worker-failures
+  (testing "setup"
+    (let [failure-state (harness/failure-state)
+          throwable (RuntimeException. "nemesis setup failed")
+          subject (worker/wrap-nemesis
+                   failure-state
+                   (test-nemesis (fn [& _] nil)
+                                 (fn [& _] (throw throwable))
+                                 (fn [& _] nil)))
+          thrown (thrown-by #(nemesis/setup! subject {}))]
+      (is (identical? throwable thrown))
+      (assert-primary-failure failure-state
+                              :nemesis
+                              {:phase :setup}
+                              throwable)))
+
   (let [failure-state (harness/failure-state)
         throwable (RuntimeException. "nemesis failed")
         op {:type :info
@@ -115,6 +167,20 @@
                             :nemesis
                             {:phase :invoke
                              :operation op}
+                            throwable)))
+
+(deftest records-db-setup-failures
+  (let [failure-state (harness/failure-state)
+        throwable (RuntimeException. "database setup failed")
+        subject (worker/wrap-db
+                 failure-state
+                 (test-db (fn [& _] (throw throwable))))
+        thrown (thrown-by #(db/setup! subject {} "n1"))]
+    (is (identical? throwable thrown))
+    (assert-primary-failure failure-state
+                            :db
+                            {:phase :setup
+                             :node "n1"}
                             throwable)))
 
 (deftest modeled-outcomes-do-not-record-failures

--- a/jepsen/test/jepsen/openraft/worker_test.clj
+++ b/jepsen/test/jepsen/openraft/worker_test.clj
@@ -25,15 +25,19 @@
     (close! [_ test]
       (close-f test))))
 
-(defn- test-nemesis [invoke-f]
-  (reify nemesis/Nemesis
-    (setup! [this _test]
-      this)
+(defn- test-nemesis
+  ([invoke-f]
+   (test-nemesis invoke-f (fn [_test])))
+  ([invoke-f teardown-f]
+   (reify nemesis/Nemesis
+     (setup! [this _test]
+       this)
 
-    (invoke! [_ test op]
-      (invoke-f test op))
+     (invoke! [_ test op]
+       (invoke-f test op))
 
-    (teardown! [_ _test])))
+     (teardown! [_ test]
+       (teardown-f test)))))
 
 (defn- thrown-by [f]
   (try
@@ -167,3 +171,36 @@
             thrown (thrown-by #(invoke failure-state throwable))]
         (is (identical? throwable thrown))
         (is (nil? (harness/primary-failure failure-state)))))))
+
+(deftest teardown-logging-failures-do-not-escape
+  (let [failure-state (harness/failure-state)
+        teardown-error (RuntimeException. "teardown failed")
+        logging-error (RuntimeException. "logging failed")
+        subject (worker/wrap-nemesis-teardown
+                 failure-state
+                 :partition
+                 (test-nemesis identity
+                               (fn [_test] (throw teardown-error))))]
+    (with-redefs-fn {#'worker/log-teardown-failure
+                     (fn [_context _throwable]
+                       (throw logging-error))}
+      #(nemesis/teardown! subject {:nodes ["n1" "n2" "n3"]}))
+    (is (identical? teardown-error
+                    (:throwable
+                     (harness/primary-failure failure-state))))
+    (let [[failure] (harness/secondary-failures failure-state)]
+      (is (= :failure-log (get-in failure [:context :diagnostic])))
+      (is (identical? logging-error (:throwable failure))))))
+
+(deftest fatal-teardown-errors-propagate
+  (let [failure-state (harness/failure-state)
+        fatal-error (StackOverflowError. "fatal")
+        subject (worker/wrap-nemesis-teardown
+                 failure-state
+                 :partition
+                 (test-nemesis identity
+                               (fn [_test] (throw fatal-error))))
+        thrown (thrown-by #(nemesis/teardown! subject {}))]
+    (is (identical? fatal-error thrown))
+    (is (nil? (harness/primary-failure failure-state)))
+    (is (empty? (harness/secondary-failures failure-state)))))

--- a/jepsen/test/jepsen/openraft/worker_test.clj
+++ b/jepsen/test/jepsen/openraft/worker_test.clj
@@ -1,0 +1,168 @@
+(ns jepsen.openraft.worker-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen [client :as client]
+             [nemesis :as nemesis]]
+            [jepsen.openraft [harness :as harness]
+             [worker :as worker]]))
+
+(defn- test-client
+  [{:keys [open-f invoke-f close-f]
+    :or {open-f (fn [this _test _node] this)
+         invoke-f (fn [_test op] (assoc op :type :ok))
+         close-f (fn [_test])}}]
+  (reify client/Client
+    (open! [this test node]
+      (open-f this test node))
+
+    (setup! [this _test]
+      this)
+
+    (invoke! [_ test op]
+      (invoke-f test op))
+
+    (teardown! [_ _test])
+
+    (close! [_ test]
+      (close-f test))))
+
+(defn- test-nemesis [invoke-f]
+  (reify nemesis/Nemesis
+    (setup! [this _test]
+      this)
+
+    (invoke! [_ test op]
+      (invoke-f test op))
+
+    (teardown! [_ _test])))
+
+(defn- thrown-by [f]
+  (try
+    (f)
+    nil
+    (catch Throwable throwable
+      throwable)))
+
+(defn- assert-primary-failure
+  [failure-state source context throwable]
+  (let [failure (harness/primary-failure failure-state)]
+    (is (= source (:source failure)))
+    (is (= context (:context failure)))
+    (is (identical? throwable (:throwable failure)))))
+
+(deftest records-client-worker-failures
+  (testing "open"
+    (let [failure-state (harness/failure-state)
+          throwable (RuntimeException. "open failed")
+          subject (worker/wrap-client
+                   failure-state
+                   (test-client {:open-f (fn [& _] (throw throwable))}))
+          thrown (thrown-by #(client/open! subject {} "n1"))]
+      (is (identical? throwable thrown))
+      (assert-primary-failure failure-state
+                              :client
+                              {:phase :open
+                               :node "n1"}
+                              throwable)))
+
+  (testing "invoke"
+    (let [failure-state (harness/failure-state)
+          throwable (RuntimeException. "invoke failed")
+          op {:type :invoke
+              :process 0
+              :f :read}
+          subject (worker/wrap-client
+                   failure-state
+                   (test-client {:invoke-f (fn [& _] (throw throwable))}))
+          opened (client/open! subject {} "n1")
+          thrown (thrown-by #(client/invoke! opened {} op))]
+      (is (identical? throwable thrown))
+      (assert-primary-failure failure-state
+                              :client
+                              {:phase :invoke
+                               :operation op}
+                              throwable)))
+
+  (testing "close"
+    (let [failure-state (harness/failure-state)
+          throwable (RuntimeException. "close failed")
+          subject (worker/wrap-client
+                   failure-state
+                   (test-client {:close-f (fn [& _] (throw throwable))}))
+          thrown (thrown-by #(client/close! subject {}))]
+      (is (identical? throwable thrown))
+      (assert-primary-failure failure-state
+                              :client
+                              {:phase :close}
+                              throwable))))
+
+(deftest records-nemesis-worker-failures
+  (let [failure-state (harness/failure-state)
+        throwable (RuntimeException. "nemesis failed")
+        op {:type :info
+            :process :nemesis
+            :f :start-partition}
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (test-nemesis (fn [& _] (throw throwable))))
+        setup-subject (nemesis/setup! subject {})
+        thrown (thrown-by #(nemesis/invoke! setup-subject {} op))]
+    (is (identical? throwable thrown))
+    (assert-primary-failure failure-state
+                            :nemesis
+                            {:phase :invoke
+                             :operation op}
+                            throwable)))
+
+(deftest modeled-outcomes-do-not-record-failures
+  (let [failure-state (harness/failure-state)
+        client-outcome {:type :info
+                        :process 0
+                        :f :write
+                        :error :timeout}
+        nemesis-outcome {:type :info
+                         :process :nemesis
+                         :f :start-partition
+                         :value :no-supported-leader}
+        client-subject (worker/wrap-client
+                        failure-state
+                        (test-client {:invoke-f (fn [& _] client-outcome)}))
+        nemesis-subject (worker/wrap-nemesis
+                         failure-state
+                         (test-nemesis (fn [& _] nemesis-outcome)))]
+    (is (= client-outcome
+           (client/invoke! (client/open! client-subject {} "n1")
+                           {}
+                           client-outcome)))
+    (is (= nemesis-outcome
+           (nemesis/invoke! (nemesis/setup! nemesis-subject {})
+                            {}
+                            nemesis-outcome)))
+    (is (nil? (harness/primary-failure failure-state)))))
+
+(deftest interruptions-propagate-without-recording
+  (doseq [[description throwable invoke]
+          [["client"
+            (InterruptedException. "interrupted")
+            (fn [failure-state throwable]
+              (let [subject (worker/wrap-client
+                             failure-state
+                             (test-client
+                              {:invoke-f (fn [& _] (throw throwable))}))]
+                (client/invoke! (client/open! subject {} "n1")
+                                {}
+                                {:type :invoke :f :read})))]
+           ["nemesis"
+            (ex-info "interrupted" {:kind :interrupted})
+            (fn [failure-state throwable]
+              (let [subject (worker/wrap-nemesis
+                             failure-state
+                             (test-nemesis
+                              (fn [& _] (throw throwable))))]
+                (nemesis/invoke! (nemesis/setup! subject {})
+                                 {}
+                                 {:type :info :f :start-partition})))]]]
+    (testing description
+      (let [failure-state (harness/failure-state)
+            thrown (thrown-by #(invoke failure-state throwable))]
+        (is (identical? throwable thrown))
+        (is (nil? (harness/primary-failure failure-state)))))))

--- a/jepsen/test/jepsen/openraft/worker_test.clj
+++ b/jepsen/test/jepsen/openraft/worker_test.clj
@@ -122,7 +122,8 @@
         nemesis-outcome {:type :info
                          :process :nemesis
                          :f :start-partition
-                         :value :no-supported-leader}
+                         :value {:status :skipped
+                                 :reason :no-supported-leader}}
         client-subject (worker/wrap-client
                         failure-state
                         (test-client {:invoke-f (fn [& _] client-outcome)}))

--- a/jepsen/test/jepsen/openraft/workload_test.clj
+++ b/jepsen/test/jepsen/openraft/workload_test.clj
@@ -1,5 +1,7 @@
 (ns jepsen.openraft.workload-test
-  (:require [clojure.java.io :as io]
+  (:require [cheshire.core :as json]
+            [cheshire.parse :as json-parse]
+            [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing]]
             [jepsen.checker :as checker]
             [jepsen.client :as client]
@@ -8,6 +10,8 @@
             [jepsen.history :as history]
             [jepsen.independent :as independent]
             [jepsen.openraft.client :as http]
+            [jepsen.openraft.harness :as harness]
+            [jepsen.openraft.worker :as worker]
             [jepsen.openraft.workload :as workload]
             [jepsen.random :as random]
             [jepsen.store :as store]))
@@ -36,11 +40,27 @@
         (doseq [file (reverse (file-seq temp-dir))]
           (io/delete-file file true))))))
 
-(defn- kv-client []
-  (workload/->KVClient nil
-                       (atom "n1:21001")
-                       ["n1:21001"]
-                       (atom {})))
+(defn- kv-client
+  ([]
+   (kv-client (atom {})))
+  ([latest-values]
+   (workload/->KVClient nil
+                        (atom "n1:21001")
+                        ["n1:21001"]
+                        latest-values)))
+
+(defn- raw-http-response [body]
+  {:method "POST"
+   :uri "http://n1:21001/write"
+   :status 200
+   :body body})
+
+(defn- http-response [body]
+  (raw-http-response (json/generate-string body)))
+
+(defn- invoke-with-response [subject op body]
+  (with-redefs [http/post! (fn [& _] (http-response body))]
+    (client/invoke! subject {} op)))
 
 (deftest classifies-timeouts-by-operation
   (let [timeout (ex-info "timeout" {:kind :request-timeout})]
@@ -50,13 +70,15 @@
         (let [op {:type :invoke :f :write :value (keyed "value")}
               result (client/invoke! (kv-client) {} op)]
           (is (= :info (:type result)))
-          (is (= :timeout (:error result)))))
+          (is (= :timeout (:error result)))
+          (is (not (contains? result :unexpected-sut-response?)))))
 
       (testing "a read timeout has no state-machine effect"
         (let [op {:type :invoke :f :read :value (keyed nil)}
               result (client/invoke! (kv-client) {} op)]
           (is (= :fail (:type result)))
-          (is (= :timeout (:error result)))))
+          (is (= :timeout (:error result)))
+          (is (not (contains? result :unexpected-sut-response?)))))
 
       (testing "a final recovery write must complete"
         (let [op {:type :invoke
@@ -65,7 +87,7 @@
                   :final? true}
               result (client/invoke! (kv-client) {} op)]
           (is (= :info (:type result)))
-          (is (:unexpected? result))
+          (is (not (contains? result :unexpected-sut-response?)))
           (is (= :request-timeout
                  (-> result :exception-data :kind))))))))
 
@@ -84,14 +106,16 @@
           (let [result (client/invoke! (kv-client) {} op)]
             (is (= :ok (:type result)))
             (is (= ["old" "new"] (val (:value result))))
-            (is (= [test-key 1 "new"] @request))))))
+            (is (= [test-key 1 "new"] @request))
+            (is (not (contains? result :unexpected-sut-response?)))))))
 
     (testing "a version mismatch is a definite failure"
       (with-redefs [http/cas! (fn [& _] nil)]
         (let [result (client/invoke! (kv-client) {} op)]
           (is (= :fail (:type result)))
           (is (= :version-mismatch (:error result)))
-          (is (= (:value op) (:value result))))))
+          (is (= (:value op) (:value result)))
+          (is (not (contains? result :unexpected-sut-response?))))))
 
     (testing "a CAS timeout is indeterminate"
       (let [timeout (ex-info "timeout" {:kind :request-timeout})]
@@ -307,59 +331,286 @@
               result (client/invoke! (kv-client) {} op)]
           (is (= :fail (:type result)))
           (is (= :quorum-not-enough (:error result)))
-          (is (not (:unexpected? result)))))))
+          (is (not (contains? result :unexpected-sut-response?)))))))
 
   (testing "HTTP 400 is fail because app-http rejects it before handler execution"
     (let [bad-request (ex-info "bad request"
                                {:kind :http-error
-                                :status 400})]
+                                :method "POST"
+                                :uri "http://n1:21001/write"
+                                :status 400
+                                :body "bad request"})]
       (with-redefs [http/write! (fn [& _]
                                   (throw bad-request))]
         (let [op {:type :invoke :f :write :value (keyed "value")}
               result (client/invoke! (kv-client) {} op)]
           (is (= :fail (:type result)))
           (is (= [:http 400] (:error result)))
-          (is (:unexpected? result))
+          (is (true? (:unexpected-sut-response? result)))
           (is (= "bad request" (:exception-message result)))
-          (is (= 400 (get-in result [:exception-data :status])))))))
+          (is (= 400 (get-in result [:exception-data :status])))
+          (is (= "bad request" (get-in result [:exception-data :body])))))))
 
   (testing "HTTP 500 is info because response serialization follows handler execution"
     (let [server-error (ex-info "server error"
                                 {:kind :http-error
-                                 :status 500})]
+                                 :method "POST"
+                                 :uri "http://n1:21001/write"
+                                 :status 500
+                                 :body "server error"})]
       (with-redefs [http/write! (fn [& _]
                                   (throw server-error))]
         (let [op {:type :invoke :f :write :value (keyed "value")}
               result (client/invoke! (kv-client) {} op)]
           (is (= :info (:type result)))
           (is (= [:http 500] (:error result)))
-          (is (:unexpected? result))
+          (is (true? (:unexpected-sut-response? result)))
           (is (= "server error" (:exception-message result)))
           (is (= 500 (get-in result [:exception-data :status]))))))))
 
-(deftest rethrows-interruptions
-  (let [op {:type :invoke :f :write :value (keyed "value")}]
-    (testing "a wrapped interruption from send! propagates instead of completing"
-      (with-redefs [http/write! (fn [& _]
-                                  (throw (ex-info "interrupted"
-                                                  {:kind :interrupted})))]
-        (is (thrown? clojure.lang.ExceptionInfo
-                     (client/invoke! (kv-client) {} op)))))
+(deftest records-clearly-unexpected-sut-responses
+  (testing "invalid JSON is a marked Outcome, not a Harness failure"
+    (let [failure-state (harness/failure-state)
+          response {:method "POST"
+                    :uri "http://n1:21001/write"
+                    :status 200
+                    :body "not-json"}
+          invalid-json (ex-info "invalid JSON"
+                                {:kind :invalid-json
+                                 :response response})
+          subject (worker/wrap-client failure-state (kv-client))]
+      (with-redefs [http/write! (fn [& _] (throw invalid-json))]
+        (let [op {:type :invoke :f :write :value (keyed "value")}
+              result (client/invoke! subject {} op)]
+          (is (= :info (:type result)))
+          (is (= :invalid-json (:error result)))
+          (is (true? (:unexpected-sut-response? result)))
+          (is (= response (get-in result [:exception-data :response])))
+          (is (nil? (harness/primary-failure failure-state)))))))
 
-    (testing "a raw InterruptedException propagates and restores the interrupt flag"
-      (with-redefs [http/write! (fn [& _]
-                                  (throw (InterruptedException. "boom")))]
-        ;; Capture the exception and interrupt flag before any assertion runs:
-        ;; clojure.test's report machinery uses dosync, which clears the flag.
-        (Thread/interrupted)
-        (let [thrown (try
-                       (client/invoke! (kv-client) {} op)
+  (testing "an unmodeled OpenRaft Err variant is marked"
+    (let [error {:UnexpectedError {:message "unsupported"}}
+          openraft-error (ex-info "unexpected OpenRaft error"
+                                  {:kind :openraft-error
+                                   :error error
+                                   :response {:status 200
+                                              :body "Err"}})]
+      (with-redefs [http/write! (fn [& _] (throw openraft-error))]
+        (let [op {:type :invoke :f :write :value (keyed "value")}
+              result (client/invoke! (kv-client) {} op)]
+          (is (= :info (:type result)))
+          (is (= :openraft-error (:error result)))
+          (is (true? (:unexpected-sut-response? result)))
+          (is (= error (get-in result [:exception-data :error]))))))))
+
+(deftest leaves-modeled-sut-outcomes-unmarked
+  (doseq [[description throwable expected-type expected-error]
+          [["connection failure"
+            (ex-info "unreachable" {:kind :unreachable})
+            :fail
+            :unreachable]
+           ["transport failure"
+            (ex-info "transport" {:kind :transport-error})
+            :info
+            :transport-error]
+           ["leader redirect without a target"
+            (ex-info "not leader"
+                     {:kind :openraft-error
+                      :error {:ForwardToLeader {}}})
+            :fail
+            :not-leader]
+           ["quorum failure"
+            (ex-info "no quorum"
+                     {:kind :openraft-error
+                      :error {:QuorumNotEnough {}}})
+            :fail
+            :quorum-not-enough]]]
+    (testing description
+      (with-redefs [http/write! (fn [& _] (throw throwable))]
+        (let [op {:type :invoke :f :write :value (keyed "value")}
+              result (client/invoke! (kv-client) {} op)]
+          (is (= expected-type (:type result)))
+          (is (= expected-error (:error result)))
+          (is (not (contains? result :unexpected-sut-response?))))))))
+
+(deftest validates-http-200-application-responses
+  (testing "a valid Ok payload completes successfully"
+    (let [op {:type :invoke :f :write :value (keyed "value")}
+          body {:Ok {:data {:value {:value "value" :version 1}}}}
+          result (invoke-with-response (kv-client) op body)]
+      (is (= :ok (:type result)))
+      (is (not (contains? result :unexpected-sut-response?)))))
+
+  (testing "a known Err remains a modeled Outcome"
+    (let [op {:type :invoke :f :read :value (keyed nil)}
+          body {:Err {:QuorumNotEnough {:cluster "n1,n2,n3"
+                                        :got ["n1"]}}}
+          result (invoke-with-response (kv-client) op body)]
+      (is (= :fail (:type result)))
+      (is (= :quorum-not-enough (:error result)))
+      (is (not (contains? result :unexpected-sut-response?)))))
+
+  (testing "invalid response unions are unexpected Outcomes"
+    (doseq [[label body reason]
+            [["missing arm" {} :missing-response-arm]
+             ["ambiguous arms"
+              {:Ok {:data {:value {:value "value" :version 1}}}
+               :Err {:ForwardToLeader {}}}
+              :ambiguous-response-arms]
+             ["unknown arm" {:Result {}} :unknown-response-arm]]]
+      (testing label
+        (let [failure-state (harness/failure-state)
+              subject (worker/wrap-client failure-state (kv-client))
+              op {:type :invoke :f :write :value (keyed "value")}
+              result (invoke-with-response subject op body)]
+          (is (= :info (:type result)))
+          (is (= :invalid-response (:error result)))
+          (is (true? (:unexpected-sut-response? result)))
+          (is (= reason (get-in result [:exception-data :reason])))
+          (is (= (json/generate-string body)
+                 (get-in result
+                         [:exception-data :response :body-preview])))
+          (is (= (count (json/generate-string body))
+                 (get-in result
+                         [:exception-data
+                          :response
+                          :body-character-count])))
+          (is (nil? (harness/primary-failure failure-state)))))))
+
+  (testing "malformed successful payloads are unexpected Outcomes"
+    (doseq [[label op body expected-type path]
+            [["write nil"
+              {:type :invoke :f :write :value (keyed "value")}
+              {:Ok {:data {:value nil}}}
+              :info
+              [:data :value]]
+             ["CAS missing value"
+              {:type :invoke
+               :f :cas
+               :value (keyed ["old" "new"])
+               :expected-version 1}
+              {:Ok {:data {}}}
+              :info
+              [:data :value]]
+             ["read malformed value"
+              {:type :invoke :f :read :value (keyed nil)}
+              {:Ok {:value {:value 1 :version 2}}}
+              :fail
+              [:value]]]]
+      (testing label
+        (let [result (invoke-with-response (kv-client) op body)]
+          (is (= expected-type (:type result)))
+          (is (= :invalid-response (:error result)))
+          (is (true? (:unexpected-sut-response? result)))
+          (is (= path (get-in result [:exception-data :payload-path])))))))
+
+  (testing "malformed modeled Err payloads are unexpected Outcomes"
+    (doseq [[label op body expected-type variant]
+            [["ForwardToLeader payload"
+              {:type :invoke :f :write :value (keyed "value")}
+              {:Err {:ForwardToLeader "not-an-object"}}
+              :info
+              :ForwardToLeader]
+             ["QuorumNotEnough payload"
+              {:type :invoke :f :read :value (keyed nil)}
+              {:Err {:QuorumNotEnough ["not" "an" "object"]}}
+              :fail
+              :QuorumNotEnough]]]
+      (testing label
+        (let [failure-state (harness/failure-state)
+              subject (worker/wrap-client failure-state (kv-client))
+              result (invoke-with-response subject op body)]
+          (is (= expected-type (:type result)))
+          (is (= :invalid-response (:error result)))
+          (is (true? (:unexpected-sut-response? result)))
+          (is (= :invalid-error-payload
+                 (get-in result [:exception-data :reason])))
+          (is (= variant
+                 (get-in result [:exception-data :error-variant])))
+          (is (nil? (harness/primary-failure failure-state))))))))
+
+(deftest rejects-invalid-json-documents-as-workload-outcomes
+  (let [failure-state (harness/failure-state)
+        subject (worker/wrap-client failure-state (kv-client))
+        op {:type :invoke :f :write :value (keyed "value")}
+        response (raw-http-response
+                  (str "{\"Ok\":{\"data\":{\"value\":"
+                       "{\"value\":\"value\",\"version\":1}}},"
+                       "\"Ok\":{\"data\":{\"value\":"
+                       "{\"value\":\"other\",\"version\":2}}}}"))
+        result (with-redefs [http/post! (fn [& _] response)]
+                 (client/invoke! subject {} op))]
+    (is (= :info (:type result)))
+    (is (= :invalid-json (:error result)))
+    (is (true? (:unexpected-sut-response? result)))
+    (is (= (count (:body response))
+           (get-in result
+                   [:exception-data :response :body-character-count])))
+    (is (nil? (harness/primary-failure failure-state)))))
+
+(deftest unexpected-mutation-responses-do-not-poison-latest-values
+  (let [original {test-key {:value "old" :version 1}}
+        latest-values (atom original)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-client failure-state
+                                    (kv-client latest-values))]
+    (doseq [[label op body reason]
+            [["write"
+              {:type :invoke :f :write :value (keyed "value")}
+              {:Ok {:data {:value {:value "other" :version 2}}}}
+              :unexpected-payload-value]
+             ["CAS value"
+              {:type :invoke
+               :f :cas
+               :value (keyed ["old" "new"])
+               :expected-version 1}
+              {:Ok {:data {:value {:value "other" :version 2}}}}
+              :unexpected-payload-value]
+             ["CAS version"
+              {:type :invoke
+               :f :cas
+               :value (keyed ["old" "new"])
+               :expected-version 1}
+              {:Ok {:data {:value {:value "new" :version 1}}}}
+              :non-increasing-cas-version]]]
+      (testing label
+        (let [result (invoke-with-response subject op body)]
+          (is (= :info (:type result)))
+          (is (= :invalid-response (:error result)))
+          (is (true? (:unexpected-sut-response? result)))
+          (is (= reason
+                 (get-in result [:exception-data :reason])))
+          (is (= original @latest-values)))))
+    (is (nil? (harness/primary-failure failure-state)))))
+
+(deftest rethrows-interruptions
+  (doseq [[label throwable]
+          [["InterruptedException"
+            (InterruptedException. "interrupted")]
+           ["InterruptedIOException"
+            (java.io.InterruptedIOException. "interrupted")]
+           ["ClosedByInterruptException"
+            (java.nio.channels.ClosedByInterruptException.)]
+           ["tagged interruption"
+            (ex-info "interrupted" {:kind :interrupted})]]]
+    (testing label
+      ;; Capture the exception and interrupt flag before any assertion runs:
+      ;; clojure.test's report machinery uses dosync, which clears the flag.
+      (Thread/interrupted)
+      (let [failure-state (harness/failure-state)
+            subject (worker/wrap-client failure-state (kv-client))
+            op {:type :invoke :f :write :value (keyed "value")}
+            thrown (with-redefs [http/write! (fn [& _] (throw throwable))]
+                     (try
+                       (client/invoke! subject {} op)
                        nil
-                       (catch InterruptedException e e))
-              interrupted (Thread/interrupted)]
-          (is (instance? InterruptedException thrown))
-          (is interrupted
-              "the interrupt flag is restored so Jepsen's control signals survive"))))))
+                       (catch Throwable e
+                         e)))
+            interrupted (Thread/interrupted)]
+        (is (identical? throwable thrown))
+        (is interrupted
+            "the interrupt flag is restored so Jepsen's control signals survive")
+        (is (nil? (harness/primary-failure failure-state)))))))
 
 (deftest rethrows-unknown-client-exceptions
   (let [op {:type :invoke :f :write :value (keyed "value")}
@@ -372,21 +623,78 @@
                        e))]
         (is (identical? throwable thrown))))))
 
-(deftest unexpected-errors-checker-flags-tagged-operations
-  (let [chk (#'workload/unexpected-errors-checker)]
-    (testing "a history without unexpected errors is valid"
-      (let [result (checker/check chk {} [{:type :ok :f :read}] {})]
-        (is (:valid? result))
-        (is (= 0 (:count result)))
-        (is (= [] (:errors result)))))
+(deftest records-unknown-parser-exceptions-as-harness-failures
+  (let [failure-state (harness/failure-state)
+        subject (worker/wrap-client failure-state (kv-client))
+        op {:type :invoke :f :write :value (keyed "value")}
+        response (http-response
+                  {:Ok {:data {:value {:value "value" :version 1}}}})
+        throwable (RuntimeException. "parser bug")
+        thrown (with-redefs [http/post! (fn [& _] response)
+                             json-parse/parse-strict (fn [& _]
+                                                       (throw throwable))]
+                 (try
+                   (client/invoke! subject {} op)
+                   nil
+                   (catch RuntimeException e
+                     e)))
+        failure (harness/primary-failure failure-state)]
+    (is (identical? throwable thrown))
+    (is (= :client (:source failure)))
+    (is (= op (get-in failure [:context :operation])))
+    (is (identical? throwable (:throwable failure)))))
 
-    (testing "unexpected-tagged operations fail the check and are surfaced"
-      (let [tagged {:type :info :f :write :error [:http 500] :unexpected? true}
-            history [{:type :ok :f :read} tagged]
+(deftest unexpected-sut-responses-checker-aggregates-marked-outcomes
+  (let [chk (#'workload/unexpected-sut-responses-checker)]
+    (testing "a history without unexpected SUT responses is valid"
+      (let [result (checker/check chk {} [{:type :ok :f :read}] {})]
+        (is (true? (:valid? result)))
+        (is (= 0 (:count result)))
+        (is (= [] (:responses result)))))
+
+    (testing "marked outcomes fail the check and are aggregated"
+      (let [first-response {:type :info
+                            :f :write
+                            :error [:http 500]
+                            :unexpected-sut-response? true}
+            second-response {:type :fail
+                             :f :read
+                             :error :invalid-json
+                             :unexpected-sut-response? true}
+            history [{:type :ok :f :read}
+                     first-response
+                     {:type :info :f :write :error :timeout}
+                     second-response]
             result (checker/check chk {} history {})]
-        (is (not (:valid? result)))
-        (is (= 1 (:count result)))
-        (is (= [tagged] (:errors result)))))))
+        (is (false? (:valid? result)))
+        (is (= 2 (:count result)))
+        (is (= [first-response second-response]
+               (:responses result)))))))
+
+(deftest workload-checker-rejects-unsuccessful-final-operations
+  (let [invocation {:process 0
+                    :type :invoke
+                    :f :write
+                    :phase :final
+                    :final? true
+                    :value (keyed "value")}
+        timeout (assoc invocation
+                       :type :info
+                       :error :timeout)
+        chk (:checker (workload/workload {}))
+        result (check-in-temp-store chk [invocation timeout])]
+    (is (false? (:valid? result)))
+    (is (false? (get-in result [:final-workload :valid?])))
+    (is (= (select-keys timeout
+                        [:process :type :f :phase :final? :value :error])
+           (-> result
+               (get-in [:final-workload :failures])
+               first
+               (select-keys
+                [:process :type :f :phase :final? :value :error]))))
+    (is (true? (get-in result [:unexpected-sut-responses :valid?])))
+    (is (contains? result :linearizable))
+    (is (contains? result :meaningful-operations))))
 
 (deftest requires-successful-main-phase-operations
   (let [chk (#'workload/meaningful-operations-checker)
@@ -455,6 +763,8 @@
         chk (:checker (workload/workload {}))
         result (check-in-temp-store chk history)]
     (is (true? (get-in result [:linearizable :valid?])))
+    (is (true? (get-in result [:final-workload :valid?])))
+    (is (true? (get-in result [:unexpected-sut-responses :valid?])))
     (is (= :unknown
            (get-in result [:meaningful-operations :valid?])))
     (is (= [:write :cas]

--- a/jepsen/test/jepsen/openraft/workload_test.clj
+++ b/jepsen/test/jepsen/openraft/workload_test.clj
@@ -361,6 +361,17 @@
           (is interrupted
               "the interrupt flag is restored so Jepsen's control signals survive"))))))
 
+(deftest rethrows-unknown-client-exceptions
+  (let [op {:type :invoke :f :write :value (keyed "value")}
+        throwable (RuntimeException. "client bug")]
+    (with-redefs [http/write! (fn [& _] (throw throwable))]
+      (let [thrown (try
+                     (client/invoke! (kv-client) {} op)
+                     nil
+                     (catch RuntimeException e
+                       e))]
+        (is (identical? throwable thrown))))))
+
 (deftest unexpected-errors-checker-flags-tagged-operations
   (let [chk (#'workload/unexpected-errors-checker)]
     (testing "a history without unexpected errors is valid"


### PR DESCRIPTION
## Summary

This PR defines and enforces a consistent error-handling model for the OpenRaft Jepsen suite.

A failed operation is not necessarily a failed test. Timeouts, connection failures, routing responses, and skipped fault injection can be valid evidence about OpenRaft. Conversely, a Client, Nemesis, checker, configuration, or control-plane failure makes the test Harness untrustworthy and must not be silently converted into an ordinary operation result.

The suite now distinguishes two runtime classes:

- **Outcome**: an observation produced by a valid Workload or Nemesis request.
- **Harness failure**: a failure in the test implementation, controller, configuration, dependencies, or execution environment.

Checker verdicts are derived from those observations; they are not a third runtime event class. Interruption remains a lifecycle signal and propagates without being converted into either class.

## Outcome handling

Outcomes are written to Jepsen history and interpreted by checkers.

### Workload outcomes

The suite records modeled Client observations as normal Jepsen outcomes, including successful operations, request timeouts, connection failures, leader-routing and quorum responses, and CAS version mismatches.

A mutating request whose effect cannot be determined remains an info history event, allowing the linearizability checker to reason about it with later reads and writes.

A valid request that receives an out-of-contract SUT response is also retained as an Outcome, marked unexpected-sut-response. This covers malformed JSON, ambiguous Ok/Err envelopes, invalid payloads, and responses that contradict the request. A dedicated checker reports these responses and rejects the run.

### Nemesis outcomes

Nemesis operations use explicit, closed outcomes:

- installed: the fault or recovery is confirmed;
- skipped: the action is known not to have been installed;
- indeterminate: the action was attempted, but its effect is unknown.

Examples of modeled skips include no safe target, no reachable leader, and a membership change already in progress. Attempted actions with an uncertain effect remain indeterminate rather than being reported as success.

## Harness failure handling

The suite treats the following as Harness failures:

- unknown exceptions from Client or Nemesis code, including setup, invocation, close, teardown, and recovery paths;
- DB setup and teardown failures;
- configuration, dependency, command-construction, permission, and environment failures;
- SSH and other control-plane failures;
- unexpected teardown or recovery execution failures;
- checker implementation exceptions; and
- escaped worker exceptions found later by the strict history checker.

The first non-interruption Harness failure is retained as run-level state, including its source and original exception. Later failures remain diagnostics without replacing the primary cause.

After a Harness failure, the suite performs a controlled stop:

1. stop scheduling new ordinary Workload and Nemesis operations;
2. allow in-flight operations to complete and retain their history;
3. run final Nemesis recovery to remove installed faults;
4. skip final Workload operations because the run is already untrustworthy; and
5. run applicable analysis while preserving nested checker results.

The final aggregate checker consumes direct Harness state and strict escaped-worker evidence. Either source forces the top-level verdict to false and produces a nonzero exit status without discarding nested checker results or established counterexamples.

Checker exceptions reject a run consistently whether the checker runs alone or as a child of a composed checker. Interruptions and fatal JVM errors still propagate unchanged.

## Scope

Jepsen core owns test-store creation, history/results/log persistence, and remote artifact download. This suite declares OpenRaft artifacts but does not replace Jepsen core artifact lifecycle.

## Verification

- Java 26 Jepsen unit suite: 173 tests, 1,213 assertions, 0 failures/errors.
- Clojure lint and formatting: clj-kondo and cljfmt clean.
- Diff validation: git diff --check.

Closes #1975

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2005)
<!-- Reviewable:end -->
