### PR TITLE
test: jepsen: close control nemesis outcomes

### DIFF
--- a/jepsen/src/jepsen/openraft/await.clj
+++ b/jepsen/src/jepsen/openraft/await.clj
@@ -1,0 +1,67 @@
+(ns jepsen.openraft.await
+  (:require [jepsen.openraft.interruption :as interruption]
+            [jepsen.util :as util]))
+
+(def ^:private retry-kind ::retry)
+(def ^:private condition-timeout-kind ::condition-timeout)
+(def ^:private escaped-exception (Object.))
+
+(defn retry!
+  "Signals that an owned SUT condition is not satisfied yet."
+  [condition details]
+  (throw (ex-info "OpenRaft SUT condition is not satisfied yet"
+                  (assoc details
+                         :kind retry-kind
+                         :condition condition))))
+
+(defn condition-timeout?
+  "True when e is a timeout produced while waiting for condition."
+  [e condition]
+  (let [data (ex-data e)]
+    (and (= condition-timeout-kind (:kind data))
+         (= condition (:condition data)))))
+
+(defn- retry-exception? [e condition]
+  (let [data (ex-data e)]
+    (and (= retry-kind (:kind data))
+         (= condition (:condition data)))))
+
+(defn- propagate! [e]
+  (when (interruption/interruption? e)
+    (.interrupt (Thread/currentThread)))
+  (throw e))
+
+(defn until!
+  "Polls until f returns, retrying only retry! for the owned condition.
+
+  Unknown exceptions return through an opaque value so Jepsen's broad
+  await-fn catch cannot retry them."
+  [condition f opts]
+  (let [result
+        (try
+          (util/await-fn
+           #(try
+              (f)
+              (catch Exception e
+                (if (retry-exception? e condition)
+                  (throw e)
+                  [escaped-exception e])))
+           opts)
+          (catch Exception e
+            (cond
+              (interruption/interruption? e)
+              (propagate! e)
+
+              (and (= :timeout (:type (ex-data e)))
+                   (retry-exception? (ex-cause e) condition))
+              (throw (ex-info "Timed out waiting for an OpenRaft SUT condition"
+                              {:kind condition-timeout-kind
+                               :condition condition}
+                              e))
+
+              :else
+              (throw e))))]
+    (if (and (vector? result)
+             (identical? escaped-exception (first result)))
+      (propagate! (second result))
+      result)))

--- a/jepsen/src/jepsen/openraft/cluster.clj
+++ b/jepsen/src/jepsen/openraft/cluster.clj
@@ -2,10 +2,10 @@
   (:require [clojure.set :as set]
             [clojure.tools.logging :refer [info]]
             [jepsen.core :as jepsen]
+            [jepsen.openraft.await :as await]
             [jepsen.openraft.client :as client]
             [jepsen.openraft.interruption :as interruption]
-            [jepsen.openraft.quorum :as quorum]
-            [jepsen.util :as util]))
+            [jepsen.openraft.quorum :as quorum]))
 
 (defn node-info [test node]
   {:node-id (client/node-host node)
@@ -67,14 +67,22 @@
     (client/metrics! (client/api-endpoint test node))
     (catch Exception e
       (if (interruption/interruption? e)
-        (let [interrupted-exception
-              (if (instance? InterruptedException e)
-                e
-                (doto (InterruptedException. (ex-message e))
-                  (.initCause e)))]
+        (do
           (.interrupt (Thread/currentThread))
-          (throw interrupted-exception))
+          (throw e))
         (throw e)))))
+
+(def ^:private modeled-metrics-failure-kinds
+  #{:http-error
+    :invalid-json
+    :invalid-response
+    :openraft-error
+    :request-timeout
+    :transport-error
+    :unreachable})
+
+(defn- modeled-metrics-failure? [e]
+  (contains? modeled-metrics-failure-kinds (:kind (ex-data e))))
 
 (defn- collect-reachable-metrics-from [test nodes]
   (into {}
@@ -84,8 +92,10 @@
              [node (node-metrics! test node)]
              (catch InterruptedException e
                (throw e))
-             (catch Exception _
-               nil)))
+             (catch Exception e
+               (if (modeled-metrics-failure? e)
+                 nil
+                 (throw e)))))
          nodes)))
 
 (defn- collect-reachable-metrics [test]
@@ -179,14 +189,14 @@
 (defn await-committed-membership!
   "Waits for a committed membership view from a quorum-supported leader."
   [test]
-  (util/await-fn
+  (await/until!
+   :committed-membership
    #(let [status (membership-status test)]
       (if (and status
                (= (:effective-log-id status)
                   (:committed-log-id status)))
         status
-        (throw (ex-info "OpenRaft membership is not committed yet"
-                        {:status status}))))
+        (await/retry! :committed-membership {:status status})))
    {:log-message "Waiting for a committed OpenRaft membership"
     :timeout 60000}))
 
@@ -196,24 +206,58 @@
    (await-stable-membership! test nil))
   ([test expected-voters]
    (let [expected-voters (some-> expected-voters set)]
-     (util/await-fn
+     (await/until!
+      :stable-membership
       #(let [status (membership-status test)]
          (if (and (:stable? status)
                   (or (nil? expected-voters)
                       (= expected-voters (:voters status))))
            status
-           (throw (ex-info "OpenRaft membership is not stable yet"
-                           {:expected-voters expected-voters
-                            :status status}))))
+           (await/retry! :stable-membership
+                         {:expected-voters expected-voters
+                          :status status})))
       {:log-message "Waiting for OpenRaft membership to become stable"
        :timeout 60000}))))
 
 (defn await-ready! [test]
-  (util/await-fn
+  (await/until!
+   :cluster-ready
    #(or (cluster-status test)
-        (throw (ex-info "OpenRaft cluster is not ready yet" {})))
+        (await/retry! :cluster-ready {}))
    {:log-message "Waiting for every OpenRaft node to agree on a leader"
     :timeout 60000}))
+
+(defn await-node-metrics!
+  "Waits for modeled SUT availability while preserving Harness exceptions."
+  [test node timeout-ms]
+  (await/until!
+   :node-metrics
+   #(try
+      (node-metrics! test node)
+      (catch Exception e
+        (if (modeled-metrics-failure? e)
+          (await/retry! :node-metrics
+                        {:node node
+                         :failure-kind (:kind (ex-data e))})
+          (throw e))))
+   {:log-message (str "Waiting for OpenRaft node " node " metrics")
+    :timeout timeout-ms}))
+
+(defn await-observed-learner!
+  "Waits for a learner in committed membership without retrying Harness errors."
+  [test node timeout-ms]
+  (await/until!
+   :learner-observed
+   #(let [status (membership-status test)]
+      (if (and (:stable? status)
+               (contains? (:learners status) node))
+        status
+        (await/retry! :learner-observed
+                      {:node node
+                       :status status})))
+   {:log-message (str "Waiting for OpenRaft learner " node
+                      " to appear in membership")
+    :timeout timeout-ms}))
 
 (defn voter-configs
   "Maps the effective OpenRaft voter configs to Jepsen node names."
@@ -243,13 +287,19 @@
     ;; which is still before that entry commits. Waiting for the leader alone
     ;; therefore races with the first add-learner, which fails with
     ;; `ChangeMembershipError::InProgress`.
-    (util/await-fn
-     #(let [metrics (client/metrics! leader-endpoint)]
-        (if (and (= leader-id (:current_leader metrics))
-                 (membership-committed? metrics))
-          metrics
-          (throw (ex-info "Initial OpenRaft leader is not ready yet"
-                          {:metrics metrics}))))
+    (await/until!
+     :bootstrap-membership
+     #(try
+        (let [metrics (client/metrics! leader-endpoint)]
+          (if (and (= leader-id (:current_leader metrics))
+                   (membership-committed? metrics))
+            metrics
+            (await/retry! :bootstrap-membership {:metrics metrics})))
+        (catch Exception e
+          (if (modeled-metrics-failure? e)
+            (await/retry! :bootstrap-membership
+                          {:failure-kind (:kind (ex-data e))})
+            (throw e))))
      {:log-message "Waiting for initial OpenRaft leader to commit its membership"
       :timeout 60000})
 

--- a/jepsen/src/jepsen/openraft/db.clj
+++ b/jepsen/src/jepsen/openraft/db.clj
@@ -5,7 +5,8 @@
              [db :as db]]
             [jepsen.control.util :as cu]
             [jepsen.openraft.client :as client]
-            [jepsen.openraft.cluster :as cluster]))
+            [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.interruption :as interruption]))
 
 (def binary "/usr/local/bin/openraft-jepsen-app")
 (def process-name "openraft-jepsen-app")
@@ -15,19 +16,193 @@
 (def pid-file (str data-dir "/openraft.pid"))
 (def default-snapshot-threshold 100)
 
+(def ^:private process-confirm-timeout-ms 30000)
+(def ^:private process-confirm-interval-ms 100)
+
+(def ^:private process-probe-script
+  (str "pids=$(pgrep -u root -f --ignore-ancestors -- \"$1\"); "
+       "rc=$?; case \"$rc\" in "
+       "0) ;; "
+       "1) printf 'absent\\n'; exit 0 ;; "
+       "*) exit \"$rc\" ;; esac; "
+       "seen=0; paused=0; running=0; other=0; "
+       "for pid in $pids; do "
+       "stat_file=\"/proc/$pid/stat\"; "
+       "if IFS= read -r stat < \"$stat_file\"; then "
+       "rest=${stat##*) }; state=${rest%% *}; "
+       "seen=$((seen + 1)); "
+       "case \"$state\" in "
+       "T|t) paused=$((paused + 1)) ;; "
+       "Z|X|x|'') other=$((other + 1)) ;; "
+       "*) running=$((running + 1)) ;; esac; "
+       "elif [ ! -e \"/proc/$pid\" ]; then :; "
+       "else printf 'unable to read %s\\n' \"$stat_file\" >&2; "
+       "exit 74; fi; "
+       "done; "
+       "if [ \"$seen\" -eq 0 ]; then printf 'absent\\n'; "
+       "elif [ \"$other\" -ne 0 ]; then printf 'mixed\\n'; "
+       "elif [ \"$paused\" -eq \"$seen\" ]; then printf 'paused\\n'; "
+       "elif [ \"$running\" -eq \"$seen\" ]; then printf 'running\\n'; "
+       "else printf 'mixed\\n'; fi"))
+
+(defn- process-pattern []
+  (str "^" binary "([[:space:]].*)?$"))
+
+(defn- rethrow-control! [e]
+  (when (interruption/interruption? e)
+    (.interrupt (Thread/currentThread)))
+  (throw e))
+
+(defn- control-exec! [& command]
+  (try
+    (apply c/exec command)
+    (catch Exception e
+      (rethrow-control! e))))
+
+(defn- probe-process! []
+  (let [result (control-exec! :bash
+                              :-c
+                              process-probe-script
+                              "openraft-process-probe"
+                              (process-pattern))]
+    (case result
+      "absent" :absent
+      "running" :running
+      "paused" :paused
+      "mixed" :mixed
+      (throw (ex-info "Unexpected OpenRaft process probe result"
+                      {:kind :unexpected-process-probe-result
+                       :result result})))))
+
+(defn- await-process-state! [expected-state]
+  (let [deadline (+ (System/nanoTime)
+                    (* 1000000 process-confirm-timeout-ms))]
+    (loop []
+      (let [state (probe-process!)]
+        (cond
+          (= expected-state state)
+          state
+
+          (>= (System/nanoTime) deadline)
+          (throw (ex-info "Timed out confirming OpenRaft process state"
+                          {:kind :process-confirmation-timeout
+                           :expected-state expected-state
+                           :observed-state state
+                           :timeout-ms process-confirm-timeout-ms}))
+
+          :else
+          (do
+            (try
+              (Thread/sleep process-confirm-interval-ms)
+              (catch InterruptedException e
+                (rethrow-control! e)))
+            (recur)))))))
+
+(defn- remove-pid-file! []
+  (control-exec! :rm :-f pid-file))
+
+(defn- no-such-process-race? [e]
+  (let [{:keys [type exit err]} (ex-data e)
+        binary-name-pattern (str "(?:"
+                                 (java.util.regex.Pattern/quote binary)
+                                 "|"
+                                 (java.util.regex.Pattern/quote process-name)
+                                 ")")]
+    (and (not (interruption/interruption? e))
+         (= :jepsen.control/nonzero-exit type)
+         (= 1 exit)
+         (re-matches (re-pattern
+                      (str "(?is)\\s*"
+                           binary-name-pattern
+                           ":\\s*no process found\\s*"))
+                     (or err "")))))
+
+(defn- signal-process! [signal confirmed-result]
+  (try
+    (control-exec! :killall :-s signal binary)
+    confirmed-result
+    (catch Exception e
+      (if (no-such-process-race? e)
+        :target-already-exited
+        (rethrow-control! e)))))
+
+(defn- signal-and-confirm! [signal expected-state confirmed-result]
+  (if (= :absent (probe-process!))
+    :target-absent
+    (let [result (signal-process! signal confirmed-result)]
+      (if (= :target-already-exited result)
+        result
+        (do
+          (await-process-state! expected-state)
+          result)))))
+
+(defn- stop-process! []
+  (let [result (signal-and-confirm! 9 :absent :killed)]
+    (remove-pid-file!)
+    result))
+
+(defn- pause-process! []
+  (signal-and-confirm! "STOP" :paused :paused))
+
+(defn- resume-process! []
+  (signal-and-confirm! "CONT" :running :resumed))
+
+(defn- start-command!
+  [node-id api-addr raft-addr snapshot-threshold]
+  (control-exec!
+   (c/env {:RUST_BACKTRACE "1"
+           :RUST_LOG "info"})
+   :start-stop-daemon
+   :--start
+   :--oknodo
+   :--background
+   :--no-close
+   :--make-pidfile
+   :--exec binary
+   :--pidfile pid-file
+   :--chdir data-dir
+   :--startas binary
+   :--
+   :--id node-id
+   :--api-addr api-addr
+   :--raft-addr raft-addr
+   :--snapshot-threshold snapshot-threshold
+   :>> log-file
+   (c/lit "2>&1")))
+
+(defn- start-process!
+  [node-id api-addr raft-addr snapshot-threshold]
+  (let [state (probe-process!)]
+    (case state
+      :running
+      :already-running
+
+      :absent
+      (do
+        (remove-pid-file!)
+        ;; --oknodo makes a start race succeed without broadly suppressing exit
+        ;; status 1, which may instead mean a control or permission failure.
+        (start-command! node-id api-addr raft-addr snapshot-threshold)
+        (await-process-state! :running)
+        :start-confirmed)
+
+      (throw (ex-info "OpenRaft process exists in an unexpected state"
+                      {:kind :unexpected-existing-process-state
+                       :state state})))))
+
 (defn- prepare-dirs! []
   (c/su
-   (c/exec :mkdir :-p data-dir log-dir)))
+   (control-exec! :mkdir :-p data-dir log-dir)))
 
 (defn- wipe-data! []
   (c/su
-   (c/exec :rm :-rf data-dir)
-   (c/exec :mkdir :-p data-dir log-dir)))
+   (control-exec! :rm :-rf data-dir)
+   (control-exec! :mkdir :-p data-dir log-dir)))
 
 (defn- wipe! []
   (wipe-data!)
   (c/su
-   (c/exec :rm :-f log-file)))
+   (control-exec! :rm :-f log-file)))
 
 (defn db [_opts]
   (reify
@@ -62,30 +237,23 @@
                                         :api-addr api-addr
                                         :raft-addr raft-addr})
         (c/su
-         (cu/start-daemon!
-          {:chdir data-dir
-           :env {:RUST_BACKTRACE "1"
-                 :RUST_LOG "info"}
-           :logfile log-file
-           :pidfile pid-file}
-          binary
-          :--id node-id
-          :--api-addr api-addr
-          :--raft-addr raft-addr
-          :--snapshot-threshold (:snapshot-threshold test)))))
+         (start-process! node-id
+                         api-addr
+                         raft-addr
+                         (:snapshot-threshold test)))))
 
     (kill! [_ _ _node]
       (c/su
-       (cu/stop-daemon! process-name pid-file)))
+       (stop-process!)))
 
     db/Pause
     (pause! [_ _ _node]
       (c/su
-       (cu/grepkill! :stop process-name)))
+       (pause-process!)))
 
     (resume! [_ _ _node]
       (c/su
-       (cu/grepkill! :cont process-name)))))
+       (resume-process!)))))
 
 (defn- start-empty-node-on-current-node! [database test node]
   (info node "starting an empty OpenRaft node")

--- a/jepsen/src/jepsen/openraft/nemesis.clj
+++ b/jepsen/src/jepsen/openraft/nemesis.clj
@@ -5,12 +5,18 @@
              [nemesis :as nemesis]
              [random :as random]]
             [jepsen.nemesis.combined :as combined]
-            [jepsen.openraft.cluster :as cluster]))
+            [jepsen.openraft.await :as await]
+            [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.interruption :as interruption]
+            [jepsen.openraft.nemesis.outcome :as outcome]))
 
 (def ^:private initial-healthy-seconds 5)
 (def ^:private retry-interval-seconds 1)
-(def ^:private retryable-skip-results
-  #{:no-reachable-pause-target :no-supported-leader})
+(def ^:private retryable-skip-reasons
+  #{:no-quorum-safe-process-target
+    :no-reachable-pause-target
+    :no-safe-partition-target
+    :no-supported-leader})
 
 (defn- jittered-interval [interval]
   (long (random/double (* 0.5 interval)
@@ -45,10 +51,17 @@
           retry-generator' (some-> retry-generator
                                    (gen/update test context event))
           completion-value (:value event)
-          retry-result (if (map? completion-value)
+          retry-reason (cond
+                         (= :skipped (:status completion-value))
+                         (:reason completion-value)
+
+                         (and (map? completion-value)
+                              (contains? completion-value :status))
                          (:status completion-value)
+
+                         :else
                          completion-value)
-          retry? (contains? retryable-skip-results retry-result)
+          retry? (contains? retryable-skip-reasons retry-reason)
           operation-event? (and stage
                                 (= :nemesis (:process event))
                                 (= operation-f (:f event)))]
@@ -102,9 +115,28 @@
     this)
 
   (invoke! [_ test op]
-    (let [{:keys [leader]} (cluster/await-ready! test)]
-      (info "OpenRaft cluster recovered with leader" leader)
-      (assoc op :value {:leader leader})))
+    (try
+      (let [{:keys [leader]} (cluster/await-ready! test)]
+        (info "OpenRaft cluster recovered with leader" leader)
+        (assoc op :value (outcome/installed {:leader leader})))
+      (catch Exception e
+        (cond
+          (interruption/interruption? e)
+          (do
+            (.interrupt (Thread/currentThread))
+            (throw e))
+
+          (await/condition-timeout? e :cluster-ready)
+          (do
+            (info "OpenRaft cluster recovery is indeterminate"
+                  {:error (ex-message e)})
+            (assoc op
+                   :value (outcome/indeterminate
+                           :recovery-timeout
+                           {:message (ex-message e)})))
+
+          :else
+          (throw e)))))
 
   (teardown! [this _test]
     this)

--- a/jepsen/src/jepsen/openraft/nemesis/outcome.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/outcome.clj
@@ -1,0 +1,27 @@
+(ns jepsen.openraft.nemesis.outcome)
+
+(defn installed
+  "Returns a confirmed Nemesis outcome with structured details."
+  [details]
+  (assoc details :status :installed))
+
+(defn skipped
+  "Returns a known non-installation with a structured reason."
+  [reason details]
+  (assoc details
+         :status :skipped
+         :reason reason))
+
+(defn indeterminate
+  "Returns an attempted action whose side effect cannot be confirmed."
+  [reason details]
+  (assoc details
+         :status :indeterminate
+         :reason reason))
+
+(defn installed-or-legacy?
+  "Checks an installed outcome, or an exact legacy success without status."
+  [value legacy-installed?]
+  (if (and (map? value) (contains? value :status))
+    (= :installed (:status value))
+    (boolean (legacy-installed? value))))

--- a/jepsen/src/jepsen/openraft/nemesis/partition.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/partition.clj
@@ -6,6 +6,7 @@
              [random :as random]]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.interruption :as interruption]
+            [jepsen.openraft.nemesis.outcome :as outcome]
             [jepsen.openraft.quorum :as quorum]))
 
 (def partition-seconds 10)
@@ -30,15 +31,21 @@
                        (throw (ex-info "Unknown partition mode"
                                        {:mode mode})))
           quorum-side (first (random/shuffle candidates))]
-      (when-not quorum-side
-        (throw (ex-info "Membership has no partition for the requested mode"
-                        {:leader leader
-                         :mode mode
-                         :configs configs})))
-      (let [other-side (remove quorum-side nodes)]
-        (if (contains? quorum-side leader)
-          [(vec (filter quorum-side nodes)) (vec other-side)]
-          [(vec other-side) (vec (filter quorum-side nodes))])))))
+      (when quorum-side
+        (let [other-side (remove quorum-side nodes)]
+          (if (contains? quorum-side leader)
+            [(vec (filter quorum-side nodes)) (vec other-side)]
+            [(vec other-side) (vec (filter quorum-side nodes))]))))))
+
+(defn- invoke-delegate! [delegate test op]
+  (try
+    (nemesis/invoke! delegate test op)
+    (catch Exception e
+      ;; Partition control runs multi-node operations on real-pmap workers.
+      ;; Restore the interrupt flag on the receiving Nemesis thread too.
+      (when (interruption/interruption? e)
+        (.interrupt (Thread/currentThread)))
+      (throw e))))
 
 (defrecord PartitionNemesis [partitioner]
   nemesis/Nemesis
@@ -51,37 +58,50 @@
       (if-let [{:keys [leader] :as status}
                (cluster/membership-status test)]
         (let [configs (cluster/voter-configs test status)
-              mode (:value op)
-              components (partition-components (:nodes test)
-                                               configs
-                                               leader
-                                               mode)
-              grudge (nemesis/complete-grudge components)]
-          (info "Partitioning OpenRaft nodes"
-                {:mode mode
-                 :leader leader
-                 :components components})
-          (nemesis/invoke! partitioner test
-                           (assoc op
-                                  :f :start
-                                  :value grudge))
-          (assoc op
-                 :value {:mode mode
-                         :leader leader
-                         :voter-configs configs
-                         :components components}))
+              mode (:value op)]
+          (if-let [components (partition-components (:nodes test)
+                                                    configs
+                                                    leader
+                                                    mode)]
+            (let [grudge (nemesis/complete-grudge components)]
+              (info "Partitioning OpenRaft nodes"
+                    {:mode mode
+                     :leader leader
+                     :components components})
+              (invoke-delegate! partitioner test
+                                (assoc op
+                                       :f :start
+                                       :value grudge))
+              (assoc op
+                     :value (outcome/installed
+                             {:mode mode
+                              :leader leader
+                              :voter-configs configs
+                              :components components})))
+            (do
+              (info "Skipping partition without a safe target"
+                    {:mode mode
+                     :leader leader
+                     :voter-configs configs})
+              (assoc op
+                     :value (outcome/skipped
+                             :no-safe-partition-target
+                             {:mode mode
+                              :leader leader
+                              :voter-configs configs})))))
         (do
           (info "Skipping partition without a quorum-supported leader")
-          (assoc op :value :no-supported-leader)))
+          (assoc op
+                 :value (outcome/skipped :no-supported-leader {}))))
 
       :stop-partition
       (do
         (info "Healing OpenRaft network partition")
-        (nemesis/invoke! partitioner test
-                         (assoc op
-                                :f :stop
-                                :value nil))
-        (assoc op :value :network-healed))))
+        (invoke-delegate! partitioner test
+                          (assoc op
+                                 :f :stop
+                                 :value nil))
+        (assoc op :value (outcome/installed {})))))
 
   (teardown! [_ test]
     (try
@@ -101,6 +121,27 @@
 
 (defn partition-nemesis []
   (PartitionNemesis. (nemesis/partitioner)))
+
+(defn- legacy-partition-start-installed? [value]
+  (and (map? value)
+       (required-partition-modes (:mode value))
+       (:leader value)
+       (coll? (:voter-configs value))
+       (coll? (:components value))))
+
+(defn- partition-start-installed? [value]
+  (and (outcome/installed-or-legacy? value
+                                     legacy-partition-start-installed?)
+       (required-partition-modes (:mode value))))
+
+(defn- partition-stop-installed? [value]
+  (outcome/installed-or-legacy? value #{:network-healed}))
+
+(defn- recovery-installed? [value]
+  (and (outcome/installed-or-legacy?
+        value
+        #(and (map? %) (:leader %)))
+       (:leader value)))
 
 (defn- partition-generator []
   (gen/cycle
@@ -128,25 +169,30 @@
   that every node follows one leader, while leftover rules from an
   indeterminate heal may still cut follower-to-follower links."
   [state op]
-  (let [operation-error? (boolean (or (:error op)
-                                      (:exception op)))]
+  (let [status (get-in op [:value :status])
+        operation-error? (boolean (or (:error op)
+                                      (:exception op)
+                                      (= :indeterminate status)))]
     (case (:f op)
       :start-partition
       (cond
         operation-error? :unknown
-        (get-in op [:value :mode]) :recovery-pending
+        (partition-start-installed? (:value op)) :recovery-pending
         :else state)
 
       :stop-partition
       (cond
         operation-error? :unknown
-        (= :network-healed (:value op)) :recovery-pending
+        (partition-stop-installed? (:value op)) :recovery-pending
         :else state)
 
       :await-recovery
       (cond
+        operation-error? (if (= :recovery-pending state)
+                           :recovery-pending
+                           :unknown)
         (= :unknown state) :unknown
-        (get-in op [:value :leader]) :intact
+        (recovery-installed? (:value op)) :intact
         :else state)
 
       state)))
@@ -156,6 +202,8 @@
     (check [_ _test history _opts]
       (let [observed-modes (->> history
                                 (filter #(= :start-partition (:f %)))
+                                (filter #(partition-start-installed?
+                                          (:value %)))
                                 (keep #(get-in % [:value :mode]))
                                 set)
             missing-modes (remove observed-modes required-partition-modes)

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -7,6 +7,7 @@
             [jepsen.nemesis.combined :as combined]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.interruption :as interruption]
+            [jepsen.openraft.nemesis.outcome :as outcome]
             [jepsen.openraft.quorum :as quorum]))
 
 (def downtime-seconds 10)
@@ -60,12 +61,14 @@
 (def ^:private disruption-start-specs
   {:process {:delegate-f :kill
              :active-key :killed
+             :active-reason :processes-already-killed
              :active-message "Processes are already stopped"
              :start-message "Killing OpenRaft processes"
              :skip-message
              "Skipping process kill without a quorum-supported leader"}
    :pause {:delegate-f :pause
            :active-key :paused
+           :active-reason :processes-already-paused
            :active-message "Processes are already paused"
            :start-message "Pausing OpenRaft processes"
            :skip-message
@@ -76,51 +79,163 @@
       (throw (ex-info "Unknown process disruption kind"
                       {:kind kind}))))
 
+(def ^:private stop-results
+  #{:killed :target-absent :target-already-exited})
+
+(def ^:private start-results
+  #{:already-running :start-confirmed})
+
+(def ^:private pause-results
+  #{:paused :target-absent :target-already-exited})
+
+(def ^:private resume-results
+  #{:resumed :target-absent :target-already-exited})
+
+(defn- complete-control-results?
+  [expected-targets allowed-results results]
+  (and (map? results)
+       (= expected-targets (set (keys results)))
+       (every? allowed-results (vals results))))
+
+(defn- invoke-delegate! [delegate test op]
+  (try
+    (nemesis/invoke! delegate test op)
+    (catch Exception e
+      ;; c/on-nodes runs multi-node control operations on worker threads.
+      ;; Restore the interrupt flag on the receiving Nemesis thread too.
+      (when (interruption/interruption? e)
+        (.interrupt (Thread/currentThread)))
+      (throw e))))
+
+(defn- delegate-results!
+  [completion targets allowed-results operation]
+  (let [results (:value completion)
+        expected-targets (set targets)]
+    (when-not (and (map? results)
+                   (= expected-targets (set (keys results)))
+                   (= (count expected-targets) (count results))
+                   (every? allowed-results (vals results)))
+      (throw (ex-info "Unexpected process control result"
+                      {:kind :unexpected-process-control-result
+                       :operation operation
+                       :expected-targets expected-targets
+                       :allowed-results allowed-results
+                       :result results})))
+    results))
+
+(defn- control-outcome
+  [details completion targets allowed-results operation result-key
+   confirmed-result]
+  (let [results (delegate-results! completion
+                                   targets
+                                   allowed-results
+                                   operation)
+        details (assoc details result-key results)]
+    [details
+     (cond
+       (some #{confirmed-result} (vals results))
+       (outcome/installed details)
+
+       (every? #{:target-absent} (vals results))
+       (outcome/skipped :target-absent details)
+
+       :else
+       (outcome/skipped :target-already-exited details))]))
+
+(defn- stop-outcome [disruption completion]
+  (control-outcome disruption
+                   completion
+                   (:nodes disruption)
+                   stop-results
+                   :kill
+                   :stop-results
+                   :killed))
+
+(defn- pause-outcome [disruption completion]
+  (control-outcome disruption
+                   completion
+                   (:nodes disruption)
+                   pause-results
+                   :pause
+                   :pause-results
+                   :paused))
+
+(defn- resume-outcome [disruption completion targets]
+  (control-outcome {:paused disruption
+                    :resumed targets}
+                   completion
+                   targets
+                   resume-results
+                   :resume
+                   :resume-results
+                   :resumed))
+
 (defn- start-disruption! [delegate active kind test op]
-  (let [{:keys [delegate-f active-key active-message
+  (let [{:keys [delegate-f active-key active-reason active-message
                 start-message skip-message]}
         (disruption-spec kind)]
-    (when @active
-      (throw (ex-info active-message
-                      {active-key @active})))
-    (if-let [status (cluster/membership-status test)]
-      (let [mode (:value op)
-            eligible-nodes (if (= :pause kind)
-                             (->> (:nodes test)
-                                  (filter (set (keys (:metrics status))))
-                                  vec)
-                             (:nodes test))]
-        (if-let [disruption (process-disruption test
-                                                status
-                                                mode
-                                                eligible-nodes)]
-          (let [targets (:nodes disruption)]
-            (info start-message disruption)
-            ;; A multi-node disruption may partially succeed before the delegate
-            ;; reports an error, so retain every node that may need recovering.
-            (reset! active disruption)
-            (nemesis/invoke! delegate test
-                             (assoc op
-                                    :f delegate-f
-                                    :value targets))
-            (assoc op :value disruption))
-          (case kind
-            :process
-            (throw (ex-info "Membership has no quorum-safe process targets"
-                            {:leader (:leader status)
+    (if-let [active-disruption @active]
+      (do
+        (info active-message {active-key active-disruption})
+        (assoc op
+               :value (outcome/skipped
+                       active-reason
+                       {:kind kind
+                        active-key active-disruption})))
+      (if-let [status (cluster/membership-status test)]
+        (let [mode (:value op)
+              eligible-nodes (if (= :pause kind)
+                               (->> (:nodes test)
+                                    (filter (set (keys (:metrics status))))
+                                    vec)
+                               (:nodes test))]
+          (if-let [disruption (process-disruption test
+                                                  status
+                                                  mode
+                                                  eligible-nodes)]
+            (let [targets (:nodes disruption)]
+              (info start-message disruption)
+              ;; A multi-node disruption may partially succeed before the
+              ;; delegate reports an error, so retain every node that may need
+              ;; recovering.
+              (reset! active disruption)
+              (let [completion (invoke-delegate! delegate
+                                                 test
+                                                 (assoc op
+                                                        :f delegate-f
+                                                        :value targets))
+                    [active-disruption value]
+                    (case kind
+                      :process (stop-outcome disruption completion)
+                      :pause (pause-outcome disruption completion))]
+                (reset! active active-disruption)
+                (assoc op :value value)))
+            (case kind
+              :process
+              (let [details {:leader (:leader status)
                              :mode mode
                              :voter-configs (cluster/voter-configs test
-                                                                   status)}))
+                                                                   status)}]
+                (info "Skipping process kill without a quorum-safe target"
+                      details)
+                (assoc op
+                       :value (outcome/skipped
+                               :no-quorum-safe-process-target
+                               details)))
 
-            :pause
-            (do
-              (info "Skipping process pause without a reachable target"
-                    {:mode mode
-                     :reachable-nodes eligible-nodes})
-              (assoc op :value :no-reachable-pause-target)))))
-      (do
-        (info skip-message)
-        (assoc op :value :no-supported-leader)))))
+              :pause
+              (let [details {:mode mode
+                             :reachable-nodes eligible-nodes}]
+                (info "Skipping process pause without a reachable target"
+                      details)
+                (assoc op
+                       :value (outcome/skipped
+                               :no-reachable-pause-target
+                               details))))))
+        (do
+          (info skip-message)
+          (assoc op
+                 :value (outcome/skipped :no-supported-leader {})))))))
 
 (defrecord ProcessNemesis [delegate killed]
   nemesis/Nemesis
@@ -134,15 +249,23 @@
 
       :restart-process
       (if-let [{:keys [nodes] :as disruption} @killed]
-        (do
-          (info "Restarting OpenRaft processes" {:nodes nodes})
-          (nemesis/invoke! delegate test
-                           (assoc op
-                                  :f :start
-                                  :value nodes))
+        (let [_ (info "Restarting OpenRaft processes" {:nodes nodes})
+              completion
+              (invoke-delegate! delegate
+                                test
+                                (assoc op
+                                       :f :start
+                                       :value nodes))
+              results (delegate-results! completion
+                                         nodes
+                                         start-results
+                                         :start)
+              value (outcome/installed
+                     (assoc disruption :start-results results))]
           (reset! killed nil)
-          (assoc op :value disruption))
-        (assoc op :value :no-processes-killed))))
+          (assoc op :value value))
+        (assoc op
+               :value (outcome/skipped :no-processes-killed {})))))
 
   (teardown! [_ test]
     (nemesis/teardown! delegate test))
@@ -165,15 +288,16 @@
       (start-disruption! delegate paused :pause test op)
 
       :resume-process
-      (let [disruption @paused]
+      (let [disruption @paused
+            targets (:nodes test)]
         (info "Resuming all OpenRaft processes" {:nodes (:nodes test)})
-        (nemesis/invoke! delegate test
-                         (assoc op
-                                :f :resume
-                                :value (:nodes test)))
-        (reset! paused nil)
-        (assoc op :value {:paused disruption
-                          :resumed (:nodes test)}))))
+        (let [completion (invoke-delegate! delegate test
+                                           (assoc op
+                                                  :f :resume
+                                                  :value targets))
+              [_ value] (resume-outcome disruption completion targets)]
+          (reset! paused nil)
+          (assoc op :value value)))))
 
   (teardown! [_ test]
     (try
@@ -198,6 +322,77 @@
 
 (defn pause-nemesis [db]
   (PauseNemesis. (combined/db-nemesis db) (atom nil)))
+
+(defn- legacy-disruption-installed? [required-modes value]
+  (and (map? value)
+       (required-modes (:mode value))
+       (:leader value)
+       (coll? (:nodes value))
+       (coll? (:voter-configs value))
+       (coll? (:survivors value))))
+
+(defn- disruption-installed? [required-modes value]
+  (and (outcome/installed-or-legacy?
+        value
+        (partial legacy-disruption-installed? required-modes))
+       (required-modes (:mode value))))
+
+(defn- pause-installed? [value]
+  (if (and (map? value) (contains? value :status))
+    (let [targets (:nodes value)
+          target-set (set targets)
+          results (:pause-results value)
+          mode (:mode value)
+          leader (:leader value)]
+      (and (= :installed (:status value))
+           (required-pause-modes mode)
+           (seq targets)
+           (map? results)
+           (= (set targets) (set (keys results)))
+           (case mode
+             :leader-paused
+             (and (contains? target-set leader)
+                  (= :paused (get results leader)))
+
+             :leader-unpaused
+             (and (not (contains? target-set leader))
+                  (some #{:paused} (vals results)))
+
+             false)))
+    (legacy-disruption-installed? required-pause-modes value)))
+
+(defn- actual-pause-installed? [value]
+  (if (and (map? value) (contains? value :status))
+    (let [targets (:nodes value)
+          results (:pause-results value)]
+      (and (= :installed (:status value))
+           (seq targets)
+           (complete-control-results? (set targets) pause-results results)
+           (some #{:paused} (vals results))))
+    (legacy-disruption-installed? required-pause-modes value)))
+
+(defn- legacy-resume-installed? [expected-nodes value]
+  (and (map? value)
+       (contains? value :paused)
+       (coll? (:resumed value))
+       (= expected-nodes (set (:resumed value)))))
+
+(defn- resume-installed? [expected-nodes value]
+  (if (and (map? value) (contains? value :status))
+    (let [results (:resume-results value)]
+      (and (= :installed (:status value))
+           (contains? value :paused)
+           (coll? (:resumed value))
+           (= expected-nodes (set (:resumed value)))
+           (complete-control-results? expected-nodes resume-results results)
+           (some #{:resumed} (vals results))))
+    (legacy-resume-installed? expected-nodes value)))
+
+(defn- recovery-installed? [value]
+  (and (outcome/installed-or-legacy?
+        value
+        #(and (map? %) (:leader %)))
+       (:leader value)))
 
 (defn- process-generator []
   (gen/cycle
@@ -229,12 +424,14 @@
 
 (defn- operation-error? [op]
   (boolean (or (:error op)
-               (:exception op))))
+               (:exception op)
+               (= :indeterminate (get-in op [:value :status])))))
 
 (defn- coverage-result
-  [required-modes operation-f invalid-states history cluster-state]
+  [required-modes operation-f installed? invalid-states history cluster-state]
   (let [observed-modes (->> history
                             (filter #(= operation-f (:f %)))
+                            (filter #(installed? (:value %)))
                             (keep #(get-in % [:value :mode]))
                             set)
         missing-modes (remove observed-modes required-modes)
@@ -260,7 +457,9 @@
                                  :unknown
 
                                  (and (= :kill-process (:f op))
-                                      (get-in op [:value :mode]))
+                                      (disruption-installed?
+                                       required-process-modes
+                                       (:value op)))
                                  :degraded
 
                                  (and (= :restart-process (:f op))
@@ -268,7 +467,7 @@
                                  :unknown
 
                                  (and (= :await-recovery (:f op))
-                                      (get-in op [:value :leader]))
+                                      (recovery-installed? (:value op)))
                                  :intact
 
                                  (and (= :await-recovery (:f op))
@@ -282,6 +481,8 @@
                            history)]
         (coverage-result required-process-modes
                          :kill-process
+                         (partial disruption-installed?
+                                  required-process-modes)
                          #{:degraded}
                          history
                          cluster-state)))))
@@ -297,29 +498,30 @@
 
 (defn- next-pause-state [expected-nodes state op]
   (let [error? (operation-error? op)
-        resumed-nodes (get-in op [:value :resumed])]
+        status (get-in op [:value :status])]
     (case (:f op)
       :pause-process
       (cond
         error? :unknown
-        (get-in op [:value :mode]) :paused
+        (actual-pause-installed? (:value op)) :paused
         :else state)
 
       :resume-process
       (cond
         error? :unknown
-        (and (coll? resumed-nodes)
-             (= expected-nodes (set resumed-nodes))) :recovery-pending
+        (resume-installed? expected-nodes (:value op)) :recovery-pending
+        (= :skipped status) state
         :else :unknown)
 
       :await-recovery
       (cond
-        (get-in op [:value :leader]) (if (= :recovery-pending state)
-                                       :intact
-                                       :unknown)
         error? (if (#{:paused :recovery-pending} state)
                  state
                  :unknown)
+        (recovery-installed? (:value op)) (if (#{:intact
+                                                 :recovery-pending} state)
+                                            :intact
+                                            :unknown)
         :else state)
 
       state)))
@@ -333,6 +535,7 @@
                                   history)]
         (coverage-result required-pause-modes
                          :pause-process
+                         pause-installed?
                          #{:paused :recovery-pending}
                          history
                          cluster-state)))))

--- a/jepsen/test/jepsen/openraft/await_test.clj
+++ b/jepsen/test/jepsen/openraft/await_test.clj
@@ -1,0 +1,70 @@
+(ns jepsen.openraft.await-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen.openraft.await :as await]))
+
+(deftest retries-only-owned-unsatisfied-conditions
+  (testing "an owned retry can later succeed"
+    (let [attempts (atom 0)
+          result (await/until!
+                  :test-condition
+                  #(if (= 1 (swap! attempts inc))
+                     (await/retry! :test-condition {})
+                     :ready)
+                  {:retry-interval 0
+                   :timeout 100})]
+      (is (= :ready result))
+      (is (= 2 @attempts))))
+
+  (testing "an unknown exception escapes immediately by identity"
+    (let [attempts (atom 0)
+          error (RuntimeException. "wait bug")
+          thrown (try
+                   (await/until! :test-condition
+                                 #(do
+                                    (swap! attempts inc)
+                                    (throw error))
+                                 {:retry-interval 0
+                                  :timeout 100})
+                   nil
+                   (catch Exception e
+                     e))]
+      (is (identical? error thrown))
+      (is (= 1 @attempts))))
+
+  (testing "only the owned condition matches a modeled timeout"
+    (let [error (try
+                  (await/until! :test-condition
+                                #(await/retry! :test-condition {})
+                                {:retry-interval 0
+                                 :timeout 0})
+                  nil
+                  (catch Exception e
+                    e))]
+      (is (await/condition-timeout? error :test-condition))
+      (is (false? (await/condition-timeout? error :other-condition))))))
+
+(deftest preserves-wait-interruptions
+  (doseq [[label make-error]
+          [[:interrupted #(InterruptedException. "interrupted")]
+           [:interrupted-io
+            #(java.io.InterruptedIOException. "interrupted")]
+           [:closed-by-interrupt
+            #(java.nio.channels.ClosedByInterruptException.)]
+           [:wrapped #(ex-info "interrupted" {:kind :interrupted})]]]
+    (testing (name label)
+      (Thread/interrupted)
+      (try
+        (let [error (make-error)
+              [thrown interrupted?]
+              (try
+                (await/until! :test-condition
+                              #(throw error)
+                              {:retry-interval 0
+                               :timeout 100})
+                [nil (.isInterrupted (Thread/currentThread))]
+                (catch Exception e
+                  [e (.isInterrupted (Thread/currentThread))]))]
+          (is (identical? error thrown))
+          (is interrupted?))
+        (finally
+          (Thread/interrupted))))))

--- a/jepsen/test/jepsen/openraft/cluster_test.clj
+++ b/jepsen/test/jepsen/openraft/cluster_test.clj
@@ -1,5 +1,5 @@
 (ns jepsen.openraft.cluster-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [jepsen.openraft.client :as client]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.util :as util]))
@@ -68,8 +68,44 @@
                                         {:kind :unreachable}))))]
       (is (nil? (#'cluster/cluster-status test-config))))))
 
+(deftest distinguishes-modeled-metrics-failures-from-harness-errors
+  (testing "recognized SUT observations make a node unavailable"
+    (doseq [kind [:http-error
+                  :invalid-json
+                  :invalid-response
+                  :openraft-error
+                  :request-timeout
+                  :transport-error
+                  :unreachable]]
+      (with-redefs [client/metrics!
+                    (fn [_endpoint]
+                      (throw (ex-info "unavailable" {:kind kind})))]
+        (is (nil? (#'cluster/cluster-status test-config)) (name kind)))))
+
+  (testing "unknown implementation exceptions propagate"
+    (let [error (RuntimeException. "metrics bug")
+          thrown (with-redefs [client/metrics! (fn [_endpoint]
+                                                 (throw error))]
+                   (try
+                     (#'cluster/cluster-status test-config)
+                     nil
+                     (catch Exception e
+                       e)))]
+      (is (identical? error thrown))))
+
+  (testing "the readiness wait preserves the unknown exception"
+    (let [error (RuntimeException. "readiness bug")
+          thrown (with-redefs [client/metrics! (fn [_endpoint]
+                                                 (throw error))]
+                   (try
+                     (cluster/await-ready! test-config)
+                     nil
+                     (catch Exception e
+                       e)))]
+      (is (identical? error thrown)))))
+
 (deftest preserves-metrics-request-interruption
-  (doseq [[label error]
+  (doseq [[label make-error]
           [[:interrupted-exception
             #(InterruptedException. "interrupted")]
            [:interrupted-io
@@ -78,19 +114,20 @@
             #(java.nio.channels.ClosedByInterruptException.)]
            [:wrapped
             #(ex-info "interrupted" {:kind :interrupted})]]]
-    (let [interrupted?
+    (let [error (make-error)
+          [thrown interrupted?]
           @(future
-             (with-redefs [client/metrics!
-                           (fn [_endpoint]
-                             (throw (error)))]
-               (try
+             (try
+               (with-redefs [client/metrics!
+                             (fn [_endpoint]
+                               (throw error))]
                  (#'cluster/cluster-status test-config)
-                 false
-                 (catch InterruptedException _
-                   (let [interrupted? (.isInterrupted
-                                       (Thread/currentThread))]
-                     (Thread/interrupted)
-                     interrupted?)))))]
+                 [nil (.isInterrupted (Thread/currentThread))])
+               (catch Exception e
+                 [e (.isInterrupted (Thread/currentThread))])
+               (finally
+                 (Thread/interrupted))))]
+      (is (identical? error thrown) (name label))
       (is interrupted? (name label)))))
 
 (defn- membership [configs]
@@ -316,6 +353,44 @@
       (is (= committed
              (cluster/await-committed-membership! test-config)))
       (is (= [:retry] @attempts)))))
+
+(deftest membership-waits-do-not-retry-harness-exceptions
+  (doseq [[label wait!]
+          [[:committed #(cluster/await-committed-membership! test-config)]
+           [:stable #(cluster/await-stable-membership! test-config)]
+           [:learner #(cluster/await-observed-learner!
+                       test-config
+                       "n4"
+                       100)]]]
+    (testing (name label)
+      (let [attempts (atom 0)
+            error (RuntimeException. "membership wait bug")
+            thrown (with-redefs [cluster/membership-status
+                                 (fn [_test]
+                                   (swap! attempts inc)
+                                   (throw error))]
+                     (try
+                       (wait!)
+                       nil
+                       (catch Exception e
+                         e)))]
+        (is (identical? error thrown))
+        (is (= 1 @attempts)))))
+
+  (testing "node metrics retries only modeled SUT availability"
+    (let [attempts (atom 0)
+          error (RuntimeException. "node metrics bug")
+          thrown (with-redefs [cluster/node-metrics!
+                               (fn [_test _node]
+                                 (swap! attempts inc)
+                                 (throw error))]
+                   (try
+                     (cluster/await-node-metrics! test-config "n4" 100)
+                     nil
+                     (catch Exception e
+                       e)))]
+      (is (identical? error thrown))
+      (is (= 1 @attempts)))))
 
 (deftest rejects-support-from-an-older-leader-term
   (let [membership (stored-membership

--- a/jepsen/test/jepsen/openraft/db_test.clj
+++ b/jepsen/test/jepsen/openraft/db_test.clj
@@ -1,22 +1,418 @@
 (ns jepsen.openraft.db-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [jepsen.control :as c]
-            [jepsen.control.util :as cu]
             [jepsen.db :as db]
             [jepsen.openraft.db :as openraft-db]))
 
-(deftest builds-test-app-start-arguments
-  (let [started-args (atom nil)
-        database (openraft-db/db {})
-        test {:api-port 21001
-              :raft-port 22001
-              :snapshot-threshold 250}]
-    (with-redefs [c/exec (fn [& _args])
-                  cu/start-daemon! (fn [_opts _binary & args]
-                                     (reset! started-args args))]
-      (db/start! database test "n1"))
-    (is (= {:--id "n1"
-            :--api-addr "n1:21001"
-            :--raft-addr "n1:22001"
-            :--snapshot-threshold 250}
-           (apply hash-map @started-args)))))
+(def test-config
+  {:api-port 21001
+   :raft-port 22001
+   :snapshot-threshold 250})
+
+(defn- command-kind [command]
+  (cond
+    (= :bash (first command)) :probe
+    (= :killall (first command)) (case (nth command 2)
+                                   9 :kill
+                                   "STOP" :pause
+                                   "CONT" :resume)
+    (= :rm (first command)) :remove
+    (= :mkdir (first command)) :mkdir
+    (some #{:start-stop-daemon} command) :start))
+
+(defn- argument-after [command argument]
+  (let [index (.indexOf command argument)]
+    (when-not (neg? index)
+      (nth command (inc index)))))
+
+(deftest starts-and-confirms-the-test-app
+  (let [calls (atom [])
+        running? (atom false)
+        database (openraft-db/db {})]
+    (with-redefs [c/exec
+                  (fn [& command]
+                    (swap! calls conj command)
+                    (case (command-kind command)
+                      :probe (if @running? "running" "absent")
+                      :start (do (reset! running? true) "")
+                      ""))]
+      (is (= :start-confirmed (db/start! database test-config "n1"))))
+    (let [start-command (first (filter #(= :start (command-kind %)) @calls))]
+      (is (some #{:--oknodo} start-command))
+      (is (= "n1" (argument-after start-command :--id)))
+      (is (= "n1:21001" (argument-after start-command :--api-addr)))
+      (is (= "n1:22001" (argument-after start-command :--raft-addr)))
+      (is (= 250 (argument-after start-command :--snapshot-threshold))))))
+
+(deftest uses-explicit-process-evidence-when-starting
+  (let [database (openraft-db/db {})]
+    (testing "an already running process is not started again"
+      (let [starts (atom 0)]
+        (with-redefs [c/exec
+                      (fn [& command]
+                        (case (command-kind command)
+                          :probe "running"
+                          :start (do (swap! starts inc) "")
+                          ""))]
+          (is (= :already-running
+                 (db/start! database test-config "n1"))))
+        (is (zero? @starts))))
+
+    (testing "a paused process is not treated as already running"
+      (let [starts (atom 0)
+            error (with-redefs [c/exec
+                                (fn [& command]
+                                  (case (command-kind command)
+                                    :probe "paused"
+                                    :start (do (swap! starts inc) "")
+                                    ""))]
+                    (try
+                      (db/start! database test-config "n1")
+                      nil
+                      (catch Exception e
+                        e)))]
+        (is (= :unexpected-existing-process-state
+               (:kind (ex-data error))))
+        (is (= :paused (:state (ex-data error))))
+        (is (zero? @starts))))
+
+    (testing "an exit-one start failure propagates unchanged"
+      (let [error (ex-info "permission denied"
+                           {:type :jepsen.control/nonzero-exit
+                            :exit 1})
+            thrown (with-redefs [c/exec
+                                 (fn [& command]
+                                   (case (command-kind command)
+                                     :probe "absent"
+                                     :start (throw error)
+                                     ""))]
+                     (try
+                       (db/start! database test-config "n1")
+                       nil
+                       (catch Exception e
+                         e)))]
+        (is (identical? error thrown))))
+
+    (testing "a background start that never appears times out"
+      (let [error
+            (with-redefs-fn
+              {#'c/exec
+               (fn [& command]
+                 (case (command-kind command)
+                   :probe "absent"
+                   ""))
+               #'openraft-db/process-confirm-timeout-ms 0}
+              #(try
+                 (db/start! database test-config "n1")
+                 nil
+                 (catch Exception e
+                   e)))]
+        (is (= :process-confirmation-timeout
+               (:kind (ex-data error))))))))
+
+(deftest pauses-and-resumes-processes-with-strict-evidence
+  (let [database (openraft-db/db {})]
+    (testing "a pause signal is confirmed"
+      (let [state (atom :running)
+            calls (atom [])]
+        (with-redefs [c/exec
+                      (fn [& command]
+                        (swap! calls conj command)
+                        (case (command-kind command)
+                          :probe (name @state)
+                          :pause (do (reset! state :paused) "")
+                          ""))]
+          (is (= :paused (db/pause! database {} "n1"))))
+        (is (= [:probe :pause :probe]
+               (mapv command-kind @calls)))))
+
+    (testing "a resume signal is confirmed"
+      (let [state (atom :paused)
+            calls (atom [])]
+        (with-redefs [c/exec
+                      (fn [& command]
+                        (swap! calls conj command)
+                        (case (command-kind command)
+                          :probe (name @state)
+                          :resume (do (reset! state :running) "")
+                          ""))]
+          (is (= :resumed (db/resume! database {} "n1"))))
+        (is (= [:probe :resume :probe]
+               (mapv command-kind @calls)))))
+
+    (doseq [[label operation]
+            [[:pause #(db/pause! database {} "n1")]
+             [:resume #(db/resume! database {} "n1")]]]
+      (testing (str (name label) " records a pre-probe absence")
+        (let [calls (atom [])]
+          (with-redefs [c/exec
+                        (fn [& command]
+                          (swap! calls conj command)
+                          (case (command-kind command)
+                            :probe "absent"
+                            ""))]
+            (is (= :target-absent (operation))))
+          (is (= [:probe] (mapv command-kind @calls))))))
+
+    (doseq [[label process-state operation]
+            [[:pause :running #(db/pause! database {} "n1")]
+             [:resume :paused #(db/resume! database {} "n1")]]]
+      (testing (str (name label) " records an explicit exit race")
+        (let [race (ex-info "no process found"
+                            {:type :jepsen.control/nonzero-exit
+                             :exit 1
+                             :err (str openraft-db/process-name
+                                       ": no process found")})]
+          (with-redefs [c/exec
+                        (fn [& command]
+                          (case (command-kind command)
+                            :probe (name process-state)
+                            (:pause :resume) (throw race)
+                            ""))]
+            (is (= :target-already-exited (operation)))))))
+
+    (doseq [[label process-state operation]
+            [[:pause :running #(db/pause! database {} "n1")]
+             [:resume :paused #(db/resume! database {} "n1")]]]
+      (testing (str (name label) " propagates control failures")
+        (let [error (ex-info "permission denied"
+                             {:type :jepsen.control/nonzero-exit
+                              :exit 1
+                              :err "permission denied"})
+              thrown (with-redefs [c/exec
+                                   (fn [& command]
+                                     (case (command-kind command)
+                                       :probe (name process-state)
+                                       (:pause :resume) (throw error)
+                                       ""))]
+                       (try
+                         (operation)
+                         nil
+                         (catch Exception e
+                           e)))]
+          (is (identical? error thrown)))))
+
+    (doseq [[label process-state operation]
+            [[:pause :running #(db/pause! database {} "n1")]
+             [:resume :paused #(db/resume! database {} "n1")]]]
+      (testing (str (name label) " has bounded confirmation")
+        (let [error
+              (with-redefs-fn
+                {#'c/exec
+                 (fn [& command]
+                   (case (command-kind command)
+                     :probe (name process-state)
+                     ""))
+                 #'openraft-db/process-confirm-timeout-ms 0}
+                #(try
+                   (operation)
+                   nil
+                   (catch Exception e
+                     e)))]
+          (is (= :process-confirmation-timeout
+                 (:kind (ex-data error)))))))))
+
+(deftest stops-processes-with-strict-evidence
+  (let [database (openraft-db/db {})]
+    (testing "a pre-probe absence is a structured no-op"
+      (let [calls (atom [])]
+        (with-redefs [c/exec
+                      (fn [& command]
+                        (swap! calls conj command)
+                        (case (command-kind command)
+                          :probe "absent"
+                          ""))]
+          (is (= :target-absent (db/kill! database {} "n1"))))
+        (is (= [:probe :remove]
+               (mapv command-kind @calls)))))
+
+    (testing "a successful kill is confirmed absent"
+      (let [running? (atom true)
+            calls (atom [])]
+        (with-redefs [c/exec
+                      (fn [& command]
+                        (swap! calls conj command)
+                        (case (command-kind command)
+                          :probe (if @running? "running" "absent")
+                          :kill (do (reset! running? false) "")
+                          ""))]
+          (is (= :killed (db/kill! database {} "n1"))))
+        (is (= [:probe :kill :probe :remove]
+               (mapv command-kind @calls)))))
+
+    (testing "an explicit exit race is skipped without polling"
+      (let [calls (atom [])
+            race (ex-info "no process found"
+                          {:type :jepsen.control/nonzero-exit
+                           :exit 1
+                           :err "openraft-jepsen-app: no process found"})]
+        (with-redefs [c/exec
+                      (fn [& command]
+                        (swap! calls conj command)
+                        (case (command-kind command)
+                          :probe "running"
+                          :kill (throw race)
+                          ""))]
+          (is (= :target-already-exited
+                 (db/kill! database {} "n1"))))
+        (is (= [:probe :kill :remove]
+               (mapv command-kind @calls)))))
+
+    (testing "permission failures are never treated as absence"
+      (let [removed? (atom false)
+            error (ex-info "permission denied"
+                           {:type :jepsen.control/nonzero-exit
+                            :exit 1
+                            :err "permission denied"})
+            thrown (with-redefs [c/exec
+                                 (fn [& command]
+                                   (case (command-kind command)
+                                     :probe "running"
+                                     :kill (throw error)
+                                     :remove (do (reset! removed? true) "")))]
+                     (try
+                       (db/kill! database {} "n1")
+                       nil
+                       (catch Exception e
+                         e)))]
+        (is (identical? error thrown))
+        (is (false? @removed?))))
+
+    (testing "mixed control diagnostics are not an explicit exit race"
+      (let [error (ex-info "kill failed"
+                           {:type :jepsen.control/nonzero-exit
+                            :exit 1
+                            :err (str "permission denied\n"
+                                      openraft-db/process-name
+                                      ": no process found")})
+            thrown (with-redefs [c/exec
+                                 (fn [& command]
+                                   (case (command-kind command)
+                                     :probe "running"
+                                     :kill (throw error)
+                                     ""))]
+                     (try
+                       (db/kill! database {} "n1")
+                       nil
+                       (catch Exception e
+                         e)))]
+        (is (identical? error thrown))))
+
+    (testing "a process that remains running fails bounded confirmation"
+      (let [error
+            (with-redefs-fn
+              {#'c/exec
+               (fn [& command]
+                 (case (command-kind command)
+                   :probe "running"
+                   ""))
+               #'openraft-db/process-confirm-timeout-ms 0}
+              #(try
+                 (db/kill! database {} "n1")
+                 nil
+                 (catch Exception e
+                   e)))]
+        (is (= :process-confirmation-timeout
+               (:kind (ex-data error))))))))
+
+(deftest process-control-preserves-interruptions
+  (doseq [[label make-error]
+          [[:interrupted #(InterruptedException. "interrupted")]
+           [:interrupted-io
+            #(java.io.InterruptedIOException. "interrupted")]
+           [:closed-by-interrupt
+            #(java.nio.channels.ClosedByInterruptException.)]
+           [:wrapped
+            #(ex-info "interrupted"
+                      {:kind :interrupted
+                       :type :jepsen.control/nonzero-exit
+                       :exit 1
+                       :err "no process found"})]]]
+    (testing (name label)
+      (Thread/interrupted)
+      (try
+        (let [error (make-error)
+              database (openraft-db/db {})
+              [thrown interrupted?]
+              (with-redefs [c/exec (fn [& _] (throw error))]
+                (try
+                  (db/kill! database {} "n1")
+                  [nil (.isInterrupted (Thread/currentThread))]
+                  (catch Exception e
+                    [e (.isInterrupted (Thread/currentThread))])))]
+          (is (identical? error thrown))
+          (is interrupted?))
+        (finally
+          (Thread/interrupted))))))
+
+(deftest every-process-control-stage-preserves-interruptions
+  (let [database (openraft-db/db {})
+        stages
+        [{:label :remove-pid
+          :operation #(db/kill! database {} "n1")
+          :exec (fn [error command]
+                  (case (command-kind command)
+                    :probe "absent"
+                    :remove (throw error)
+                    ""))}
+         {:label :kill-signal
+          :operation #(db/kill! database {} "n1")
+          :exec (fn [error command]
+                  (case (command-kind command)
+                    :probe "running"
+                    :kill (throw error)
+                    ""))}
+         {:label :pause-signal
+          :operation #(db/pause! database {} "n1")
+          :exec (fn [error command]
+                  (case (command-kind command)
+                    :probe "running"
+                    :pause (throw error)
+                    ""))}
+         {:label :resume-signal
+          :operation #(db/resume! database {} "n1")
+          :exec (fn [error command]
+                  (case (command-kind command)
+                    :probe "paused"
+                    :resume (throw error)
+                    ""))}
+         {:label :start-command
+          :operation #(db/start! database test-config "n1")
+          :exec (fn [error command]
+                  (case (command-kind command)
+                    :probe "absent"
+                    :start (throw error)
+                    ""))}]]
+    (doseq [{:keys [label operation exec]} stages]
+      (testing (name label)
+        (Thread/interrupted)
+        (try
+          (let [error (InterruptedException. "interrupted")
+                [thrown interrupted?]
+                (with-redefs [c/exec (fn [& command]
+                                       (exec error command))]
+                  (try
+                    (operation)
+                    [nil (.isInterrupted (Thread/currentThread))]
+                    (catch Exception e
+                      [e (.isInterrupted (Thread/currentThread))])))]
+            (is (identical? error thrown))
+            (is interrupted?))
+          (finally
+            (Thread/interrupted)))))))
+
+(deftest passes-the-process-pattern-as-a-separate-argument
+  (let [calls (atom [])
+        adversarial "/tmp/openraft app; touch /tmp/not-run"
+        database (openraft-db/db {})]
+    (with-redefs [openraft-db/binary adversarial
+                  c/exec (fn [& command]
+                           (swap! calls conj command)
+                           (if (= :probe (command-kind command))
+                             "absent"
+                             ""))]
+      (is (= :target-absent (db/kill! database {} "n1"))))
+    (let [probe (first @calls)]
+      (is (not (.contains ^String (nth probe 2) adversarial)))
+      (is (= (str "^" adversarial "([[:space:]].*)?$")
+             (last probe))))))

--- a/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
@@ -2,12 +2,24 @@
   (:require [clojure.set :as set]
             [clojure.test :refer [deftest is testing]]
             [jepsen [checker :as checker]
+             [control :as c]
              [nemesis :as nemesis]]
-            [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft [cluster :as cluster]
+             [harness :as harness]
+             [worker :as worker]]
             [jepsen.openraft.nemesis.partition :as partition]
             [jepsen.openraft.quorum :as quorum]))
 
 (def nodes ["n1" "n2" "n3"])
+
+(defn- installed [details]
+  (assoc details :status :installed))
+
+(defn- skipped [reason details]
+  (assoc details :status :skipped :reason reason))
+
+(defn- indeterminate [reason details]
+  (assoc details :status :indeterminate :reason reason))
 
 (defn- teardown-partitioner [teardown]
   (reify nemesis/Nemesis
@@ -70,14 +82,30 @@
           (is (= :leader-in-minority
                  (-> result :value :mode)))
           (is (= "n2"
-                 (-> result :value :leader))))))
+                 (-> result :value :leader)))
+          (is (= :installed (get-in result [:value :status]))))))
 
     (testing "no partition is installed without a supported leader"
       (reset! invocations [])
       (with-redefs [cluster/membership-status (constantly nil)]
-        (is (= :no-supported-leader
+        (is (= (skipped :no-supported-leader {})
                (:value (nemesis/invoke! subject {:nodes nodes} op))))
-        (is (empty? @invocations))))))
+        (is (empty? @invocations))))
+
+    (testing "no partition is installed without a safe target"
+      (reset! invocations [])
+      (with-redefs [cluster/membership-status
+                    (constantly {:leader "n1"})
+                    cluster/voter-configs
+                    (fn [_test _status] [#{"n1"}])]
+        (let [value (:value (nemesis/invoke! subject
+                                             {:nodes ["n1"]}
+                                             (assoc op
+                                                    :value
+                                                    :leader-in-majority)))]
+          (is (= :skipped (:status value)))
+          (is (= :no-safe-partition-target (:reason value)))
+          (is (empty? @invocations)))))))
 
 (deftest partition-cleanup-failure-does-not-mask-analysis
   (let [attempted? (atom false)
@@ -89,6 +117,96 @@
     (nemesis/teardown! (partition/->PartitionNemesis partitioner)
                        {:nodes nodes})
     (is @attempted?)))
+
+(deftest partition-control-failures-take-the-harness-path
+  (let [error (ex-info "SSH failed" {:kind :ssh})
+        partitioner (reify nemesis/Nemesis
+                      (setup! [this _test]
+                        this)
+                      (invoke! [_ _test _op]
+                        (throw error))
+                      (teardown! [this _test]
+                        this))
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (partition/->PartitionNemesis partitioner))
+        setup-subject (nemesis/setup! subject {:nodes nodes})
+        op {:type :info
+            :process :nemesis
+            :f :start-partition
+            :value :leader-in-minority}
+        thrown (with-redefs [cluster/membership-status
+                             (constantly {:leader "n1"})
+                             cluster/voter-configs
+                             (fn [_test _status] [(set nodes)])]
+                 (try
+                   (nemesis/invoke! setup-subject {:nodes nodes} op)
+                   nil
+                   (catch Exception e
+                     e)))]
+    (is (identical? error thrown))
+    (is (identical? error
+                    (:throwable (harness/primary-failure failure-state))))))
+
+(deftest runtime-partition-control-restores-receiving-thread-interruption
+  (let [test {:nodes nodes
+              :sessions (zipmap nodes (repeat :unused-session))}
+        cases [[:interrupted-exception
+                #(InterruptedException. "interrupted")]
+               [:interrupted-io
+                #(java.io.InterruptedIOException. "interrupted")]
+               [:closed-by-interrupt
+                #(java.nio.channels.ClosedByInterruptException.)]
+               [:wrapped
+                #(ex-info "interrupted" {:kind :interrupted})]]
+        operations [[:start
+                     {:type :info
+                      :process :nemesis
+                      :f :start-partition
+                      :value :leader-in-minority}]
+                    [:stop
+                     {:type :info
+                      :process :nemesis
+                      :f :stop-partition}]]]
+    (doseq [[operation op] operations
+            [interruption make-error] cases]
+      (testing (str (name operation) " " (name interruption))
+        (Thread/interrupted)
+        (try
+          (let [error (make-error)
+                partitioner
+                (reify nemesis/Nemesis
+                  (setup! [this _test]
+                    this)
+                  (invoke! [_ test _op]
+                    (c/on-nodes test
+                                (fn [_test node]
+                                  (if (= "n2" node)
+                                    (throw error)
+                                    :ok))))
+                  (teardown! [this _test]
+                    this))
+                failure-state (harness/failure-state)
+                subject (->> partitioner
+                             partition/->PartitionNemesis
+                             (worker/wrap-nemesis failure-state))
+                setup-subject (nemesis/setup! subject test)
+                [thrown interrupted?]
+                (with-redefs [cluster/membership-status
+                              (constantly {:leader "n1"})
+                              cluster/voter-configs
+                              (fn [_test _status] [(set nodes)])]
+                  (try
+                    (nemesis/invoke! setup-subject test op)
+                    [nil (.isInterrupted (Thread/currentThread))]
+                    (catch Exception e
+                      [e (.isInterrupted (Thread/currentThread))])))]
+            (is (identical? error thrown))
+            (is interrupted?)
+            (is (nil? (harness/primary-failure failure-state))))
+          (finally
+            (Thread/interrupted)))))))
 
 (deftest partition-cleanup-preserves-interruptions
   (doseq [[label error]
@@ -119,35 +237,40 @@
 (deftest requires-both-partitions-and-an-intact-cluster
   (let [subject (#'partition/coverage-checker)
         complete-history [{:f :start-partition
-                           :value {:mode :leader-in-majority}}
+                           :value (installed {:mode :leader-in-majority})}
                           {:f :stop-partition
-                           :value :network-healed}
+                           :value (installed {})}
                           {:f :start-partition
-                           :value {:mode :leader-in-minority}}
+                           :value (installed {:mode :leader-in-minority})}
                           {:f :stop-partition
-                           :value :network-healed}
+                           :value (installed {})}
                           {:f :await-recovery
-                           :value {:leader "n2"}}]
+                           :value (installed {:leader "n2"})}]
         missing-mode-history [{:f :start-partition
-                               :value {:mode :leader-in-majority}}
+                               :value (installed
+                                       {:mode :leader-in-majority})}
                               {:f :stop-partition
-                               :value :network-healed}
+                               :value (installed {})}
                               {:f :start-partition
-                               :value :no-supported-leader}
+                               :value (skipped :no-supported-leader {})}
                               {:f :stop-partition
-                               :value :network-healed}
+                               :value (installed {})}
                               {:f :await-recovery
-                               :value {:leader "n2"}}]
+                               :value (installed {:leader "n2"})}]
         unrecovered-history [{:f :start-partition
-                              :value {:mode :leader-in-majority}}
+                              :value (installed
+                                      {:mode :leader-in-majority})}
                              {:f :stop-partition
-                              :value :network-healed}
+                              :value (installed {})}
                              {:f :start-partition
-                              :value {:mode :leader-in-minority}}
+                              :value (installed
+                                      {:mode :leader-in-minority})}
                              {:f :stop-partition
-                              :value :network-healed}
+                              :value (installed {})}
                              {:f :await-recovery
-                              :error :timeout}]]
+                              :value (indeterminate
+                                      :recovery-timeout
+                                      {})}]]
     (testing "both modes complete and the cluster recovers"
       (let [result (checker/check subject {} complete-history {})]
         (is (:valid? result))
@@ -172,8 +295,8 @@
                  {:type :info
                   :process :nemesis
                   :f :start-partition
-                  :value {:mode :leader-in-majority
-                          :leader "n1"}}
+                  :value (installed {:mode :leader-in-majority
+                                     :leader "n1"})}
                  {:type :info
                   :process :nemesis
                   :f :stop-partition
@@ -181,7 +304,7 @@
                  {:type :info
                   :process :nemesis
                   :f :stop-partition
-                  :value :network-healed}
+                  :value (installed {})}
                  {:type :info
                   :process :nemesis
                   :f :start-partition
@@ -189,8 +312,8 @@
                  {:type :info
                   :process :nemesis
                   :f :start-partition
-                  :value {:mode :leader-in-minority
-                          :leader "n1"}}
+                  :value (installed {:mode :leader-in-minority
+                                     :leader "n1"})}
                  {:type :info
                   :process :nemesis
                   :f :stop-partition
@@ -198,7 +321,7 @@
                  {:type :info
                   :process :nemesis
                   :f :stop-partition
-                  :value :network-healed}
+                  :value (installed {})}
                  {:type :info
                   :process :nemesis
                   :f :await-recovery
@@ -206,7 +329,7 @@
                  {:type :info
                   :process :nemesis
                   :f :await-recovery
-                  :value {:leader "n2"}}
+                  :value (installed {:leader "n2"})}
                  {:type :info
                   :process :nemesis
                   :f :await-recovery
@@ -214,33 +337,65 @@
                  {:type :info
                   :process :nemesis
                   :f :await-recovery
-                  :value {:leader "n2"}}]
+                  :value (installed {:leader "n2"})}]
         result (checker/check subject {} history {})]
     (is (:valid? result))
     (is (= [:leader-in-majority :leader-in-minority]
            (:observed-modes result)))
     (is (= :intact (:cluster-state result)))))
 
+(deftest reanalyzes-exact-legacy-partition-history
+  (let [subject (#'partition/coverage-checker)
+        start (fn [mode]
+                {:f :start-partition
+                 :value {:mode mode
+                         :leader "n1"
+                         :voter-configs [(set nodes)]
+                         :components [["n1" "n2"] ["n3"]]}})
+        history [(start :leader-in-majority)
+                 {:f :stop-partition :value :network-healed}
+                 (start :leader-in-minority)
+                 {:f :stop-partition :value :network-healed}
+                 {:f :await-recovery :value {:leader "n2"}}]]
+    (testing "the exact pre-status success shapes remain valid"
+      (let [result (checker/check subject {} history {})]
+        (is (true? (:valid? result)))
+        (is (= :intact (:cluster-state result)))))
+
+    (testing "an explicit status is authoritative over legacy-looking fields"
+      (doseq [status [:skipped :indeterminate]]
+        (let [changed (assoc-in history [0 :value :status] status)
+              result (checker/check subject {} changed {})]
+          (is (false? (:valid? result)) (name status))
+          (is (= [:leader-in-majority]
+                 (:missing-modes result)) (name status))))
+
+      (doseq [status [:skipped :indeterminate]]
+        (let [changed (assoc-in history [4 :value :status] status)
+              result (checker/check subject {} changed {})]
+          (is (false? (:valid? result)) (name status))
+          (is (= :recovery-pending
+                 (:cluster-state result)) (name status)))))))
+
 (deftest reports-an-indeterminate-partition-state
   (let [subject (#'partition/coverage-checker)
         covered-history [{:f :start-partition
-                          :value {:mode :leader-in-majority}}
+                          :value (installed {:mode :leader-in-majority})}
                          {:f :stop-partition
-                          :value :network-healed}
+                          :value (installed {})}
                          {:f :start-partition
-                          :value {:mode :leader-in-minority}}
+                          :value (installed {:mode :leader-in-minority})}
                          {:f :stop-partition
-                          :value :network-healed}
+                          :value (installed {})}
                          {:f :await-recovery
-                          :value {:leader "n2"}}]
+                          :value (installed {:leader "n2"})}]
         indeterminate-history
         (conj covered-history
               {:type :info
                :process :nemesis
                :f :start-partition
-               :value :leader-in-majority
-               :error "indeterminate: partition failed"
-               :exception (ex-info "partition failed" {})})
+               :value (indeterminate :effect-unknown
+                                     {:mode :leader-in-majority})})
         result (checker/check subject {} indeterminate-history {})]
     (is (= :unknown (:valid? result)))
     (is (= :unknown (:cluster-state result)))))
@@ -248,21 +403,25 @@
 (deftest reports-an-indeterminate-heal-state
   (let [subject (#'partition/coverage-checker)
         history-before-heal [{:f :start-partition
-                              :value {:mode :leader-in-majority}}
+                              :value (installed
+                                      {:mode :leader-in-majority})}
                              {:f :stop-partition
-                              :value :network-healed}
+                              :value (installed {})}
                              {:f :start-partition
-                              :value {:mode :leader-in-minority}}
+                              :value (installed
+                                      {:mode :leader-in-minority})}
                              {:f :stop-partition
-                              :error :heal-failed}]
+                              :value (indeterminate
+                                      :effect-unknown
+                                      {})}]
         indeterminate-history (conj history-before-heal
                                     {:f :await-recovery
-                                     :value {:leader "n2"}})
+                                     :value (installed {:leader "n2"})})
         recovered-history (into history-before-heal
                                 [{:f :stop-partition
-                                  :value :network-healed}
+                                  :value (installed {})}
                                  {:f :await-recovery
-                                  :value {:leader "n2"}}])]
+                                  :value (installed {:leader "n2"})}])]
     (testing "a successful readiness check cannot prove that a failed heal completed"
       (let [result (checker/check subject {} indeterminate-history {})]
         (is (= :unknown (:valid? result)))

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -1,6 +1,7 @@
 (ns jepsen.openraft.nemesis.process-test
   (:require [clojure.test :refer [deftest is testing]]
             [jepsen [checker :as checker]
+             [db :as db]
              [nemesis :as nemesis]
              [random :as random]]
             [jepsen.openraft.cluster :as cluster]
@@ -10,13 +11,31 @@
 
 (def voters ["n1" "n2" "n3" "n4" "n5"])
 
+(defn- installed [details]
+  (assoc details :status :installed))
+
+(defn- skipped [reason details]
+  (assoc details :status :skipped :reason reason))
+
+(defn- indeterminate [reason details]
+  (assoc details :status :indeterminate :reason reason))
+
+(defn- delegate-completion [op]
+  (case (:f op)
+    :kill (assoc op :value (zipmap (:value op) (repeat :killed)))
+    :start (assoc op :value (zipmap (:value op)
+                                    (repeat :start-confirmed)))
+    :pause (assoc op :value (zipmap (:value op) (repeat :paused)))
+    :resume (assoc op :value (zipmap (:value op) (repeat :resumed)))
+    op))
+
 (defn- recording-nemesis [invocations]
   (reify nemesis/Nemesis
     (setup! [this _test]
       this)
     (invoke! [_ _test op]
       (swap! invocations conj op)
-      op)
+      (delegate-completion op))
     (teardown! [this _test]
       this)))
 
@@ -28,7 +47,7 @@
       (swap! invocations conj op)
       (when (= failing-f (:f op))
         (throw error))
-      op)
+      (delegate-completion op))
     (teardown! [this _test]
       this)))
 
@@ -82,9 +101,316 @@
                         :f :restart-process})]
         (is (= ["n1"] (get-in killed [:value :nodes])))
         (is (= ["n1"] (get-in restarted [:value :nodes])))
+        (is (= :installed (get-in killed [:value :status])))
+        (is (= :installed (get-in restarted [:value :status])))
+        (is (= {"n1" :killed}
+               (get-in killed [:value :stop-results])))
+        (is (= {"n1" :start-confirmed}
+               (get-in restarted [:value :start-results])))
         (is (= [[:kill ["n1"]]
                 [:start ["n1"]]]
                (mapv (juxt :f :value) @invocations)))))))
+
+(deftest derives-process-outcomes-from-confirmed-node-results
+  (let [test {:nodes ["n1" "n2" "n3"]}
+        status {:leader "n1"}
+        invoke-with-results
+        (fn [results]
+          (let [delegate (reify nemesis/Nemesis
+                           (setup! [this _test] this)
+                           (invoke! [_ _test op]
+                             (assoc op :value results))
+                           (teardown! [this _test] this))
+                subject (process/->ProcessNemesis delegate (atom nil))]
+            (with-redefs [cluster/membership-status (constantly status)
+                          cluster/voter-configs
+                          (fn [_test _status] [(set (:nodes test))])]
+              (nemesis/invoke! subject
+                               test
+                               {:type :info
+                                :f :kill-process
+                                :value :leader-killed}))))]
+    (testing "every pre-probe absence skips the kill"
+      (let [value (:value (invoke-with-results {"n1" :target-absent}))]
+        (is (= :skipped (:status value)))
+        (is (= :target-absent (:reason value)))))
+
+    (testing "an explicit exit race skips the kill"
+      (let [value (:value
+                   (invoke-with-results {"n1" :target-already-exited}))]
+        (is (= :skipped (:status value)))
+        (is (= :target-already-exited (:reason value)))))
+
+    (testing "any confirmed kill installs a multi-node disruption"
+      (let [five-node-test {:nodes voters}
+            results {"n2" :killed
+                     "n3" :target-absent}
+            delegate (reify nemesis/Nemesis
+                       (setup! [this _test] this)
+                       (invoke! [_ _test op]
+                         (assoc op :value results))
+                       (teardown! [this _test] this))
+            subject (process/->ProcessNemesis delegate (atom nil))
+            prefer-targets (fn [candidates]
+                             (cons #{"n2" "n3"}
+                                   (remove #{#{"n2" "n3"}} candidates)))]
+        (with-redefs [cluster/membership-status
+                      (constantly {:leader "n1"})
+                      cluster/voter-configs
+                      (fn [_test _status] [(set voters)])
+                      random/shuffle prefer-targets]
+          (let [value (:value
+                       (nemesis/invoke! subject
+                                        five-node-test
+                                        {:type :info
+                                         :f :kill-process
+                                         :value :leader-survives}))]
+            (is (= :installed (:status value)))
+            (is (= results (:stop-results value)))))))))
+
+(deftest derives-pause-outcomes-from-confirmed-node-results
+  (let [test {:nodes ["n1" "n2" "n3"]}
+        status {:leader "n1"
+                :metrics (zipmap (:nodes test) (repeat {}))}
+        invoke-with-result
+        (fn [result]
+          (let [delegate (reify nemesis/Nemesis
+                           (setup! [this _test] this)
+                           (invoke! [_ _test op]
+                             (assoc op
+                                    :value (zipmap (:value op)
+                                                   (repeat result))))
+                           (teardown! [this _test] this))
+                subject (process/->PauseNemesis delegate (atom nil))]
+            (with-redefs [cluster/membership-status (constantly status)
+                          cluster/voter-configs
+                          (fn [_test _status] [(set (:nodes test))])]
+              (nemesis/invoke! subject
+                               test
+                               {:type :info
+                                :f :pause-process
+                                :value :leader-paused}))))]
+    (testing "every pre-probe absence skips the pause"
+      (let [value (:value (invoke-with-result :target-absent))]
+        (is (= :skipped (:status value)))
+        (is (= :target-absent (:reason value)))
+        (is (= {"n1" :target-absent} (:pause-results value)))))
+
+    (testing "an explicit exit race skips the pause"
+      (let [value (:value (invoke-with-result :target-already-exited))]
+        (is (= :skipped (:status value)))
+        (is (= :target-already-exited (:reason value)))
+        (is (= {"n1" :target-already-exited}
+               (:pause-results value)))))
+
+    (testing "a confirmed pause installs the disruption"
+      (let [value (:value (invoke-with-result :paused))]
+        (is (= :installed (:status value)))
+        (is (= {"n1" :paused} (:pause-results value)))))))
+
+(deftest derives-resume-outcomes-from-confirmed-node-results
+  (let [test {:nodes ["n1" "n2" "n3"]}
+        disruption {:mode :leader-paused
+                    :leader "n1"
+                    :nodes ["n1"]
+                    :voter-configs [(set (:nodes test))]
+                    :survivors ["n2" "n3"]
+                    :pause-results {"n1" :paused}}
+        invoke-with-results
+        (fn [results]
+          (let [delegate (reify nemesis/Nemesis
+                           (setup! [this _test] this)
+                           (invoke! [_ _test op]
+                             (assoc op :value results))
+                           (teardown! [this _test] this))
+                active (atom disruption)
+                subject (process/->PauseNemesis delegate active)
+                completion (nemesis/invoke! subject
+                                            test
+                                            {:type :info
+                                             :f :resume-process})]
+            [completion @active]))]
+    (testing "every absent target skips the resume"
+      (let [results (zipmap (:nodes test) (repeat :target-absent))
+            [completion active] (invoke-with-results results)
+            value (:value completion)]
+        (is (= :skipped (:status value)))
+        (is (= :target-absent (:reason value)))
+        (is (= results (:resume-results value)))
+        (is (nil? active))))
+
+    (testing "an explicit exit race skips the resume"
+      (let [results {"n1" :target-absent
+                     "n2" :target-already-exited
+                     "n3" :target-absent}
+            [completion active] (invoke-with-results results)
+            value (:value completion)]
+        (is (= :skipped (:status value)))
+        (is (= :target-already-exited (:reason value)))
+        (is (= results (:resume-results value)))
+        (is (nil? active))))
+
+    (testing "any confirmed resume installs multi-node recovery"
+      (let [results {"n1" :resumed
+                     "n2" :target-absent
+                     "n3" :target-already-exited}
+            [completion active] (invoke-with-results results)
+            value (:value completion)]
+        (is (= :installed (:status value)))
+        (is (= results (:resume-results value)))
+        (is (= disruption (:paused value)))
+        (is (nil? active))))))
+
+(deftest rejects-malformed-process-control-results-and-retains-recovery-state
+  (let [test {:nodes ["n1" "n2" "n3"]}
+        invocations (atom 0)
+        delegate (reify nemesis/Nemesis
+                   (setup! [this _test] this)
+                   (invoke! [_ _test op]
+                     (swap! invocations inc)
+                     (assoc op :value {}))
+                   (teardown! [this _test] this))
+        active (atom nil)
+        subject (process/->ProcessNemesis delegate active)]
+    (with-redefs [cluster/membership-status (constantly {:leader "n1"})
+                  cluster/voter-configs
+                  (fn [_test _status] [(set (:nodes test))])]
+      (let [error (try
+                    (nemesis/invoke! subject
+                                     test
+                                     {:type :info
+                                      :f :kill-process
+                                      :value :leader-killed})
+                    nil
+                    (catch Exception e
+                      e))]
+        (is (= :unexpected-process-control-result
+               (:kind (ex-data error))))
+        (is (= ["n1"] (:nodes @active))))
+
+      (let [error (try
+                    (nemesis/invoke! subject
+                                     test
+                                     {:type :info
+                                      :f :restart-process})
+                    nil
+                    (catch Exception e
+                      e))]
+        (is (= :unexpected-process-control-result
+               (:kind (ex-data error))))
+        (is (= ["n1"] (:nodes @active)))
+        (is (= 2 @invocations))))))
+
+(deftest rejects-malformed-pause-control-results-and-retains-recovery-state
+  (let [test {:nodes ["n1" "n2" "n3"]}
+        status {:leader "n1"
+                :metrics (zipmap (:nodes test) (repeat {}))}
+        delegate (reify nemesis/Nemesis
+                   (setup! [this _test] this)
+                   (invoke! [_ _test op]
+                     (assoc op :value {}))
+                   (teardown! [this _test] this))
+        active (atom nil)
+        subject (process/->PauseNemesis delegate active)]
+    (with-redefs [cluster/membership-status (constantly status)
+                  cluster/voter-configs
+                  (fn [_test _status] [(set (:nodes test))])]
+      (let [error (try
+                    (nemesis/invoke! subject
+                                     test
+                                     {:type :info
+                                      :f :pause-process
+                                      :value :leader-paused})
+                    nil
+                    (catch Exception e
+                      e))]
+        (is (= :unexpected-process-control-result
+               (:kind (ex-data error))))
+        (is (= ["n1"] (:nodes @active))))
+
+      (let [active-before-resume @active
+            error (try
+                    (nemesis/invoke! subject
+                                     test
+                                     {:type :info
+                                      :f :resume-process})
+                    nil
+                    (catch Exception e
+                      e))]
+        (is (= :unexpected-process-control-result
+               (:kind (ex-data error))))
+        (is (= active-before-resume @active))))))
+
+(deftest multi-node-control-restores-the-receiving-thread-interrupt-flag
+  (let [test {:nodes voters
+              :sessions (zipmap voters (repeat :unused-session))}
+        planned #{"n2" "n3"}
+        disruption {:mode :leader-unpaused
+                    :leader "n1"
+                    :nodes ["n2" "n3"]
+                    :voter-configs [(set voters)]
+                    :survivors ["n1" "n4" "n5"]
+                    :pause-results {"n2" :paused "n3" :paused}}
+        prefer-planned (fn [candidates]
+                         (cons planned (remove #{planned} candidates)))
+        cases
+        [[:kill
+          #(InterruptedException. "interrupted")
+          process/process-nemesis
+          nil
+          {:type :info :f :kill-process :value :leader-survives}]
+         [:start
+          #(java.io.InterruptedIOException. "interrupted")
+          process/process-nemesis
+          :killed
+          {:type :info :f :restart-process}]
+         [:pause
+          #(java.nio.channels.ClosedByInterruptException.)
+          process/pause-nemesis
+          nil
+          {:type :info :f :pause-process :value :leader-unpaused}]
+         [:resume
+          #(ex-info "interrupted" {:kind :interrupted})
+          process/pause-nemesis
+          :paused
+          {:type :info :f :resume-process}]]]
+    (doseq [[label make-error make-subject active-key op] cases]
+      (testing (name label)
+        (Thread/interrupted)
+        (try
+          (let [error (make-error)
+                database (reify
+                           db/Process
+                           (kill! [_ _test _node]
+                             (throw error))
+                           (start! [_ _test _node]
+                             (throw error))
+
+                           db/Pause
+                           (pause! [_ _test _node]
+                             (throw error))
+                           (resume! [_ _test _node]
+                             (throw error)))
+                subject (make-subject database)
+                _ (when active-key
+                    (reset! (get subject active-key) disruption))
+                [thrown interrupted?]
+                (with-redefs [cluster/membership-status
+                              (constantly
+                               {:leader "n1"
+                                :metrics (zipmap voters (repeat {}))})
+                              cluster/voter-configs
+                              (fn [_test _status] [(set voters)])
+                              random/shuffle prefer-planned]
+                  (try
+                    (nemesis/invoke! subject test op)
+                    [nil (.isInterrupted (Thread/currentThread))]
+                    (catch Exception e
+                      [e (.isInterrupted (Thread/currentThread))])))]
+            (is (identical? error thrown))
+            (is interrupted?))
+          (finally
+            (Thread/interrupted)))))))
 
 (deftest restarts-all-planned-processes-after-a-kill-error
   (let [invocations (atom [])
@@ -116,7 +442,7 @@
                 [:start ["n2" "n3"]]]
                (mapv (juxt :f :value) @invocations)))))))
 
-(deftest rejects-a-pause-after-a-pause-error
+(deftest skips-a-pause-after-a-pause-error
   (let [invocations (atom [])
         delegate (failing-nemesis invocations
                                   :pause
@@ -134,12 +460,12 @@
            (nemesis/invoke! subject test {:type :info
                                           :f :pause-process
                                           :value :leader-paused})))
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #"Processes are already paused"
-           (nemesis/invoke! subject test {:type :info
-                                          :f :pause-process
-                                          :value :leader-unpaused})))
+      (let [skipped-value
+            (:value (nemesis/invoke! subject test {:type :info
+                                                   :f :pause-process
+                                                   :value :leader-unpaused}))]
+        (is (= :skipped (:status skipped-value)))
+        (is (= :processes-already-paused (:reason skipped-value))))
       (is (= [[:pause ["n1"]]]
              (mapv (juxt :f :value) @invocations)))
       (let [resumed (nemesis/invoke! subject
@@ -177,10 +503,7 @@
                   cluster/voter-configs
                   (fn [_test _status] [(set (:nodes test))])]
       (let [leader-pause (invoke! :pause-process :leader-paused)
-            _ (is (thrown-with-msg?
-                   clojure.lang.ExceptionInfo
-                   #"Processes are already paused"
-                   (invoke! :pause-process :leader-unpaused)))
+            duplicate-pause (invoke! :pause-process :leader-unpaused)
             leader-resume (invoke! :resume-process)
             leader-recovery (recover!)
             follower-pause (invoke! :pause-process :leader-unpaused)
@@ -197,14 +520,23 @@
                      cleanup-resume
                      cleanup-recovery]
             result (checker/check coverage-checker test history {})]
-        (is (= {:paused (:value leader-pause)
-                :resumed (:nodes test)}
+        (is (= :skipped (get-in duplicate-pause [:value :status])))
+        (is (= :processes-already-paused
+               (get-in duplicate-pause [:value :reason])))
+        (is (= {:paused (dissoc (:value leader-pause) :status)
+                :resumed (:nodes test)
+                :resume-results (zipmap (:nodes test) (repeat :resumed))
+                :status :installed}
                (:value leader-resume)))
-        (is (= {:paused (:value follower-pause)
-                :resumed (:nodes test)}
+        (is (= {:paused (dissoc (:value follower-pause) :status)
+                :resumed (:nodes test)
+                :resume-results (zipmap (:nodes test) (repeat :resumed))
+                :status :installed}
                (:value follower-resume)))
         (is (= {:paused nil
-                :resumed (:nodes test)}
+                :resumed (:nodes test)
+                :resume-results (zipmap (:nodes test) (repeat :resumed))
+                :status :installed}
                (:value cleanup-resume)))
         (is (= [[:pause (get-in leader-pause [:value :nodes])]
                 [:resume (:nodes test)]
@@ -275,7 +607,9 @@
                                   test
                                   [completion]
                                   {})]
-        (is (= :no-reachable-pause-target (:value completion)))
+        (is (= :skipped (get-in completion [:value :status])))
+        (is (= :no-reachable-pause-target
+               (get-in completion [:value :reason])))
         (is (empty? @invocations))
         (is (empty? (:observed-modes result)))))))
 
@@ -334,32 +668,79 @@
                       :value :leader-paused}]]]
     (with-redefs [cluster/membership-status (constantly nil)]
       (doseq [[subject op] operations]
-        (is (= :no-supported-leader
+        (is (= (skipped :no-supported-leader {})
                (:value (nemesis/invoke! subject test op))))))
+    (is (empty? @invocations))))
+
+(deftest skips-known-process-precondition-misses
+  (let [invocations (atom [])
+        delegate (recording-nemesis invocations)
+        test {:nodes ["n1"]}
+        subject (process/->ProcessNemesis delegate (atom nil))]
+    (testing "there is no quorum-safe kill target"
+      (with-redefs [cluster/membership-status
+                    (constantly {:leader "n1"})
+                    cluster/voter-configs
+                    (fn [_test _status] [#{"n1"}])]
+        (let [value (:value
+                     (nemesis/invoke! subject
+                                      test
+                                      {:type :info
+                                       :f :kill-process
+                                       :value :leader-survives}))]
+          (is (= :skipped (:status value)))
+          (is (= :no-quorum-safe-process-target (:reason value))))))
+
+    (testing "there are no killed processes to restart"
+      (is (= (skipped :no-processes-killed {})
+             (:value (nemesis/invoke! subject
+                                      test
+                                      {:type :info
+                                       :f :restart-process})))))
+
+    (testing "a tracked disruption is already active"
+      (let [active {:mode :leader-killed
+                    :nodes ["n1"]}
+            active-subject (process/->ProcessNemesis delegate
+                                                     (atom active))
+            value (:value
+                   (nemesis/invoke! active-subject
+                                    test
+                                    {:type :info
+                                     :f :kill-process
+                                     :value :leader-killed}))]
+        (is (= :skipped (:status value)))
+        (is (= :processes-already-killed (:reason value)))
+        (is (= active (:killed value)))))
+
     (is (empty? @invocations))))
 
 (deftest requires-both-process-modes-and-an-intact-cluster
   (let [subject (#'process/coverage-checker)
         complete-history [{:f :kill-process
-                           :value {:mode :leader-survives}}
+                           :value (installed {:mode :leader-survives})}
                           {:f :await-recovery
-                           :value {:leader "n1"}}
+                           :value (installed {:leader "n1"})}
                           {:f :kill-process
-                           :value {:mode :leader-killed}}
+                           :value (installed {:mode :leader-killed})}
                           {:f :await-recovery
-                           :value {:leader "n2"}}]
+                           :value (installed {:leader "n2"})}]
         missing-mode-history [{:f :kill-process
-                               :value {:mode :leader-survives}}
+                               :value (installed {:mode :leader-survives})}
                               {:f :kill-process
-                               :value :no-supported-leader}]
+                               :value (skipped
+                                       :no-supported-leader
+                                       {})}]
         unrecovered-history [{:f :kill-process
-                              :value {:mode :leader-survives}}
+                              :value (installed {:mode :leader-survives})}
                              {:f :await-recovery
-                              :value {:leader "n1"}}
+                              :value (installed {:leader "n1"})}
                              {:f :kill-process
-                              :value {:mode :leader-killed}}
+                              :value (installed {:mode :leader-killed})}
                              {:f :await-recovery
-                              :error :timeout}]]
+                              :value (indeterminate
+                                      :recovery-timeout
+                                      {})}]]
     (let [result (checker/check subject {} complete-history {})]
       (is (:valid? result))
       (is (= :intact (:cluster-state result))))
@@ -375,20 +756,21 @@
 (deftest reports-an-indeterminate-process-state
   (let [subject (#'process/coverage-checker)
         covered-history [{:f :kill-process
-                          :value {:mode :leader-survives}}
+                          :value (installed {:mode :leader-survives})}
                          {:f :await-recovery
-                          :value {:leader "n1"}}
+                          :value (installed {:leader "n1"})}
                          {:f :kill-process
-                          :value {:mode :leader-killed}}
+                          :value (installed {:mode :leader-killed})}
                          {:f :await-recovery
-                          :value {:leader "n2"}}]
+                          :value (installed {:leader "n2"})}]
         indeterminate-history (conj covered-history
                                     {:f :kill-process
-                                     :value :leader-killed
-                                     :error :kill-failed})
+                                     :value (indeterminate
+                                             :effect-unknown
+                                             {:mode :leader-killed})})
         recovered-history (conj indeterminate-history
                                 {:f :await-recovery
-                                 :value {:leader "n2"}})]
+                                 :value (installed {:leader "n2"})})]
     (let [result (checker/check subject {} indeterminate-history {})]
       (is (= :unknown (:valid? result)))
       (is (= :unknown (:cluster-state result))))
@@ -396,43 +778,122 @@
       (is (:valid? result))
       (is (= :intact (:cluster-state result))))))
 
+(deftest reanalyzes-exact-legacy-process-history
+  (let [process-checker (#'process/coverage-checker)
+        disruption (fn [mode nodes]
+                     {:mode mode
+                      :leader "n1"
+                      :nodes nodes
+                      :voter-configs [(set voters)]
+                      :survivors (vec (remove (set nodes) voters))})
+        process-history [{:f :kill-process
+                          :value (disruption :leader-survives ["n2" "n3"])}
+                         {:f :await-recovery :value {:leader "n1"}}
+                         {:f :kill-process
+                          :value (disruption :leader-killed ["n1" "n2"])}
+                         {:f :await-recovery :value {:leader "n3"}}]
+        pause-checker (#'process/pause-coverage-checker)
+        resumed {:paused nil :resumed voters}
+        pause-history [{:f :pause-process
+                        :value (disruption :leader-unpaused ["n2" "n3"])}
+                       {:f :resume-process :value resumed}
+                       {:f :await-recovery :value {:leader "n1"}}
+                       {:f :pause-process
+                        :value (disruption :leader-paused ["n1" "n2"])}
+                       {:f :resume-process :value resumed}
+                       {:f :await-recovery :value {:leader "n3"}}]
+        process-check #(checker/check process-checker {} % {})
+        pause-check #(checker/check pause-checker {:nodes voters} % {})]
+    (testing "exact pre-status process and pause shapes remain valid"
+      (is (true? (:valid? (process-check process-history))))
+      (is (true? (:valid? (pause-check pause-history)))))
+
+    (testing "explicit disruption status overrides legacy-looking evidence"
+      (doseq [status [:skipped :indeterminate]]
+        (let [process-result
+              (process-check (assoc-in process-history
+                                       [0 :value :status]
+                                       status))
+              pause-result
+              (pause-check (assoc-in pause-history
+                                     [0 :value :status]
+                                     status))]
+          (is (false? (:valid? process-result)) (name status))
+          (is (= [:leader-survives]
+                 (:missing-modes process-result)) (name status))
+          (is (false? (:valid? pause-result)) (name status))
+          (is (= [:leader-unpaused]
+                 (:missing-modes pause-result)) (name status)))))
+
+    (testing "explicit recovery and resume statuses are authoritative"
+      (doseq [status [:skipped :indeterminate]]
+        (is (false?
+             (:valid? (process-check
+                       (assoc-in process-history
+                                 [3 :value :status]
+                                 status))))
+            (name status))
+        (is (not (true?
+                  (:valid? (pause-check
+                            (assoc-in pause-history
+                                      [4 :value :status]
+                                      status)))))
+            (name status))))))
+
 (deftest checks-pause-coverage-and-recovery-state
   (let [subject (#'process/pause-coverage-checker)
         test {:nodes voters}
         check #(checker/check subject test % {})
-        resumed-all {:paused nil
-                     :resumed voters}
+        pause-value (fn [mode nodes]
+                      (installed
+                       {:mode mode
+                        :leader "n1"
+                        :nodes nodes
+                        :voter-configs [(set voters)]
+                        :survivors (vec (remove (set nodes) voters))
+                        :pause-results (zipmap nodes (repeat :paused))}))
+        leader-unpaused (pause-value :leader-unpaused ["n2" "n3"])
+        leader-paused (pause-value :leader-paused ["n1" "n2"])
+        resumed-all (installed
+                     {:paused nil
+                      :resumed voters
+                      :resume-results (zipmap voters (repeat :resumed))})
         complete-history [{:f :pause-process
-                           :value {:mode :leader-unpaused}}
+                           :value leader-unpaused}
                           {:f :resume-process
                            :value resumed-all}
                           {:f :await-recovery
-                           :value {:leader "n1"}}
+                           :value (installed {:leader "n1"})}
                           {:f :pause-process
-                           :value {:mode :leader-paused}}
+                           :value leader-paused}
                           {:f :resume-process
                            :value resumed-all}
                           {:f :await-recovery
-                           :value {:leader "n2"}}]
+                           :value (installed {:leader "n2"})}]
         missing-mode-history [{:f :pause-process
-                               :value {:mode :leader-unpaused}}
+                               :value leader-unpaused}
                               {:f :resume-process
                                :value resumed-all}
                               {:f :await-recovery
-                               :value {:leader "n1"}}
+                               :value (installed {:leader "n1"})}
                               {:f :pause-process
-                               :value :no-supported-leader}]
+                               :value (skipped
+                                       :no-supported-leader
+                                       {})}]
         unrecovered-history (-> complete-history
                                 pop
                                 (conj {:f :await-recovery
-                                       :error :timeout}))
+                                       :value (indeterminate
+                                               :recovery-timeout
+                                               {})}))
         indeterminate-history (conj complete-history
                                     {:f :pause-process
-                                     :value :leader-paused
-                                     :error :pause-failed})
+                                     :value (indeterminate
+                                             :effect-unknown
+                                             {:mode :leader-paused})})
         paused-history (conj complete-history
                              {:f :pause-process
-                              :value {:mode :leader-paused}})
+                              :value leader-paused})
         resuming-history (conj paused-history
                                {:type :info
                                 :f :resume-process})
@@ -440,10 +901,35 @@
                                 [{:f :resume-process
                                   :value resumed-all}
                                  {:f :await-recovery
-                                  :value {:leader "n2"}}])
+                                  :value (installed {:leader "n2"})}])
         partial-resume-history (assoc-in complete-history
                                          [4 :value :resumed]
-                                         ["n1"])]
+                                         ["n1"])
+        mixed-leader-pause (assoc-in leader-paused
+                                     [:pause-results "n1"]
+                                     :target-absent)
+        mixed-pause-history (conj (subvec complete-history 0 3)
+                                  {:f :pause-process
+                                   :value mixed-leader-pause})
+        covered-then-mixed-pause-history
+        (conj complete-history
+              {:f :pause-process
+               :value mixed-leader-pause})
+        mixed-resume-history (assoc-in complete-history
+                                       [4 :value :resume-results "n5"]
+                                       :target-absent)
+        mixed-resume-history (assoc-in mixed-resume-history
+                                       [4 :value :resume-results "n4"]
+                                       :target-already-exited)
+        missing-resume-result-history
+        (update-in complete-history
+                   [4 :value :resume-results]
+                   dissoc
+                   "n5")
+        no-resume-history
+        (assoc-in complete-history
+                  [4 :value :resume-results]
+                  (zipmap voters (repeat :target-absent)))]
     (testing "both pause modes complete and recover"
       (is (= {:valid? true
               :cluster-state :intact}
@@ -480,6 +966,38 @@
       (is (= {:valid? :unknown
               :cluster-state :unknown}
              (select-keys (check partial-resume-history)
+                          [:valid? :cluster-state]))))
+
+    (testing "mixed pause evidence does not credit the planned leader mode"
+      (is (= {:valid? false
+              :missing-modes [:leader-paused]
+              :cluster-state :paused}
+             (select-keys (check mixed-pause-history)
+                          [:valid? :missing-modes :cluster-state]))))
+
+    (testing "a terminal mixed pause invalidates prior complete coverage"
+      (is (= {:valid? false
+              :missing-modes []
+              :cluster-state :paused}
+             (select-keys (check covered-then-mixed-pause-history)
+                          [:valid? :missing-modes :cluster-state]))))
+
+    (testing "mixed evidence confirms every target has no remaining pause"
+      (is (= {:valid? true
+              :cluster-state :intact}
+             (select-keys (check mixed-resume-history)
+                          [:valid? :cluster-state]))))
+
+    (testing "missing resume evidence does not confirm recovery"
+      (is (= {:valid? :unknown
+              :cluster-state :unknown}
+             (select-keys (check missing-resume-result-history)
+                          [:valid? :cluster-state]))))
+
+    (testing "an installed resume requires an actual resumed process"
+      (is (= {:valid? :unknown
+              :cluster-state :unknown}
+             (select-keys (check no-resume-history)
                           [:valid? :cluster-state]))))
 
     (testing "resume completion and recovery resolve an in-flight resume"

--- a/jepsen/test/jepsen/openraft/nemesis_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis_test.clj
@@ -3,8 +3,13 @@
             [jepsen.checker :as checker]
             [jepsen.generator :as gen]
             [jepsen.generator.test :as gen-test]
-            [jepsen.openraft.db :as db]
-            [jepsen.openraft.nemesis :as openraft-nemesis]
+            [jepsen.nemesis :as nemesis]
+            [jepsen.openraft [await :as await]
+             [cluster :as cluster]
+             [db :as db]
+             [harness :as harness]
+             [nemesis :as openraft-nemesis]
+             [worker :as worker]]
             [jepsen.openraft.nemesis.membership :as membership]
             [jepsen.openraft.nemesis.partition :as partition]
             [jepsen.openraft.nemesis.process :as process]))
@@ -13,9 +18,16 @@
   {:nodes ["n1" "n2" "n3" "n4" "n5"]})
 
 (deftest schedules-and-retries-skipped-faults
-  (doseq [skip-result [:no-supported-leader
-                       :no-reachable-pause-target
-                       {:status :no-supported-leader}]]
+  (doseq [skip-result (concat
+                       (map (fn [reason]
+                              {:status :skipped
+                               :reason reason})
+                            [:no-quorum-safe-process-target
+                             :no-reachable-pause-target
+                             :no-safe-partition-target
+                             :no-supported-leader])
+                       [{:status :no-supported-leader}
+                        :no-supported-leader])]
     (testing (str skip-result)
       (let [faults (#'openraft-nemesis/interval-schedule
                     10
@@ -82,21 +94,38 @@
                                history
                                {}))
         history [{:f :start-partition
-                  :value {:mode :leader-in-majority}}
+                  :value {:status :installed
+                          :mode :leader-in-majority}}
                  {:f :stop-partition
-                  :value :network-healed}
+                  :value {:status :installed}}
                  {:f :pause-process
-                  :value {:mode :leader-unpaused}}
+                  :value {:status :installed
+                          :mode :leader-unpaused
+                          :leader "n1"
+                          :nodes ["n2"]
+                          :voter-configs [all-voters]
+                          :survivors (vec (disj all-voters "n2"))
+                          :pause-results {"n2" :paused}}}
                  {:f :resume-process
-                  :value {:mode :leader-unpaused}}
+                  :value {:status :installed
+                          :paused nil
+                          :resumed (:nodes test-config)
+                          :resume-results
+                          (zipmap (:nodes test-config) (repeat :resumed))}}
                  {:f :shrink
-                  :value {:change :shrink
+                  :value {:status :installed
+                          :change :shrink
+                          :node "n5"
+                          :leader "n1"
                           :before all-voters
                           :after fewer-voters}}
                  {:f :restore-membership
-                  :value {:voters all-voters}}
+                  :value {:status :installed
+                          :leader "n1"
+                          :voters all-voters}}
                  {:f :await-recovery
-                  :value {:leader "n1"}}]]
+                  :value {:status :installed
+                          :leader "n1"}}]]
     (testing "one successful mode covers each fault class in chaos"
       (let [result (check history)]
         (is (:valid? result))
@@ -107,8 +136,103 @@
 
     (testing "a skipped fault does not count as execution"
       (let [result (check (mapv #(if (= :pause-process (:f %))
-                                   (assoc % :value :no-supported-leader)
+                                   (assoc % :value
+                                          {:status :skipped
+                                           :reason :no-supported-leader})
                                    %)
                                 history))]
         (is (false? (:valid? result)))
         (is (false? (get-in result [:pause :fault-class-executed?])))))))
+
+(defn- condition-timeout [condition]
+  (try
+    (await/until! condition
+                  #(await/retry! condition {})
+                  {:timeout 0
+                   :retry-interval 0})
+    nil
+    (catch Exception e
+      e)))
+
+(deftest classifies-recovery-outcomes
+  (let [op {:type :info
+            :process :nemesis
+            :f :await-recovery}
+        subject (openraft-nemesis/->RecoveryNemesis)]
+    (testing "confirmed recovery is installed"
+      (with-redefs [cluster/await-ready! (constantly {:leader "n2"})]
+        (is (= {:status :installed
+                :leader "n2"}
+               (:value (nemesis/invoke! subject test-config op))))))
+
+    (testing "a modeled readiness timeout is indeterminate"
+      (let [error (condition-timeout :cluster-ready)]
+        (with-redefs [cluster/await-ready! (fn [_test] (throw error))]
+          (let [value (:value (nemesis/invoke! subject test-config op))]
+            (is (= :indeterminate (:status value)))
+            (is (= :recovery-timeout (:reason value)))))))
+
+    (testing "an unexpected recovery exception takes the Harness path"
+      (let [failure-state (harness/failure-state)
+            error (RuntimeException. "recovery bug")
+            wrapped (worker/wrap-nemesis failure-state subject)
+            setup-subject (nemesis/setup! wrapped test-config)
+            thrown (with-redefs [cluster/await-ready! (fn [_test]
+                                                        (throw error))]
+                     (try
+                       (nemesis/invoke! setup-subject test-config op)
+                       nil
+                       (catch Exception e
+                         e)))]
+        (is (identical? error thrown))
+        (is (identical? error
+                        (:throwable
+                         (harness/primary-failure failure-state))))))
+
+    (testing "an unrelated timeout tag takes the Harness path"
+      (let [failure-state (harness/failure-state)
+            error (ex-info "unknown timeout" {:type :timeout})
+            wrapped (worker/wrap-nemesis failure-state subject)
+            setup-subject (nemesis/setup! wrapped test-config)
+            thrown (with-redefs [cluster/await-ready! (fn [_test]
+                                                        (throw error))]
+                     (try
+                       (nemesis/invoke! setup-subject test-config op)
+                       nil
+                       (catch Exception e
+                         e)))]
+        (is (identical? error thrown))
+        (is (identical? error
+                        (:throwable
+                         (harness/primary-failure failure-state))))))
+
+    (testing "interruption takes priority over timeout classification"
+      (doseq [[label make-error]
+              [[:interrupted #(InterruptedException. "interrupted")]
+               [:interrupted-io
+                #(java.io.InterruptedIOException. "interrupted")]
+               [:closed-by-interrupt
+                #(java.nio.channels.ClosedByInterruptException.)]
+               [:wrapped
+                #(ex-info "interrupted"
+                          {:kind :interrupted
+                           :type :timeout})]]]
+        (Thread/interrupted)
+        (try
+          (let [failure-state (harness/failure-state)
+                error (make-error)
+                wrapped (worker/wrap-nemesis failure-state subject)
+                setup-subject (nemesis/setup! wrapped test-config)
+                [thrown interrupted?]
+                (with-redefs [cluster/await-ready!
+                              (fn [_test] (throw error))]
+                  (try
+                    (nemesis/invoke! setup-subject test-config op)
+                    [nil (.isInterrupted (Thread/currentThread))]
+                    (catch Exception e
+                      [e (.isInterrupted (Thread/currentThread))])))]
+            (is (identical? error thrown) (name label))
+            (is interrupted? (name label))
+            (is (nil? (harness/primary-failure failure-state)) (name label)))
+          (finally
+            (Thread/interrupted)))))))

--- a/jepsen/test/jepsen/openraft/worker_test.clj
+++ b/jepsen/test/jepsen/openraft/worker_test.clj
@@ -122,7 +122,8 @@
         nemesis-outcome {:type :info
                          :process :nemesis
                          :f :start-partition
-                         :value :no-supported-leader}
+                         :value {:status :skipped
+                                 :reason :no-supported-leader}}
         client-subject (worker/wrap-client
                         failure-state
                         (test-client {:invoke-f (fn [& _] client-outcome)}))


### PR DESCRIPTION
## Summary

This PR gives the control-oriented Nemeses — partition, process kill, and
pause/resume — closed, evidence-backed outcomes. A fault is no longer reported
as installed merely because a control command was attempted.

- report only `:installed`, `:skipped`, or `:indeterminate` public outcomes
- require observed per-node control evidence before checkers award fault or
  recovery credit
- distinguish confirmed idempotent no-target cases from failed SSH, permission,
  configuration, and control-plane operations
- preserve interruption identity and restore the receiving worker thread
  interrupt flag after multi-node control work
- retry only modeled readiness conditions; unexpected local failures continue
  to the Harness-failure boundary
- keep checkers compatible with the exact confirmed-success shapes in stored
  histories created before these outcome statuses existed

This keeps SUT uncertainty in the Nemesis history while preventing Harness or
control-plane failures from being reported as successful fault injection.

## Verification

- `JAVA_CMD=/opt/homebrew/opt/openjdk@26/bin/java make -C jepsen unit-test`
  — 141 tests, 905 assertions, 0 failures/errors
- `JAVA_CMD=/opt/homebrew/opt/openjdk@26/bin/java make -C jepsen clojure-lint`
  — clj-kondo and cljfmt passed
- `git diff --check upstream/main...HEAD`

Refs #1975

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2014)
<!-- Reviewable:end -->
