### PR TITLE
docs: getting-started: add a production checklist

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -452,13 +452,10 @@ jobs:
         env:
           RUSTFLAGS: --cfg tokio_unstable
 
-      - name: Build-doc
-        run: cargo doc --all --no-deps
-        env:
-          RUSTDOCFLAGS: '-D warnings'
-
-      - name: Doc tests
-        run: cargo test --doc --all
+      # Documentation build, doctests, and the repository-link check. Run
+      # through the Make target so contributors gate on the same command.
+      - name: Docs
+        run: make docs-check
 
       - name: Install cargo-audit
         uses: taiki-e/install-action@v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,24 +5,36 @@
 Always use `make` targets for checking and linting:
 
 ```bash
-# Format and lint
-make lint
+# Completion gate: check format, Clippy, tests, doctests, and doc.
+# Never writes to the worktree.
+make verify
 
-# Full check: format, lint, tests, doc
-make basic_check
+# Rewrite the worktree: Clippy fixes, typo fixes, formatting
+make fix
 
 # Run all tests
 make test
 ```
 
+Finish a change with `make verify`. Run `make fix` only when the change is
+yours to rewrite: it edits files in place, so it must never run on a diff
+someone else has already reviewed.
+
 Do not run `cargo clippy` or `cargo fmt` directly. The Makefile targets apply the same settings across every workspace crate.
 
 ## Key Makefile Targets
 
-- `make lint`: format all crates and run Clippy
-- `make basic_check`: run linting, tests, and documentation checks
+Read-only:
+
+- `make verify`: format check, Clippy, tests, doctests, and documentation build
 - `make test`: run all tests
 - `make doc`: build documentation
+
+Modifies files:
+
+- `make fix`: apply Clippy fixes, typo fixes, and formatting
+- `make fmt`: format all crates
+- `make lint`: format all crates and run Clippy
 
 ## Rust Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,13 +28,15 @@ Read-only:
 
 - `make verify`: format check, Clippy, tests, doctests, and documentation build
 - `make test`: run all tests
-- `make doc`: build documentation
+- `make docs-check`: documentation build, doctests, and repository-link check;
+  both `make verify` and the CI lint job run it
 
 Modifies files:
 
 - `make fix`: apply Clippy fixes, typo fixes, and formatting
 - `make fmt`: format all crates
 - `make lint`: format all crates and run Clippy
+- `make doc`: regenerate the FAQ and feature-flag pages, then build documentation
 
 ## Rust Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,9 @@
 
 ## Validate your changes
 
-Run `make basic_check` before opening a pull request. It runs the project's formatting, lint, test, and documentation checks.
+Run `make verify` before opening a pull request. It runs the project's formatting, lint, test, and documentation checks, and never modifies your worktree, so what you reviewed is what you submit.
+
+`make fix` is the mutating counterpart: it applies Clippy fixes, typo fixes, and formatting.
 
 ## Code style
 
@@ -34,6 +36,6 @@ PRs that read as unreviewed AI output will be sent back for a cleanup pass befor
 
 ## Release checklist
 
-- `make basic_check` passes.
+- `make verify` passes.
 - The `[workspace.package]` version in the root `Cargo.toml` and every sibling `path` dependency that pins it are updated. Use a prior `chore: bump version` commit as the complete reference.
 - After release CI finishes, open the release page, update the release notes, and publish.

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,10 @@ compile:
 # Read-only completion gate: it never writes to the worktree, so a
 # human-reviewed diff stays exactly as reviewed. `make fix` is the mutating
 # counterpart.
-verify: fmt_check clippy
+verify: fmt_check clippy docs-check
 	cargo test --lib
 	cargo test --test '*'
 	# cargo test --features single-threaded --lib
-	cargo test --doc --all
-	RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --all --no-deps
 	# test result in different output on CI are ignored and only run locally
 	cargo test -p openraft-macros -- --ignored
 
@@ -88,6 +86,14 @@ doc:
 	make -C openraft/src/docs/faq
 	make -C openraft/src/docs/feature_flags
 	RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --all --no-deps
+
+# Read-only counterpart of `doc`: it builds the documentation, runs the
+# doctests, and checks that repository links still resolve, without
+# regenerating any file. The CI lint job runs this same target.
+docs-check:
+	RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --all --no-deps
+	cargo test --doc --all
+	./scripts/check-doc-links.py
 
 check_missing_doc:
 	# Warn about missing doc for public API
@@ -251,4 +257,4 @@ clean:
 	cargo clean --manifest-path jepsen/openraft-test-app/Cargo.toml
 	rm -rf tests/_log
 
-.PHONY: test verify basic_check fmt fmt_check fix clippy lint clean doc guide detsim typos
+.PHONY: test verify basic_check fmt fmt_check fix clippy lint clean doc docs-check guide detsim typos

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,25 @@
 all: test defensive_test send_delay_test check_all
 
-check_all: lint fmt doc unused_dep typos detsim
+check_all: lint doc unused_dep typos detsim
 
 compile:
 	cargo test --lib
 	cargo test --test '*'
 	cargo test --features single-threaded --lib
 
-basic_check:
-	cargo fmt
-	cargo clippy --no-deps --all-targets --fix --allow-dirty --allow-staged
+# Read-only completion gate: it never writes to the worktree, so a
+# human-reviewed diff stays exactly as reviewed. `make fix` is the mutating
+# counterpart.
+verify: fmt_check clippy
 	cargo test --lib
 	cargo test --test '*'
 	# cargo test --features single-threaded --lib
-	cargo clippy --no-deps --all-targets -- -D warnings
+	cargo test --doc --all
 	RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --all --no-deps
 	# test result in different output on CI are ignored and only run locally
 	cargo test -p openraft-macros -- --ignored
+
+basic_check: verify
 
 defensive_test:
 	OPENRAFT_STORE_DEFENSIVE=on cargo test
@@ -71,11 +74,15 @@ bench_cluster_of_3:
 bench_cluster_of_5:
 	$(BENCH_RUSTFLAGS) cargo run --manifest-path benchmarks/minimal/Cargo.toml --release --bin bench $(BENCH_FEATURES_FLAG) -- -m 5
 
-fmt:
-	cargo fmt
+fmt_check:
+	$(MAKE) fmt FMT_ARGS='-- --check'
 
+# Apply every automatic rewrite: Clippy fixes first, then typo fixes, then
+# formatting last so it also formats what the two fixers produced.
 fix:
-	cargo fix --allow-staged
+	cargo clippy --no-deps --all-targets --fix --allow-dirty --allow-staged
+	$(MAKE) typos
+	$(MAKE) fmt
 
 doc:
 	make -C openraft/src/docs/faq
@@ -94,32 +101,38 @@ guide:
 detsim:
 	cd tests-turmoil && cargo run --bin fuzz -- --iterations 5 --max-steps 10000
 
-lint:
-	cargo fmt
-	cargo fmt --manifest-path multiraft/Cargo.toml
-	cargo fmt --manifest-path rt-compio/Cargo.toml
-	cargo fmt --manifest-path rt-monoio/Cargo.toml
-	cargo fmt --manifest-path rt-tokio/Cargo.toml
-	cargo fmt --manifest-path metrics-otel/Cargo.toml
-	cargo fmt --manifest-path benchmarks/minimal/Cargo.toml
-	cargo fmt --manifest-path examples/app-http/Cargo.toml
-	cargo fmt --manifest-path examples/network-v1-http/Cargo.toml
-	cargo fmt --manifest-path examples/network-v2-http/Cargo.toml
-	cargo fmt --manifest-path examples/dir-transfer/Cargo.toml
-	cargo fmt --manifest-path examples/log-mem/Cargo.toml
-	cargo fmt --manifest-path examples/log-rocks/Cargo.toml
-	cargo fmt --manifest-path examples/sm-mem/Cargo.toml
-	cargo fmt --manifest-path examples/sm-rocks/Cargo.toml
-	cargo fmt --manifest-path examples/types-kv/Cargo.toml
-	cargo fmt --manifest-path examples/raft-kv-memstore-grpc/Cargo.toml
-	cargo fmt --manifest-path examples/raft-kv-memstore-network-v1/Cargo.toml
-	cargo fmt --manifest-path examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml
-	cargo fmt --manifest-path examples/raft-kv-memstore-single-threaded/Cargo.toml
-	cargo fmt --manifest-path examples/raft-kv-memstore/Cargo.toml
-	cargo fmt --manifest-path examples/raft-kv-rocksdb/Cargo.toml
-	cargo fmt --manifest-path examples/multi-raft-kv/Cargo.toml
-	cargo fmt --manifest-path tests-turmoil/Cargo.toml
-	cargo fmt --manifest-path jepsen/openraft-test-app/Cargo.toml
+# Extra arguments passed to every `cargo fmt` below. Empty rewrites the files;
+# `fmt_check` overrides it with `-- --check` to report without rewriting.
+FMT_ARGS ?=
+
+fmt:
+	cargo fmt $(FMT_ARGS)
+	cargo fmt --manifest-path multiraft/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path rt-compio/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path rt-monoio/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path rt-tokio/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path metrics-otel/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path benchmarks/minimal/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/app-http/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/network-v1-http/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/network-v2-http/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/dir-transfer/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/log-mem/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/log-rocks/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/sm-mem/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/sm-rocks/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/types-kv/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/raft-kv-memstore-grpc/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/raft-kv-memstore-network-v1/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/raft-kv-memstore-opendal-snapshot-data/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/raft-kv-memstore-single-threaded/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/raft-kv-memstore/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/raft-kv-rocksdb/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path examples/multi-raft-kv/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path tests-turmoil/Cargo.toml $(FMT_ARGS)
+	cargo fmt --manifest-path jepsen/openraft-test-app/Cargo.toml $(FMT_ARGS)
+
+clippy:
 	@# The three workspace clippy runs mirror the CI lint job
 	@# (.github/workflows/ci.yaml); keep them in sync so `make lint` fails
 	@# exactly where CI would, feature unification included.
@@ -158,6 +171,8 @@ lint:
 	@# https://github.com/rust-lang/rust/issues/72686#issuecomment-635539688
 	@# Thus we only check unused deps for lib
 	RUSTFLAGS=-Wunused-crate-dependencies cargo clippy --no-deps  --lib -- -D warnings
+
+lint: fmt clippy
 
 unused_dep:
 	cargo machete
@@ -236,4 +251,4 @@ clean:
 	cargo clean --manifest-path jepsen/openraft-test-app/Cargo.toml
 	rm -rf tests/_log
 
-.PHONY: test fmt lint clean doc guide detsim
+.PHONY: test verify basic_check fmt fmt_check fix clippy lint clean doc guide detsim typos

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,12 @@ This directory contains example applications demonstrating different implementat
 
 ## Complete Applications
 
+Start with [raft-kv-memstore], the canonical example application: the
+[getting-started guide](https://docs.rs/openraft/latest/openraft/docs/getting_started/index.html)
+follows it step by step. Every other row in the table below is that same
+application with one component swapped — storage, network interface, transport,
+or runtime.
+
 ### Component Overview
 
 - **Log**: LogStore implementation for storing raft logs
@@ -16,8 +22,8 @@ This directory contains example applications demonstrating different implementat
 
 | Example | Log | State Machine | RaftNetwork Impl | RaftNetwork | Client | Server | Special Features |
 |---------|-----|---------------|------------------|-------------|--------|--------|------------------|
-| [raft-kv-memstore] | [log-mem] | [sm-mem] | HTTP/reqwest([network-v2]) | RaftNetworkV2 | [app-http] | [app-http] | Basic example |
-| [raft-kv-rocksdb] | [log-rocks] | RocksDB | HTTP/reqwest([network-v2]) | RaftNetworkV2 | [app-http] | [app-http] | Persistent storage |
+| [raft-kv-memstore] | [log-mem] | [sm-mem] | HTTP/reqwest([network-v2]) | RaftNetworkV2 | [app-http] | [app-http] | Canonical example — start here |
+| [raft-kv-rocksdb] | [log-rocks] | RocksDB | HTTP/reqwest([network-v2]) | RaftNetworkV2 | [app-http] | [app-http] | [raft-kv-memstore] with persistent storage |
 | [raft-kv-memstore-network-v1] | [log-mem] | [sm-mem] | HTTP/reqwest([network-v1]) | RaftNetwork | [app-http] | [app-http] | Legacy V1 network + chunked snapshot replication |
 | [multi-raft-kv] | [log-mem] | [sm-mem] | HTTP/channel | GroupRouter | channel | in-memory | Multi-Raft groups |
 | [raft-kv-memstore-grpc] | [log-mem] | in-memory | gRPC/tonic | RaftNetworkV2 sub-traits | tonic | tonic | gRPC transport |

--- a/openraft/src/docs/getting_started/getting-started.md
+++ b/openraft/src/docs/getting_started/getting-started.md
@@ -501,9 +501,86 @@ Additionally, two test scripts for setting up a cluster are available:
   Its sibling tests in the same directory cover membership changes, snapshots,
   and the three read modes.
 
+## 7. Production checklist
+
+A cluster built from the steps above runs. Staying correct across crashes and
+network partitions takes the guarantees below; each item states one requirement
+and links the trait, protocol page, or test suite that defines it.
+
+- **Durable, ordered vote and log writes.** [`save_vote()`] must return only
+  after the vote is on disk, and [`append()`] must call its callback only after
+  the entries are on disk. A vote write and a log write must never be reordered
+  against each other, because a reorder can lose committed data:
+  [IO ordering in Raft][`docs::io-ordering`]. [`append()`], [`truncate_after()`]
+  and [`purge()`] must also leave no hole in the log, because Raft examines only
+  the last log id.
+
+- **Storage conformance.** Run `Suite::test_all(builder)` from the
+  [storage test suite][`LogSuite`] against the store the deployment actually
+  uses, passing a [`StoreBuilder`] that constructs that store, as the
+  [`sm-rocks` test](https://github.com/databendlabs/openraft/blob/main/examples/sm-rocks/src/test.rs)
+  does.
+
+- **Snapshot persistence and restart recovery.** After a restart,
+  [`get_current_snapshot()`] must return the snapshot the node last built or
+  installed, and [`applied_state()`] must report a log id whose effects are
+  already durable in the state machine, because Openraft re-applies only entries
+  above the reported id. [`install_snapshot()`] replaces the state machine
+  wholesale, so a half-installed snapshot must not survive a crash. See
+  [snapshot replication][`docs::snapshot-replication`].
+
+- **Peer identity and RPC timeouts.** A [`RaftNetworkV2`] implementation must
+  confirm it reached the node it addressed rather than whichever node now holds
+  that address
+  ([ensure connection to the correct node][`docs::connect-to-correct-node`]),
+  must honor the deadlines in [`RPCOption`], and must report a peer it cannot
+  reach as [`Unreachable`] so Openraft backs off instead of retrying
+  immediately.
+
+- **Cluster initialization and membership changes.** Call [`Raft::initialize()`]
+  once, on one pristine node
+  ([cluster formation][`docs::cluster-formation`]). A new voter then joins in two
+  steps: [`Raft::add_learner()`] with `blocking = true`, which returns once the
+  leader sees that node's log caught up, and then [`Raft::change_membership()`],
+  which promotes the learner to voter. Promoting a learner that is still far
+  behind puts a node into the new quorum that cannot acknowledge writes yet, and
+  commits stall until that node catches up
+  ([dynamic membership][`docs::dynamic-membership`]).
+
+- **Read semantics.** A read served straight from the local state machine is not
+  linearizable: it can return stale data from a deposed leader. A linearizable
+  read calls [`Raft::ensure_linearizable()`] on the leader, or
+  [`Raft::get_read_linearizer()`] on the leader followed by
+  [`Linearizer::await_ready()`] on the follower that serves the read. The
+  [`ReadPolicy`] chooses what the guarantee rests on: [`ReadPolicy::ReadIndex`]
+  rests on a quorum round-trip, [`ReadPolicy::LeaseRead`] on bounded clock
+  drift. See [read operations][`docs::read`]; the canonical example serves all
+  three modes as `/read`, `/linearizable_read` and `/follower_read` in
+  [http_api.rs](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/src/http_api.rs).
+
+- **Metrics, fatal errors and shutdown.** Watch [`Raft::metrics()`] for
+  leadership, replication lag and membership
+  ([monitoring and maintenance][`docs::monitoring-maintenance`]). A [`Fatal`]
+  error means the Raft core has stopped and will not recover on its own: take
+  the node out of service instead of retrying against it. Call
+  [`Raft::shutdown()`] and await its completion before the process exits.
+
+- **On-disk compatibility before an upgrade.** Data written by one Openraft
+  version is not automatically readable by the next. Before upgrading, read the
+  [upgrade guide][`docs::upgrade`]: a `DataChange:` entry in the change log for
+  the target version means the stored format changed and a migration is
+  required.
+
 
 [`declare_raft_types!`]:                `crate::declare_raft_types`
 [`Raft`]:                               `crate::Raft`
+[`Raft::initialize()`]:                 `crate::Raft::initialize`
+[`Raft::add_learner()`]:                `crate::Raft::add_learner`
+[`Raft::change_membership()`]:          `crate::Raft::change_membership`
+[`Raft::ensure_linearizable()`]:        `crate::Raft::ensure_linearizable`
+[`Raft::get_read_linearizer()`]:        `crate::Raft::get_read_linearizer`
+[`Raft::metrics()`]:                    `crate::Raft::metrics`
+[`Raft::shutdown()`]:                   `crate::Raft::shutdown`
 [`Raft::append_entries()`]:             `crate::Raft::append_entries`
 [`Raft::stream_append()`]:              `crate::Raft::stream_append`
 [`Raft::vote()`]:                       `crate::Raft::vote`
@@ -558,6 +635,11 @@ Additionally, two test scripts for setting up a cluster are available:
 [`install_snapshot()`]:                 `crate::storage::RaftStateMachine::install_snapshot`
 [`get_snapshot_builder()`]:             `crate::storage::RaftStateMachine::get_snapshot_builder`
 
+[`Linearizer::await_ready()`]:          `crate::raft::linearizable_read::Linearizer::await_ready`
+[`ReadPolicy`]:                         `crate::ReadPolicy`
+[`ReadPolicy::ReadIndex`]:              `crate::ReadPolicy::ReadIndex`
+[`ReadPolicy::LeaseRead`]:              `crate::ReadPolicy::LeaseRead`
+
 [`RaftNetworkFactory`]:                 `crate::network::RaftNetworkFactory`
 [`RaftNetworkFactory::new_client()`]:   `crate::network::RaftNetworkFactory::new_client`
 [`RaftNetworkV2`]:                      `crate::network::RaftNetworkV2`
@@ -565,6 +647,7 @@ Additionally, two test scripts for setting up a cluster are available:
 [`stream_append()`]:                    `crate::network::RaftNetworkV2::stream_append`
 [`vote()`]:                             `crate::network::RaftNetworkV2::vote`
 [`full_snapshot()`]:                    `crate::network::RaftNetworkV2::full_snapshot`
+[`RPCOption`]:                          `crate::network::RPCOption`
 
 
 [`RaftSnapshotBuilder`]:                `crate::storage::RaftSnapshotBuilder`
@@ -574,8 +657,15 @@ Additionally, two test scripts for setting up a cluster are available:
 [`StoreBuilder`]:                       `crate::testing::log::StoreBuilder`
 [`LogSuite`]:                              `crate::testing::log::Suite`
 
-[`Fatal`]:                              `crate::error::Fatal`
-[`Unreachable`]:                        `crate::error::Unreachable`
+[`Fatal`]:                              `crate::errors::Fatal`
+[`Unreachable`]:                        `crate::errors::Unreachable`
 
 [`docs::connect-to-correct-node`]:      `crate::docs::cluster_control::dynamic_membership#ensure-connection-to-the-correct-node`
 [`docs::node-id-reuse`]:                `crate::docs::cluster_control::dynamic_membership#node-ids-must-not-be-reused`
+[`docs::io-ordering`]:                  `crate::docs::protocol::io_ordering`
+[`docs::snapshot-replication`]:         `crate::docs::protocol::replication::snapshot_replication`
+[`docs::read`]:                         `crate::docs::protocol::read`
+[`docs::cluster-formation`]:            `crate::docs::cluster_control::cluster_formation`
+[`docs::dynamic-membership`]:           `crate::docs::cluster_control::dynamic_membership`
+[`docs::monitoring-maintenance`]:       `crate::docs::cluster_control::monitoring_maintenance`
+[`docs::upgrade`]:                      `crate::docs::upgrade_guide`

--- a/openraft/src/docs/getting_started/getting-started.md
+++ b/openraft/src/docs/getting_started/getting-started.md
@@ -36,13 +36,32 @@ A response is some data that the Raft state machine returns to the client.
 
 Request and response can be any types that implement [`AppData`] and [`AppDataResponse`], for example:
 
-```ignore
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Request {key: String}
+```rust
+use std::fmt;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Response(Result<Option<String>, ClientError>);
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Request {
+    pub key: String,
+}
+
+// `AppData` requires `Display` in addition to `Debug`.
+impl fmt::Display for Request {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Set({})", self.key)
+    }
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Response {
+    pub value: Option<String>,
+}
 ```
+
+[`AppData`] requires `OptionalFeatures`, which requires `Serialize` and
+`Deserialize` whenever Openraft is built with its `serde` feature. The
+`cfg_attr` attribute above adds the two derives in exactly that case.
 
 These two types are entirely application-specific and are mainly related to the
 state machine implementation in [`RaftStateMachine`].
@@ -52,16 +71,26 @@ state machine implementation in [`RaftStateMachine`].
 
 Openraft is a generic implementation of Raft. It requires the application to define
 concrete types for its generic arguments. Most types are parameterized by
-[`RaftTypeConfig`] and will be used to create a `Raft` instance.
+[`RaftTypeConfig`], as [`Raft`] itself is:
 
-```ignore
-pub struct Raft<C: RaftTypeConfig> {}
+```text
+pub struct Raft<C: RaftTypeConfig> { .. }
 ```
 
 The simplest way to define your types config for example `TypeConfig`
 is using [`declare_raft_types!`] macro:
 
-```ignore
+```rust
+# use std::fmt;
+# #[derive(Clone, Debug)]
+# #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+# pub struct Request { pub key: String }
+# impl fmt::Display for Request {
+#     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "Set({})", self.key) }
+# }
+# #[derive(Clone, Debug)]
+# #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+# pub struct Response { pub value: Option<String> }
 openraft::declare_raft_types!(
    pub TypeConfig: D = Request, R = Response
 );
@@ -100,13 +129,27 @@ Openraft provides default implementations for mostly used types:
 
 You can use these implementations directly or define your own custom types.
 The canonical example overrides one of these defaults, `Node`, because each
-node in that example carries two addresses, `api_addr` and `raft_addr`:
+node in that example carries two addresses, `api_addr` and `raft_addr`. The
+example takes `D` and `R` from the shared
+[`types-kv`](https://github.com/databendlabs/openraft/blob/main/examples/types-kv/src/lib.rs)
+crate, while the snippet below reuses the `Request` and `Response` declared
+above:
 
-```ignore
+```rust
+# use std::fmt;
+# #[derive(Clone, Debug)]
+# #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+# pub struct Request { pub key: String }
+# impl fmt::Display for Request {
+#     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "Set({})", self.key) }
+# }
+# #[derive(Clone, Debug)]
+# #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+# pub struct Response { pub value: Option<String> }
 openraft::declare_raft_types!(
     pub TypeConfig:
-        D = types_kv::Request,
-        R = types_kv::Response,
+        D = Request,
+        R = Response,
         Node = openraft::NodeInfo,
 );
 ```
@@ -153,7 +196,8 @@ Most of the APIs are quite straightforward, except two indirect APIs:
 -   Read logs:
     [`RaftLogStorage`] defines a method [`get_log_reader()`] to get log reader [`RaftLogReader`] :
 
-    ```ignore
+    ```text
+    // Abbreviated; see `RaftLogStorage` for the full signature.
     trait RaftLogStorage<C: RaftTypeConfig> {
         type LogReader: RaftLogReader<C>;
         async fn get_log_reader(&mut self) -> Self::LogReader;
@@ -164,10 +208,11 @@ Most of the APIs are quite straightforward, except two indirect APIs:
     - [`try_get_log_entries()`] get log entries in a range;
     - [`read_vote()`] read vote;
 
-    ```ignore
+    ```text
+    // Abbreviated; see `RaftLogReader` for the full signature.
     trait RaftLogReader<C: RaftTypeConfig> {
-        async fn try_get_log_entries<RB: RangeBounds<u64>>(&mut self, range: RB) -> Result<Vec<C::Entry>, ...>;
-        async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, ...>>;
+        async fn try_get_log_entries<RB: RangeBounds<u64>>(&mut self, range: RB) -> Result<Vec<C::Entry>, ..>;
+        async fn read_vote(&mut self) -> Result<Option<Vote<C::NodeId>>, ..>;
     }
     ```
 
@@ -199,13 +244,14 @@ The raft correctness highly depends on a reliable store.
 Raft nodes communicate with each other to achieve consensus about the logs.
 The trait [`RaftNetworkV2`] defines the data transmission protocol.
 
-```ignore
+```text
+// Abbreviated; see `RaftNetworkV2` for the full signature.
 pub trait RaftNetworkV2<C: RaftTypeConfig>: Send + Sync + 'static {
     type SnapshotData: OptionalSend + 'static;
 
-    async fn append_entries(&mut self, rpc: AppendEntriesRequest<C>, option: RPCOption) -> Result<...>;
-    async fn vote(&mut self, rpc: VoteRequest<C>, option: RPCOption) -> Result<...>;
-    async fn full_snapshot(&mut self, vote: Vote<C::NodeId>, snapshot: SnapshotOf<C, Self::SnapshotData>, cancel: impl Future<...>, option: RPCOption) -> Result<...>;
+    async fn append_entries(&mut self, rpc: AppendEntriesRequest<C>, option: RPCOption) -> Result<..>;
+    async fn vote(&mut self, rpc: VoteRequest<C>, option: RPCOption) -> Result<..>;
+    async fn full_snapshot(&mut self, vote: Vote<C::NodeId>, snapshot: SnapshotOf<C, Self::SnapshotData>, cancel: impl Future<..>, option: RPCOption) -> Result<..>;
 
     // Optional: override for pipelined replication
     fn stream_append(&mut self, input: impl Stream<Item = AppendEntriesRequest<C>>, option: RPCOption) -> BoxFuture<Result<BoxStream<StreamAppendResult<C>>>>;
@@ -263,7 +309,8 @@ For a real-world implementation, you may want to use [Tonic gRPC](https://github
 
 [`RaftNetworkFactory`] is a singleton responsible for creating [`RaftNetworkV2`] instances for each replication target node.
 
-```ignore
+```text
+// Abbreviated; see `RaftNetworkFactory` for the full signature.
 pub trait RaftNetworkFactory<C: RaftTypeConfig>: Send + Sync + 'static {
     type Network: RaftNetworkV2<C>;
     async fn new_client(&mut self, target: C::NodeId, node: &C::Node) -> Self::Network;
@@ -320,13 +367,16 @@ Flow:
 
 The same pattern applies to other RPC methods: [`vote()`], [`full_snapshot()`].
 
-**Example server implementation**:
+**Example server implementation.** A handler takes the shape below; the
+compiled version is
+[`network-v2-http`'s `/append` route](https://github.com/databendlabs/openraft/blob/main/examples/network-v2-http/src/server.rs):
 
-```rust,ignore
+```text
+// Pseudocode: `ServerError` stands for the application's own error type.
 async fn handle_append_entries(
     raft: Arc<Raft<TypeConfig, StateMachineStore>>,
     req: AppendEntriesRequest<TypeConfig>,
-) -> Result<AppendEntriesResponse, ServerError> {
+) -> Result<AppendEntriesResponse<TypeConfig>, ServerError> {
     let resp = raft.append_entries(req).await?;
     Ok(resp)
 }
@@ -337,12 +387,23 @@ async fn handle_append_entries(
 
 In Openraft, an implementation of [`RaftNetworkV2`] needs to connect to remote Raft peers. To store additional information about each peer, you need to specify the `Node` type in `RaftTypeConfig`:
 
-```ignore
-pub struct TypeConfig {}
-impl openraft::RaftTypeConfig for TypeConfig {
-   // ...
-   type Node = BasicNode;
-}
+```rust
+# use std::fmt;
+# #[derive(Clone, Debug)]
+# #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+# pub struct Request { pub key: String }
+# impl fmt::Display for Request {
+#     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "Set({})", self.key) }
+# }
+# #[derive(Clone, Debug)]
+# #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+# pub struct Response { pub value: Option<String> }
+openraft::declare_raft_types!(
+    pub TypeConfig:
+        D = Request,
+        R = Response,
+        Node = openraft::BasicNode,
+);
 ```
 
 Then use `Raft::add_learner(node_id, BasicNode::new("127.0.0.1"), ...)` to instruct Openraft to store node information in [`Membership`]. This information is then consistently replicated across all nodes, and will be passed to [`RaftNetworkFactory::new_client()`] to connect to remote Raft peers:
@@ -373,7 +434,11 @@ that an inbound Raft RPC reaches the matching [`Raft`] method; splitting the two
 kinds of traffic across two listeners is the example's own choice, explained in
 [Two servers per node](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/README.md#two-servers-per-node).
 
-```ignore
+The excerpt below abridges that file. CI builds and tests the complete file as
+part of the `raft-kv-memstore` crate, whose sibling crates supply the types
+named here.
+
+```rust,ignore
 pub async fn start_example_raft_node(node_id: NodeId, api_addr: String, raft_addr: String) -> std::io::Result<()> {
     let config = Arc::new(Config::default().validate().unwrap());
 

--- a/openraft/src/docs/getting_started/getting-started.md
+++ b/openraft/src/docs/getting_started/getting-started.md
@@ -2,14 +2,17 @@
 
 In this chapter, we will build a key-value store cluster using Openraft.
 
-1. [examples/raft-kv-memstore](https://github.com/databendlabs/openraft/tree/main/examples/raft-kv-memstore)
-   is a complete example application that includes the server, client, and a demo cluster. This example uses an in-memory store for data storage.
+[examples/raft-kv-memstore](https://github.com/databendlabs/openraft/tree/main/examples/raft-kv-memstore)
+is the canonical example application: a server, a client, and a demo cluster
+that keeps its data in memory. This chapter follows that example, so every code
+link below points at a file in `raft-kv-memstore` or in one of the crates it
+depends on. The example's
+[README](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/README.md)
+maps each component to the file that implements it.
 
-1. [examples/raft-kv-rocksdb](https://github.com/databendlabs/openraft/tree/main/examples/raft-kv-rocksdb)
-   is another complete example application that includes the server, client, and a demo cluster. This example uses RocksDB for persistent storage.
-
-You can use these examples as a starting point for building your own key-value
-store cluster with Openraft.
+[examples/raft-kv-rocksdb](https://github.com/databendlabs/openraft/tree/main/examples/raft-kv-rocksdb)
+is the same application with RocksDB persistent storage; read it after this
+chapter, as a storage variation of `raft-kv-memstore`.
 
 ---
 
@@ -71,27 +74,9 @@ This macro call adds the above `Request` and `Response` to the `TypeConfig` stru
 - `R = Response` is the response that the state machine returns to the client after applying a `Request`.
 
 There are several more generic types that could be defined in [`RaftTypeConfig`].
-The above macro call sets these absent types to the default values,
-and it generates the following type definitions:
+The macro call above leaves each of them at its default value, and
+[`declare_raft_types!`] documents the complete list of defaults:
 
-```ignore
-pub struct TypeConfig {}
-
-impl openraft::RaftTypeConfig for TypeConfig {
-    type D                = Request;
-    type R                = Response;
-
-    // Following are absent in `declare_raft_types` and filled with default values:
-    type NodeId           = u64;
-    type Node             = openraft::impls::BasicNode;
-    type Entry            = openraft::impls::Entry<TypeConfig>;
-    type Responder<T>     = openraft::impls::OneshotResponder<TypeConfig, T>
-        where T: openraft::OptionalSend + 'static;
-    type AsyncRuntime     = openraft::impls::TokioRuntime;
-}
-```
-
-> In the above `TypeConfig` declaration,
 > - `NodeId` is the identifier of a node in the cluster, which implements
 >   [`NodeId`] trait. A node ID identifies one node, holding one log, for the
 >   lifetime of the cluster: never give the ID of a removed node to a node that
@@ -107,12 +92,24 @@ impl openraft::RaftTypeConfig for TypeConfig {
 >   instance, which implements [`AsyncRuntime`] trait.
 
 Openraft provides default implementations for mostly used types:
-- `Node`: [`EmptyNode`] and [`BasicNode`],
+- `Node`: [`EmptyNode`], [`BasicNode`] and [`NodeInfo`],
 - log `Entry`: [`Entry`],
 - `AsyncRuntime`: [`TokioRuntime`], which is a wrapper of tokio runtime,
-- `Responder`: [`OneshotResponder`], which is a wrapper of oneshot sender and receiver provided by [`AsyncRuntime`].
+- `Responder`: [`ProgressResponder`], the default, which notifies the caller both when the entry is committed and when it is applied;
+  and [`OneshotResponder`], which is a wrapper of oneshot sender and receiver provided by [`AsyncRuntime`].
 
 You can use these implementations directly or define your own custom types.
+The canonical example overrides one of these defaults, `Node`, because each
+node in that example carries two addresses, `api_addr` and `raft_addr`:
+
+```ignore
+openraft::declare_raft_types!(
+    pub TypeConfig:
+        D = types_kv::Request,
+        R = types_kv::Response,
+        Node = openraft::NodeInfo,
+);
+```
 
 A [`RaftTypeConfig`] is also used by other components such as [`RaftLogStorage`], [`RaftStateMachine`],
 [`RaftNetworkFactory`] and [`RaftNetworkV2`].
@@ -251,12 +248,13 @@ response stream.
 |--------------------------|----------------------------|-----------------------------------------------|
 | [`stream_append()`]      | [`AppendEntriesRequest`] stream | remote node [`Raft::stream_append()`]    |
 
-[Mem KV Network](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/src/network/raft_network_impl.rs)
+The canonical example gets both sides from the [`network-v2-http`](https://github.com/databendlabs/openraft/tree/main/examples/network-v2-http)
+crate. Its [client](https://github.com/databendlabs/openraft/blob/main/examples/network-v2-http/src/client.rs)
 demonstrates how to forward messages to other Raft nodes using [`reqwest`](https://docs.rs/reqwest/latest/reqwest/) as network transport layer.
 
 To receive and handle these requests, there should be a server endpoint for each of these RPCs.
 When the server receives a Raft RPC, it simply passes it to its `raft` instance and replies with the returned result:
-[Mem KV Server](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/src/network/raft.rs).
+[network-v2-http server](https://github.com/databendlabs/openraft/blob/main/examples/network-v2-http/src/server.rs).
 
 For a real-world implementation, you may want to use [Tonic gRPC](https://github.com/hyperium/tonic) to handle gRPC-based communication between Raft nodes. The [databend-meta](https://github.com/databendlabs/databend/blob/6603392a958ba8593b1f4b01410bebedd484c6a9/metasrv/src/network.rs#L89) project provides an excellent real-world example of a Tonic gRPC-based Raft network implementation.
 
@@ -367,71 +365,53 @@ See: [Ensure connection to the correct node][`docs::connect-to-correct-node`]
 
 ## 5. Put everything together
 
-Finally, we put these parts together and boot up a raft node
-[lib.rs](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/src/lib.rs):
+Finally, we put these parts together and boot up a raft node in
+[lib.rs](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/src/lib.rs).
+Each node listens on two addresses: `raft_addr` serves the Raft RPCs that peers
+send, and `api_addr` serves client and admin requests. Openraft requires only
+that an inbound Raft RPC reaches the matching [`Raft`] method; splitting the two
+kinds of traffic across two listeners is the example's own choice, explained in
+[Two servers per node](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/README.md#two-servers-per-node).
 
 ```ignore
-openraft::declare_raft_types!(
-    pub TypeConfig:
-        D = Request,
-        R = Response,
-);
-
-#[actix_web::main]
-async fn main() -> std::io::Result<()> {
-
-    let node_id = 1;
+pub async fn start_example_raft_node(node_id: NodeId, api_addr: String, raft_addr: String) -> std::io::Result<()> {
     let config = Arc::new(Config::default().validate().unwrap());
 
     let log_store = LogStore::default();
-    let state_machine_store = Arc::new(StateMachineStore::default());
-    let network = Network {};
+    let state_machine_store = StateMachineStore::default();
+    let network = network_v2_http::NetworkFactory::new();
 
-    let raft = openraft::Raft::new(
-        node_id,
-        config.clone(),
-        network,
-        log_store.clone(),
-        state_machine_store.clone(),
-    )
-    .await
-    .unwrap();
+    let raft = openraft::Raft::new(node_id, config, network, log_store, state_machine_store.clone()).await.unwrap();
 
-    let app_data = Data::new(App {
+    let app = Arc::new(App {
         id: node_id,
-        addr: "127.0.0.1:9999".to_string(),
+        api_addr: api_addr.clone(),
+        raft_addr: raft_addr.clone(),
         raft,
-        log_store,
-        state_machine_store,
-        config,
+        data: state_machine_store,
     });
 
-    HttpServer::new(move || {
-      App::new()
-              .wrap(Logger::default())
-              .wrap(Logger::new("%a %{User-Agent}i"))
-              .wrap(middleware::Compress::default())
-              .app_data(app.clone())
+    // Raft RPCs from peer nodes: `/append`, `/vote`, `/snapshot`, ...
+    let raft_server = network_v2_http::Server::new(app.raft.clone()).run(raft_addr);
 
-              // raft internal RPC
-              .service(raft::append).service(raft::snapshot).service(raft::vote)
+    // Client and admin API: `/init`, `/add-learner`, `/write`, `/read`, ...
+    let app_server = app_http::Server::new(app)
+        .add_openraft_routes()
+        .post("/read", http_api::read)
+        .post("/linearizable_read", http_api::linearizable_read)
+        .post("/follower_read", http_api::follower_read)
+        .run(api_addr);
 
-              // admin API
-              .service(management::init)
-              .service(management::add_learner)
-              .service(management::change_membership)
-              .service(management::metrics)
-              .service(management::list_nodes)
-
-              // application API
-              .service(api::write).service(api::read)
-    })
-    .bind(options.http_addr)?
-    .run()
-    .await
+    tokio::try_join!(raft_server, app_server)?;
+    Ok(())
 }
-
 ```
+
+`add_openraft_routes()` registers the admin and write endpoints that every
+example shares, defined in
+[app-http](https://github.com/databendlabs/openraft/blob/main/examples/app-http/src/app.rs);
+the three `post()` calls add `raft-kv-memstore`'s own read endpoints from
+[http_api.rs](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/src/http_api.rs).
 
 ## 6. Run the cluster
 
@@ -451,8 +431,10 @@ Additionally, two test scripts for setting up a cluster are available:
   is a minimal Bash script that uses `curl` to communicate with the Raft
   cluster. It demonstrates the plain HTTP messages being sent and received.
 
-- [test_cluster.rs](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/tests/cluster/test_cluster.rs)
+- [test_basic.rs](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/tests/cluster/test_basic.rs)
   uses `app_http::Client` to set up a cluster, write data, and read it back.
+  Its sibling tests in the same directory cover membership changes, snapshots,
+  and the three read modes.
 
 
 [`declare_raft_types!`]:                `crate::declare_raft_types`
@@ -476,11 +458,13 @@ Additionally, two test scripts for setting up a cluster are available:
 
 [`TokioRuntime`]:                       `crate::impls::TokioRuntime`
 [`OneshotResponder`]:                   `crate::impls::OneshotResponder`
+[`ProgressResponder`]:                  `crate::impls::ProgressResponder`
 
 [`LogId`]:                              `crate::LogId`
 [`Membership`]:                         `crate::Membership`
 [`EmptyNode`]:                          `crate::EmptyNode`
 [`BasicNode`]:                          `crate::BasicNode`
+[`NodeInfo`]:                           `crate::NodeInfo`
 [`Entry`]:                              `crate::entry::Entry`
 [`Vote`]:                               `crate::vote::Vote`
 [`LogState`]:                           `crate::storage::LogState`

--- a/openraft/src/docs/protocol/read.md
+++ b/openraft/src/docs/protocol/read.md
@@ -85,9 +85,9 @@ let val = my_raft.with_state_machine(|sm| { sm.read("foo") }).await?;
 ```
 
 See a complete implementation in the [raft-kv-memstore example](https://github.com/databendlabs/openraft/tree/main/examples/raft-kv-memstore):
-- [`/get_linearizer` endpoint](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/src/network/management.rs) - Leader provides linearizer data
-- [`/follower_read` endpoint](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/src/network/api.rs) - Follower read implementation
-- [Test coverage](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/tests/cluster/test_follower_read.rs)
+- [`/get_linearizer` endpoint](https://github.com/databendlabs/openraft/blob/main/examples/app-http/src/app.rs) - `App::get_linearizer()`, where the leader provides linearizer data
+- [`/follower_read` endpoint](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/src/http_api.rs) - Follower read implementation
+- [Test coverage](https://github.com/databendlabs/openraft/blob/main/examples/raft-kv-memstore/tests/cluster/test_read_modes.rs)
 
 
 ## Ensuring Linearizability with `read_log_id`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,21 @@ If `./change-log/<version>.md` exists, it skips re-building it from git-log.
 Thus you can generate semi-automatic change-logs by editing `./change-log/<version>.md` and running the script again, which will just only the `./change-log.md`.
 
 
+### `check-doc-links.py`
+
+Check that markdown links pointing into this repository resolve to a file.
+
+- Usage: `./scripts/check-doc-links.py`: check every tracked markdown file.
+- Usage: `./scripts/check-doc-links.py openraft/`: check one subtree.
+- Install: standard library only.
+
+It resolves relative links against the file that contains them, and translates
+`https://github.com/databendlabs/openraft/{blob,tree}/main/...` URLs back into
+working-tree paths. It skips links to other hosts, links pinned to a commit or
+tag, and Rustdoc intra-doc targets such as `crate::docs::getting_started`.
+Both `make docs-check` and the CI lint job run it.
+
+
 ### `check.kdl`
 
 Run daily tests in parallel:

--- a/scripts/check-doc-links.py
+++ b/scripts/check-doc-links.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Check that markdown links pointing into this repository resolve to a file.
+
+Two link forms are checked:
+
+- relative paths, such as `[client](../app-http/src/client.rs)`, resolved
+  against the directory holding the file that contains them;
+- GitHub URLs pinned to `main`, such as
+  `https://github.com/databendlabs/openraft/blob/main/examples/...`, translated
+  back into a path in the working tree.
+
+Everything else is left alone:
+
+- URLs to other hosts, and URLs to this repository pinned to a commit or a tag,
+  since those name a historical snapshot rather than the current tree;
+- pure `#anchor` links;
+- Rustdoc intra-doc targets such as `crate::docs::getting_started`, which are
+  item paths rather than file paths, and would otherwise be reported as missing
+  files;
+- markdown files that are symlinks, since the file they point at is checked at
+  its own path, where its relative links resolve.
+
+Anchors are stripped before the check, so `README.md#two-servers-per-node`
+passes when `README.md` exists; the anchor itself is not validated.
+
+Usage:
+
+    ./scripts/check-doc-links.py             # every tracked markdown file
+    ./scripts/check-doc-links.py openraft/   # only files under a path
+
+Exits 1 if any link is broken, so it can gate CI. It writes nothing.
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# A link into this repository at its current state. Only `main` is translated:
+# a URL pinned to a commit or tag names a snapshot, not the working tree.
+REPO_URL = re.compile(r"^https://github\.com/databendlabs/openraft/(?:blob|tree)/main/(.+)$")
+
+# `[text](destination)`, with an optional `"title"` and optional `<>` around
+# the destination.
+INLINE_LINK = re.compile(r"\[[^\]]*\]\(\s*<?([^)\s>]+)>?(?:\s+[\"'][^\"']*[\"'])?\s*\)")
+
+# `[label]: destination`, the reference-style definition.
+REFERENCE_DEF = re.compile(r"^\s{0,3}\[[^\]]+\]:\s*<?([^\s>]+)>?\s*(?:[\"'].*[\"'])?\s*$")
+
+
+def repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=True
+    )
+    return Path(out.stdout.strip())
+
+
+def markdown_files(root: Path, paths: list[str]) -> list[Path]:
+    """Tracked markdown files under `paths`, symlinks excluded."""
+    cmd = ["git", "ls-files", "-z", "--"] + [p + "*.md" if p.endswith("/") else p for p in paths]
+    out = subprocess.run(cmd, cwd=root, capture_output=True, text=True, check=True)
+    files = []
+    for name in out.stdout.split("\0"):
+        if not name.endswith(".md"):
+            continue
+        if (root / name).is_symlink():
+            continue
+        files.append(Path(name))
+    return files
+
+
+def destinations(line: str) -> list[str]:
+    found = INLINE_LINK.findall(line)
+    ref = REFERENCE_DEF.match(line)
+    if ref:
+        found.append(ref.group(1))
+    return found
+
+
+def resolve(root: Path, md_file: Path, dest: str) -> Path | None:
+    """The working-tree path `dest` refers to, or None if it refers elsewhere."""
+    repo_url = REPO_URL.match(dest)
+    if repo_url:
+        target = repo_url.group(1)
+        base = root
+    elif "://" in dest or dest.startswith(("#", "mailto:", "`")) or "::" in dest:
+        return None
+    elif dest.startswith("/"):
+        target = dest.lstrip("/")
+        base = root
+    else:
+        target = dest
+        base = (root / md_file).parent
+
+    target = target.split("#")[0].split("?")[0]
+    if not target:
+        return None
+    return base / target
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "paths", nargs="*", default=["*.md"], help="limit the scan to these paths (default: all)"
+    )
+    args = parser.parse_args()
+
+    root = repo_root()
+    checked = 0
+    broken = []
+
+    for md_file in markdown_files(root, args.paths):
+        lines = (root / md_file).read_text(encoding="utf-8").splitlines()
+        for lineno, line in enumerate(lines, 1):
+            for dest in destinations(line):
+                path = resolve(root, md_file, dest)
+                if path is None:
+                    continue
+                checked += 1
+                if not path.exists():
+                    broken.append(f"{md_file}:{lineno}: {dest}")
+
+    if broken:
+        print(f"broken repository links: {len(broken)}", file=sys.stderr)
+        for item in broken:
+            print(f"  {item}", file=sys.stderr)
+        return 1
+
+    print(f"checked {checked} repository links, all resolve")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -o errexit
-
-cargo fmt
-cargo test --lib
-cargo test --test '*'
-cargo clippy --no-deps --all-targets -- -D warnings
-RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --all --no-deps


### PR DESCRIPTION

## Changelog

##### docs: getting-started: add a production checklist
# Summary

The guide now ends with the correctness-sensitive obligations a
deployment carries beyond what the examples demonstrate, each linked to
the trait, protocol page, or test suite that defines it.

# Details

The guide previously stopped at a running demo cluster and said only that
every example is a demonstration. That left an application author to
infer which parts of a demo are unsafe in production, and where each
obligation is specified.

Section 7 states one obligation per item and links its authority instead
of restating the implementation: durable and unreordered vote and log
writes, the storage conformance suite and its invocation, snapshot
persistence and restart recovery, peer identity and RPC deadlines,
initialization and membership sequencing, the three read modes and what
each read policy rests on, metrics/fatal-error/shutdown handling, and
on-disk compatibility before an upgrade.

The `Fatal` and `Unreachable` link definitions move from the deprecated
`crate::error` alias to `crate::errors`, because the checklist is the
first text in the guide that resolves them.


##### docs: getting-started: state the version and capability contract
# Summary

The guide never said which release line, feature set, network API, or runtime
it describes, leaving a reader to infer them from example manifests that use
repository path dependencies. It now opens with that contract, and the
dependency declaration in it is generated from a fixture that compiles it.

# Details

`tests-consumer` is a crate outside the root workspace holding the dependency
declaration the guide documents. Being its own workspace is the point: an
application elsewhere gets no feature unification, so a feature the documented
list omits fails there rather than in a reader's first build. It compiles a
`RaftTypeConfig` declaration, names `RaftNetworkV2`, and resolves the default
`AsyncRuntime`, which is what makes the guide's claims about the feature list,
the network API, and the runtime checkable rather than aspirational.

`scripts/build_version_contract.py` renders the guide's opening block from two
places that cannot drift from the code: the version from `[workspace.package]`,
and the crate name and features from that fixture. It refuses to render when
the fixture's declared version and the workspace version disagree, which is the
mistake a release bump invites.

`make doc` regenerates the block, `make docs-check` and the CI lint job check
it, and a new CI job builds the fixture. A version bump that misses the guide,
or an edit to the block, now fails in CI.

The prose beside the generated block covers what a version string cannot: that
`RaftNetwork` moved to `openraft-legacy`, that tokio arrives through a default
feature, why a networked application needs `serde`, which examples are
canonical, specialized, or legacy, and that every example is a demonstration
rather than a production component.


##### docs: getting-started: compile the copyable snippets, check doc links
# Summary

The getting-started guide's Rust blocks were all fenced `ignore`, so nothing
in CI compiled them and the guide could drift from the API without any test
failing. Its copyable blocks are doctests now, its abbreviated fragments are
visibly not Rust, and a new `make docs-check` gates documentation on the same
command CI runs.

# Details

The four blocks a reader pastes into their own crate — the `Request`/`Response`
types and three `declare_raft_types!` declarations — are compiled doctests.
Renaming a macro key or changing a bound now fails `cargo test --doc`. The
setup each one needs is repeated in hidden `#` lines, so every block still
renders as the few lines that carry the lesson.

The type definitions gained two things the old snippet omitted and a reader
would have hit as a compile error: a `Display` impl, which `AppData` requires,
and serde derives behind `#[cfg_attr(feature = "serde", ...)]`, which
`OptionalFeatures` requires whenever the crate is built with `serde`. The cfg
is what lets one block compile both with and without the feature; the workspace
enables it through `openraft-memstore`, a bare `cargo test --doc -p openraft`
does not.

Blocks that were never valid Rust — trait signatures abbreviated with `..`, and
the handler sketch naming an application error type — are `text` now, each
labelled with what it abbreviates, so they read as illustrations rather than
code to copy. The node assembly stays `rust,ignore` and says why: it is an
excerpt of `examples/raft-kv-memstore/src/lib.rs`, which CI compiles as part of
that example, and its types live in the example's sibling crates.

`scripts/check-doc-links.py` resolves relative markdown links and translates
`github.com/databendlabs/openraft/{blob,tree}/main/...` URLs back into
working-tree paths, so a moved or deleted source file fails CI at the link that
names it. It deliberately leaves alone URLs pinned to a commit or tag, which
name a historical snapshot, and Rustdoc intra-doc targets such as
`crate::docs::getting_started`, which a filesystem checker would report as
missing files. It currently checks 111 links.

`make docs-check` runs the documentation build, the doctests, and that link
check. `make verify` depends on it and the CI lint job invokes it, replacing
that job's two separate doc steps, so contributors and CI gate on one command.


##### docs: getting-started: follow the current raft-kv-memstore example
# Summary

The getting-started guide described an application that no longer exists: it
linked to five files deleted when the examples were split into helper crates,
and assembled the server with Actix, which the examples dropped. It now
declares `examples/raft-kv-memstore` as the canonical example and follows that
example's current wiring.

# Details

Every repository link in `openraft/src/docs` now resolves to a tracked file.
The six dead ones pointed at `raft-kv-memstore/src/network/`, removed when
node-to-node RPC moved to the `network-v2-http` crate and the application API
to `app-http`, and at two tests renamed since.

Section 5 previously showed an Actix `HttpServer` with `.service()` routes. The
example runs two servers instead — `network_v2_http::Server` on `raft_addr` for
peer RPCs and `app_http::Server` on `api_addr` for client and admin requests —
so the section now mirrors `start_example_raft_node()` and says which part is
Openraft's requirement and which is the example's choice.

Section 2 hand-copied the type list that `declare_raft_types!` generates, and
that copy had drifted: it showed `Entry<TypeConfig>`, which now takes four
generic arguments, and `OneshotResponder` as the default `Responder`, which is
`ProgressResponder`. The copy is replaced by a pointer to the macro's own
documentation plus the canonical example's declaration, which overrides only
`Node`.

`raft-kv-rocksdb` is no longer presented as an equal starting point in the
guide or in `examples/README.md`; it is the same application with persistent
storage. It still has no README of its own, so it stays a variation to read
after the canonical example rather than a second entry point.

An AI assistant reading this chapter previously mixed the removed modules and
the Actix assembly into plausible code that cannot compile, which is what makes
the stale links and the obsolete assembly worth repairing together.

The Rust blocks stay `ignore`-fenced, so documentation CI still cannot catch
the next such drift; making the copyable blocks compile is separate work.


##### refactor: make: split mutating fixes from a read-only verifier
# Summary

`make verify` is the new completion gate: it checks formatting, Clippy,
tests, doctests, and documentation without writing to the worktree, so a
reviewed diff reaches CI exactly as reviewed. `make fix` collects every
automatic rewrite that the old gate performed silently.

# Details

`make basic_check`, the command CONTRIBUTING.md and CLAUDE.md advertised
as the pre-PR check, ran `cargo fmt` in write mode and Clippy with
`--fix --allow-dirty --allow-staged`. Verifying a change therefore
modified it, which is unusable for anyone — an agent in particular — that
must confirm a human-reviewed diff without altering it. `basic_check` is
now an alias for `verify`, so the old name is read-only too.

The format sweep is a single list shared by both directions: `fmt`
formats every crate, and `fmt_check` re-enters it with
`FMT_ARGS='-- --check'`. Splitting the former `lint` recipe into `fmt`
and `clippy` lets `verify` reuse the Clippy invocations that already
mirror the CI lint job, instead of maintaining a second set of flags;
`lint` keeps its meaning as `fmt clippy`.

`verify` also gains `cargo test --doc --all`, which CI runs but
`basic_check` did not.

`scripts/check.sh` is removed. Nothing referenced it, and it was a
mutating duplicate of the gate that `verify` now provides.

Upgrade tip:

Replace `make basic_check` with:

    make verify

and apply formatting, Clippy, and typo fixes with:

    make fix

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2009)
<!-- Reviewable:end -->
