### PR TITLE
test: jepsen: validate SUT responses

### DIFF
--- a/jepsen/src/jepsen/openraft/client.clj
+++ b/jepsen/src/jepsen/openraft/client.clj
@@ -1,7 +1,14 @@
 (ns jepsen.openraft.client
   (:require [cheshire.core :as json]
-            [clojure.string :as str])
-  (:import (java.net ConnectException URI)
+            [cheshire.factory :as json-factory]
+            [cheshire.parse :as json-parse]
+            [clojure.string :as str]
+            [jepsen.openraft.interruption :as interruption])
+  (:import (com.fasterxml.jackson.core JsonFactory
+                                       JsonParseException
+                                       JsonParser$Feature
+                                       JsonToken)
+           (java.net ConnectException URI)
            (java.net.http HttpClient
                           HttpConnectTimeoutException
                           HttpRequest
@@ -12,6 +19,18 @@
 
 (def default-api-port 21001)
 (def default-raft-port 22001)
+
+(def ^:private max-u64 18446744073709551615N)
+(def ^:private response-body-preview-limit 1024)
+(def ^:private modeled-error-variants
+  #{:ForwardToLeader :QuorumNotEnough})
+
+(def ^:private ^JsonFactory preflight-json-factory
+  (json-factory/make-json-factory {}))
+
+(def ^:private ^JsonFactory strict-json-factory
+  (doto (json-factory/make-json-factory {})
+    (.enable JsonParser$Feature/STRICT_DUPLICATE_DETECTION)))
 
 (def ^:private http-client
   (-> (HttpClient/newBuilder)
@@ -42,6 +61,11 @@
   (doto (HttpRequest/newBuilder (URI/create (node-url endpoint path)))
     (.timeout (Duration/ofSeconds 5))))
 
+(defn- propagate-interruption! [e]
+  (when (interruption/interruption? e)
+    (.interrupt (Thread/currentThread))
+    (throw e)))
+
 (defn- send! [request]
   (let [request-info {:method (.method request)
                       :uri (str (.uri request))}
@@ -60,14 +84,12 @@
                                      (assoc request-info :kind :request-timeout)
                                      e)))
                    (catch java.io.IOException e
+                     (propagate-interruption! e)
                      (throw (ex-info "HTTP request failed"
                                      (assoc request-info :kind :transport-error)
                                      e)))
                    (catch InterruptedException e
-                     (.interrupt (Thread/currentThread))
-                     (throw (ex-info "HTTP request interrupted"
-                                     (assoc request-info :kind :interrupted)
-                                     e))))
+                     (propagate-interruption! e)))
         status (.statusCode response)
         body (.body response)
         result (assoc request-info
@@ -78,24 +100,149 @@
                       (assoc result :kind :http-error))))
     result))
 
+(defn- response-evidence [response]
+  (let [body (:body response)]
+    (cond-> (select-keys response [:method :uri :status])
+      (string? body)
+      (assoc :body-character-count (count body)
+             :body-preview (subs body
+                                 0
+                                 (min response-body-preview-limit
+                                      (count body)))))))
+
+(defn- invalid-response! [response reason details]
+  (throw (ex-info "OpenRaft API returned an invalid response"
+                  (merge {:kind :invalid-response
+                          :reason reason
+                          :response (response-evidence response)}
+                         details))))
+
 (defn- parse-body [response]
   (try
-    (json/parse-string (:body response) true)
-    (catch Exception e
+    (with-open [parser (.createParser preflight-json-factory
+                                      ^String (:body response))]
+      (let [token (.nextToken parser)]
+        (when (nil? token)
+          (throw (JsonParseException.
+                  parser
+                  "OpenRaft API response has no JSON document")))
+        (when-not (= JsonToken/START_OBJECT token)
+          (.skipChildren parser)
+          (when (.nextToken parser)
+            (throw (JsonParseException.
+                    parser
+                    "Trailing content after OpenRaft API response")))
+          (invalid-response! response
+                             :response-union-not-map
+                             {:response-arm-count nil}))))
+    (with-open [parser (.createParser strict-json-factory
+                                      ^String (:body response))]
+      (let [body (json-parse/parse-strict parser
+                                          true
+                                          ::missing-json-root
+                                          nil)]
+        (when (= ::missing-json-root body)
+          (throw (JsonParseException.
+                  parser
+                  "OpenRaft API response has no JSON document")))
+        (when (.nextToken parser)
+          (throw (JsonParseException.
+                  parser
+                  "Trailing content after OpenRaft API response")))
+        body))
+    (catch JsonParseException e
       (throw (ex-info "Failed to parse OpenRaft API response"
                       {:kind :invalid-json
-                       :response response}
+                       :response (response-evidence response)}
                       e)))))
 
+(defn- invalid-union-reason [body]
+  (cond
+    (not (map? body)) :response-union-not-map
+    (empty? body) :missing-response-arm
+    (and (contains? body :Ok)
+         (contains? body :Err)) :ambiguous-response-arms
+    (not-any? #{:Ok :Err} (keys body)) :unknown-response-arm
+    :else :invalid-response-union))
+
 (defn- ok-value [response]
-  (let [body (parse-body response)]
+  (let [body (parse-body response)
+        arms (when (map? body)
+               (set (filter #{:Ok :Err} (keys body))))]
     (cond
-      (contains? body :Ok) (:Ok body)
-      (contains? body :Err) (throw (ex-info "OpenRaft API returned Err"
-                                            {:kind :openraft-error
-                                             :error (:Err body)
-                                             :response response}))
-      :else body)))
+      (= #{:Ok} arms)
+      (:Ok body)
+
+      (= #{:Err} arms)
+      (let [error (:Err body)]
+        (if (and (map? error) (= 1 (count error)))
+          (let [[variant payload] (first error)]
+            (if (and (modeled-error-variants variant)
+                     (not (map? payload)))
+              (invalid-response! response
+                                 :invalid-error-payload
+                                 {:error-variant variant})
+              (throw (ex-info "OpenRaft API returned Err"
+                              {:kind :openraft-error
+                               :error error
+                               :response response}))))
+          (invalid-response! response
+                             :invalid-error-union
+                             {:error-arm-count (when (map? error)
+                                                 (count error))})))
+
+      :else
+      (invalid-response! response
+                         (invalid-union-reason body)
+                         {:response-arm-count (when arms
+                                                (count arms))}))))
+
+(defn- versioned-value? [value]
+  (and (map? value)
+       (contains? value :value)
+       (string? (:value value))
+       (contains? value :version)
+       (integer? (:version value))
+       (<= 0 (:version value) max-u64)))
+
+(defn- response-value [response payload path allow-nil?]
+  (let [value (get-in payload path ::missing)]
+    (cond
+      (= ::missing value)
+      (invalid-response! response
+                         :missing-payload-field
+                         {:payload-path path})
+
+      (nil? value)
+      (if allow-nil?
+        nil
+        (invalid-response! response
+                           :nil-payload-field
+                           {:payload-path path}))
+
+      (versioned-value? value)
+      value
+
+      :else
+      (invalid-response! response
+                         :invalid-versioned-value
+                         {:payload-path path}))))
+
+(defn- require-echoed-value [response versioned-value expected]
+  (when (and versioned-value
+             (not= expected (:value versioned-value)))
+    (invalid-response! response
+                       :unexpected-payload-value
+                       {:payload-path [:data :value :value]}))
+  versioned-value)
+
+(defn- require-newer-cas-version [response versioned-value expected-version]
+  (when (and versioned-value
+             (<= (:version versioned-value) expected-version))
+    (invalid-response! response
+                       :non-increasing-cas-version
+                       {:payload-path [:data :value :version]}))
+  versioned-value)
 
 (defn- forward-to-leader? [e]
   ;; contains? returns false for a nil map, so no nil guard is needed.
@@ -195,23 +342,34 @@
 ;; These functions make one HTTP attempt. KVClient performs leader routing and
 ;; classifies errors based on whether the operation may have taken effect.
 (defn write! [endpoint key value]
-  (-> (post! endpoint "/write"
-             {:Set {:key key
-                    :value value}})
-      ok-value
-      :data
-      :value))
+  (let [response (post! endpoint "/write"
+                        {:Set {:key key
+                               :value value}})
+        payload (ok-value response)
+        versioned-value (response-value response
+                                        payload
+                                        [:data :value]
+                                        false)]
+    (require-echoed-value response versioned-value value)))
 
 (defn cas! [endpoint key expected-version value]
-  (-> (post! endpoint "/write"
-             {:CompareAndSet {:key key
-                              :expected_version expected-version
-                              :value value}})
-      ok-value
-      :data
-      :value))
+  (let [response (post! endpoint "/write"
+                        {:CompareAndSet {:key key
+                                         :expected_version expected-version
+                                         :value value}})
+        payload (ok-value response)
+        versioned-value (response-value response
+                                        payload
+                                        [:data :value]
+                                        true)
+        versioned-value (require-echoed-value response
+                                              versioned-value
+                                              value)]
+    (require-newer-cas-version response
+                               versioned-value
+                               expected-version)))
 
 (defn linearizable-read! [endpoint key]
-  (-> (post! endpoint "/linearizable_read" key)
-      ok-value
-      :value))
+  (let [response (post! endpoint "/linearizable_read" key)
+        payload (ok-value response)]
+    (response-value response payload [:value] true)))

--- a/jepsen/src/jepsen/openraft/workload.clj
+++ b/jepsen/src/jepsen/openraft/workload.clj
@@ -6,6 +6,7 @@
              [independent :as independent]
              [random :as random]]
             [jepsen.openraft.client :as http]
+            [jepsen.openraft.interruption :as interruption]
             [knossos.model :as model]))
 
 (def ^:private key-names
@@ -108,81 +109,87 @@
 (defn- mutation? [op]
   (#{:write :cas} (:f op)))
 
-(defn- complete-with-error [op type error unexpected?]
+(defn- complete-with-error [op type error unexpected-sut-response?]
   (cond-> (assoc op
                  :type type
                  :error error)
-    unexpected? (assoc :unexpected? true)))
+    unexpected-sut-response? (assoc :unexpected-sut-response? true)))
 
 (defn- complete-with-ambiguous-outcome
   "Marks an ambiguous mutation as info and a read as failed."
-  [op error unexpected?]
+  [op error unexpected-sut-response?]
   (complete-with-error op
                        (if (mutation? op) :info :fail)
                        error
-                       unexpected?))
+                       unexpected-sut-response?))
 
 (defn- handle-operation-exception
   "Classifies a client exception and returns a completed Jepsen operation.
   Thread interruptions are rethrown so Jepsen's control signals survive."
   [op e]
-  ;; A raw InterruptedException (thrown outside send!, which clears the interrupt
-  ;; flag) would otherwise fall through to the :client-error default and be
-  ;; swallowed. Restore the flag and rethrow so the interrupt is not lost.
-  (when (instance? InterruptedException e)
+  (when (interruption/interruption? e)
     (.interrupt (Thread/currentThread))
     (throw e))
-  (let [{:keys [kind status error]} (ex-data e)]
-    ;; send! already re-interrupted the thread for wrapped interruptions.
-    (if (= :interrupted kind)
-      (throw e)
-      (let [result
-            (case kind
-              :unreachable
-              (complete-with-error op :fail :unreachable false)
+  (let [{:keys [kind status error]} (ex-data e)
+        result
+        (case kind
+          :unreachable
+          (complete-with-error op :fail :unreachable false)
 
-              :request-timeout
-              (complete-with-ambiguous-outcome op :timeout false)
+          :request-timeout
+          (complete-with-ambiguous-outcome op :timeout false)
 
-              :transport-error
-              (complete-with-ambiguous-outcome op :transport-error false)
+          :transport-error
+          (complete-with-ambiguous-outcome op :transport-error false)
 
-              :http-error
-              ;; app-http returns 4xx before invoking a handler, while a 5xx
-              ;; may occur while serializing a response after a mutation has
-              ;; completed.
-              (if (and status (<= 400 status 499))
-                (complete-with-error op :fail [:http status] true)
-                (complete-with-ambiguous-outcome op [:http status] true))
+          :http-error
+            ;; app-http returns 4xx before invoking a handler, while a 5xx
+            ;; may occur while serializing a response after a mutation has
+            ;; completed.
+          (if (and status (<= 400 status 499))
+            (complete-with-error op :fail [:http status] true)
+            (complete-with-ambiguous-outcome op [:http status] true))
 
-              :invalid-json
-              (complete-with-ambiguous-outcome op :invalid-json true)
+          :invalid-json
+          (complete-with-ambiguous-outcome op :invalid-json true)
 
-              :openraft-error
-              (cond
-                (contains? error :ForwardToLeader)
-                (complete-with-error op :fail :not-leader false)
+          :invalid-response
+          (complete-with-ambiguous-outcome op :invalid-response true)
 
-                (contains? error :QuorumNotEnough)
-                (complete-with-error op :fail :quorum-not-enough false)
+          :openraft-error
+          (cond
+            (contains? error :ForwardToLeader)
+            (complete-with-error op :fail :not-leader false)
 
-                :else
-                (complete-with-ambiguous-outcome op :openraft-error true))
+            (contains? error :QuorumNotEnough)
+            (complete-with-error op :fail :quorum-not-enough false)
 
-              (throw e))]
-        (cond-> result
-          (or (:unexpected? result) (:final? op))
-          (assoc :exception-message (ex-message e)
-                 :exception-data (ex-data e)
-                 :unexpected? true))))))
+            :else
+            (complete-with-ambiguous-outcome op :openraft-error true))
 
-(defn- unexpected-errors-checker []
+          (throw e))]
+    (cond-> result
+      (or (:unexpected-sut-response? result) (:final? op))
+      (assoc :exception-message (ex-message e)
+             :exception-data (ex-data e)))))
+
+(defn- unexpected-sut-responses-checker []
   (reify checker/Checker
     (check [_ _test history _opts]
-      (let [errors (filter :unexpected? history)]
-        {:valid? (empty? errors)
-         :count (count errors)
-         :errors (vec (take 10 errors))}))))
+      (let [responses (filter :unexpected-sut-response? history)]
+        {:valid? (empty? responses)
+         :count (count responses)
+         :responses (vec (take 10 responses))}))))
+
+(defn- final-workload-checker []
+  (reify checker/Checker
+    (check [_ _test history _opts]
+      (let [failures (filter #(and (:final? %)
+                                   (#{:fail :info} (:type %)))
+                             history)]
+        {:valid? (empty? failures)
+         :count (count failures)
+         :failures (vec (take 10 failures))}))))
 
 (defn- empty-operation-counts []
   (into {}
@@ -302,4 +309,6 @@
                                (checker/linearizable
                                 {:model (model/cas-register)}))
                 :meaningful-operations (meaningful-operations-checker)
-                :unexpected-errors (unexpected-errors-checker)})}))
+                :final-workload (final-workload-checker)
+                :unexpected-sut-responses
+                (unexpected-sut-responses-checker)})}))

--- a/jepsen/test/jepsen/openraft/client_test.clj
+++ b/jepsen/test/jepsen/openraft/client_test.clj
@@ -1,6 +1,29 @@
 (ns jepsen.openraft.client-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cheshire.core :as json]
+            [cheshire.parse :as json-parse]
+            [clojure.test :refer [deftest is testing]]
             [jepsen.openraft.client :as client]))
+
+(defn- raw-http-response [body]
+  {:method "POST"
+   :uri "http://n1:21001/write"
+   :status 200
+   :body body})
+
+(defn- http-response [body]
+  (raw-http-response (json/generate-string body)))
+
+(defn- caught [f]
+  (try
+    (f)
+    nil
+    (catch Throwable throwable
+      throwable)))
+
+(defn- throwing-http-client [throwable]
+  (proxy [java.net.http.HttpClient] []
+    (send [_request _handler]
+      (throw throwable))))
 
 (defn- forward-error
   ([]
@@ -130,3 +153,294 @@
     (is (= ["n1:21001" "n2:21001" "n3:21001"] @attempts))
     (is (= "n1:21001" @leader)
         "a retry candidate becomes the cached leader only after it succeeds")))
+
+(deftest accepts-valid-workload-responses
+  (testing "write returns a versioned value, including an empty string"
+    (let [versioned {:value "" :version 0}]
+      (with-redefs [client/post! (fn [& _]
+                                   (http-response
+                                    {:Ok {:data {:value versioned}}}))]
+        (is (= versioned (client/write! "n1:21001" "key" ""))))))
+
+  (testing "write accepts the largest u64 version"
+    (let [versioned {:value "value" :version 18446744073709551615N}]
+      (with-redefs [client/post! (fn [& _]
+                                   (http-response
+                                    {:Ok {:data {:value versioned}}}))]
+        (is (= versioned
+               (client/write! "n1:21001" "key" "value"))))))
+
+  (testing "CAS accepts an explicit nil value as a version mismatch"
+    (with-redefs [client/post! (fn [& _]
+                                 (http-response
+                                  {:Ok {:data {:value nil}}}))]
+      (is (nil? (client/cas! "n1:21001" "key" 1 "value")))))
+
+  (testing "CAS accepts a matching non-nil value"
+    (let [versioned {:value "new" :version 2}]
+      (with-redefs [client/post! (fn [& _]
+                                   (http-response
+                                    {:Ok {:data {:value versioned}}}))]
+        (is (= versioned
+               (client/cas! "n1:21001" "key" 1 "new"))))))
+
+  (testing "read accepts an explicit nil value for a missing key"
+    (with-redefs [client/post! (fn [& _]
+                                 (http-response {:Ok {:value nil}}))]
+      (is (nil? (client/linearizable-read! "n1:21001" "key")))))
+
+  (testing "additive response fields do not invalidate the Ok arm"
+    (let [versioned {:value "value" :version 1}]
+      (with-redefs [client/post! (fn [& _]
+                                   (http-response
+                                    {:Ok {:data {:value versioned}}
+                                     :trace "diagnostic"}))]
+        (is (= versioned
+               (client/write! "n1:21001" "key" "value")))))))
+
+(deftest preserves-known-application-errors
+  (let [error {:QuorumNotEnough {:cluster "n1,n2,n3"
+                                 :got ["n1"]}}
+        response (http-response {:Err error})
+        thrown (with-redefs [client/post! (fn [& _] response)]
+                 (caught #(client/linearizable-read! "n1:21001" "key")))]
+    (is (= :openraft-error (:kind (ex-data thrown))))
+    (is (= error (:error (ex-data thrown))))
+    (is (= response (:response (ex-data thrown))))))
+
+(deftest rejects-invalid-application-response-unions
+  (doseq [[label body reason]
+          [["missing arm" {} :missing-response-arm]
+           ["ambiguous arms"
+            {:Ok {:data {:value {:value "value" :version 1}}}
+             :Err {:ForwardToLeader {}}}
+            :ambiguous-response-arms]
+           ["unknown arm" {:Result {}} :unknown-response-arm]
+           ["non-object union" [] :response-union-not-map]]]
+    (testing label
+      (let [response (http-response body)
+            thrown (with-redefs [client/post! (fn [& _] response)]
+                     (caught #(client/write! "n1:21001" "key" "value")))
+            data (ex-data thrown)]
+        (is (= :invalid-response (:kind data)))
+        (is (= reason (:reason data)))
+        (is (= (when (map? body)
+                 (count (filter #{:Ok :Err} (keys body))))
+               (:response-arm-count data)))
+        (is (= (select-keys response [:method :uri :status])
+               (select-keys (:response data) [:method :uri :status])))
+        (is (= (count (:body response))
+               (get-in data [:response :body-character-count])))
+        (is (= (:body response)
+               (get-in data [:response :body-preview])))
+        (is (not (contains? data :decoded-response))))))
+
+  (testing "Err contains exactly one error variant"
+    (let [body {:Err {:ForwardToLeader {}
+                      :QuorumNotEnough {}}}
+          response (http-response body)
+          thrown (with-redefs [client/post! (fn [& _] response)]
+                   (caught #(client/write! "n1:21001" "key" "value")))
+          data (ex-data thrown)]
+      (is (= :invalid-response (:kind data)))
+      (is (= :invalid-error-union (:reason data)))
+      (is (= 2 (:error-arm-count data)))
+      (is (= (:body response)
+             (get-in data [:response :body-preview])))))
+
+  (testing "a non-object root is rejected without materializing it"
+    (let [decoded? (atom false)
+          response (http-response [])
+          thrown (with-redefs [client/post! (fn [& _] response)
+                               json-parse/parse-strict
+                               (fn [& _]
+                                 (reset! decoded? true)
+                                 (throw (RuntimeException.
+                                         "unexpected full decode")))]
+                   (caught #(client/write! "n1:21001" "key" "value")))]
+      (is (= :invalid-response (:kind (ex-data thrown))))
+      (is (= :response-union-not-map (:reason (ex-data thrown))))
+      (is (false? @decoded?)))))
+
+(deftest rejects-incomplete-or-ambiguous-json-documents
+  (let [valid-ok
+        "{\"Ok\":{\"data\":{\"value\":{\"value\":\"value\",\"version\":1}}}}"]
+    (doseq [[label body]
+            [["duplicate top-level key"
+              (str "{\"Ok\":{\"data\":{\"value\":"
+                   "{\"value\":\"value\",\"version\":1}}},"
+                   "\"Ok\":{\"data\":{\"value\":"
+                   "{\"value\":\"value\",\"version\":2}}}}")]
+             ["duplicate nested key"
+              "{\"Err\":{\"ForwardToLeader\":{},\"ForwardToLeader\":[]}}"]
+             ["second root document"
+              (str valid-ok " {\"Err\":{\"ForwardToLeader\":{}}}")]
+             ["trailing garbage" (str valid-ok " garbage")]
+             ["empty body" ""]
+             ["whitespace-only body" " \n\t"]]]
+      (testing label
+        (let [response (raw-http-response body)
+              thrown (with-redefs [client/post! (fn [& _] response)]
+                       (caught #(client/write! "n1:21001" "key" "value")))]
+          (is (= :invalid-json (:kind (ex-data thrown))))
+          (is (= (select-keys response [:method :uri :status])
+                 (select-keys (:response (ex-data thrown))
+                              [:method :uri :status])))
+          (is (= (count body)
+                 (get-in (ex-data thrown)
+                         [:response :body-character-count]))))))
+
+    (testing "trailing whitespace is part of one complete document"
+      (let [response (raw-http-response (str valid-ok " \n\t"))]
+        (with-redefs [client/post! (fn [& _] response)]
+          (is (= {:value "value" :version 1}
+                 (client/write! "n1:21001" "key" "value"))))))))
+
+(deftest validates-modeled-error-payload-containers
+  (testing "an empty ForwardToLeader object remains modeled"
+    (let [error {:ForwardToLeader {}}
+          thrown (with-redefs [client/post! (fn [& _]
+                                              (http-response {:Err error}))]
+                   (caught #(client/write! "n1:21001" "key" "value")))]
+      (is (= :openraft-error (:kind (ex-data thrown))))
+      (is (= error (:error (ex-data thrown))))))
+
+  (doseq [[variant payload]
+          [[:ForwardToLeader "not-an-object"]
+           [:QuorumNotEnough ["not" "an" "object"]]]]
+    (testing (name variant)
+      (let [thrown (with-redefs [client/post! (fn [& _]
+                                                (http-response
+                                                 {:Err {variant payload}}))]
+                     (caught #(client/write! "n1:21001" "key" "value")))
+            data (ex-data thrown)]
+        (is (= :invalid-response (:kind data)))
+        (is (= :invalid-error-payload (:reason data)))
+        (is (= variant (:error-variant data)))))))
+
+(deftest bounds-invalid-response-evidence
+  (let [body {:Unknown (apply str (repeat 2048 "x"))}
+        response (http-response body)
+        thrown (with-redefs [client/post! (fn [& _] response)]
+                 (caught #(client/write! "n1:21001" "key" "value")))
+        data (ex-data thrown)
+        evidence (:response data)]
+    (is (= :invalid-response (:kind data)))
+    (is (= :unknown-response-arm (:reason data)))
+    (is (= (count (:body response)) (:body-character-count evidence)))
+    (is (= 1024 (count (:body-preview evidence))))
+    (is (not (contains? data :decoded-response)))
+    (is (not (contains? data :payload)))))
+
+(deftest rejects-malformed-workload-payloads
+  (doseq [[label invoke body reason path]
+          [["write nil"
+            #(client/write! "n1:21001" "key" "value")
+            {:Ok {:data {:value nil}}}
+            :nil-payload-field
+            [:data :value]]
+           ["write missing data"
+            #(client/write! "n1:21001" "key" "value")
+            {:Ok {}}
+            :missing-payload-field
+            [:data :value]]
+           ["CAS missing value"
+            #(client/cas! "n1:21001" "key" 1 "value")
+            {:Ok {:data {}}}
+            :missing-payload-field
+            [:data :value]]
+           ["read malformed value"
+            #(client/linearizable-read! "n1:21001" "key")
+            {:Ok {:value {:value 1 :version 2}}}
+            :invalid-versioned-value
+            [:value]]
+           ["write version exceeds u64"
+            #(client/write! "n1:21001" "key" "value")
+            {:Ok {:data {:value {:value "value"
+                                 :version 18446744073709551616N}}}}
+            :invalid-versioned-value
+            [:data :value]]
+           ["write returns a different logical value"
+            #(client/write! "n1:21001" "key" "value")
+            {:Ok {:data {:value {:value "other" :version 1}}}}
+            :unexpected-payload-value
+            [:data :value :value]]
+           ["CAS returns a different logical value"
+            #(client/cas! "n1:21001" "key" 1 "new")
+            {:Ok {:data {:value {:value "other" :version 2}}}}
+            :unexpected-payload-value
+            [:data :value :value]]
+           ["CAS returns a non-increasing version"
+            #(client/cas! "n1:21001" "key" 2 "new")
+            {:Ok {:data {:value {:value "new" :version 2}}}}
+            :non-increasing-cas-version
+            [:data :value :version]]]]
+    (testing label
+      (let [response (http-response body)
+            thrown (with-redefs [client/post! (fn [& _] response)]
+                     (caught invoke))
+            data (ex-data thrown)]
+        (is (= :invalid-response (:kind data)))
+        (is (= reason (:reason data)))
+        (is (= path (:payload-path data)))
+        (is (= (count (:body response))
+               (get-in data [:response :body-character-count])))
+        (is (= (:body response)
+               (get-in data [:response :body-preview])))
+        (is (not (contains? data :payload)))))))
+
+(deftest distinguishes-invalid-json-from-parser-failures
+  (testing "malformed JSON is a SUT response error"
+    (let [response (assoc (http-response {}) :body "{")
+          thrown (with-redefs [client/post! (fn [& _] response)]
+                   (caught #(client/write! "n1:21001" "key" "value")))]
+      (is (= :invalid-json (:kind (ex-data thrown))))
+      (is (= (select-keys response [:method :uri :status])
+             (select-keys (:response (ex-data thrown))
+                          [:method :uri :status])))
+      (is (= 1 (get-in (ex-data thrown)
+                       [:response :body-character-count])))
+      (is (= "{" (get-in (ex-data thrown)
+                         [:response :body-preview])))))
+
+  (testing "an unknown parser exception escapes unchanged"
+    (let [throwable (RuntimeException. "parser bug")
+          response (http-response
+                    {:Ok {:data {:value {:value "value" :version 1}}}})
+          thrown (with-redefs [client/post! (fn [& _] response)
+                               json-parse/parse-strict (fn [& _]
+                                                         (throw throwable))]
+                   (caught #(client/write! "n1:21001" "key" "value")))]
+      (is (identical? throwable thrown)))))
+
+(deftest propagates-http-client-interruptions
+  (doseq [[label throwable]
+          [["InterruptedException" (InterruptedException. "interrupted")]
+           ["InterruptedIOException"
+            (java.io.InterruptedIOException. "interrupted")]
+           ["ClosedByInterruptException"
+            (java.nio.channels.ClosedByInterruptException.)]]]
+    (testing label
+      (Thread/interrupted)
+      (let [fake-client (throwing-http-client throwable)
+            thrown (with-redefs-fn
+                     {(ns-resolve 'jepsen.openraft.client 'http-client)
+                      fake-client}
+                     #(caught
+                       (fn []
+                         (client/post! "n1:21001" "/write" {}))))
+            interrupted (Thread/interrupted)]
+        (is (identical? throwable thrown))
+        (is interrupted))))
+
+  (testing "ordinary I/O remains a transport error"
+    (let [throwable (java.io.IOException. "broken pipe")
+          fake-client (throwing-http-client throwable)
+          thrown (with-redefs-fn
+                   {(ns-resolve 'jepsen.openraft.client 'http-client)
+                    fake-client}
+                   #(caught
+                     (fn []
+                       (client/post! "n1:21001" "/write" {}))))]
+      (is (= :transport-error (:kind (ex-data thrown))))
+      (is (identical? throwable (ex-cause thrown))))))

--- a/jepsen/test/jepsen/openraft/workload_test.clj
+++ b/jepsen/test/jepsen/openraft/workload_test.clj
@@ -1,5 +1,7 @@
 (ns jepsen.openraft.workload-test
-  (:require [clojure.java.io :as io]
+  (:require [cheshire.core :as json]
+            [cheshire.parse :as json-parse]
+            [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing]]
             [jepsen.checker :as checker]
             [jepsen.client :as client]
@@ -8,6 +10,8 @@
             [jepsen.history :as history]
             [jepsen.independent :as independent]
             [jepsen.openraft.client :as http]
+            [jepsen.openraft.harness :as harness]
+            [jepsen.openraft.worker :as worker]
             [jepsen.openraft.workload :as workload]
             [jepsen.random :as random]
             [jepsen.store :as store]))
@@ -36,11 +40,27 @@
         (doseq [file (reverse (file-seq temp-dir))]
           (io/delete-file file true))))))
 
-(defn- kv-client []
-  (workload/->KVClient nil
-                       (atom "n1:21001")
-                       ["n1:21001"]
-                       (atom {})))
+(defn- kv-client
+  ([]
+   (kv-client (atom {})))
+  ([latest-values]
+   (workload/->KVClient nil
+                        (atom "n1:21001")
+                        ["n1:21001"]
+                        latest-values)))
+
+(defn- raw-http-response [body]
+  {:method "POST"
+   :uri "http://n1:21001/write"
+   :status 200
+   :body body})
+
+(defn- http-response [body]
+  (raw-http-response (json/generate-string body)))
+
+(defn- invoke-with-response [subject op body]
+  (with-redefs [http/post! (fn [& _] (http-response body))]
+    (client/invoke! subject {} op)))
 
 (deftest classifies-timeouts-by-operation
   (let [timeout (ex-info "timeout" {:kind :request-timeout})]
@@ -50,13 +70,15 @@
         (let [op {:type :invoke :f :write :value (keyed "value")}
               result (client/invoke! (kv-client) {} op)]
           (is (= :info (:type result)))
-          (is (= :timeout (:error result)))))
+          (is (= :timeout (:error result)))
+          (is (not (contains? result :unexpected-sut-response?)))))
 
       (testing "a read timeout has no state-machine effect"
         (let [op {:type :invoke :f :read :value (keyed nil)}
               result (client/invoke! (kv-client) {} op)]
           (is (= :fail (:type result)))
-          (is (= :timeout (:error result)))))
+          (is (= :timeout (:error result)))
+          (is (not (contains? result :unexpected-sut-response?)))))
 
       (testing "a final recovery write must complete"
         (let [op {:type :invoke
@@ -65,7 +87,7 @@
                   :final? true}
               result (client/invoke! (kv-client) {} op)]
           (is (= :info (:type result)))
-          (is (:unexpected? result))
+          (is (not (contains? result :unexpected-sut-response?)))
           (is (= :request-timeout
                  (-> result :exception-data :kind))))))))
 
@@ -84,14 +106,16 @@
           (let [result (client/invoke! (kv-client) {} op)]
             (is (= :ok (:type result)))
             (is (= ["old" "new"] (val (:value result))))
-            (is (= [test-key 1 "new"] @request))))))
+            (is (= [test-key 1 "new"] @request))
+            (is (not (contains? result :unexpected-sut-response?)))))))
 
     (testing "a version mismatch is a definite failure"
       (with-redefs [http/cas! (fn [& _] nil)]
         (let [result (client/invoke! (kv-client) {} op)]
           (is (= :fail (:type result)))
           (is (= :version-mismatch (:error result)))
-          (is (= (:value op) (:value result))))))
+          (is (= (:value op) (:value result)))
+          (is (not (contains? result :unexpected-sut-response?))))))
 
     (testing "a CAS timeout is indeterminate"
       (let [timeout (ex-info "timeout" {:kind :request-timeout})]
@@ -307,59 +331,286 @@
               result (client/invoke! (kv-client) {} op)]
           (is (= :fail (:type result)))
           (is (= :quorum-not-enough (:error result)))
-          (is (not (:unexpected? result)))))))
+          (is (not (contains? result :unexpected-sut-response?)))))))
 
   (testing "HTTP 400 is fail because app-http rejects it before handler execution"
     (let [bad-request (ex-info "bad request"
                                {:kind :http-error
-                                :status 400})]
+                                :method "POST"
+                                :uri "http://n1:21001/write"
+                                :status 400
+                                :body "bad request"})]
       (with-redefs [http/write! (fn [& _]
                                   (throw bad-request))]
         (let [op {:type :invoke :f :write :value (keyed "value")}
               result (client/invoke! (kv-client) {} op)]
           (is (= :fail (:type result)))
           (is (= [:http 400] (:error result)))
-          (is (:unexpected? result))
+          (is (true? (:unexpected-sut-response? result)))
           (is (= "bad request" (:exception-message result)))
-          (is (= 400 (get-in result [:exception-data :status])))))))
+          (is (= 400 (get-in result [:exception-data :status])))
+          (is (= "bad request" (get-in result [:exception-data :body])))))))
 
   (testing "HTTP 500 is info because response serialization follows handler execution"
     (let [server-error (ex-info "server error"
                                 {:kind :http-error
-                                 :status 500})]
+                                 :method "POST"
+                                 :uri "http://n1:21001/write"
+                                 :status 500
+                                 :body "server error"})]
       (with-redefs [http/write! (fn [& _]
                                   (throw server-error))]
         (let [op {:type :invoke :f :write :value (keyed "value")}
               result (client/invoke! (kv-client) {} op)]
           (is (= :info (:type result)))
           (is (= [:http 500] (:error result)))
-          (is (:unexpected? result))
+          (is (true? (:unexpected-sut-response? result)))
           (is (= "server error" (:exception-message result)))
           (is (= 500 (get-in result [:exception-data :status]))))))))
 
-(deftest rethrows-interruptions
-  (let [op {:type :invoke :f :write :value (keyed "value")}]
-    (testing "a wrapped interruption from send! propagates instead of completing"
-      (with-redefs [http/write! (fn [& _]
-                                  (throw (ex-info "interrupted"
-                                                  {:kind :interrupted})))]
-        (is (thrown? clojure.lang.ExceptionInfo
-                     (client/invoke! (kv-client) {} op)))))
+(deftest records-clearly-unexpected-sut-responses
+  (testing "invalid JSON is a marked Outcome, not a Harness failure"
+    (let [failure-state (harness/failure-state)
+          response {:method "POST"
+                    :uri "http://n1:21001/write"
+                    :status 200
+                    :body "not-json"}
+          invalid-json (ex-info "invalid JSON"
+                                {:kind :invalid-json
+                                 :response response})
+          subject (worker/wrap-client failure-state (kv-client))]
+      (with-redefs [http/write! (fn [& _] (throw invalid-json))]
+        (let [op {:type :invoke :f :write :value (keyed "value")}
+              result (client/invoke! subject {} op)]
+          (is (= :info (:type result)))
+          (is (= :invalid-json (:error result)))
+          (is (true? (:unexpected-sut-response? result)))
+          (is (= response (get-in result [:exception-data :response])))
+          (is (nil? (harness/primary-failure failure-state)))))))
 
-    (testing "a raw InterruptedException propagates and restores the interrupt flag"
-      (with-redefs [http/write! (fn [& _]
-                                  (throw (InterruptedException. "boom")))]
-        ;; Capture the exception and interrupt flag before any assertion runs:
-        ;; clojure.test's report machinery uses dosync, which clears the flag.
-        (Thread/interrupted)
-        (let [thrown (try
-                       (client/invoke! (kv-client) {} op)
+  (testing "an unmodeled OpenRaft Err variant is marked"
+    (let [error {:UnexpectedError {:message "unsupported"}}
+          openraft-error (ex-info "unexpected OpenRaft error"
+                                  {:kind :openraft-error
+                                   :error error
+                                   :response {:status 200
+                                              :body "Err"}})]
+      (with-redefs [http/write! (fn [& _] (throw openraft-error))]
+        (let [op {:type :invoke :f :write :value (keyed "value")}
+              result (client/invoke! (kv-client) {} op)]
+          (is (= :info (:type result)))
+          (is (= :openraft-error (:error result)))
+          (is (true? (:unexpected-sut-response? result)))
+          (is (= error (get-in result [:exception-data :error]))))))))
+
+(deftest leaves-modeled-sut-outcomes-unmarked
+  (doseq [[description throwable expected-type expected-error]
+          [["connection failure"
+            (ex-info "unreachable" {:kind :unreachable})
+            :fail
+            :unreachable]
+           ["transport failure"
+            (ex-info "transport" {:kind :transport-error})
+            :info
+            :transport-error]
+           ["leader redirect without a target"
+            (ex-info "not leader"
+                     {:kind :openraft-error
+                      :error {:ForwardToLeader {}}})
+            :fail
+            :not-leader]
+           ["quorum failure"
+            (ex-info "no quorum"
+                     {:kind :openraft-error
+                      :error {:QuorumNotEnough {}}})
+            :fail
+            :quorum-not-enough]]]
+    (testing description
+      (with-redefs [http/write! (fn [& _] (throw throwable))]
+        (let [op {:type :invoke :f :write :value (keyed "value")}
+              result (client/invoke! (kv-client) {} op)]
+          (is (= expected-type (:type result)))
+          (is (= expected-error (:error result)))
+          (is (not (contains? result :unexpected-sut-response?))))))))
+
+(deftest validates-http-200-application-responses
+  (testing "a valid Ok payload completes successfully"
+    (let [op {:type :invoke :f :write :value (keyed "value")}
+          body {:Ok {:data {:value {:value "value" :version 1}}}}
+          result (invoke-with-response (kv-client) op body)]
+      (is (= :ok (:type result)))
+      (is (not (contains? result :unexpected-sut-response?)))))
+
+  (testing "a known Err remains a modeled Outcome"
+    (let [op {:type :invoke :f :read :value (keyed nil)}
+          body {:Err {:QuorumNotEnough {:cluster "n1,n2,n3"
+                                        :got ["n1"]}}}
+          result (invoke-with-response (kv-client) op body)]
+      (is (= :fail (:type result)))
+      (is (= :quorum-not-enough (:error result)))
+      (is (not (contains? result :unexpected-sut-response?)))))
+
+  (testing "invalid response unions are unexpected Outcomes"
+    (doseq [[label body reason]
+            [["missing arm" {} :missing-response-arm]
+             ["ambiguous arms"
+              {:Ok {:data {:value {:value "value" :version 1}}}
+               :Err {:ForwardToLeader {}}}
+              :ambiguous-response-arms]
+             ["unknown arm" {:Result {}} :unknown-response-arm]]]
+      (testing label
+        (let [failure-state (harness/failure-state)
+              subject (worker/wrap-client failure-state (kv-client))
+              op {:type :invoke :f :write :value (keyed "value")}
+              result (invoke-with-response subject op body)]
+          (is (= :info (:type result)))
+          (is (= :invalid-response (:error result)))
+          (is (true? (:unexpected-sut-response? result)))
+          (is (= reason (get-in result [:exception-data :reason])))
+          (is (= (json/generate-string body)
+                 (get-in result
+                         [:exception-data :response :body-preview])))
+          (is (= (count (json/generate-string body))
+                 (get-in result
+                         [:exception-data
+                          :response
+                          :body-character-count])))
+          (is (nil? (harness/primary-failure failure-state)))))))
+
+  (testing "malformed successful payloads are unexpected Outcomes"
+    (doseq [[label op body expected-type path]
+            [["write nil"
+              {:type :invoke :f :write :value (keyed "value")}
+              {:Ok {:data {:value nil}}}
+              :info
+              [:data :value]]
+             ["CAS missing value"
+              {:type :invoke
+               :f :cas
+               :value (keyed ["old" "new"])
+               :expected-version 1}
+              {:Ok {:data {}}}
+              :info
+              [:data :value]]
+             ["read malformed value"
+              {:type :invoke :f :read :value (keyed nil)}
+              {:Ok {:value {:value 1 :version 2}}}
+              :fail
+              [:value]]]]
+      (testing label
+        (let [result (invoke-with-response (kv-client) op body)]
+          (is (= expected-type (:type result)))
+          (is (= :invalid-response (:error result)))
+          (is (true? (:unexpected-sut-response? result)))
+          (is (= path (get-in result [:exception-data :payload-path])))))))
+
+  (testing "malformed modeled Err payloads are unexpected Outcomes"
+    (doseq [[label op body expected-type variant]
+            [["ForwardToLeader payload"
+              {:type :invoke :f :write :value (keyed "value")}
+              {:Err {:ForwardToLeader "not-an-object"}}
+              :info
+              :ForwardToLeader]
+             ["QuorumNotEnough payload"
+              {:type :invoke :f :read :value (keyed nil)}
+              {:Err {:QuorumNotEnough ["not" "an" "object"]}}
+              :fail
+              :QuorumNotEnough]]]
+      (testing label
+        (let [failure-state (harness/failure-state)
+              subject (worker/wrap-client failure-state (kv-client))
+              result (invoke-with-response subject op body)]
+          (is (= expected-type (:type result)))
+          (is (= :invalid-response (:error result)))
+          (is (true? (:unexpected-sut-response? result)))
+          (is (= :invalid-error-payload
+                 (get-in result [:exception-data :reason])))
+          (is (= variant
+                 (get-in result [:exception-data :error-variant])))
+          (is (nil? (harness/primary-failure failure-state))))))))
+
+(deftest rejects-invalid-json-documents-as-workload-outcomes
+  (let [failure-state (harness/failure-state)
+        subject (worker/wrap-client failure-state (kv-client))
+        op {:type :invoke :f :write :value (keyed "value")}
+        response (raw-http-response
+                  (str "{\"Ok\":{\"data\":{\"value\":"
+                       "{\"value\":\"value\",\"version\":1}}},"
+                       "\"Ok\":{\"data\":{\"value\":"
+                       "{\"value\":\"other\",\"version\":2}}}}"))
+        result (with-redefs [http/post! (fn [& _] response)]
+                 (client/invoke! subject {} op))]
+    (is (= :info (:type result)))
+    (is (= :invalid-json (:error result)))
+    (is (true? (:unexpected-sut-response? result)))
+    (is (= (count (:body response))
+           (get-in result
+                   [:exception-data :response :body-character-count])))
+    (is (nil? (harness/primary-failure failure-state)))))
+
+(deftest unexpected-mutation-responses-do-not-poison-latest-values
+  (let [original {test-key {:value "old" :version 1}}
+        latest-values (atom original)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-client failure-state
+                                    (kv-client latest-values))]
+    (doseq [[label op body reason]
+            [["write"
+              {:type :invoke :f :write :value (keyed "value")}
+              {:Ok {:data {:value {:value "other" :version 2}}}}
+              :unexpected-payload-value]
+             ["CAS value"
+              {:type :invoke
+               :f :cas
+               :value (keyed ["old" "new"])
+               :expected-version 1}
+              {:Ok {:data {:value {:value "other" :version 2}}}}
+              :unexpected-payload-value]
+             ["CAS version"
+              {:type :invoke
+               :f :cas
+               :value (keyed ["old" "new"])
+               :expected-version 1}
+              {:Ok {:data {:value {:value "new" :version 1}}}}
+              :non-increasing-cas-version]]]
+      (testing label
+        (let [result (invoke-with-response subject op body)]
+          (is (= :info (:type result)))
+          (is (= :invalid-response (:error result)))
+          (is (true? (:unexpected-sut-response? result)))
+          (is (= reason
+                 (get-in result [:exception-data :reason])))
+          (is (= original @latest-values)))))
+    (is (nil? (harness/primary-failure failure-state)))))
+
+(deftest rethrows-interruptions
+  (doseq [[label throwable]
+          [["InterruptedException"
+            (InterruptedException. "interrupted")]
+           ["InterruptedIOException"
+            (java.io.InterruptedIOException. "interrupted")]
+           ["ClosedByInterruptException"
+            (java.nio.channels.ClosedByInterruptException.)]
+           ["tagged interruption"
+            (ex-info "interrupted" {:kind :interrupted})]]]
+    (testing label
+      ;; Capture the exception and interrupt flag before any assertion runs:
+      ;; clojure.test's report machinery uses dosync, which clears the flag.
+      (Thread/interrupted)
+      (let [failure-state (harness/failure-state)
+            subject (worker/wrap-client failure-state (kv-client))
+            op {:type :invoke :f :write :value (keyed "value")}
+            thrown (with-redefs [http/write! (fn [& _] (throw throwable))]
+                     (try
+                       (client/invoke! subject {} op)
                        nil
-                       (catch InterruptedException e e))
-              interrupted (Thread/interrupted)]
-          (is (instance? InterruptedException thrown))
-          (is interrupted
-              "the interrupt flag is restored so Jepsen's control signals survive"))))))
+                       (catch Throwable e
+                         e)))
+            interrupted (Thread/interrupted)]
+        (is (identical? throwable thrown))
+        (is interrupted
+            "the interrupt flag is restored so Jepsen's control signals survive")
+        (is (nil? (harness/primary-failure failure-state)))))))
 
 (deftest rethrows-unknown-client-exceptions
   (let [op {:type :invoke :f :write :value (keyed "value")}
@@ -372,21 +623,78 @@
                        e))]
         (is (identical? throwable thrown))))))
 
-(deftest unexpected-errors-checker-flags-tagged-operations
-  (let [chk (#'workload/unexpected-errors-checker)]
-    (testing "a history without unexpected errors is valid"
-      (let [result (checker/check chk {} [{:type :ok :f :read}] {})]
-        (is (:valid? result))
-        (is (= 0 (:count result)))
-        (is (= [] (:errors result)))))
+(deftest records-unknown-parser-exceptions-as-harness-failures
+  (let [failure-state (harness/failure-state)
+        subject (worker/wrap-client failure-state (kv-client))
+        op {:type :invoke :f :write :value (keyed "value")}
+        response (http-response
+                  {:Ok {:data {:value {:value "value" :version 1}}}})
+        throwable (RuntimeException. "parser bug")
+        thrown (with-redefs [http/post! (fn [& _] response)
+                             json-parse/parse-strict (fn [& _]
+                                                       (throw throwable))]
+                 (try
+                   (client/invoke! subject {} op)
+                   nil
+                   (catch RuntimeException e
+                     e)))
+        failure (harness/primary-failure failure-state)]
+    (is (identical? throwable thrown))
+    (is (= :client (:source failure)))
+    (is (= op (get-in failure [:context :operation])))
+    (is (identical? throwable (:throwable failure)))))
 
-    (testing "unexpected-tagged operations fail the check and are surfaced"
-      (let [tagged {:type :info :f :write :error [:http 500] :unexpected? true}
-            history [{:type :ok :f :read} tagged]
+(deftest unexpected-sut-responses-checker-aggregates-marked-outcomes
+  (let [chk (#'workload/unexpected-sut-responses-checker)]
+    (testing "a history without unexpected SUT responses is valid"
+      (let [result (checker/check chk {} [{:type :ok :f :read}] {})]
+        (is (true? (:valid? result)))
+        (is (= 0 (:count result)))
+        (is (= [] (:responses result)))))
+
+    (testing "marked outcomes fail the check and are aggregated"
+      (let [first-response {:type :info
+                            :f :write
+                            :error [:http 500]
+                            :unexpected-sut-response? true}
+            second-response {:type :fail
+                             :f :read
+                             :error :invalid-json
+                             :unexpected-sut-response? true}
+            history [{:type :ok :f :read}
+                     first-response
+                     {:type :info :f :write :error :timeout}
+                     second-response]
             result (checker/check chk {} history {})]
-        (is (not (:valid? result)))
-        (is (= 1 (:count result)))
-        (is (= [tagged] (:errors result)))))))
+        (is (false? (:valid? result)))
+        (is (= 2 (:count result)))
+        (is (= [first-response second-response]
+               (:responses result)))))))
+
+(deftest workload-checker-rejects-unsuccessful-final-operations
+  (let [invocation {:process 0
+                    :type :invoke
+                    :f :write
+                    :phase :final
+                    :final? true
+                    :value (keyed "value")}
+        timeout (assoc invocation
+                       :type :info
+                       :error :timeout)
+        chk (:checker (workload/workload {}))
+        result (check-in-temp-store chk [invocation timeout])]
+    (is (false? (:valid? result)))
+    (is (false? (get-in result [:final-workload :valid?])))
+    (is (= (select-keys timeout
+                        [:process :type :f :phase :final? :value :error])
+           (-> result
+               (get-in [:final-workload :failures])
+               first
+               (select-keys
+                [:process :type :f :phase :final? :value :error]))))
+    (is (true? (get-in result [:unexpected-sut-responses :valid?])))
+    (is (contains? result :linearizable))
+    (is (contains? result :meaningful-operations))))
 
 (deftest requires-successful-main-phase-operations
   (let [chk (#'workload/meaningful-operations-checker)
@@ -455,6 +763,8 @@
         chk (:checker (workload/workload {}))
         result (check-in-temp-store chk history)]
     (is (true? (get-in result [:linearizable :valid?])))
+    (is (true? (get-in result [:final-workload :valid?])))
+    (is (true? (get-in result [:unexpected-sut-responses :valid?])))
     (is (= :unknown
            (get-in result [:meaningful-operations :valid?])))
     (is (= [:write :cas]


### PR DESCRIPTION
## Summary

This PR makes the Jepsen Client/Workload boundary distinguish modeled SUT
outcomes from responses that violate the OpenRaft application protocol.

- validate that an HTTP 200 body is one complete JSON object with exactly one
  `Ok` or `Err` arm
- validate operation-specific successful payloads, including unsigned versions,
  write echoes, and CAS version advancement
- keep modeled timeouts, connectivity failures, routing, quorum outcomes, and
  CAS mismatches as ordinary Outcomes
- record malformed or unmodeled SUT replies as structured unexpected-response
  Outcomes for the checker to reject
- preserve interruption identity and propagation; unknown client exceptions
  continue to escape to the Harness-failure boundary

This prevents malformed replies from silently corrupting the workload model or
being misclassified as Harness failures.

## Verification

- `JAVA_CMD=/opt/homebrew/opt/openjdk@26/bin/java make -C jepsen unit-test`
  — 119 tests, 668 assertions, 0 failures/errors
- `JAVA_CMD=/opt/homebrew/opt/openjdk@26/bin/java make -C jepsen clojure-lint`
  — clj-kondo and cljfmt passed
- `git diff --check upstream/main...HEAD`

Refs #1975

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2012)
<!-- Reviewable:end -->
