### PR TITLE
test: jepsen: handle harness failures

### DIFF
--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -186,6 +186,165 @@ shared readiness check. Client operations continue while faults are active and
 during recovery. Final recovery performs one write and one read per register;
 every operation must succeed.
 
+### Outcome Semantics and Evidence
+
+[Jepsen error-handling semantics](error-handling-semantics.md) defines the
+agreed target contract. It is authoritative where the implementation notes
+below differ.
+
+An unsuccessful operation is often a correct and necessary Jepsen observation,
+not a failure of the test itself. This document uses *outcome* for the result of
+a Client or Nemesis operation, *SUT failure* for an OpenRaft property violation
+established by a checker, and *Harness failure* for a defect in the test code,
+configuration, or execution environment. An `:error` field in an EDN record is
+diagnostic data; its presence alone does not decide which category applies. The
+classification depends on whether the condition is a modeled external result,
+not on whether it occurred before, during, or after a Client or Nemesis call.
+There is no separate generic "Client error" category.
+
+#### Workload Outcomes
+
+Every Client invocation and completion belongs in `history.edn`:
+
+- `:ok` means the operation completed successfully.
+- `:fail` means the operation did not take effect.
+- `:info` means a mutating operation may or may not have taken effect, so its
+  result is indeterminate.
+
+Connection failures, request timeouts, and version mismatches can therefore be
+valid workload outcomes. Even when a Nemesis caused them, they remain workload
+outcomes because they describe what the Client observed from the SUT. Workload
+checkers interpret these outcomes together rather than treating every
+unsuccessful request as a broken test. The Client converts only recognized
+transport, HTTP, and OpenRaft API conditions into workload outcomes. A recognized
+protocol violation, such as invalid JSON, is recorded as an unexpected outcome
+for the workload checker. An exception that the Client does not recognize is a
+Harness failure, not a catch-all `:client-error` outcome.
+
+The current workload still has a catch-all `:client-error` fallback for unknown
+exceptions. Its unexpected-error checker prevents such a run from passing, but
+the fallback must be removed to enforce the boundary described above.
+
+#### Nemesis Outcomes
+
+Nemesis invocations and completions also belong in `history.edn`. Their outcomes
+describe whether a requested fault was installed, skipped, failed, or became
+indeterminate. For example, `:no-supported-leader` and
+`:no-reachable-pause-target` mean that no fault was installed and must not count
+toward fault coverage. A partial or uncertain fault leaves the affected cluster
+state unknown until a later cleanup or recovery operation proves otherwise.
+
+Nemesis operations use informational history events by convention, so their
+`:type` alone does not establish success. The OpenRaft Nemesis checkers inspect
+their structured values, errors, observed modes, and final recovery state. An
+expected operational problem must be converted into a structured Nemesis
+outcome. An unexpected implementation exception, such as a null dereference, is
+a Harness failure even when it occurs while a Nemesis operation is running.
+
+The partition, process, and pause wrappers treat exceptions from delegated fault
+injection as Harness failures. Only explicitly modeled conditions, such as a
+missing supported leader, become Nemesis outcomes. A new expected failure mode
+requires a narrow classifier; delegate exceptions must not be caught by a
+generic fallback.
+
+#### Checker Verdicts
+
+Checkers turn the collected evidence into separate verdicts. Property checkers
+decide whether OpenRaft satisfies a property: for example, the linearizability
+checker may prove that no legal sequential execution explains the Client
+history, or the crash checker may find the stable panic marker in an OpenRaft
+node log. Coverage checkers instead decide whether the run produced enough
+evidence that required scenarios were successfully exercised, such as all
+required Nemesis modes and successful main-phase operations. Nemesis checkers
+also verify a separate lifecycle postcondition: after fault cleanup, the cluster
+must return to the required state within the recovery deadline.
+
+A coverage failure rejects the run but does not by itself identify an OpenRaft
+failure or its root cause. For example, `:missing-modes` is written to
+`results.edn`; the mode may be absent from `history.edn`, skipped by an outcome
+such as `:no-supported-leader`, or blocked by a Harness failure recorded in
+`jepsen.log`. Start with the nested checker result, inspect the corresponding
+operations in `history.edn`, and then use `jepsen.log` for Harness diagnostics.
+
+The top-level `:valid?` combines these independent verdicts and answers only
+whether the entire run can be accepted. It does not by itself identify an
+OpenRaft property violation or the state of the Harness.
+
+#### Harness Failures
+
+Harness failures include Client or Nemesis implementation bugs, invalid test
+configuration, missing runtime dependencies, and unexpected failures in setup,
+teardown, artifact storage, or checker execution. They make the run unacceptable
+and must not be reclassified as ordinary workload or Nemesis outcomes. They do
+not automatically erase a conclusion already established by a nested checker.
+`jepsen.log` is the primary diagnostic record for these failures. Jepsen may also
+attach a worker exception to the operation being executed in `history.edn`; that
+association is diagnostic evidence, not a successful or expected outcome.
+
+Best-effort teardown is different from formal fault cleanup. When cleanup and
+recovery completions exist in `history.edn`, they determine the checker verdict;
+teardown must not manufacture a successful outcome. An expected teardown
+cleanup failure should be logged as a warning and must not prevent analysis of
+the recorded history. An unexpected teardown implementation failure remains a
+Harness failure.
+
+The current partition and pause teardown implementations do not yet enforce
+this boundary: they log every non-interruption exception as a cleanup warning.
+They must be narrowed so unexpected implementation exceptions remain Harness
+failures.
+
+The required Harness policy is controlled fail-fast. The first unhandled
+exception should be retained as the run-level cause, stop new Client and Nemesis
+operations, run best-effort fault cleanup, preserve the available artifacts,
+and exit nonzero. The run cannot pass, although individual property and coverage
+checkers may still produce independent verdicts. A Harness failure does not by
+itself prove an SUT failure.
+
+Interruption is a cancellation mechanism, not an operation outcome or a
+standalone failure category. Client and Nemesis code must restore the thread's
+interrupt flag and rethrow instead of converting interruption into `:fail`,
+`:info`, or a cleanup warning. Normal Jepsen completion does not use
+interruption: after the generator is exhausted, the interpreter drains
+outstanding operations and stops its workers. If the interpreter exits
+abnormally, worker interruption is a secondary cleanup signal rather than the
+original failure. Client and Nemesis code must therefore propagate interruption
+without trying to infer its cause. Controlled fail-fast instead needs a
+run-level channel for the first unhandled exception, not cancellation-origin or
+Harness fields in `history.edn`.
+
+The current implementation does not yet have this run-level failure channel or
+stop the schedule immediately. Jepsen catches a worker exception, records an
+`:info` completion with `:exception`, and continues running. The strict
+unhandled-exception checker reports `:unknown`, so such a run cannot pass;
+another nested checker may still make the composed top-level result `false`.
+Controlled fail-fast remains necessary to report the Harness failure at the
+point where it occurs.
+
+#### Stored Evidence
+
+A run normally stores its artifacts under
+`jepsen/store/<test-name>/<timestamp>/`:
+
+- `history.edn` is the structured Client and Nemesis history used by the
+  workload, Nemesis, statistics, and unhandled-exception checkers. `history.txt`
+  is a human-readable rendering of the same history.
+- `jepsen.log` records Harness activity and diagnostics from setup, workers,
+  fault injection, teardown, and analysis. Checkers do not use it as an
+  observation source.
+- `<node>/openraft.log` is the collected runtime log of the OpenRaft test
+  application on that node. The crash checker scans it for the test
+  application's stable panic marker.
+- `results.edn` contains the composed checker results and top-level verdict. It
+  is a summary, not the raw execution record.
+- `test.jepsen` contains the original test map, including run options and the
+  random seed. It remains useful when a Harness failure prevents `results.edn`
+  from being written.
+
+Use `history.edn` to reconstruct requests and the fault schedule, `jepsen.log`
+to diagnose the Harness, and each node's `openraft.log` to investigate the
+OpenRaft process. Start with `results.edn` when the run reached analysis and a
+checker verdict is available.
+
 ### Interpreting Results
 
 Each run writes its checker output to

--- a/jepsen/error-handling-semantics.md
+++ b/jepsen/error-handling-semantics.md
@@ -1,0 +1,162 @@
+# Jepsen Error-Handling Semantics
+
+This document defines the agreed error-handling contract for OpenRaft Jepsen
+runs. It specifies the target behavior. Current implementation notes may
+describe gaps, but Client, Nemesis, lifecycle, and checker code must preserve
+these boundaries.
+
+## Classification Model
+
+OpenRaft Jepsen recognizes only two runtime event classes:
+
+- An **Outcome** is a result or observation recorded at a Workload or Nemesis
+  boundary.
+- A **Harness failure** is a failure in the test code, controller, configuration,
+  dependencies, or execution environment.
+
+Checker verdicts are derived from the recorded history and outcomes. They are
+analysis results, not a third event class alongside Outcomes and Harness
+failures. A checker can reject a run because it found a system under test (SUT)
+property violation, insufficient coverage, or another failed postcondition.
+
+Interruption is not a runtime event class. It is a lifecycle signal that must
+propagate to the caller.
+
+## Workload Outcomes
+
+Workload outcomes include successful operations, modeled failures, and
+ambiguous observations. Request timeouts and connection failures are valid
+outcomes when they describe what a Client observed through the SUT API. For a
+mutating request, such an observation may leave the operation's effect unknown.
+
+`:unexpected-sut-response?` is an attribute on a Workload outcome, not a new
+outcome class. Set it only when a valid request receives a SUT response outside
+the modeled API contract, such as an unexpected HTTP response or invalid
+response shape. Keep that outcome in the history so the
+`unexpected-sut-responses` checker can report it and reject the run.
+
+Do not set `:unexpected-sut-response?` on modeled failures or ambiguous
+observations, including timeouts, connection failures, or quorum-related
+rejections. Unknown Client, Nemesis, or other Harness exceptions must not
+receive the marker. They are Harness failures.
+
+## Nemesis Outcomes
+
+A Nemesis operation has only three modeled outcomes:
+
+- `installed` means the requested fault is known to have been installed, or the
+  requested restoration is known to have completed.
+- `skipped` means the action is known not to have been installed. Reasons
+  include no safe target, no reachable leader, or a membership change already
+  in progress.
+- `indeterminate` means the action was attempted, but the available evidence
+  cannot establish whether its side effect occurred.
+
+There is no generic `failed` Nemesis outcome. A condition belongs in `skipped`
+or `indeterminate` only when its meaning is explicitly modeled. An unclassified
+exception or execution failure is a Harness failure.
+
+The modeled `skipped` reasons assume a functioning control plane. Failure to
+find or control a target because SSH failed is a Harness failure.
+
+## Harness Failures
+
+Harness failures include:
+
+- configuration, dependency, and environment failures;
+- every SSH and other control-plane failure;
+- unknown exceptions from Client, Nemesis, or checker code;
+- command construction, permission, and environment-execution failures; and
+- unexpected teardown or recovery failures.
+
+SSH carries controller-to-node management traffic for setup, fault control,
+recovery, and artifact collection. It is separate from Client traffic through
+the SUT API and from node-to-node Raft traffic. An SSH authentication,
+connection, session, or remote-execution failure is therefore always a Harness
+failure, including when it occurs during a Nemesis operation. Uncertainty after
+an SSH command was dispatched does not turn that failure into a Nemesis
+`indeterminate` outcome.
+
+## Controlled Stop After the First Harness Failure
+
+The first Harness failure starts a controlled stop:
+
+1. Record the first failure as run-level state, including its source and
+   original exception. Later failures must not replace it.
+2. A gate around the ordinary runtime generator returns `nil` whenever Jepsen
+   asks for another operation. This stops new ordinary Client and Nemesis
+   operations from being scheduled.
+3. Preserve completions from operations already in flight.
+4. Run the final Nemesis recovery generator so installed faults can be removed
+   and the cluster can recover.
+5. Skip final Workload reads and writes. They cannot make a compromised run
+   acceptable and would add new Workload history after the experiment stopped.
+6. Run applicable analysis and retain its checker outputs.
+7. Finish with a nonzero exit status.
+
+The generator gate does not throw and does not perform cleanup. Returning `nil`
+means normal generator exhaustion. It is neither an exception nor an
+interruption. Existing lifecycle handling drains in-flight operations and then
+runs final recovery, teardown, artifact collection, and applicable analysis.
+
+## Teardown, Recovery, and Interruption
+
+Membership and Recovery Nemeses have empty `teardown!` methods. Their formal
+recovery belongs in final Nemesis operations.
+
+Other Nemeses may perform cleanup during teardown. A failure in a non-empty
+teardown is a Harness failure. Record it, then continue independent cleanup,
+artifact collection, and applicable analysis. Teardown must not exit early
+because one cleanup failed, and the failure must not be reduced to a warning.
+
+A modeled final-recovery outcome remains a Nemesis outcome, and a failed
+recovery postcondition remains a checker verdict. An unexpected execution
+failure while recovery is running is a Harness failure.
+
+Interruption must propagate through Client, Nemesis, teardown, and recovery
+code. Restore the thread's interruption state when required by the runtime and
+rethrow the interruption. Do not convert it into an Outcome or Harness failure.
+
+## `strict-unhandled-exceptions`
+
+`strict-unhandled-exceptions` is a fallback diagnostic checker. An exception
+that escapes a Client or Nemesis worker shows that the Harness missed a
+classification boundary. The exception is a Harness failure.
+
+The run-level first-failure state remains authoritative for runtime control.
+This checker runs after teardown, when it cannot retroactively stop work or
+recover the original `Throwable`. If it finds an escaped worker exception that
+the run-level path missed, it emits structured post-hoc Harness evidence and
+rejects the final verdict. It does not synthesize or mutate runtime failure
+state from history.
+
+Interruption is excluded from this rule and continues to propagate as a
+lifecycle signal.
+
+## Checker Exceptions
+
+A non-interruption, non-fatal exception from checker implementation code is a
+post-hoc Harness failure. The checker records serializable exception evidence
+on its own result and returns a `false` verdict. This rule applies equally to a
+checker run alone, a checker used as a composed child, and the composition
+itself. Other independent checkers may still run and retain their results.
+
+Checker exceptions do not mutate run-level failure state: analysis happens
+after execution, so they cannot retroactively control scheduling or recover the
+original runtime context.
+
+## Run Acceptance
+
+Any Harness failure makes the whole run unacceptable and requires a nonzero
+exit. It does not erase recorded history, logs, nested checker results, or an
+existing counterexample. A Harness failure does not by itself prove a SUT
+property violation, and it does not invalidate a property violation that a
+checker already established from retained evidence.
+
+## Jepsen Core Artifact Lifecycle
+
+Jepsen core owns test-store creation, history and result persistence, Harness
+log persistence, and remote artifact download. This suite declares OpenRaft
+artifacts but does not wrap or replace that lifecycle. Consequently, artifact
+persistence failures are not suite-level Harness failures specified here;
+their handling belongs to Jepsen core.

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -85,13 +85,16 @@
 (defn- lifecycle-generator
   [failure-state time-limit workload nemesis-package]
   (gen/phases
-   (openraft-generator/stop-on-harness-failure
-    failure-state
-    (gen/shortest-any
-     (gen/nemesis
-      (gen/time-limit time-limit (:generator nemesis-package)))
+   (gen/shortest-any
+    (gen/nemesis
+     (gen/phases
+      (openraft-generator/stop-on-harness-failure
+       failure-state
+       (gen/time-limit time-limit (:generator nemesis-package)))
+      (:final-generator nemesis-package)))
+    (openraft-generator/pending-on-harness-failure
+     failure-state
      (:generator workload)))
-   (gen/nemesis (:final-generator nemesis-package))
    (delay
      (when-not (harness/primary-failure failure-state)
        (openraft-generator/stop-on-harness-failure

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -8,7 +8,10 @@
              [tests :as tests]]
             [jepsen.openraft [checker :as openraft-checker]
              [db :as openraft-db]
+             [generator :as openraft-generator]
+             [harness :as harness]
              [nemesis :as openraft-nemesis]
+             [worker :as worker]
              [workload :as workload]]
             [jepsen.openraft.nemesis [membership :as membership]
              [partition :as partition]
@@ -79,8 +82,25 @@
               (random/set-seed! seed)
               (assoc options :seed seed)))))
 
+(defn- lifecycle-generator
+  [failure-state time-limit workload nemesis-package]
+  (gen/phases
+   (openraft-generator/stop-on-harness-failure
+    failure-state
+    (gen/shortest-any
+     (gen/nemesis
+      (gen/time-limit time-limit (:generator nemesis-package)))
+     (:generator workload)))
+   (gen/nemesis (:final-generator nemesis-package))
+   (delay
+     (when-not (harness/primary-failure failure-state)
+       (openraft-generator/stop-on-harness-failure
+        failure-state
+        (:final-generator workload))))))
+
 (defn openraft-test [opts]
-  (let [database (openraft-db/db opts)
+  (let [failure-state (harness/failure-state)
+        database (openraft-db/db opts)
         workload (workload/workload opts)
         nemesis-types (normalize-nemeses (:nemesis opts))
         nemesis-package
@@ -104,18 +124,13 @@
            {:name (str "openraft linearizable registers "
                        (str/join "," (map name nemesis-types)))
             :db database
-            :client (:client workload)
-            :nemesis (:nemesis nemesis-package)
-            :generator (gen/phases
-                        (gen/shortest-any
-                         (gen/nemesis
-                          (gen/phases
-                           (gen/time-limit
-                            (:time-limit opts)
-                            (:generator nemesis-package))
-                           (:final-generator nemesis-package)))
-                         (:generator workload))
-                        (:final-generator workload))
+            :client (worker/wrap-client failure-state (:client workload))
+            :nemesis (worker/wrap-nemesis failure-state
+                                          (:nemesis nemesis-package))
+            :generator (lifecycle-generator failure-state
+                                            (:time-limit opts)
+                                            workload
+                                            nemesis-package)
             :checker (checker/compose
                       {:seed (openraft-checker/random-seed-checker)
                        :stats (checker/stats)

--- a/jepsen/src/jepsen/openraft/generator.clj
+++ b/jepsen/src/jepsen/openraft/generator.clj
@@ -19,3 +19,25 @@
   [failure-state generator]
   (when generator
     (StopOnHarnessFailure. failure-state generator)))
+
+(defrecord PendingOnHarnessFailure [failure-state generator]
+  gen/Generator
+  (op [_ test context]
+    (if (harness/primary-failure failure-state)
+      [:pending (PendingOnHarnessFailure. failure-state generator)]
+      (when-let [[operation generator'] (gen/op generator test context)]
+        [operation (PendingOnHarnessFailure. failure-state generator')])))
+
+  (update [_ test context event]
+    (let [generator' (gen/update generator test context event)]
+      (if (harness/primary-failure failure-state)
+        (PendingOnHarnessFailure. failure-state generator')
+        (when generator'
+          (PendingOnHarnessFailure. failure-state generator'))))))
+
+(defn pending-on-harness-failure
+  "Stops scheduling work after a Harness failure without exhausting a parent
+  generator that must still run recovery."
+  [failure-state generator]
+  (when generator
+    (PendingOnHarnessFailure. failure-state generator)))

--- a/jepsen/src/jepsen/openraft/generator.clj
+++ b/jepsen/src/jepsen/openraft/generator.clj
@@ -1,0 +1,21 @@
+(ns jepsen.openraft.generator
+  (:require [jepsen.generator :as gen]
+            [jepsen.openraft.harness :as harness]))
+
+(defrecord StopOnHarnessFailure [failure-state generator]
+  gen/Generator
+  (op [_ test context]
+    (when-not (harness/primary-failure failure-state)
+      (when-let [[operation generator'] (gen/op generator test context)]
+        (when-not (harness/primary-failure failure-state)
+          [operation (StopOnHarnessFailure. failure-state generator')]))))
+
+  (update [_ test context event]
+    (when-let [generator' (gen/update generator test context event)]
+      (StopOnHarnessFailure. failure-state generator'))))
+
+(defn stop-on-harness-failure
+  "Stops new operations after a Harness failure while forwarding updates."
+  [failure-state generator]
+  (when generator
+    (StopOnHarnessFailure. failure-state generator)))

--- a/jepsen/src/jepsen/openraft/harness.clj
+++ b/jepsen/src/jepsen/openraft/harness.clj
@@ -1,0 +1,22 @@
+(ns jepsen.openraft.harness
+  (:require [jepsen.openraft.interruption :as interruption]))
+
+(defn failure-state
+  "Creates run-scoped state for the primary Harness failure."
+  []
+  (atom nil))
+
+(defn primary-failure
+  "Returns the first recorded Harness failure, or nil."
+  [state]
+  @state)
+
+(defn record-failure!
+  "Atomically records the first non-interruption Harness failure."
+  [state source context throwable]
+  (and (not (interruption/interruption? throwable))
+       (compare-and-set! state
+                         nil
+                         {:source source
+                          :context context
+                          :throwable throwable})))

--- a/jepsen/src/jepsen/openraft/worker.clj
+++ b/jepsen/src/jepsen/openraft/worker.clj
@@ -1,0 +1,65 @@
+(ns jepsen.openraft.worker
+  (:require [jepsen [client :as client]
+             [nemesis :as nemesis]]
+            [jepsen.openraft.harness :as harness]))
+
+(defn- call-recording-failure
+  [failure-state source context f]
+  (try
+    (f)
+    (catch Throwable throwable
+      (harness/record-failure! failure-state source context throwable)
+      (throw throwable))))
+
+(defn wrap-client
+  "Records failures from Client worker lifecycle and invocation boundaries."
+  [failure-state delegate]
+  (reify client/Client
+    (open! [_ test node]
+      (wrap-client
+       failure-state
+       (call-recording-failure failure-state
+                               :client
+                               {:phase :open
+                                :node node}
+                               #(client/open! delegate test node))))
+
+    (setup! [_ test]
+      (wrap-client failure-state (client/setup! delegate test)))
+
+    (invoke! [_ test op]
+      (call-recording-failure failure-state
+                              :client
+                              {:phase :invoke
+                               :operation op}
+                              #(client/invoke! delegate test op)))
+
+    (teardown! [_ test]
+      (client/teardown! delegate test))
+
+    (close! [_ test]
+      (call-recording-failure failure-state
+                              :client
+                              {:phase :close}
+                              #(client/close! delegate test)))
+
+    client/Reusable
+    (reusable? [_ test]
+      (client/is-reusable? delegate test))))
+
+(defn wrap-nemesis
+  "Records failures from the Nemesis worker invocation boundary."
+  [failure-state delegate]
+  (reify nemesis/Nemesis
+    (setup! [_ test]
+      (wrap-nemesis failure-state (nemesis/setup! delegate test)))
+
+    (invoke! [_ test op]
+      (call-recording-failure failure-state
+                              :nemesis
+                              {:phase :invoke
+                               :operation op}
+                              #(nemesis/invoke! delegate test op)))
+
+    (teardown! [_ test]
+      (nemesis/teardown! delegate test))))

--- a/jepsen/src/jepsen/openraft/workload.clj
+++ b/jepsen/src/jepsen/openraft/workload.clj
@@ -169,7 +169,7 @@
                 :else
                 (complete-with-ambiguous-outcome op :openraft-error true))
 
-              (complete-with-ambiguous-outcome op :client-error true))]
+              (throw e))]
         (cond-> result
           (or (:unexpected? result) (:final? op))
           (assoc :exception-message (ex-message e)

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -1,8 +1,13 @@
 (ns jepsen.openraft.cli-test
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.tools.cli :as tools-cli]
+            [jepsen.generator :as gen]
+            [jepsen.generator.test :as gen-test]
             [jepsen.openraft.cli :as cli]
             [jepsen.openraft.db :as openraft-db]
+            [jepsen.openraft.generator :as openraft-generator]
+            [jepsen.openraft.harness :as harness]
+            [jepsen.openraft.worker :as worker]
             [jepsen.random :as random]))
 
 (deftest records-and-applies-the-random-seed
@@ -75,3 +80,109 @@
            (set (keys checkers))))
     (is (= #{:partition :membership}
            (set (keys nemesis-checkers))))))
+
+(deftest shares-one-harness-state-across-workers-and-generators
+  (let [failure-state (harness/failure-state)
+        wrapped-states (atom [])
+        generator-states (atom [])
+        wrap (fn [source]
+               (fn [state delegate]
+                 (swap! wrapped-states conj [source state])
+                 delegate))
+        stop (fn [state generator]
+               (swap! generator-states conj state)
+               generator)]
+    (with-redefs [harness/failure-state (constantly failure-state)
+                  worker/wrap-client (wrap :client)
+                  worker/wrap-nemesis (wrap :nemesis)
+                  openraft-generator/stop-on-harness-failure stop]
+      (cli/openraft-test {:nemesis :partition
+                          :nodes ["n1" "n2" "n3"]
+                          :time-limit 10}))
+    (is (= [:client :nemesis] (mapv first @wrapped-states)))
+    (is (every? #(identical? failure-state (second %))
+                @wrapped-states))
+    (is (= 1 (count @generator-states)))
+    (is (identical? failure-state (first @generator-states)))))
+
+(defn- lifecycle-test-generator [failure-state]
+  (#'cli/lifecycle-generator
+   failure-state
+   0.3
+   {:generator (gen/clients
+                (gen/delay 0.1 (repeat {:f :ordinary-workload})))
+    :final-generator (gen/clients [{:f :final-workload-1}
+                                   {:f :final-workload-2}])}
+   {:generator (gen/delay
+                 0.1
+                 (repeat {:type :info :f :ordinary-nemesis}))
+    :final-generator {:type :info :f :final-nemesis}}))
+
+(defn- simulate-lifecycle [failure-state failure-operation]
+  (let [operations (atom [])
+        failure-recorded? (atom false)
+        history (gen-test/simulate
+                 (lifecycle-test-generator failure-state)
+                 (fn [_context operation]
+                   (swap! operations conj (:f operation))
+                   (when (and (= failure-operation (:f operation))
+                              (compare-and-set! failure-recorded? false true))
+                     (harness/record-failure!
+                      failure-state
+                      :client
+                      {:operation operation}
+                      (RuntimeException. "client failed")))
+                   (-> operation
+                       (assoc :type (if (= :nemesis (:process operation))
+                                      :info
+                                      :ok))
+                       (update :time + 10))))]
+    {:history history
+     :operations @operations}))
+
+(deftest runs-the-full-lifecycle-without-a-harness-failure
+  (let [{:keys [operations]}
+        (simulate-lifecycle (harness/failure-state) nil)]
+    (is (some #{:ordinary-workload} operations))
+    (is (some #{:ordinary-nemesis} operations))
+    (is (= [:final-nemesis :final-workload-1 :final-workload-2]
+           (filter #{:final-nemesis
+                     :final-workload-1
+                     :final-workload-2}
+                   operations)))))
+
+(deftest recovers-and-skips-final-workload-after-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        {:keys [history operations]}
+        (simulate-lifecycle failure-state :ordinary-workload)
+        workload-completion-index
+        (first (keep-indexed (fn [index operation]
+                               (when (and (= :ordinary-workload
+                                             (:f operation))
+                                          (= :ok (:type operation)))
+                                 index))
+                             history))
+        recovery-index
+        (first (keep-indexed (fn [index operation]
+                               (when (= :final-nemesis (:f operation))
+                                 index))
+                             history))]
+    (is (some? (harness/primary-failure failure-state)))
+    (is (< workload-completion-index recovery-index))
+    (is (= 1 (count (filter #{:ordinary-workload} operations))))
+    (is (= [:final-nemesis]
+           (filter #{:final-nemesis
+                     :final-workload-1
+                     :final-workload-2}
+                   operations)))))
+
+(deftest stops-final-workload-after-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        {:keys [operations]}
+        (simulate-lifecycle failure-state :final-workload-1)]
+    (is (some? (harness/primary-failure failure-state)))
+    (is (= [:final-nemesis :final-workload-1]
+           (filter #{:final-nemesis
+                     :final-workload-1
+                     :final-workload-2}
+                   operations)))))

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -84,26 +84,33 @@
 (deftest shares-one-harness-state-across-workers-and-generators
   (let [failure-state (harness/failure-state)
         wrapped-states (atom [])
-        generator-states (atom [])
+        stopped-states (atom [])
+        pending-states (atom [])
         wrap (fn [source]
                (fn [state delegate]
                  (swap! wrapped-states conj [source state])
                  delegate))
         stop (fn [state generator]
-               (swap! generator-states conj state)
+               (swap! stopped-states conj state)
                generator)]
     (with-redefs [harness/failure-state (constantly failure-state)
                   worker/wrap-client (wrap :client)
                   worker/wrap-nemesis (wrap :nemesis)
-                  openraft-generator/stop-on-harness-failure stop]
+                  openraft-generator/stop-on-harness-failure stop
+                  openraft-generator/pending-on-harness-failure
+                  (fn [state generator]
+                    (swap! pending-states conj state)
+                    generator)]
       (cli/openraft-test {:nemesis :partition
                           :nodes ["n1" "n2" "n3"]
                           :time-limit 10}))
     (is (= [:client :nemesis] (mapv first @wrapped-states)))
     (is (every? #(identical? failure-state (second %))
                 @wrapped-states))
-    (is (= 1 (count @generator-states)))
-    (is (identical? failure-state (first @generator-states)))))
+    (is (= 1 (count @stopped-states)))
+    (is (identical? failure-state (first @stopped-states)))
+    (is (= 1 (count @pending-states)))
+    (is (identical? failure-state (first @pending-states)))))
 
 (defn- lifecycle-test-generator [failure-state]
   (#'cli/lifecycle-generator
@@ -116,7 +123,10 @@
    {:generator (gen/delay
                  0.1
                  (repeat {:type :info :f :ordinary-nemesis}))
-    :final-generator {:type :info :f :final-nemesis}}))
+    :final-generator (gen/delay
+                       0.3
+                       [{:type :info :f :final-nemesis-1}
+                        {:type :info :f :final-nemesis-2}])}))
 
 (defn- simulate-lifecycle [failure-state failure-operation]
   (let [operations (atom [])
@@ -141,12 +151,20 @@
      :operations @operations}))
 
 (deftest runs-the-full-lifecycle-without-a-harness-failure
-  (let [{:keys [operations]}
-        (simulate-lifecycle (harness/failure-state) nil)]
+  (let [{:keys [history operations]}
+        (simulate-lifecycle (harness/failure-state) nil)
+        recovery-start (first (filter #(= :final-nemesis-1 (:f %)) history))
+        recovery-end (first (filter #(= :final-nemesis-2 (:f %)) history))]
     (is (some #{:ordinary-workload} operations))
     (is (some #{:ordinary-nemesis} operations))
-    (is (= [:final-nemesis :final-workload-1 :final-workload-2]
-           (filter #{:final-nemesis
+    (is (some (fn [operation]
+                (and (= :ordinary-workload (:f operation))
+                     (> (:time operation) (:time recovery-start))
+                     (< (:time operation) (:time recovery-end))))
+              history))
+    (is (= [:final-nemesis-1 :final-nemesis-2
+            :final-workload-1 :final-workload-2]
+           (filter #{:final-nemesis-1 :final-nemesis-2
                      :final-workload-1
                      :final-workload-2}
                    operations)))))
@@ -164,14 +182,14 @@
                              history))
         recovery-index
         (first (keep-indexed (fn [index operation]
-                               (when (= :final-nemesis (:f operation))
+                               (when (= :final-nemesis-1 (:f operation))
                                  index))
                              history))]
     (is (some? (harness/primary-failure failure-state)))
     (is (< workload-completion-index recovery-index))
     (is (= 1 (count (filter #{:ordinary-workload} operations))))
-    (is (= [:final-nemesis]
-           (filter #{:final-nemesis
+    (is (= [:final-nemesis-1 :final-nemesis-2]
+           (filter #{:final-nemesis-1 :final-nemesis-2
                      :final-workload-1
                      :final-workload-2}
                    operations)))))
@@ -181,8 +199,8 @@
         {:keys [operations]}
         (simulate-lifecycle failure-state :final-workload-1)]
     (is (some? (harness/primary-failure failure-state)))
-    (is (= [:final-nemesis :final-workload-1]
-           (filter #{:final-nemesis
+    (is (= [:final-nemesis-1 :final-nemesis-2 :final-workload-1]
+           (filter #{:final-nemesis-1 :final-nemesis-2
                      :final-workload-1
                      :final-workload-2}
                    operations)))))

--- a/jepsen/test/jepsen/openraft/generator_test.clj
+++ b/jepsen/test/jepsen/openraft/generator_test.clj
@@ -1,0 +1,55 @@
+(ns jepsen.openraft.generator-test
+  (:require [clojure.test :refer [deftest is]]
+            [jepsen.generator :as gen]
+            [jepsen.generator.test :as gen-test]
+            [jepsen.openraft.generator :as openraft-generator]
+            [jepsen.openraft.harness :as harness]))
+
+(deftest stops-new-operations-after-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        generator (openraft-generator/stop-on-harness-failure
+                   failure-state
+                   [{:f :first} {:f :second}])
+        [operation generator'] (gen/op generator
+                                       gen-test/default-test
+                                       gen-test/default-context)]
+    (is (= :first (:f operation)))
+    (harness/record-failure! failure-state
+                             :client
+                             {:operation operation}
+                             (RuntimeException. "client failed"))
+    (is (nil? (gen/op generator'
+                      gen-test/default-test
+                      gen-test/default-context)))))
+
+(deftest forwards-in-flight-updates-after-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        events (atom [])
+        delegate (gen/on-update
+                  (fn [generator _test _context event]
+                    (swap! events conj event)
+                    generator)
+                  (repeat {:f :ordinary-workload}))
+        generator (openraft-generator/stop-on-harness-failure
+                   failure-state
+                   delegate)
+        [operation generator'] (gen/op generator
+                                       gen-test/default-test
+                                       gen-test/default-context)
+        completion (assoc operation :type :ok)]
+    (harness/record-failure! failure-state
+                             :client
+                             {:operation operation}
+                             (RuntimeException. "client failed"))
+    (let [after-invocation (gen/update generator'
+                                       gen-test/default-test
+                                       gen-test/default-context
+                                       operation)
+          after-completion (gen/update after-invocation
+                                       gen-test/default-test
+                                       gen-test/default-context
+                                       completion)]
+      (is (= [operation completion] @events))
+      (is (nil? (gen/op after-completion
+                        gen-test/default-test
+                        gen-test/default-context))))))

--- a/jepsen/test/jepsen/openraft/generator_test.clj
+++ b/jepsen/test/jepsen/openraft/generator_test.clj
@@ -53,3 +53,30 @@
       (is (nil? (gen/op after-completion
                         gen-test/default-test
                         gen-test/default-context))))))
+
+(deftest keeps-a-parent-generator-alive-after-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        generator (openraft-generator/pending-on-harness-failure
+                   failure-state
+                   [{:f :ordinary-workload}])
+        [operation generator'] (gen/op generator
+                                       gen-test/default-test
+                                       gen-test/default-context)]
+    (is (= :ordinary-workload (:f operation)))
+    (harness/record-failure! failure-state
+                             :client
+                             {:operation operation}
+                             (RuntimeException. "client failed"))
+    (let [[pending generator''] (gen/op generator'
+                                        gen-test/default-test
+                                        gen-test/default-context)]
+      (is (= :pending pending))
+      (is (some? generator''))
+      (let [after-completion (gen/update generator''
+                                         gen-test/default-test
+                                         gen-test/default-context
+                                         (assoc operation :type :ok))
+            [pending _] (gen/op after-completion
+                                gen-test/default-test
+                                gen-test/default-context)]
+        (is (= :pending pending))))))

--- a/jepsen/test/jepsen/openraft/harness_test.clj
+++ b/jepsen/test/jepsen/openraft/harness_test.clj
@@ -1,0 +1,51 @@
+(ns jepsen.openraft.harness-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen.openraft.harness :as harness]))
+
+(deftest starts-without-a-primary-failure
+  (is (nil? (harness/primary-failure (harness/failure-state)))))
+
+(deftest records-the-first-failure
+  (let [state (harness/failure-state)
+        context {:operation :write
+                 :node :n1}
+        throwable (ex-info "Client failed" {:kind :client-error})]
+    (harness/record-failure! state :client context throwable)
+    (let [failure (harness/primary-failure state)]
+      (is (= :client (:source failure)))
+      (is (= context (:context failure)))
+      (is (identical? throwable (:throwable failure))))))
+
+(deftest retains-the-first-failure
+  (let [state (harness/failure-state)
+        first-throwable (RuntimeException. "first")
+        later-throwable (RuntimeException. "later")]
+    (harness/record-failure! state
+                             :nemesis
+                             {:operation :partition}
+                             first-throwable)
+    (harness/record-failure! state
+                             :teardown
+                             {:operation :heal}
+                             later-throwable)
+    (let [failure (harness/primary-failure state)]
+      (is (= :nemesis (:source failure)))
+      (is (= {:operation :partition} (:context failure)))
+      (is (identical? first-throwable (:throwable failure))))))
+
+(deftest ignores-interruptions
+  (doseq [[description throwable]
+          [["InterruptedException" (InterruptedException. "interrupted")]
+           ["InterruptedIOException"
+            (java.io.InterruptedIOException. "interrupted")]
+           ["ClosedByInterruptException"
+            (java.nio.channels.ClosedByInterruptException.)]
+           ["interrupted ex-info"
+            (ex-info "interrupted" {:kind :interrupted})]]]
+    (testing description
+      (let [state (harness/failure-state)]
+        (harness/record-failure! state
+                                 :client
+                                 {:operation :read}
+                                 throwable)
+        (is (nil? (harness/primary-failure state)))))))

--- a/jepsen/test/jepsen/openraft/worker_test.clj
+++ b/jepsen/test/jepsen/openraft/worker_test.clj
@@ -1,0 +1,168 @@
+(ns jepsen.openraft.worker-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen [client :as client]
+             [nemesis :as nemesis]]
+            [jepsen.openraft [harness :as harness]
+             [worker :as worker]]))
+
+(defn- test-client
+  [{:keys [open-f invoke-f close-f]
+    :or {open-f (fn [this _test _node] this)
+         invoke-f (fn [_test op] (assoc op :type :ok))
+         close-f (fn [_test])}}]
+  (reify client/Client
+    (open! [this test node]
+      (open-f this test node))
+
+    (setup! [this _test]
+      this)
+
+    (invoke! [_ test op]
+      (invoke-f test op))
+
+    (teardown! [_ _test])
+
+    (close! [_ test]
+      (close-f test))))
+
+(defn- test-nemesis [invoke-f]
+  (reify nemesis/Nemesis
+    (setup! [this _test]
+      this)
+
+    (invoke! [_ test op]
+      (invoke-f test op))
+
+    (teardown! [_ _test])))
+
+(defn- thrown-by [f]
+  (try
+    (f)
+    nil
+    (catch Throwable throwable
+      throwable)))
+
+(defn- assert-primary-failure
+  [failure-state source context throwable]
+  (let [failure (harness/primary-failure failure-state)]
+    (is (= source (:source failure)))
+    (is (= context (:context failure)))
+    (is (identical? throwable (:throwable failure)))))
+
+(deftest records-client-worker-failures
+  (testing "open"
+    (let [failure-state (harness/failure-state)
+          throwable (RuntimeException. "open failed")
+          subject (worker/wrap-client
+                   failure-state
+                   (test-client {:open-f (fn [& _] (throw throwable))}))
+          thrown (thrown-by #(client/open! subject {} "n1"))]
+      (is (identical? throwable thrown))
+      (assert-primary-failure failure-state
+                              :client
+                              {:phase :open
+                               :node "n1"}
+                              throwable)))
+
+  (testing "invoke"
+    (let [failure-state (harness/failure-state)
+          throwable (RuntimeException. "invoke failed")
+          op {:type :invoke
+              :process 0
+              :f :read}
+          subject (worker/wrap-client
+                   failure-state
+                   (test-client {:invoke-f (fn [& _] (throw throwable))}))
+          opened (client/open! subject {} "n1")
+          thrown (thrown-by #(client/invoke! opened {} op))]
+      (is (identical? throwable thrown))
+      (assert-primary-failure failure-state
+                              :client
+                              {:phase :invoke
+                               :operation op}
+                              throwable)))
+
+  (testing "close"
+    (let [failure-state (harness/failure-state)
+          throwable (RuntimeException. "close failed")
+          subject (worker/wrap-client
+                   failure-state
+                   (test-client {:close-f (fn [& _] (throw throwable))}))
+          thrown (thrown-by #(client/close! subject {}))]
+      (is (identical? throwable thrown))
+      (assert-primary-failure failure-state
+                              :client
+                              {:phase :close}
+                              throwable))))
+
+(deftest records-nemesis-worker-failures
+  (let [failure-state (harness/failure-state)
+        throwable (RuntimeException. "nemesis failed")
+        op {:type :info
+            :process :nemesis
+            :f :start-partition}
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (test-nemesis (fn [& _] (throw throwable))))
+        setup-subject (nemesis/setup! subject {})
+        thrown (thrown-by #(nemesis/invoke! setup-subject {} op))]
+    (is (identical? throwable thrown))
+    (assert-primary-failure failure-state
+                            :nemesis
+                            {:phase :invoke
+                             :operation op}
+                            throwable)))
+
+(deftest modeled-outcomes-do-not-record-failures
+  (let [failure-state (harness/failure-state)
+        client-outcome {:type :info
+                        :process 0
+                        :f :write
+                        :error :timeout}
+        nemesis-outcome {:type :info
+                         :process :nemesis
+                         :f :start-partition
+                         :value :no-supported-leader}
+        client-subject (worker/wrap-client
+                        failure-state
+                        (test-client {:invoke-f (fn [& _] client-outcome)}))
+        nemesis-subject (worker/wrap-nemesis
+                         failure-state
+                         (test-nemesis (fn [& _] nemesis-outcome)))]
+    (is (= client-outcome
+           (client/invoke! (client/open! client-subject {} "n1")
+                           {}
+                           client-outcome)))
+    (is (= nemesis-outcome
+           (nemesis/invoke! (nemesis/setup! nemesis-subject {})
+                            {}
+                            nemesis-outcome)))
+    (is (nil? (harness/primary-failure failure-state)))))
+
+(deftest interruptions-propagate-without-recording
+  (doseq [[description throwable invoke]
+          [["client"
+            (InterruptedException. "interrupted")
+            (fn [failure-state throwable]
+              (let [subject (worker/wrap-client
+                             failure-state
+                             (test-client
+                              {:invoke-f (fn [& _] (throw throwable))}))]
+                (client/invoke! (client/open! subject {} "n1")
+                                {}
+                                {:type :invoke :f :read})))]
+           ["nemesis"
+            (ex-info "interrupted" {:kind :interrupted})
+            (fn [failure-state throwable]
+              (let [subject (worker/wrap-nemesis
+                             failure-state
+                             (test-nemesis
+                              (fn [& _] (throw throwable))))]
+                (nemesis/invoke! (nemesis/setup! subject {})
+                                 {}
+                                 {:type :info :f :start-partition})))]]]
+    (testing description
+      (let [failure-state (harness/failure-state)
+            thrown (thrown-by #(invoke failure-state throwable))]
+        (is (identical? throwable thrown))
+        (is (nil? (harness/primary-failure failure-state)))))))

--- a/jepsen/test/jepsen/openraft/workload_test.clj
+++ b/jepsen/test/jepsen/openraft/workload_test.clj
@@ -361,6 +361,17 @@
           (is interrupted
               "the interrupt flag is restored so Jepsen's control signals survive"))))))
 
+(deftest rethrows-unknown-client-exceptions
+  (let [op {:type :invoke :f :write :value (keyed "value")}
+        throwable (RuntimeException. "client bug")]
+    (with-redefs [http/write! (fn [& _] (throw throwable))]
+      (let [thrown (try
+                     (client/invoke! (kv-client) {} op)
+                     nil
+                     (catch RuntimeException e
+                       e))]
+        (is (identical? throwable thrown))))))
+
 (deftest unexpected-errors-checker-flags-tagged-operations
   (let [chk (#'workload/unexpected-errors-checker)]
     (testing "a history without unexpected errors is valid"


### PR DESCRIPTION
## Summary

This is the foundation of a planned five-part Jepsen error-handling series.

A Jepsen run previously had no shared distinction between an observation from OpenRaft and a failure in the test Harness. Unknown Client or Nemesis exceptions could be converted into ordinary operation results, allowing untrustworthy test runs to continue.

This PR defines that boundary and introduces the runtime mechanism for acting on it.

## What changes

- Documents the Outcome and Harness failure model for the OpenRaft Jepsen suite.
- Adds shared run-level Harness failure state that retains the first
  non-interruption failure and later diagnostic failures.
- Records unknown Client and Nemesis worker exceptions at their execution
  boundaries while preserving the original exception.
- Stops scheduling new ordinary Workload and Nemesis operations after a
  Harness failure, while allowing in-flight operations to complete.
- Runs final Nemesis recovery but skips final Workload operations after a
  Harness failure.

Modeled SUT observations remain Outcomes. They continue through history and
checker analysis rather than triggering controlled stop.

## Why

A Harness failure makes the experiment untrustworthy, but abruptly killing the
run would discard in-flight evidence and leave installed faults behind. The
controlled-stop path rejects the run while preserving necessary recovery and
available analysis.

## Planned series

The complete implementation is 31 files, with 6,509 additions and 837
deletions. It is split into the following reviewable steps:

1. **Harness foundation** (this PR): define the model, record direct Harness
   failures, and stop ordinary work in a controlled way.
2. **Workload outcomes and response contracts**: validate Client responses and
   keep modeled SUT observations separate from unexpected SUT responses.
3. **Control Nemesis outcomes**: close Partition, Process, and Pause outcomes
   around confirmed evidence, control failures, and interruption.
4. **Membership outcomes**: define Membership and final membership-recovery
   behavior for attempted, skipped, and indeterminate changes.
5. **Final rejection and lifecycle boundaries**: reject direct and post-hoc
   Harness failures in the final verdict; cover setup, teardown, and checker
   exceptions.

If maintainers prefer to review the entire cross-cutting change as one larger
PR, I can instead submit the complete series as a single PR.

## Verification

- Java 26 Jepsen unit suite: 102 tests, 405 assertions, 0 failures/errors.
- Clojure lint and formatting: clj-kondo and cljfmt clean.
- Diff validation: git diff --check.

Refs #1975

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2006)
<!-- Reviewable:end -->
