### PR TITLE
test: jepsen: close membership outcomes

### DIFF
--- a/jepsen/src/jepsen/openraft/nemesis/membership.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/membership.clj
@@ -3,16 +3,20 @@
             [jepsen [checker :as checker]
              [generator :as gen]
              [nemesis :as nemesis]
-             [random :as random]
-             [util :as util]]
+             [random :as random]]
+            [jepsen.openraft.await :as await]
             [jepsen.openraft [client :as client]
              [cluster :as cluster]
              [db :as openraft-db]]
+            [jepsen.openraft.nemesis.outcome :as outcome]
             [jepsen.openraft.quorum :as quorum]))
 
 (def change-seconds 10)
 (def minimum-voters 3)
 (def learner-wait-timeout-ms 60000)
+
+(def ^:private membership-error-arm-limit 8)
+(def ^:private membership-error-arm-name-limit 128)
 
 (defn- select-node [test candidates]
   (->> (:nodes test)
@@ -33,7 +37,10 @@
 
 (defn- ambiguous-request-error? [e]
   (let [{:keys [kind status]} (ex-data e)]
-    (or (#{:request-timeout :transport-error :invalid-json} kind)
+    (or (#{:request-timeout
+           :transport-error
+           :invalid-json
+           :invalid-response} kind)
         (and (= :http-error kind)
              (or (nil? status)
                  (<= 500 status 599))))))
@@ -43,25 +50,44 @@
     (or (= :unreachable kind)
         (contains? error :ForwardToLeader))))
 
+(defn- change-membership-error [e]
+  (let [error (:error (ex-data e))]
+    (when (and (map? error)
+               (contains? error :ChangeMembershipError))
+      {:payload (:ChangeMembershipError error)})))
+
+(defn- bounded-arm-name [arm]
+  (let [arm-name (if (keyword? arm) (name arm) (str arm))]
+    (subs arm-name 0 (min membership-error-arm-name-limit
+                          (count arm-name)))))
+
+(defn- malformed-membership-error-evidence [e]
+  (when-let [{:keys [payload]} (change-membership-error e)]
+    (when-not (and (map? payload) (= 1 (count payload)))
+      {:error-shape (if (map? payload) :map :not-map)
+       :error-arm-count (when (map? payload) (count payload))
+       :error-arm-names (if (map? payload)
+                          (->> (keys payload)
+                               (take membership-error-arm-limit)
+                               (map bounded-arm-name)
+                               sort
+                               vec)
+                          [])})))
+
+(defn- membership-error-variant [e]
+  (let [payload (:payload (change-membership-error e))]
+    (when (and (map? payload) (= 1 (count payload)))
+      (ffirst payload))))
+
 (defn- membership-change-in-progress? [e]
-  (contains? (get-in (ex-data e)
-                     [:error :ChangeMembershipError])
-             :InProgress))
+  (= :InProgress (membership-error-variant e)))
+
+(defn- unexpected-membership-error-outcome [e]
+  (when-let [evidence (malformed-membership-error-evidence e)]
+    (outcome/indeterminate :unexpected-sut-response evidence)))
 
 (defn- await-reachable-learner! [test node]
-  (try
-    (util/await-fn
-     #(cluster/node-metrics! test node)
-     {:log-message (str "Waiting for OpenRaft learner " node)
-      :timeout learner-wait-timeout-ms})
-    (catch InterruptedException e
-      (.interrupt (Thread/currentThread))
-      (throw e))
-    (catch Exception e
-      (throw (ex-info "Existing OpenRaft learner is unreachable"
-                      {:kind :learner-unreachable
-                       :node node}
-                      e)))))
+  (cluster/await-node-metrics! test node learner-wait-timeout-ms))
 
 (defn- request-membership-change!
   [test leader-endpoint target-voters]
@@ -72,79 +98,232 @@
      #(client/change-membership! % (voter-ids test target-voters)))
     :completed
     (catch Exception e
-      (cond
-        (leader-routing-error? e)
-        :no-supported-leader
+      (let [unexpected (unexpected-membership-error-outcome e)]
+        (cond
+          (leader-routing-error? e)
+          :no-supported-leader
 
-        (ambiguous-request-error? e)
-        (do
-          (info "OpenRaft membership change result is indeterminate"
-                {:target-voters target-voters
-                 :error (ex-message e)})
-          :indeterminate)
+          unexpected
+          unexpected
 
-        (membership-change-in-progress? e)
-        (do
-          (info "OpenRaft membership change is already in progress"
-                {:target-voters target-voters
-                 :error (ex-message e)})
-          :in-progress)
+          (ambiguous-request-error? e)
+          (do
+            (info "OpenRaft membership change result is indeterminate"
+                  {:target-voters target-voters
+                   :error (ex-message e)})
+            :indeterminate)
 
-        :else
-        (throw e)))))
+          (membership-change-in-progress? e)
+          (do
+            (info "OpenRaft membership change is already in progress"
+                  {:target-voters target-voters
+                   :error (ex-message e)})
+            :in-progress)
+
+          :else
+          (throw e))))))
+
+(def ^:private restoration-outcome-kind ::restoration-outcome)
+
+(defn- closed-outcome? [value]
+  (contains? #{:installed :skipped :indeterminate} (:status value)))
+
+(defn- restoration-context [pending]
+  (atom
+   (cond-> (merge {:attempted? (= :indeterminate (:status pending))}
+                  (select-keys pending
+                               [:stage
+                                :error-variant
+                                :error-shape
+                                :error-arm-count
+                                :error-arm-names]))
+     (= :indeterminate (:status pending))
+     (assoc :reason (or (:reason pending) :request-result-unknown))
+     (= :in-progress (:status pending))
+     (assoc :skip-reason :membership-change-in-progress)
+     (#{:learner-unreachable :no-supported-leader :node-starting}
+      (:status pending))
+     (assoc :skip-reason (:status pending)))))
+
+(defn- return-restoration-outcome! [value]
+  (throw (ex-info "OpenRaft membership restoration has a modeled outcome"
+                  {:kind restoration-outcome-kind
+                   :outcome value})))
+
+(defn- note-restoration-request!
+  [context stage result details]
+  (let [status (if (map? result) (:status result) result)
+        evidence (when (map? result)
+                   (select-keys result
+                                [:reason
+                                 :error-variant
+                                 :error-shape
+                                 :error-arm-count
+                                 :error-arm-names]))]
+    (case status
+      :completed
+      (swap! context assoc
+             :attempted? true
+             :stage stage)
+
+      :indeterminate
+      (swap! context
+             #(merge %
+                     evidence
+                     {:attempted? true
+                      :reason (or (:reason evidence)
+                                  :request-result-unknown)
+                      :stage stage}))
+
+      :in-progress
+      (swap! context assoc
+             :skip-reason :membership-change-in-progress
+             :stage stage)
+
+      :no-supported-leader
+      (let [{:keys [attempted? reason]
+             prior-stage :stage} @context
+            details (assoc details :stage (or prior-stage stage))]
+        (return-restoration-outcome!
+         (if attempted?
+           (outcome/indeterminate
+            (or reason :membership-recovery-unconfirmed)
+            details)
+           (outcome/skipped :no-supported-leader details))))
+
+      nil))
+  result)
+
+(defn- restoration-timeout-outcome [context e]
+  (let [{:keys [attempted? reason skip-reason] :as state} @context
+        details (merge {:condition (:condition (ex-data e))
+                        :message (ex-message e)}
+                       (select-keys state
+                                    [:stage
+                                     :error-variant
+                                     :error-shape
+                                     :error-arm-count
+                                     :error-arm-names]))]
+    (if attempted?
+      (outcome/indeterminate
+       (or reason :membership-recovery-unconfirmed)
+       details)
+      (outcome/skipped (or skip-reason :membership-not-ready)
+                       details))))
+
+(defn- request-membership-change-when-ready!
+  [test leader-endpoint target-voters context]
+  (let [waiting-for-stable? (atom false)]
+    (await/until!
+     :membership-change-request-ready
+     #(let [waiting? @waiting-for-stable?
+            status (when waiting? (cluster/membership-status test))]
+        (cond
+          (and waiting? (not (:stable? status)))
+          (await/retry! :membership-change-request-ready
+                        {:target-voters target-voters
+                         :status status})
+
+          (and waiting? (= target-voters (:voters status)))
+          status
+
+          :else
+          (do
+            (reset! waiting-for-stable? false)
+            (let [result (request-membership-change! test
+                                                     leader-endpoint
+                                                     target-voters)]
+              (note-restoration-request! context
+                                         :change-membership
+                                         result
+                                         {:target-voters target-voters})
+              (cond
+                (closed-outcome? result)
+                (return-restoration-outcome!
+                 (assoc result :stage :change-membership))
+
+                (= :in-progress result)
+                (do
+                  (reset! waiting-for-stable? true)
+                  (await/retry! :membership-change-request-ready
+                                {:target-voters target-voters}))
+
+                :else
+                result)))))
+     {:log-message "Waiting to retry an OpenRaft membership change"
+      :timeout learner-wait-timeout-ms})))
 
 (defn- complete-joint-membership!
-  [test {:keys [leader effective-voter-configs]}]
+  [test {:keys [leader effective-voter-configs]} context]
   (let [target-voters (peek effective-voter-configs)
-        leader-endpoint (atom (client/api-endpoint test leader))]
+        leader-endpoint (atom (client/api-endpoint test leader))
+        result (request-membership-change-when-ready! test
+                                                      leader-endpoint
+                                                      target-voters
+                                                      context)]
     (info "Completing an existing joint OpenRaft membership"
           {:configs effective-voter-configs
            :target-voters target-voters})
-    (request-membership-change! test leader-endpoint target-voters)
-    (cluster/await-stable-membership! test target-voters)))
+    (if (map? result)
+      result
+      (cluster/await-stable-membership! test target-voters))))
 
-(defn- stable-membership! [test]
-  (let [{:keys [stable?] :as status}
-        (cluster/await-committed-membership! test)]
-    (if stable?
-      status
-      (complete-joint-membership! test status))))
+(defn- stable-membership!
+  ([test]
+   (stable-membership! test (restoration-context nil)))
+  ([test context]
+   (let [{:keys [stable?] :as status}
+         (cluster/await-committed-membership! test)]
+     (if stable?
+       status
+       (complete-joint-membership! test status context)))))
 
 (defn- change-membership-and-await!
-  [test leader-endpoint target-voters]
-  (when (= :in-progress
-           (request-membership-change! test leader-endpoint target-voters))
-    (let [status (stable-membership! test)]
-      (when-not (= target-voters (:voters status))
-        (request-membership-change!
-         test
-         leader-endpoint
-         target-voters))))
-  (try
-    (cluster/await-stable-membership! test target-voters)
-    (catch Exception e
-      (when-not (= :timeout (:type (ex-data e)))
-        (throw e))
-      (let [status (stable-membership! test)]
-        (if (= target-voters (:voters status))
-          status
-          (throw e))))))
+  [test leader-endpoint target-voters context]
+  (let [result (request-membership-change-when-ready! test
+                                                      leader-endpoint
+                                                      target-voters
+                                                      context)]
+    (if (map? result)
+      result
+      (try
+        (cluster/await-stable-membership! test target-voters)
+        (catch Exception e
+          (when-not (await/condition-timeout? e :stable-membership)
+            (throw e))
+          (let [status (stable-membership! test context)]
+            (if (= target-voters (:voters status))
+              status
+              (throw e))))))))
 
 (defn- await-observed-learner! [test node]
-  (util/await-fn
-   #(let [status (cluster/membership-status test)]
-      (if (and (:stable? status)
-               (contains? (:learners status) node))
-        status
-        (throw (ex-info "OpenRaft learner is not committed yet"
-                        {:node node
-                         :status status}))))
-   {:log-message (str "Waiting for OpenRaft learner " node
-                      " to appear in membership")
-    :timeout learner-wait-timeout-ms}))
+  (cluster/await-observed-learner! test node learner-wait-timeout-ms))
+
+(defn- validate-add-learner-request!
+  [test node node-id api-addr raft-addr]
+  (let [configured? (contains? (set (:nodes test)) node)
+        expected {:node-id (client/node-host node)
+                  :api-addr (client/api-endpoint test node)
+                  :raft-addr (client/raft-addr test node)}
+        actual {:node-id node-id
+                :api-addr api-addr
+                :raft-addr raft-addr}]
+    (when-not (and configured? (= expected actual))
+      (throw (ex-info "Invalid OpenRaft add-learner request"
+                      {:kind :invalid-add-learner-request
+                       :node node
+                       :configured? configured?
+                       :expected expected
+                       :actual actual})))))
+
+(defn- unexpected-add-learner-error-variant [e]
+  (let [variant (membership-error-variant e)]
+    (when (#{:LearnerNotFound :EmptyMembership} variant)
+      variant)))
 
 (defn- request-add-learner!
   [test leader-endpoint node node-id api-addr raft-addr]
+  (validate-add-learner-request! test node node-id api-addr raft-addr)
   (try
     (request-leader!
      test
@@ -152,35 +331,102 @@
      #(client/add-learner! % node-id api-addr raft-addr))
     :completed
     (catch Exception e
-      (cond
-        (leader-routing-error? e)
-        :no-supported-leader
+      (let [unexpected (unexpected-membership-error-outcome e)]
+        (cond
+          (leader-routing-error? e)
+          :no-supported-leader
 
-        (ambiguous-request-error? e)
-        (do
-          (info "OpenRaft learner addition result is indeterminate"
-                {:node node
-                 :error (ex-message e)})
-          :indeterminate)
+          unexpected
+          unexpected
 
-        :else
-        (throw e)))))
+          (ambiguous-request-error? e)
+          (do
+            (info "OpenRaft learner addition result is indeterminate"
+                  {:node node
+                   :error (ex-message e)})
+            :indeterminate)
+
+          (membership-change-in-progress? e)
+          (do
+            (info "OpenRaft learner addition found a membership change in progress"
+                  {:node node
+                   :error (ex-message e)})
+            :in-progress)
+
+          (unexpected-add-learner-error-variant e)
+          (let [variant (unexpected-add-learner-error-variant e)]
+            (info "OpenRaft learner addition returned an unexpected error"
+                  {:node node
+                   :error-variant variant})
+            (outcome/indeterminate :unexpected-sut-response
+                                   {:error-variant variant}))
+
+          :else
+          (throw e))))))
+
+(defn- request-add-learner-when-ready!
+  [test leader-endpoint node node-id api-addr raft-addr context]
+  (let [waiting-for-stable? (atom false)]
+    (await/until!
+     :add-learner-request-ready
+     #(let [waiting? @waiting-for-stable?
+            status (when waiting? (cluster/membership-status test))]
+        (cond
+          (and waiting? (not (:stable? status)))
+          (await/retry! :add-learner-request-ready
+                        {:node node
+                         :status status})
+
+          (and waiting?
+               (or (contains? (:learners status) node)
+                   (contains? (:voters status) node)))
+          status
+
+          :else
+          (do
+            (reset! waiting-for-stable? false)
+            (let [result (request-add-learner! test
+                                               leader-endpoint
+                                               node
+                                               node-id
+                                               api-addr
+                                               raft-addr)]
+              (note-restoration-request! context
+                                         :add-learner
+                                         result
+                                         {:node node})
+              (cond
+                (closed-outcome? result)
+                (return-restoration-outcome! (assoc result
+                                                    :stage
+                                                    :add-learner))
+
+                (= :in-progress result)
+                (do
+                  (reset! waiting-for-stable? true)
+                  (await/retry! :add-learner-request-ready {:node node}))
+
+                :else
+                result)))))
+     {:log-message (str "Waiting to retry adding OpenRaft learner " node)
+      :timeout learner-wait-timeout-ms})))
 
 (defn- add-learner-and-confirm!
-  [test leader-endpoint node node-id api-addr raft-addr]
-  (let [result (request-add-learner! test
-                                     leader-endpoint
-                                     node
-                                     node-id
-                                     api-addr
-                                     raft-addr)]
-    (when (= :indeterminate result)
-      (await-observed-learner! test node))
-    result))
+  [test leader-endpoint node node-id api-addr raft-addr context]
+  (let [result (request-add-learner-when-ready! test
+                                                leader-endpoint
+                                                node
+                                                node-id
+                                                api-addr
+                                                raft-addr
+                                                context)]
+    (if (= :indeterminate result)
+      (await-observed-learner! test node)
+      result)))
 
-(defn- grow! [database test]
+(defn- grow! [database test context]
   (let [{:keys [leader voters learners non-members metrics]}
-        (stable-membership! test)
+        (stable-membership! test context)
         source (if (seq learners) :learner :non-member)
         node (select-node test
                           (if (= :learner source)
@@ -202,29 +448,35 @@
               {:node node
                :source source
                :leader leader})
-        (add-learner-and-confirm!
-         test
-         leader-endpoint
-         node
-         node-id
-         api-addr
-         raft-addr)
-
-        (info "Growing OpenRaft membership"
-              {:node node
-               :before voters
-               :after target-voters})
-
-        (let [final-status
-              (change-membership-and-await!
+        (let [learner-status
+              (add-learner-and-confirm!
                test
                leader-endpoint
-               target-voters)]
-          {:node node
-           :source source
-           :leader (:leader final-status)
-           :before voters
-           :after (:voters final-status)})))))
+               node
+               node-id
+               api-addr
+               raft-addr
+               context)]
+
+          (info "Growing OpenRaft membership"
+                {:node node
+                 :before voters
+                 :after target-voters})
+
+          (let [final-status
+                (if (and (map? learner-status)
+                         (= target-voters (:voters learner-status)))
+                  learner-status
+                  (change-membership-and-await!
+                   test
+                   leader-endpoint
+                   target-voters
+                   context))]
+            {:node node
+             :source source
+             :leader (:leader final-status)
+             :before voters
+             :after (:voters final-status)}))))))
 
 (defn- shrink-candidates [{:keys [voters metrics]}]
   (let [reachable (set (keys metrics))]
@@ -238,14 +490,45 @@
   [pending-change pending leader]
   (reset! pending-change nil)
   (-> pending
-      (dissoc :target)
+      (dissoc :target
+              :status
+              :reason
+              :stage
+              :error-variant
+              :error-shape
+              :error-arm-count
+              :error-arm-names)
       (assoc :leader leader
              :after (:target pending))))
 
+(defn- retained-status-reason [status]
+  (case status
+    :indeterminate :request-result-unknown
+    :in-progress :membership-change-in-progress
+    :learner-unreachable :learner-unreachable
+    :no-supported-leader :no-supported-leader
+    :node-starting :node-starting
+    nil))
+
 (defn- retain-pending-change!
-  [pending-change pending status]
-  (reset! pending-change pending)
-  (assoc pending :status status))
+  [pending-change pending result]
+  (let [current @pending-change
+        status (if (map? result) (:status result) result)
+        reason (if (map? result)
+                 (:reason result)
+                 (retained-status-reason status))
+        evidence (when (map? result)
+                   (select-keys result
+                                [:error-variant
+                                 :error-shape
+                                 :error-arm-count
+                                 :error-arm-names]))
+        retained (if (= :indeterminate (:status current))
+                   current
+                   (cond-> (merge pending evidence {:status status})
+                     reason (assoc :reason reason)))]
+    (reset! pending-change retained)
+    retained))
 
 (defn- request-pending-membership-change!
   [pending-change test status pending]
@@ -274,8 +557,22 @@
                           api-addr
                           raft-addr)]
       (if-not (= :completed learner-result)
-        (retain-pending-change! pending-change pending learner-result)
-        (do
+        (retain-pending-change! pending-change
+                                (assoc pending :stage :add-learner)
+                                learner-result)
+        (let [current @pending-change
+              pending (cond-> (assoc pending
+                                     :stage :change-membership)
+                        (and (= :indeterminate (:status current))
+                             (= :add-learner (:stage current)))
+                        (dissoc :status
+                                :reason
+                                :error-variant
+                                :error-shape
+                                :error-arm-count
+                                :error-arm-names))]
+          (when current
+            (reset! pending-change pending))
           (info "Growing OpenRaft membership"
                 {:node node
                  :before (:before pending)
@@ -384,7 +681,10 @@
                 (-> pending
                     (dissoc :target)
                     (assoc :after target-voters)))
-              (retain-pending-change! pending-change pending result))))
+              (retain-pending-change! pending-change
+                                      (assoc pending
+                                             :stage :change-membership)
+                                      result))))
         :no-quorum-safe-shrink))))
 
 (defn- resolve-pending-removal!
@@ -413,9 +713,9 @@
                 test
                 (atom (client/api-endpoint test (:leader status)))
                 target-voters)]
-    {:status result
-     :target target-voters
-     :voter-configs (:effective-voter-configs status)}))
+    (merge (if (map? result) result {:status result})
+           {:target target-voters
+            :voter-configs (:effective-voter-configs status)})))
 
 (defn- request-membership-operation!
   [database pending-change test operation]
@@ -440,16 +740,103 @@
       (request-shrink! database pending-change test status))
     :no-supported-leader))
 
+(def ^:private skipped-results
+  #{:learner-pending
+    :membership-full
+    :minimum-membership
+    :no-quorum-safe-shrink
+    :no-supported-leader})
+
+(def ^:private skipped-status-reasons
+  {:in-progress :membership-change-in-progress
+   :learner-unreachable :learner-unreachable
+   :no-supported-leader :no-supported-leader
+   :node-starting :node-starting})
+
+(defn- normalize-membership-result [result]
+  (cond
+    (= :indeterminate result)
+    (outcome/indeterminate :request-result-unknown {})
+
+    (contains? skipped-results result)
+    (outcome/skipped result {})
+
+    (map? result)
+    (let [status (:status result)
+          details (dissoc result :status :reason)]
+      (cond
+        (= :completed status)
+        (outcome/installed details)
+
+        (= :indeterminate status)
+        (outcome/indeterminate (or (:reason result)
+                                   :request-result-unknown)
+                               details)
+
+        (contains? skipped-status-reasons status)
+        (outcome/skipped (get skipped-status-reasons status) details)
+
+        (contains? result :after)
+        (outcome/installed (dissoc result :reason))
+
+        :else
+        (throw (ex-info "Unknown membership Nemesis result"
+                        {:result result}))))
+
+    :else
+    (throw (ex-info "Unknown membership Nemesis result"
+                    {:result result}))))
+
+(defn- membership-operation-outcome [operation result]
+  (let [normalized (normalize-membership-result result)
+        actual-change (when (map? result) (:change result))
+        indeterminate? (= :indeterminate (:status normalized))]
+    (cond
+      (and indeterminate?
+           actual-change
+           (not= operation actual-change))
+      (outcome/indeterminate (:reason normalized)
+                             {:pending-change normalized})
+
+      (and indeterminate?
+           (map? result)
+           (contains? result :voter-configs))
+      (outcome/indeterminate (:reason normalized)
+                             {:existing-change normalized})
+
+      (and actual-change (not= operation actual-change))
+      (outcome/skipped
+       :pending-membership-change
+       {(if (= :installed (:status normalized))
+          :resolved-change
+          :pending-change) normalized})
+
+      (and (map? result) (contains? result :voter-configs))
+      (outcome/skipped :membership-change-in-progress
+                       {:existing-change normalized})
+
+      :else
+      normalized)))
+
+(defn- restoration-outcome [result]
+  (if (closed-outcome? result)
+    result
+    (outcome/installed
+     (cond-> result
+       (:resolved-change result)
+       (update :resolved-change outcome/installed)))))
+
 (defn- complete-pending-removal-and-await!
-  [database pending-change test]
+  [database pending-change test context]
   (when-let [{:keys [node target] :as pending} @pending-change]
-    (let [status (stable-membership! test)
+    (let [status (stable-membership! test context)
           final-status (if (= target (:voters status))
                          status
                          (change-membership-and-await!
                           test
                           (atom (client/api-endpoint test (:leader status)))
-                          target))]
+                          target
+                          context))]
       (openraft-db/stop-and-wipe-node! database test node)
       (reset! pending-change nil)
       (-> pending
@@ -457,46 +844,87 @@
           (assoc :leader (:leader final-status)
                  :after target)))))
 
-(defn- confirm-pending-grow!
-  [pending-change test]
-  (let [{:keys [target] :as pending} @pending-change
-        status (stable-membership! test)]
-    (reset! pending-change nil)
-    (when (= target (:voters status))
+(defn- confirm-pending-grow-status!
+  [pending-change status]
+  (when-let [{:keys [change target] :as pending} @pending-change]
+    (when (and (= :grow change)
+               (= target (:voters status)))
+      (reset! pending-change nil)
       (-> pending
-          (dissoc :target)
+          (dissoc :target
+                  :status
+                  :reason
+                  :stage
+                  :error-variant
+                  :error-shape
+                  :error-arm-count
+                  :error-arm-names)
           (assoc :leader (:leader status)
                  :after target)))))
 
+(defn- confirm-pending-grow!
+  [pending-change test context]
+  (let [status (stable-membership! test context)]
+    (confirm-pending-grow-status! pending-change status)))
+
 (defn- complete-pending-change-and-await!
-  [database pending-change test]
+  [database pending-change test context]
   (case (:change @pending-change)
-    :grow (confirm-pending-grow! pending-change test)
+    :grow (confirm-pending-grow! pending-change test context)
     :shrink (complete-pending-removal-and-await!
              database
              pending-change
-             test)
+             test
+             context)
     nil nil))
 
-(defn- restore-membership! [database pending-change test]
+(defn- restore-membership! [database pending-change test context]
   (let [resolved-change (complete-pending-change-and-await!
                          database
                          pending-change
-                         test)
+                         test
+                         context)
         target-voters (set (:nodes test))]
-    (loop [status (stable-membership! test)]
+    (loop [status (stable-membership! test context)]
       (if (= target-voters (:voters status))
-        (cond-> {:leader (:leader status)
-                 :voters (:voters status)}
-          resolved-change
-          (assoc :resolved-change resolved-change))
-        (let [result (grow! database test)]
+        (let [resolved-change (or resolved-change
+                                  (confirm-pending-grow-status!
+                                   pending-change
+                                   status))]
+          (cond-> {:leader (:leader status)
+                   :voters (:voters status)}
+            resolved-change
+            (assoc :resolved-change resolved-change)))
+        (let [result (grow! database test context)]
           (when (keyword? result)
-            (throw (ex-info "Unable to restore OpenRaft membership"
-                            {:result result
-                             :status status
-                             :target-voters target-voters})))
-          (recur (stable-membership! test)))))))
+            (return-restoration-outcome!
+             (outcome/skipped result
+                              {:status status
+                               :target-voters target-voters})))
+          (recur (stable-membership! test context)))))))
+
+(defn- restore-membership-outcome!
+  [database pending-change test]
+  (let [context (restoration-context @pending-change)]
+    (try
+      (restoration-outcome
+       (restore-membership! database pending-change test context))
+      (catch Exception e
+        (cond
+          (= restoration-outcome-kind (:kind (ex-data e)))
+          (:outcome (ex-data e))
+
+          (some #(await/condition-timeout? e %)
+                [:add-learner-request-ready
+                 :committed-membership
+                 :learner-observed
+                 :membership-change-request-ready
+                 :node-metrics
+                 :stable-membership])
+          (restoration-timeout-outcome context e)
+
+          :else
+          (throw e))))))
 
 (defrecord MembershipNemesis [database pending-change]
   nemesis/Nemesis
@@ -506,24 +934,27 @@
   (invoke! [_ test op]
     (case (:f op)
       :grow
-      (assoc op :value (request-membership-operation!
-                        database
-                        pending-change
-                        test
-                        :grow))
+      (let [result (request-membership-operation!
+                    database
+                    pending-change
+                    test
+                    :grow)]
+        (assoc op :value (membership-operation-outcome :grow result)))
 
       :shrink
-      (assoc op :value (request-membership-operation!
-                        database
-                        pending-change
-                        test
-                        :shrink))
+      (let [result (request-membership-operation!
+                    database
+                    pending-change
+                    test
+                    :shrink)]
+        (assoc op :value (membership-operation-outcome :shrink result)))
 
       :restore-membership
-      (assoc op :value (restore-membership!
-                        database
-                        pending-change
-                        test))))
+      (assoc op
+             :value (restore-membership-outcome!
+                     database
+                     pending-change
+                     test))))
 
   (teardown! [_ _test])
 
@@ -544,6 +975,38 @@
                       :f :grow})
              (repeat {:type :info
                       :f :shrink})])))
+
+(defn- membership-change-installed? [required-changes change]
+  (and (outcome/installed-or-legacy?
+        change
+        #(and (map? %)
+              (required-changes (:change %))
+              (:node %)
+              (:leader %)
+              (coll? (:before %))
+              (coll? (:after %))
+              (not= (:before %) (:after %))))
+       (required-changes (:change change))
+       (:node change)
+       (:leader change)
+       (coll? (:before change))
+       (coll? (:after change))
+       (not= (:before change) (:after change))))
+
+(defn- membership-restored? [expected-voters value]
+  (and (outcome/installed-or-legacy?
+        value
+        #(and (map? %)
+              (:leader %)
+              (= expected-voters (:voters %))))
+       (:leader value)
+       (= expected-voters (:voters value))))
+
+(defn- recovery-installed? [value]
+  (and (outcome/installed-or-legacy?
+        value
+        #(and (map? %) (:leader %)))
+       (:leader value)))
 
 (defn- coverage-checker []
   (reify checker/Checker
@@ -568,27 +1031,23 @@
                                         (:resolved-change value)])))
                                   (keep
                                    (fn [change]
-                                     (when (and (map? change)
-                                                (required-changes
-                                                 (:change change))
-                                                (contains? change :before)
-                                                (contains? change :after)
-                                                (not= (:before change)
-                                                      (:after change)))
+                                     (when (membership-change-installed?
+                                            required-changes
+                                            change)
                                        (:change change))))
                                   set)
             missing-changes (remove observed-changes
                                     required-changes)
             final-operation (peek membership-history)
             restored? (and (= :restore-membership (:f final-operation))
-                           (= expected-voters
-                              (get-in final-operation
-                                      [:value :voters])))
+                           (membership-restored?
+                            expected-voters
+                            (:value final-operation)))
             final-recovery (->> history
                                 (filter #(= :await-recovery (:f %)))
                                 last)
-            recovered? (boolean (get-in final-recovery
-                                        [:value :leader]))]
+            recovered? (boolean
+                        (recovery-installed? (:value final-recovery)))]
         {:valid? (and (empty? errors)
                       (empty? missing-changes)
                       restored?

--- a/jepsen/test/jepsen/openraft/nemesis/membership_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/membership_test.clj
@@ -2,9 +2,12 @@
   (:require [clojure.test :refer [deftest is testing]]
             [jepsen [checker :as checker]
              [nemesis :as nemesis]]
-            [jepsen.openraft [client :as client]
+            [jepsen.openraft [await :as await]
+             [client :as client]
              [cluster :as cluster]
-             [db :as openraft-db]]
+             [db :as openraft-db]
+             [harness :as harness]
+             [worker :as worker]]
             [jepsen.openraft.nemesis.membership :as membership]
             [jepsen.random :as random]))
 
@@ -14,6 +17,25 @@
   {:nodes nodes
    :api-port 21001
    :raft-port 22001})
+
+(defn- installed [details]
+  (assoc details :status :installed))
+
+(defn- skipped [reason details]
+  (assoc details :status :skipped :reason reason))
+
+(defn- indeterminate [reason details]
+  (assoc details :status :indeterminate :reason reason))
+
+(defn- condition-timeout [condition]
+  (try
+    (await/until! condition
+                  #(await/retry! condition {})
+                  {:timeout 0
+                   :retry-interval 0})
+    nil
+    (catch Exception e
+      e)))
 
 (defn- membership-nemesis []
   (membership/->MembershipNemesis :database (atom nil)))
@@ -64,7 +86,8 @@
                                     test-config
                                     {:type :info
                                      :f :grow})]
-        (is (= :node-starting (get-in starting [:value :status])))
+        (is (= :skipped (get-in starting [:value :status])))
+        (is (= :node-starting (get-in starting [:value :reason])))
         (is (= [[:start-empty :database "n5"]
                 [:add-learner
                  "n1:21001"
@@ -81,7 +104,8 @@
                 :before before
                 :after after}
                (select-keys (:value result)
-                            [:change :node :source :before :after])))))))
+                            [:change :node :source :before :after])))
+        (is (= :installed (get-in result [:value :status])))))))
 
 (deftest handles-an-existing-learner
   (let [before #{"n1" "n2" "n3" "n4"}
@@ -109,7 +133,8 @@
                                       {:type :info
                                        :f :grow})]
           (is (= [:add-learner :change-membership] @calls))
-          (is (= after (get-in result [:value :after]))))))
+          (is (= after (get-in result [:value :after])))
+          (is (= :installed (get-in result [:value :status]))))))
 
     (testing "an unreachable learner is reported without blocking"
       (reset! calls [])
@@ -121,8 +146,9 @@
                                       test-config
                                       {:type :info
                                        :f :grow})]
+          (is (= :skipped (get-in result [:value :status])))
           (is (= :learner-unreachable
-                 (get-in result [:value :status])))
+                 (get-in result [:value :reason])))
           (is (empty? @calls)))))))
 
 (deftest defers-an-indeterminate-learner-addition
@@ -147,7 +173,230 @@
                                     {:type :info
                                      :f :grow})]
         (is (= :indeterminate (get-in result [:value :status])))
+        (is (= :request-result-unknown
+               (get-in result [:value :reason])))
         (is (false? @changed?))))))
+
+(deftest skips-an-add-learner-during-an-existing-membership-change
+  (let [before #{"n1" "n2" "n3" "n4"}
+        status (update (stable-status before) :metrics assoc "n5" {})
+        changed? (atom false)
+        pending (atom nil)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database pending))]
+    (with-redefs [cluster/membership-status (constantly status)
+                  client/add-learner!
+                  (fn [& _]
+                    (throw (ex-info
+                            "membership change in progress"
+                            {:kind :openraft-error
+                             :error {:ChangeMembershipError
+                                     {:InProgress {}}}})))
+                  client/change-membership!
+                  (fn [& _] (reset! changed? true))]
+      (let [value (:value
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info :f :grow}))]
+        (is (= :skipped (:status value)))
+        (is (= :membership-change-in-progress (:reason value)))
+        (is (= :add-learner (:stage value)))
+        (is (= {:status :in-progress
+                :reason :membership-change-in-progress
+                :stage :add-learner}
+               (select-keys @pending [:status :reason :stage])))
+        (is (false? @changed?))
+        (is (nil? (harness/primary-failure failure-state)))))))
+
+(deftest classifies-invalid-membership-responses-after-the-attempt
+  (testing "an invalid add-learner response is indeterminate"
+    (let [before #{"n1" "n2" "n3" "n4"}
+          status (update (stable-status before) :metrics assoc "n5" {})
+          failure-state (harness/failure-state)
+          changed? (atom false)
+          subject (worker/wrap-nemesis failure-state
+                                       (membership-nemesis))]
+      (with-redefs [cluster/membership-status (constantly status)
+                    client/add-learner!
+                    (fn [& _]
+                      (throw (ex-info "invalid response"
+                                      {:kind :invalid-response})))
+                    client/change-membership!
+                    (fn [& _]
+                      (reset! changed? true))]
+        (let [setup-subject (nemesis/setup! subject test-config)
+              value (:value (nemesis/invoke! setup-subject
+                                             test-config
+                                             {:type :info :f :grow}))]
+          (is (= :indeterminate (:status value)))
+          (is (= :request-result-unknown (:reason value)))
+          (is (= :add-learner (:stage value)))
+          (is (false? @changed?))
+          (is (nil? (harness/primary-failure failure-state)))))))
+
+  (testing "an invalid change-membership response is indeterminate"
+    (let [failure-state (harness/failure-state)
+          cleaned? (atom false)
+          subject (worker/wrap-nemesis failure-state
+                                       (membership-nemesis))]
+      (with-redefs [cluster/membership-status
+                    (constantly (stable-status (set nodes)))
+                    random/shuffle reverse
+                    client/change-membership!
+                    (fn [& _]
+                      (throw (ex-info "invalid response"
+                                      {:kind :invalid-response})))
+                    openraft-db/stop-and-wipe-node!
+                    (fn [& _]
+                      (reset! cleaned? true))]
+        (let [setup-subject (nemesis/setup! subject test-config)
+              value (:value (nemesis/invoke! setup-subject
+                                             test-config
+                                             {:type :info :f :shrink}))]
+          (is (= :indeterminate (:status value)))
+          (is (= :request-result-unknown (:reason value)))
+          (is (= :change-membership (:stage value)))
+          (is (false? @cleaned?))
+          (is (nil? (harness/primary-failure failure-state)))))))
+
+  (testing "an unknown request exception still records Harness failure"
+    (let [before #{"n1" "n2" "n3" "n4"}
+          status (update (stable-status before) :metrics assoc "n5" {})
+          failure-state (harness/failure-state)
+          error (RuntimeException. "request bug")
+          subject (worker/wrap-nemesis failure-state
+                                       (membership-nemesis))]
+      (with-redefs [cluster/membership-status (constantly status)
+                    client/add-learner! (fn [& _] (throw error))]
+        (let [setup-subject (nemesis/setup! subject test-config)
+              thrown (try
+                       (nemesis/invoke! setup-subject
+                                        test-config
+                                        {:type :info :f :grow})
+                       nil
+                       (catch Exception e
+                         e))]
+          (is (identical? error thrown))
+          (is (identical? error
+                          (:throwable
+                           (harness/primary-failure failure-state)))))))))
+
+(deftest malformed-membership-error-unions-are-unexpected-sut-responses
+  (doseq [[description payload expected-shape expected-count expected-names]
+          [["scalar payload" "not-a-union" :not-map nil []]
+           ["multiple variants"
+            {:InProgress {}
+             :LearnerNotFound {:node_id "n5"}}
+            :map
+            2
+            ["InProgress" "LearnerNotFound"]]]]
+    (testing (str description " from add-learner")
+      (let [before #{"n1" "n2" "n3" "n4"}
+            status (update (stable-status before) :metrics assoc "n5" {})
+            failure-state (harness/failure-state)
+            subject (worker/wrap-nemesis failure-state
+                                         (membership-nemesis))]
+        (with-redefs [cluster/membership-status (constantly status)
+                      client/add-learner!
+                      (fn [& _]
+                        (throw
+                         (ex-info
+                          "malformed membership error"
+                          {:kind :openraft-error
+                           :error {:ChangeMembershipError payload}
+                           :response {:body (apply str (repeat 2048 "x"))}})))]
+          (let [value (:value
+                       (nemesis/invoke! subject
+                                        test-config
+                                        {:type :info :f :grow}))]
+            (is (= :indeterminate (:status value)))
+            (is (= :unexpected-sut-response (:reason value)))
+            (is (= :add-learner (:stage value)))
+            (is (= expected-shape (:error-shape value)))
+            (is (= expected-count (:error-arm-count value)))
+            (is (= expected-names (:error-arm-names value)))
+            (is (not (contains? value :error)))
+            (is (not (contains? value :response)))
+            (is (nil? (harness/primary-failure failure-state)))))))
+
+    (testing (str description " from change-membership")
+      (let [failure-state (harness/failure-state)
+            cleaned? (atom false)
+            subject (worker/wrap-nemesis failure-state
+                                         (membership-nemesis))]
+        (with-redefs [cluster/membership-status
+                      (constantly (stable-status (set nodes)))
+                      random/shuffle reverse
+                      client/change-membership!
+                      (fn [& _]
+                        (throw
+                         (ex-info
+                          "malformed membership error"
+                          {:kind :openraft-error
+                           :error {:ChangeMembershipError payload}
+                           :response {:body (apply str (repeat 2048 "x"))}})))
+                      openraft-db/stop-and-wipe-node!
+                      (fn [& _] (reset! cleaned? true))]
+          (let [value (:value
+                       (nemesis/invoke! subject
+                                        test-config
+                                        {:type :info :f :shrink}))]
+            (is (= :indeterminate (:status value)))
+            (is (= :unexpected-sut-response (:reason value)))
+            (is (= :change-membership (:stage value)))
+            (is (= expected-shape (:error-shape value)))
+            (is (= expected-count (:error-arm-count value)))
+            (is (= expected-names (:error-arm-names value)))
+            (is (not (contains? value :error)))
+            (is (not (contains? value :response)))
+            (is (false? @cleaned?))
+            (is (nil? (harness/primary-failure failure-state)))))))))
+
+(deftest ordinary-grow-classifies-impossible-add-learner-errors
+  (doseq [[variant payload]
+          [[:LearnerNotFound {:node_id "n5"}]
+           [:EmptyMembership {}]]]
+    (testing (name variant)
+      (let [before #{"n1" "n2" "n3" "n4"}
+            status (update (stable-status before) :metrics assoc "n5" {})
+            pending (atom nil)
+            changed? (atom false)
+            failure-state (harness/failure-state)
+            subject (worker/wrap-nemesis
+                     failure-state
+                     (membership/->MembershipNemesis :database pending))]
+        (with-redefs [cluster/membership-status (constantly status)
+                      client/add-learner!
+                      (fn [& _]
+                        (throw
+                         (ex-info
+                          "unexpected add-learner response"
+                          {:kind :openraft-error
+                           :error {:ChangeMembershipError
+                                   {variant payload}}})))
+                      client/change-membership!
+                      (fn [& _]
+                        (reset! changed? true))]
+          (let [value (:value
+                       (nemesis/invoke! subject
+                                        test-config
+                                        {:type :info :f :grow}))]
+            (is (= {:status :indeterminate
+                    :reason :unexpected-sut-response
+                    :stage :add-learner
+                    :error-variant variant}
+                   (select-keys value
+                                [:status :reason :stage :error-variant])))
+            (is (= {:status :indeterminate
+                    :reason :unexpected-sut-response
+                    :stage :add-learner
+                    :error-variant variant}
+                   (select-keys @pending
+                                [:status :reason :stage :error-variant])))
+            (is (false? @changed?))
+            (is (nil? (harness/primary-failure failure-state)))))))))
 
 (deftest defers-a-grow-when-leader-routing-is-exhausted
   (let [before #{"n1" "n2" "n3" "n4"}
@@ -170,16 +419,18 @@
                      ["n1:21001" "n2:21001" "n3:21001"
                       "n4:21001" "n5:21001"])
                @attempts))
-        (is (= {:type :info
-                :f :grow
-                :value {:change :grow
-                        :node "n5"
-                        :source :non-member
-                        :leader "n1"
-                        :before before
-                        :target (conj before "n5")
-                        :status :no-supported-leader}}
-               result))))))
+        (is (= :skipped (get-in result [:value :status])))
+        (is (= :no-supported-leader
+               (get-in result [:value :reason])))
+        (is (= :add-learner (get-in result [:value :stage])))
+        (is (= {:change :grow
+                :node "n5"
+                :source :non-member
+                :leader "n1"
+                :before before
+                :target (conj before "n5")}
+               (select-keys (:value result)
+                            [:change :node :source :leader :before :target])))))))
 
 (deftest confirms-an-indeterminate-grow-from-membership-state
   (let [before #{"n1" "n2" "n3" "n4"}
@@ -214,11 +465,48 @@
                                       {:type :info
                                        :f :shrink})]
         (is (= 1 @change-attempts))
+        (is (= :skipped (get-in resolved [:value :status])))
+        (is (= :pending-membership-change
+               (get-in resolved [:value :reason])))
         (is (= {:change :grow
                 :before before
                 :after after}
-               (select-keys (:value resolved)
+               (select-keys (get-in resolved
+                                    [:value :resolved-change])
                             [:change :before :after])))))))
+
+(deftest opposite-operation-preserves-an-indeterminate-pending-retry
+  (let [before (set nodes)
+        after (disj before "n5")
+        pending (atom {:change :shrink
+                       :node "n5"
+                       :leader "n1"
+                       :before before
+                       :target after
+                       :stage :change-membership})
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database pending))]
+    (with-redefs [cluster/membership-status
+                  (constantly (stable-status before))
+                  client/change-membership!
+                  (fn [& _]
+                    (throw (ex-info "timeout" {:kind :request-timeout})))
+                  openraft-db/stop-and-wipe-node!
+                  (fn [& _]
+                    (throw (ex-info "MUST NOT clean up" {})))]
+      (let [value (:value
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info :f :grow}))]
+        (is (= :indeterminate (:status value)))
+        (is (= :request-result-unknown (:reason value)))
+        (is (= :indeterminate
+               (get-in value [:pending-change :status])))
+        (is (= :shrink (get-in value [:pending-change :change])))
+        (is (= :indeterminate (:status @pending)))
+        (is (nil? (harness/primary-failure failure-state)))))))
 
 (deftest shrinks-without-waiting-before-cleanup
   (let [calls (atom [])
@@ -251,7 +539,8 @@
                 :before before
                 :after after}
                (select-keys (:value result)
-                            [:change :node :before :after])))))))
+                            [:change :node :before :after])))
+        (is (= :installed (get-in result [:value :status])))))))
 
 (deftest defers-cleanup-after-an-indeterminate-shrink
   (let [calls (atom [])
@@ -286,10 +575,14 @@
                                       {:type :info
                                        :f :grow})]
         (is (= [:change-membership [:stop-and-wipe "n5"]] @calls))
+        (is (= :skipped (get-in resolved [:value :status])))
+        (is (= :pending-membership-change
+               (get-in resolved [:value :reason])))
         (is (= {:change :shrink
                 :before before
                 :after after}
-               (select-keys (:value resolved)
+               (select-keys (get-in resolved
+                                    [:value :resolved-change])
                             [:change :before :after])))))))
 
 (deftest defers-a-shrink-when-leader-routing-is-exhausted
@@ -319,15 +612,41 @@
                      ["n1:21001" "n2:21001" "n3:21001"
                       "n4:21001" "n5:21001"])
                @attempts))
-        (is (= {:type :info
-                :f :shrink
-                :value {:change :shrink
-                        :node "n5"
-                        :leader "n1"
-                        :before before
-                        :target after
-                        :status :no-supported-leader}}
-               result))))))
+        (is (= :skipped (get-in result [:value :status])))
+        (is (= :no-supported-leader
+               (get-in result [:value :reason])))
+        (is (= :change-membership (get-in result [:value :stage])))
+        (is (= {:change :shrink
+                :node "n5"
+                :leader "n1"
+                :before before
+                :target after}
+               (select-keys (:value result)
+                            [:change :node :leader :before :target])))))))
+
+(deftest skips-a-membership-change-that-is-already-in-progress
+  (let [cleaned? (atom false)]
+    (with-redefs [cluster/membership-status
+                  (constantly (stable-status (set nodes)))
+                  random/shuffle reverse
+                  client/change-membership!
+                  (fn [& _]
+                    (throw (ex-info
+                            "membership change in progress"
+                            {:kind :openraft-error
+                             :error {:ChangeMembershipError
+                                     {:InProgress {}}}})))
+                  openraft-db/stop-and-wipe-node!
+                  (fn [& _]
+                    (reset! cleaned? true))]
+      (let [value (:value
+                   (nemesis/invoke! (membership-nemesis)
+                                    test-config
+                                    {:type :info :f :shrink}))]
+        (is (= :skipped (:status value)))
+        (is (= :membership-change-in-progress (:reason value)))
+        (is (= :change-membership (:stage value)))
+        (is (false? @cleaned?))))))
 
 (deftest advances-a-joint-membership-without-waiting
   (let [before #{"n1" "n2" "n3"}
@@ -353,9 +672,39 @@
                  "n1:21001"
                  ["n1" "n2" "n3" "n4"]]]
                @calls))
-        (is (= {:status :completed
-                :target target}
-               (select-keys (:value result) [:status :target])))))))
+        (is (= :skipped (get-in result [:value :status])))
+        (is (= :membership-change-in-progress
+               (get-in result [:value :reason])))
+        (is (= :installed
+               (get-in result [:value :existing-change :status])))
+        (is (= target
+               (get-in result [:value :existing-change :target])))))))
+
+(deftest joint-membership-ambiguity-remains-indeterminate
+  (let [before #{"n1" "n2" "n3"}
+        target (conj before "n4")
+        joint {:leader "n1"
+               :stable? false
+               :effective-voter-configs [before target]}
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis failure-state
+                                     (membership-nemesis))]
+    (with-redefs [cluster/membership-status (constantly joint)
+                  client/change-membership!
+                  (fn [& _]
+                    (throw (ex-info "timeout" {:kind :request-timeout})))]
+      (let [value (:value
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info :f :grow}))]
+        (is (= :indeterminate (:status value)))
+        (is (= :request-result-unknown (:reason value)))
+        (is (= :indeterminate
+               (get-in value [:existing-change :status])))
+        (is (= target (get-in value [:existing-change :target])))
+        (is (= [before target]
+               (get-in value [:existing-change :voter-configs])))
+        (is (nil? (harness/primary-failure failure-state)))))))
 
 (deftest final-restoration-resolves-a-pending-removal
   (let [before (set nodes)
@@ -372,16 +721,16 @@
         calls (atom [])]
     (with-redefs-fn
       {#'membership/stable-membership!
-       (fn [_test]
+       (fn [_test _context]
          (let [status (first @statuses)]
            (swap! statuses subvec 1)
            status))
        #'membership/change-membership-and-await!
-       (fn [_test _leader-endpoint target]
+       (fn [_test _leader-endpoint target _context]
          (swap! calls conj [:complete-removal target])
          (stable-status after))
        #'membership/grow!
-       (fn [_database _test]
+       (fn [_database _test _context]
          (swap! calls conj :grow))
        #'openraft-db/stop-and-wipe-node!
        (fn [_database _test node]
@@ -397,12 +746,16 @@
                  @calls))
           (is (= {:leader "n1"
                   :voters before
-                  :resolved-change {:change :shrink
-                                    :node "n5"
-                                    :before before
-                                    :leader "n1"
-                                    :after after}}
-                 (:value result)))
+                  :status :installed}
+                 (select-keys (:value result)
+                              [:leader :voters :status])))
+          (is (= {:change :shrink
+                  :node "n5"
+                  :before before
+                  :leader "n1"
+                  :after after
+                  :status :installed}
+                 (get-in result [:value :resolved-change])))
           (is (nil? @pending)))))))
 
 (deftest final-restoration-confirms-a-completed-grow
@@ -415,7 +768,7 @@
                        :target after})
         subject (membership/->MembershipNemesis :database pending)]
     (with-redefs-fn
-      {#'membership/stable-membership! (fn [_test]
+      {#'membership/stable-membership! (fn [_test _context]
                                          (stable-status after))
        #'membership/grow! (fn [& _]
                             (throw (ex-info "MUST NOT grow again" {})))}
@@ -429,9 +782,383 @@
                   :source :non-member
                   :before before
                   :leader "n1"
-                  :after after}
+                  :after after
+                  :status :installed}
                  (get-in result [:value :resolved-change])))
+          (is (= :installed (get-in result [:value :status])))
           (is (nil? @pending)))))))
+
+(deftest final-restoration-waits-for-an-in-progress-learner-add
+  (let [before #{"n1" "n2" "n3" "n4"}
+        after (conj before "n5")
+        initial-status (update (stable-status before)
+                               :metrics
+                               assoc
+                               "n5"
+                               {})
+        learner-status (assoc initial-status
+                              :learners #{"n5"}
+                              :non-members #{})
+        original-until! await/until!]
+    (doseq [{:keys [description observed-status expected-calls]}
+            [{:description "continues when the learner is already present"
+              :observed-status learner-status
+              :expected-calls [:start-empty
+                               [:add-learner 1]
+                               :membership-status
+                               :change-membership
+                               :await-stable]}
+             {:description "retries add-learner when the node is still absent"
+              :observed-status initial-status
+              :expected-calls [:start-empty
+                               [:add-learner 1]
+                               :membership-status
+                               [:add-learner 2]
+                               :change-membership
+                               :await-stable]}]]
+      (testing description
+        (let [calls (atom [])
+              statuses (atom [initial-status
+                              initial-status
+                              (stable-status after)])
+              add-attempts (atom 0)
+              failure-state (harness/failure-state)
+              subject (worker/wrap-nemesis
+                       failure-state
+                       (membership/->MembershipNemesis :database (atom nil)))]
+          (with-redefs [await/until!
+                        (fn [condition f opts]
+                          (original-until!
+                           condition
+                           f
+                           (assoc opts :retry-interval 0)))
+                        cluster/await-committed-membership!
+                        (fn [_test]
+                          (let [status (first @statuses)]
+                            (swap! statuses subvec 1)
+                            status))
+                        cluster/membership-status
+                        (fn [_test]
+                          (swap! calls conj :membership-status)
+                          observed-status)
+                        cluster/await-stable-membership!
+                        (fn [_test target]
+                          (swap! calls conj :await-stable)
+                          (is (= after target))
+                          (stable-status after))
+                        openraft-db/start-empty-node!
+                        (fn [& _]
+                          (swap! calls conj :start-empty))
+                        client/add-learner!
+                        (fn [& _]
+                          (let [attempt (swap! add-attempts inc)]
+                            (swap! calls conj [:add-learner attempt])
+                            (when (= 1 attempt)
+                              (throw
+                               (ex-info
+                                "membership change in progress"
+                                {:kind :openraft-error
+                                 :error {:ChangeMembershipError
+                                         {:InProgress {}}}})))))
+                        client/change-membership!
+                        (fn [& _]
+                          (swap! calls conj :change-membership))]
+            (let [value (:value
+                         (nemesis/invoke! subject
+                                          test-config
+                                          {:type :info
+                                           :f :restore-membership}))]
+              (is (= :installed (:status value)))
+              (is (= after (:voters value)))
+              (is (= expected-calls @calls))
+              (is (empty? @statuses))
+              (is (nil? (harness/primary-failure failure-state))))))))))
+
+(deftest final-restoration-bounds-an-in-progress-learner-add
+  (let [before #{"n1" "n2" "n3" "n4"}
+        status (update (stable-status before) :metrics assoc "n5" {})
+        add-attempts (atom 0)
+        changed? (atom false)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database (atom nil)))]
+    (with-redefs [membership/learner-wait-timeout-ms 0
+                  cluster/await-committed-membership! (constantly status)
+                  openraft-db/start-empty-node! (fn [& _])
+                  client/add-learner!
+                  (fn [& _]
+                    (swap! add-attempts inc)
+                    (throw
+                     (ex-info
+                      "membership change in progress"
+                      {:kind :openraft-error
+                       :error {:ChangeMembershipError {:InProgress {}}}})))
+                  client/change-membership!
+                  (fn [& _]
+                    (reset! changed? true))]
+      (let [value (:value
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info
+                                     :f :restore-membership}))]
+        (is (= :skipped (:status value)))
+        (is (= :membership-change-in-progress (:reason value)))
+        (is (= :add-learner (:stage value)))
+        (is (= :add-learner-request-ready (:condition value)))
+        (is (= 1 @add-attempts))
+        (is (false? @changed?))
+        (is (nil? (harness/primary-failure failure-state)))))))
+
+(deftest final-restoration-classifies-impossible-add-learner-errors
+  (doseq [[variant payload]
+          [[:LearnerNotFound {:node_id "n5"}]
+           [:EmptyMembership {}]]]
+    (testing (name variant)
+      (let [before #{"n1" "n2" "n3" "n4"}
+            status (update (stable-status before) :metrics assoc "n5" {})
+            calls (atom [])
+            failure-state (harness/failure-state)
+            subject (worker/wrap-nemesis
+                     failure-state
+                     (membership/->MembershipNemesis :database (atom nil)))]
+        (with-redefs [cluster/await-committed-membership!
+                      (constantly status)
+                      openraft-db/start-empty-node!
+                      (fn [& _]
+                        (swap! calls conj :start-empty))
+                      client/add-learner!
+                      (fn [endpoint node-id api-addr raft-addr]
+                        (swap! calls conj :add-learner)
+                        (is (= ["n1:21001"
+                                "n5"
+                                "n5:21001"
+                                "n5:22001"]
+                               [endpoint node-id api-addr raft-addr]))
+                        (throw
+                         (ex-info
+                          "unexpected add-learner response"
+                          {:kind :openraft-error
+                           :error {:ChangeMembershipError
+                                   {variant payload}}
+                           :response {:body (apply str (repeat 2048 "x"))}})))
+                      client/change-membership!
+                      (fn [& _]
+                        (swap! calls conj :change-membership))]
+          (let [value (:value
+                       (nemesis/invoke! subject
+                                        test-config
+                                        {:type :info
+                                         :f :restore-membership}))]
+            (is (= {:status :indeterminate
+                    :reason :unexpected-sut-response
+                    :stage :add-learner
+                    :error-variant variant}
+                   value))
+            (is (= [:start-empty :add-learner] @calls))
+            (is (not (contains? value :response)))
+            (is (not (contains? value :error)))
+            (is (nil? (harness/primary-failure failure-state)))))))))
+
+(deftest rejects-a-noncanonical-add-learner-request-before-http
+  (let [before #{"n1" "n2" "n3" "n4"}
+        status (update (stable-status before) :metrics assoc "n5" {})
+        http-called? (atom false)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database (atom nil)))
+        thrown (with-redefs [cluster/await-committed-membership!
+                             (constantly status)
+                             cluster/node-info
+                             (fn [_test _node]
+                               {:node-id "n5"
+                                :api-addr "wrong:21001"
+                                :raft-addr "n5:22001"})
+                             openraft-db/start-empty-node! (fn [& _])
+                             client/add-learner!
+                             (fn [& _]
+                               (reset! http-called? true))]
+                 (try
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info
+                                     :f :restore-membership})
+                   nil
+                   (catch Exception e
+                     e)))]
+    (is (= :invalid-add-learner-request (:kind (ex-data thrown))))
+    (is (= {:node-id "n5"
+            :api-addr "n5:21001"
+            :raft-addr "n5:22001"}
+           (:expected (ex-data thrown))))
+    (is (false? @http-called?))
+    (is (identical? thrown
+                    (:throwable (harness/primary-failure failure-state))))))
+
+(deftest final-restoration-keeps-a-prior-indeterminate-add-sticky
+  (let [before #{"n1" "n2" "n3" "n4"}
+        status (update (stable-status before) :metrics assoc "n5" {})
+        pending (atom nil)
+        add-attempts (atom 0)
+        changed? (atom false)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database pending))]
+    (with-redefs [membership/learner-wait-timeout-ms 0
+                  cluster/membership-status (constantly status)
+                  cluster/await-committed-membership! (constantly status)
+                  openraft-db/start-empty-node! (fn [& _])
+                  client/add-learner!
+                  (fn [& _]
+                    (case (swap! add-attempts inc)
+                      1 (throw (ex-info "invalid response"
+                                        {:kind :invalid-response}))
+                      (throw
+                       (ex-info
+                        "membership change in progress"
+                        {:kind :openraft-error
+                         :error {:ChangeMembershipError
+                                 {:InProgress {}}}}))))
+                  client/change-membership!
+                  (fn [& _]
+                    (reset! changed? true))]
+      (let [runtime-value (:value
+                           (nemesis/invoke! subject
+                                            test-config
+                                            {:type :info :f :grow}))
+            retained @pending
+            final-value (:value
+                         (nemesis/invoke! subject
+                                          test-config
+                                          {:type :info
+                                           :f :restore-membership}))]
+        (is (= :indeterminate (:status runtime-value)))
+        (is (= :request-result-unknown (:reason runtime-value)))
+        (is (= :add-learner (:stage runtime-value)))
+        (is (= :indeterminate (:status retained)))
+        (is (= :request-result-unknown (:reason retained)))
+        (is (= :add-learner (:stage retained)))
+        (is (= :indeterminate (:status final-value)))
+        (is (= :request-result-unknown (:reason final-value)))
+        (is (= :add-learner (:stage final-value)))
+        (is (= retained @pending))
+        (is (= 2 @add-attempts))
+        (is (false? @changed?))
+        (is (nil? (harness/primary-failure failure-state)))))))
+
+(deftest final-restoration-preserves-an-indeterminate-request
+  (let [before (set nodes)
+        after (disj before "n5")
+        pending-value {:change :shrink
+                       :node "n5"
+                       :leader "n1"
+                       :before before
+                       :target after
+                       :stage :change-membership}
+        pending (atom pending-value)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database pending))
+        cleaned? (atom false)
+        timeout (condition-timeout :stable-membership)]
+    (with-redefs [cluster/await-committed-membership!
+                  (constantly (stable-status before))
+                  cluster/await-stable-membership!
+                  (fn [& _] (throw timeout))
+                  client/change-membership!
+                  (fn [& _]
+                    (throw (ex-info "invalid application response"
+                                    {:kind :invalid-response})))
+                  openraft-db/stop-and-wipe-node!
+                  (fn [& _] (reset! cleaned? true))]
+      (let [value (:value
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info
+                                     :f :restore-membership}))]
+        (is (= :indeterminate (:status value)))
+        (is (= :request-result-unknown (:reason value)))
+        (is (= :change-membership (:stage value)))
+        (is (= pending-value @pending))
+        (is (false? @cleaned?))
+        (is (nil? (harness/primary-failure failure-state)))))))
+
+(deftest final-restoration-does-not-demote-earlier-ambiguity
+  (let [before (set nodes)
+        after (disj before "n5")
+        pending-value {:change :shrink
+                       :node "n5"
+                       :leader "n1"
+                       :before before
+                       :target after
+                       :stage :change-membership
+                       :status :indeterminate}
+        pending (atom pending-value)
+        failure-state (harness/failure-state)
+        subject (worker/wrap-nemesis
+                 failure-state
+                 (membership/->MembershipNemesis :database pending))
+        cleaned? (atom false)]
+    (with-redefs [cluster/await-committed-membership!
+                  (constantly (stable-status before))
+                  client/change-membership!
+                  (fn [& _]
+                    (throw (ex-info "no leader" {:kind :unreachable})))
+                  openraft-db/stop-and-wipe-node!
+                  (fn [& _] (reset! cleaned? true))]
+      (let [value (:value
+                   (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info
+                                     :f :restore-membership}))]
+        (is (= :indeterminate (:status value)))
+        (is (= :request-result-unknown (:reason value)))
+        (is (= :change-membership (:stage value)))
+        (is (= pending-value @pending))
+        (is (false? @cleaned?))
+        (is (nil? (harness/primary-failure failure-state)))))))
+
+(deftest final-restoration-distinguishes-pre-attempt-and-harness-failures
+  (testing "a modeled wait expiry before a request is skipped"
+    (let [failure-state (harness/failure-state)
+          subject (worker/wrap-nemesis
+                   failure-state
+                   (membership/->MembershipNemesis :database (atom nil)))
+          timeout (condition-timeout :committed-membership)]
+      (with-redefs [cluster/await-committed-membership!
+                    (fn [_test] (throw timeout))]
+        (let [value (:value
+                     (nemesis/invoke! subject
+                                      test-config
+                                      {:type :info
+                                       :f :restore-membership}))]
+          (is (= :skipped (:status value)))
+          (is (= :membership-not-ready (:reason value)))
+          (is (nil? (harness/primary-failure failure-state)))))))
+
+  (testing "an unknown wait exception takes the direct Harness path"
+    (let [failure-state (harness/failure-state)
+          error (RuntimeException. "membership wait bug")
+          subject (worker/wrap-nemesis
+                   failure-state
+                   (membership/->MembershipNemesis :database (atom nil)))
+          thrown (with-redefs [cluster/await-committed-membership!
+                               (fn [_test] (throw error))]
+                   (try
+                     (nemesis/invoke! subject
+                                      test-config
+                                      {:type :info
+                                       :f :restore-membership})
+                     nil
+                     (catch Exception e
+                       e)))]
+      (is (identical? error thrown))
+      (is (identical? error
+                      (:throwable
+                       (harness/primary-failure failure-state)))))))
 
 (deftest preserves-the-minimum-membership
   (let [changed? (atom false)
@@ -444,7 +1171,7 @@
                                     test-config
                                     {:type :info
                                      :f :shrink})]
-        (is (= :minimum-membership (:value result)))
+        (is (= (skipped :minimum-membership {}) (:value result)))
         (is (false? @changed?))))))
 
 (deftest membership-package-requires-room-to-change
@@ -468,21 +1195,25 @@
         four-voters (disj all-voters "n5")
         shrink {:type :info
                 :f :grow
-                :value {:change :shrink
-                        :before all-voters
-                        :after four-voters}}
+                :value (installed {:change :shrink
+                                   :node "n5"
+                                   :leader "n1"
+                                   :before all-voters
+                                   :after four-voters})}
         grow {:type :info
               :f :grow
-              :value {:change :grow
-                      :before four-voters
-                      :after all-voters}}
+              :value (installed {:change :grow
+                                 :node "n5"
+                                 :leader "n1"
+                                 :before four-voters
+                                 :after all-voters})}
         restore {:type :info
                  :f :restore-membership
-                 :value {:leader "n1"
-                         :voters all-voters}}
+                 :value (installed {:leader "n1"
+                                    :voters all-voters})}
         recovery {:type :info
                   :f :await-recovery
-                  :value {:leader "n1"}}]
+                  :value (installed {:leader "n1"})}]
     (testing "a resolved change is attributed to its actual fault class"
       (is (:valid? (checker/check subject
                                   test-config
@@ -494,10 +1225,11 @@
                     subject
                     test-config
                     [(assoc shrink
-                            :value {:change :shrink
-                                    :status :indeterminate
-                                    :before all-voters
-                                    :target four-voters})
+                            :value (indeterminate
+                                    :request-result-unknown
+                                    {:change :shrink
+                                     :before all-voters
+                                     :target four-voters}))
                      grow
                      restore
                      recovery]
@@ -510,10 +1242,11 @@
                     subject
                     test-config
                     [(assoc shrink
-                            :value {:change :shrink
-                                    :status :indeterminate
-                                    :before all-voters
-                                    :target four-voters})
+                            :value (indeterminate
+                                    :request-result-unknown
+                                    {:change :shrink
+                                     :before all-voters
+                                     :target four-voters}))
                      grow
                      (assoc-in restore
                                [:value :resolved-change]
@@ -539,8 +1272,9 @@
                                    restore
                                    recovery
                                    (assoc recovery
-                                          :value nil
-                                          :error :timeout)]
+                                          :value (indeterminate
+                                                  :recovery-timeout
+                                                  {}))]
                                   {})]
         (is (false? (:valid? result)))
         (is (false? (:recovered? result)))))
@@ -552,3 +1286,54 @@
                                   {})]
         (is (false? (:valid? result)))
         (is (false? (:restored? result)))))))
+
+(deftest reanalyzes-exact-legacy-membership-history
+  (let [subject (:checker (membership/membership-package
+                           :database
+                           test-config))
+        all-voters (set nodes)
+        four-voters (disj all-voters "n5")
+        shrink {:change :shrink
+                :node "n5"
+                :leader "n1"
+                :before all-voters
+                :after four-voters}
+        grow {:change :grow
+              :node "n5"
+              :leader "n1"
+              :before four-voters
+              :after all-voters}
+        history [{:f :shrink :value shrink}
+                 {:f :restore-membership
+                  :value {:leader "n1"
+                          :voters all-voters
+                          :resolved-change grow}}
+                 {:f :await-recovery :value {:leader "n1"}}]
+        check #(checker/check subject test-config % {})]
+    (testing "exact pre-status change, restore, and recovery shapes remain valid"
+      (is (true? (:valid? (check history)))))
+
+    (testing "explicit status overrides direct legacy-looking change evidence"
+      (doseq [status [:skipped :indeterminate]]
+        (let [result (check (assoc-in history [0 :value :status] status))]
+          (is (false? (:valid? result)) (name status))
+          (is (= [:shrink] (:missing-changes result)) (name status)))))
+
+    (testing "explicit status overrides nested resolved-change evidence"
+      (doseq [status [:skipped :indeterminate]]
+        (let [result (check (assoc-in history
+                                      [1 :value :resolved-change :status]
+                                      status))]
+          (is (false? (:valid? result)) (name status))
+          (is (= [:grow] (:missing-changes result)) (name status)))))
+
+    (testing "explicit restore and recovery status remain authoritative"
+      (doseq [status [:skipped :indeterminate]]
+        (let [restore-result (check (assoc-in history
+                                              [1 :value :status]
+                                              status))
+              recovery-result (check (assoc-in history
+                                               [2 :value :status]
+                                               status))]
+          (is (false? (:restored? restore-result)) (name status))
+          (is (false? (:recovered? recovery-result)) (name status)))))))


### PR DESCRIPTION
## Summary

Membership operations can be accepted asynchronously, rejected before a write,
or leave their effect unknowable. This PR gives the Membership Nemesis explicit
Outcome semantics instead of allowing those cases to be misreported as either
success or a Harness failure.

- report membership actions as `:installed`, `:skipped`, or `:indeterminate`
  with bounded, structured evidence
- preserve attempted-but-unknown membership changes across later recovery work
  instead of demoting them to a less informative result
- treat only modeled progress/readiness conditions as retryable; unexpected
  local exceptions continue to the Harness-failure boundary
- make final membership recovery bounded and state-driven: wait for an
  in-progress change, re-read membership, then continue only when safe
- classify malformed or impossible add-learner responses as indeterminate SUT
  observations, rather than silently accepting or misclassifying them

The checker and final recovery now retain the distinction between confirmed
membership state and an attempted mutation whose effect cannot be known.

## Verification

- `JAVA_CMD=/opt/homebrew/opt/openjdk@26/bin/java make -C jepsen unit-test`
  — 157 tests, 1086 assertions, 0 failures/errors
- `JAVA_CMD=/opt/homebrew/opt/openjdk@26/bin/java make -C jepsen clojure-lint`
  — clj-kondo and cljfmt passed
- `git diff --check upstream/main...HEAD`

Refs #1975

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2016)
<!-- Reviewable:end -->
