### PR TITLE
test: jepsen: finalize error semantics

### DIFF
--- a/jepsen/src/jepsen/openraft/checker.clj
+++ b/jepsen/src/jepsen/openraft/checker.clj
@@ -1,6 +1,7 @@
 (ns jepsen.openraft.checker
   (:require [clojure.java.io :as io]
             [jepsen.checker :as checker]
+            [jepsen.openraft.harness :as harness]
             [jepsen.store :as store]))
 
 ;; Emitted by openraft-test-app's panic hook.
@@ -13,14 +14,62 @@
       {:valid? true
        :seed (:seed test)})))
 
+(defn- escaped-worker-evidence [exceptions]
+  (mapv (fn [exception]
+          (update exception :example #(when % (into {} %))))
+        exceptions))
+
 (defn strict-unhandled-exceptions []
   (let [delegate (checker/unhandled-exceptions)]
     (reify checker/Checker
       (check [_ test history opts]
         (let [result (checker/check delegate test history opts)]
           (if (seq (:exceptions result))
-            (assoc result :valid? :unknown)
+            (assoc result
+                   :valid? false
+                   :escaped-worker-exceptions
+                   (escaped-worker-evidence (:exceptions result)))
             result))))))
+
+(defn- failure-evidence [{:keys [source context throwable]}]
+  {:source source
+   :context context
+   :exception {:class (.getName (class throwable))
+               :message (ex-message throwable)}})
+
+(defrecord HarnessFailureChecker [failure-state delegate strict-checker-key]
+  checker/Checker
+  (check [_ test history opts]
+    (let [{:keys [primary secondary]}
+          (harness/failure-snapshot failure-state)
+          result (checker/check delegate test history opts)
+          strict-evidence
+          (when strict-checker-key
+            (get-in result
+                    [strict-checker-key :escaped-worker-exceptions]))]
+      (if (or primary (seq strict-evidence))
+        (assoc result
+               :valid? false
+               :harness-failure
+               (cond-> {:valid? false}
+                 primary
+                 (assoc :primary (failure-evidence primary)
+                        :secondary (mapv failure-evidence secondary))
+
+                 (seq strict-evidence)
+                 (assoc :strict-fallback
+                        {:escaped-worker-exceptions strict-evidence})))
+        result))))
+
+(defn reject-harness-failures
+  "Rejects recorded Harness failures after retaining aggregate analysis.
+
+  When strict-checker-key is supplied, escaped-worker evidence from that
+  composed child also rejects the final verdict as a post-hoc fallback."
+  ([failure-state delegate]
+   (HarnessFailureChecker. failure-state delegate nil))
+  ([failure-state delegate strict-checker-key]
+   (HarnessFailureChecker. failure-state delegate strict-checker-key)))
 
 (defn- log-matches [pattern node file]
   (with-open [reader (io/reader file)]

--- a/jepsen/src/jepsen/openraft/checker.clj
+++ b/jepsen/src/jepsen/openraft/checker.clj
@@ -2,17 +2,57 @@
   (:require [clojure.java.io :as io]
             [jepsen.checker :as checker]
             [jepsen.openraft.harness :as harness]
+            [jepsen.openraft.interruption :as interruption]
             [jepsen.store :as store]))
 
 ;; Emitted by openraft-test-app's panic hook.
 (def node-panic-pattern
   #"OPENRAFT_JEPSEN_PANIC")
 
+(defn- fatal-throwable? [throwable]
+  (or (instance? ThreadDeath throwable)
+      (instance? VirtualMachineError throwable)))
+
+(defn- checker-exception-evidence [throwable]
+  {:class (.getName (class throwable))
+   :message (ex-message throwable)})
+
+(defn reject-checker-exceptions
+  "Turns non-interruption checker exceptions into Harness evidence.
+
+  The wrapper is suitable for both standalone and composed checkers."
+  [delegate]
+  (reify
+    clojure.lang.ILookup
+    (valAt [_ key]
+      (get delegate key))
+    (valAt [_ key not-found]
+      (get delegate key not-found))
+
+    checker/Checker
+    (check [_ test history opts]
+      (try
+        (checker/check delegate test history opts)
+        (catch Throwable throwable
+          (cond
+            (interruption/interruption? throwable)
+            (do
+              (.interrupt (Thread/currentThread))
+              (throw throwable))
+
+            (fatal-throwable? throwable)
+            (throw throwable)
+
+            :else
+            {:valid? false
+             :checker-exception (checker-exception-evidence throwable)}))))))
+
 (defn random-seed-checker []
-  (reify checker/Checker
-    (check [_ test _history _opts]
-      {:valid? true
-       :seed (:seed test)})))
+  (reject-checker-exceptions
+   (reify checker/Checker
+     (check [_ test _history _opts]
+       {:valid? true
+        :seed (:seed test)}))))
 
 (defn- escaped-worker-evidence [exceptions]
   (mapv (fn [exception]
@@ -21,15 +61,16 @@
 
 (defn strict-unhandled-exceptions []
   (let [delegate (checker/unhandled-exceptions)]
-    (reify checker/Checker
-      (check [_ test history opts]
-        (let [result (checker/check delegate test history opts)]
-          (if (seq (:exceptions result))
-            (assoc result
-                   :valid? false
-                   :escaped-worker-exceptions
-                   (escaped-worker-evidence (:exceptions result)))
-            result))))))
+    (reject-checker-exceptions
+     (reify checker/Checker
+       (check [_ test history opts]
+         (let [result (checker/check delegate test history opts)]
+           (if (seq (:exceptions result))
+             (assoc result
+                    :valid? false
+                    :escaped-worker-exceptions
+                    (escaped-worker-evidence (:exceptions result)))
+             result)))))))
 
 (defn- failure-evidence [{:keys [source context throwable]}]
   {:source source
@@ -81,27 +122,28 @@
           (line-seq reader))))
 
 (defn required-log-file-pattern [pattern filename]
-  (reify checker/Checker
-    (check [_ test _history _opts]
-      (let [node-files (mapv (fn [node]
-                               [node (store/path test node filename)])
-                             (:nodes test))
-            missing-nodes (->> node-files
-                               (remove (fn [[_ file]]
-                                         (.isFile ^java.io.File file)))
-                               (mapv first))
-            matches (->> node-files
-                         (filter (fn [[_ file]]
-                                   (.isFile ^java.io.File file)))
-                         (mapcat (fn [[node file]]
-                                   (log-matches pattern node file)))
-                         vec)
-            valid? (cond
-                     (seq matches) false
-                     (seq missing-nodes) :unknown
-                     :else true)]
-        {:valid? valid?
-         :filename filename
-         :missing-nodes missing-nodes
-         :count (count matches)
-         :matches matches}))))
+  (reject-checker-exceptions
+   (reify checker/Checker
+     (check [_ test _history _opts]
+       (let [node-files (mapv (fn [node]
+                                [node (store/path test node filename)])
+                              (:nodes test))
+             missing-nodes (->> node-files
+                                (remove (fn [[_ file]]
+                                          (.isFile ^java.io.File file)))
+                                (mapv first))
+             matches (->> node-files
+                          (filter (fn [[_ file]]
+                                    (.isFile ^java.io.File file)))
+                          (mapcat (fn [[node file]]
+                                    (log-matches pattern node file)))
+                          vec)
+             valid? (cond
+                      (seq matches) false
+                      (seq missing-nodes) :unknown
+                      :else true)]
+         {:valid? valid?
+          :filename filename
+          :missing-nodes missing-nodes
+          :count (count matches)
+          :matches matches})))))

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -108,6 +108,7 @@
         nemesis-types (normalize-nemeses (:nemesis opts))
         nemesis-package
         (openraft-nemesis/compose-packages
+         failure-state
          (mapv (fn [nemesis-type]
                  (case nemesis-type
                    :partition
@@ -134,15 +135,18 @@
                                             (:time-limit opts)
                                             workload
                                             nemesis-package)
-            :checker (checker/compose
-                      {:seed (openraft-checker/random-seed-checker)
-                       :stats (checker/stats)
-                       :exceptions (openraft-checker/strict-unhandled-exceptions)
-                       :crash (openraft-checker/required-log-file-pattern
-                               openraft-checker/node-panic-pattern
-                               "openraft.log")
-                       :nemesis (:checker nemesis-package)
-                       :workload (:checker workload)})})))
+            :checker (openraft-checker/reject-harness-failures
+                      failure-state
+                      (checker/compose
+                       {:seed (openraft-checker/random-seed-checker)
+                        :stats (checker/stats)
+                        :exceptions (openraft-checker/strict-unhandled-exceptions)
+                        :crash (openraft-checker/required-log-file-pattern
+                                openraft-checker/node-panic-pattern
+                                "openraft.log")
+                        :nemesis (:checker nemesis-package)
+                        :workload (:checker workload)})
+                      :exceptions)})))
 
 (defn -main [& args]
   (cli/run! (cli/single-test-cmd {:test-fn openraft-test

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -127,7 +127,7 @@
            opts
            {:name (str "openraft linearizable registers "
                        (str/join "," (map name nemesis-types)))
-            :db database
+            :db (worker/wrap-db failure-state database)
             :client (worker/wrap-client failure-state (:client workload))
             :nemesis (worker/wrap-nemesis failure-state
                                           (:nemesis nemesis-package))

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -135,18 +135,22 @@
                                             (:time-limit opts)
                                             workload
                                             nemesis-package)
-            :checker (openraft-checker/reject-harness-failures
-                      failure-state
-                      (checker/compose
-                       {:seed (openraft-checker/random-seed-checker)
-                        :stats (checker/stats)
-                        :exceptions (openraft-checker/strict-unhandled-exceptions)
-                        :crash (openraft-checker/required-log-file-pattern
-                                openraft-checker/node-panic-pattern
-                                "openraft.log")
-                        :nemesis (:checker nemesis-package)
-                        :workload (:checker workload)})
-                      :exceptions)})))
+            :checker (openraft-checker/reject-checker-exceptions
+                      (openraft-checker/reject-harness-failures
+                       failure-state
+                       (openraft-checker/reject-checker-exceptions
+                        (checker/compose
+                         {:seed (openraft-checker/random-seed-checker)
+                          :stats (openraft-checker/reject-checker-exceptions
+                                  (checker/stats))
+                          :exceptions
+                          (openraft-checker/strict-unhandled-exceptions)
+                          :crash (openraft-checker/required-log-file-pattern
+                                  openraft-checker/node-panic-pattern
+                                  "openraft.log")
+                          :nemesis (:checker nemesis-package)
+                          :workload (:checker workload)}))
+                       :exceptions))})))
 
 (defn -main [& args]
   (cli/run! (cli/single-test-cmd {:test-fn openraft-test

--- a/jepsen/src/jepsen/openraft/harness.clj
+++ b/jepsen/src/jepsen/openraft/harness.clj
@@ -2,21 +2,41 @@
   (:require [jepsen.openraft.interruption :as interruption]))
 
 (defn failure-state
-  "Creates run-scoped state for the primary Harness failure."
+  "Creates run-scoped state for Harness failures."
   []
-  (atom nil))
+  (atom {:primary nil
+         :secondary []}))
 
 (defn primary-failure
   "Returns the first recorded Harness failure, or nil."
   [state]
+  (:primary @state))
+
+(defn secondary-failures
+  "Returns Harness failures recorded after the primary failure."
+  [state]
+  (:secondary @state))
+
+(defn failure-snapshot
+  "Returns an immutable snapshot of all recorded Harness failures."
+  [state]
   @state)
 
 (defn record-failure!
-  "Atomically records the first non-interruption Harness failure."
+  "Atomically records a non-interruption Harness failure.
+
+  Returns true only when this call records the primary failure. Later failures
+  are retained as secondary diagnostic evidence."
   [state source context throwable]
-  (and (not (interruption/interruption? throwable))
-       (compare-and-set! state
-                         nil
-                         {:source source
-                          :context context
-                          :throwable throwable})))
+  (if (interruption/interruption? throwable)
+    false
+    (let [failure {:source source
+                   :context context
+                   :throwable throwable}
+          [before _]
+          (swap-vals! state
+                      (fn [{:keys [primary] :as failures}]
+                        (if primary
+                          (update failures :secondary conj failure)
+                          (assoc failures :primary failure))))]
+      (nil? (:primary before)))))

--- a/jepsen/src/jepsen/openraft/nemesis.clj
+++ b/jepsen/src/jepsen/openraft/nemesis.clj
@@ -8,7 +8,8 @@
             [jepsen.openraft.await :as await]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.interruption :as interruption]
-            [jepsen.openraft.nemesis.outcome :as outcome]))
+            [jepsen.openraft.nemesis.outcome :as outcome]
+            [jepsen.openraft.worker :as worker]))
 
 (def ^:private initial-healthy-seconds 5)
 (def ^:private retry-interval-seconds 1)
@@ -190,21 +191,32 @@
 
 (defn compose-packages
   "Composes interval-bearing fault packages and confirms final recovery."
-  [packages]
-  (when-not (seq packages)
-    (throw (ex-info "At least one nemesis package is required" {})))
-  (let [packages (->> packages
-                      (mapv #(assoc % :perf (or (:perf %) #{})))
-                      cleanup-order
-                      (mapv schedule-package))
-        composed (combined/compose-packages
-                  (conj packages (recovery-package)))
-        checkers (into {}
-                       (map (fn [{:keys [name checker]}]
-                              [name (fault-class-checker checker)])
-                            packages))]
-    (assoc composed
-           :nemesis (nemesis/validate (:nemesis composed))
-           :checker (if (= 1 (count packages))
-                      (:checker (first packages))
-                      (checker/compose checkers)))))
+  ([packages]
+   (compose-packages nil packages))
+  ([failure-state packages]
+   (when-not (seq packages)
+     (throw (ex-info "At least one nemesis package is required" {})))
+   (let [packages (->> packages
+                       (mapv (fn [{:keys [name] :as package}]
+                               (cond-> (assoc package
+                                              :perf
+                                              (or (:perf package) #{}))
+                                 failure-state
+                                 (update :nemesis
+                                         #(worker/wrap-nemesis-teardown
+                                           failure-state
+                                           name
+                                           %)))))
+                       cleanup-order
+                       (mapv schedule-package))
+         composed (combined/compose-packages
+                   (conj packages (recovery-package)))
+         checkers (into {}
+                        (map (fn [{:keys [name checker]}]
+                               [name (fault-class-checker checker)])
+                             packages))]
+     (assoc composed
+            :nemesis (nemesis/validate (:nemesis composed))
+            :checker (if (= 1 (count packages))
+                       (:checker (first packages))
+                       (checker/compose checkers))))))

--- a/jepsen/src/jepsen/openraft/nemesis.clj
+++ b/jepsen/src/jepsen/openraft/nemesis.clj
@@ -6,6 +6,7 @@
              [random :as random]]
             [jepsen.nemesis.combined :as combined]
             [jepsen.openraft.await :as await]
+            [jepsen.openraft.checker :as openraft-checker]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.interruption :as interruption]
             [jepsen.openraft.nemesis.outcome :as outcome]
@@ -153,26 +154,27 @@
    :perf #{}})
 
 (defn- fault-class-checker [fault-checker]
-  (reify checker/Checker
-    (check [_ test history opts]
-      (let [result (checker/check fault-checker test history opts)
-            observed (or (:observed-modes result)
-                         (:observed-changes result))
-            executed? (boolean (seq observed))
-            cluster-state (:cluster-state result)
-            valid? (cond
-                     (not executed?) false
-                     (pos? (or (:error-count result) 0)) false
-                     (contains? result :restored?)
-                     (and (:restored? result)
-                          (:recovered? result))
-                     (= :intact cluster-state) true
-                     (= :unknown cluster-state) :unknown
-                     :else false)]
-        (-> result
-            (dissoc :missing-modes :missing-changes)
-            (assoc :valid? valid?
-                   :fault-class-executed? executed?))))))
+  (openraft-checker/reject-checker-exceptions
+   (reify checker/Checker
+     (check [_ test history opts]
+       (let [result (checker/check fault-checker test history opts)
+             observed (or (:observed-modes result)
+                          (:observed-changes result))
+             executed? (boolean (seq observed))
+             cluster-state (:cluster-state result)
+             valid? (cond
+                      (not executed?) false
+                      (pos? (or (:error-count result) 0)) false
+                      (contains? result :restored?)
+                      (and (:restored? result)
+                           (:recovered? result))
+                      (= :intact cluster-state) true
+                      (= :unknown cluster-state) :unknown
+                      :else false)]
+         (-> result
+             (dissoc :missing-modes :missing-changes)
+             (assoc :valid? valid?
+                    :fault-class-executed? executed?)))))))
 
 (defn- cleanup-order [packages]
   (let [membership? #(= :membership (:name %))]
@@ -219,4 +221,5 @@
             :nemesis (nemesis/validate (:nemesis composed))
             :checker (if (= 1 (count packages))
                        (:checker (first packages))
-                       (checker/compose checkers))))))
+                       (openraft-checker/reject-checker-exceptions
+                        (checker/compose checkers)))))))

--- a/jepsen/src/jepsen/openraft/nemesis/membership.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/membership.clj
@@ -6,6 +6,7 @@
              [random :as random]]
             [jepsen.openraft.await :as await]
             [jepsen.openraft [client :as client]
+             [checker :as openraft-checker]
              [cluster :as cluster]
              [db :as openraft-db]]
             [jepsen.openraft.nemesis.outcome :as outcome]
@@ -1070,4 +1071,5 @@
    :generator (membership-generator)
    :final-generator {:type :info
                      :f :restore-membership}
-   :checker (coverage-checker)})
+   :checker (openraft-checker/reject-checker-exceptions
+             (coverage-checker))})

--- a/jepsen/src/jepsen/openraft/nemesis/partition.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/partition.clj
@@ -5,6 +5,7 @@
              [nemesis :as nemesis]
              [random :as random]]
             [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.checker :as openraft-checker]
             [jepsen.openraft.interruption :as interruption]
             [jepsen.openraft.nemesis.outcome :as outcome]
             [jepsen.openraft.quorum :as quorum]))
@@ -221,4 +222,5 @@
    :generator (partition-generator)
    :final-generator {:type :info
                      :f :stop-partition}
-   :checker (coverage-checker)})
+   :checker (openraft-checker/reject-checker-exceptions
+             (coverage-checker))})

--- a/jepsen/src/jepsen/openraft/nemesis/partition.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/partition.clj
@@ -1,5 +1,5 @@
 (ns jepsen.openraft.nemesis.partition
-  (:require [clojure.tools.logging :refer [info warn]]
+  (:require [clojure.tools.logging :refer [info]]
             [jepsen [checker :as checker]
              [generator :as gen]
              [nemesis :as nemesis]
@@ -107,13 +107,9 @@
     (try
       (nemesis/teardown! partitioner test)
       (catch Exception e
-        (if (interruption/interruption? e)
-          (do
-            (.interrupt (Thread/currentThread))
-            (throw e))
-          (warn e
-                "Failed to heal network partition during teardown"
-                {:nodes (:nodes test)})))))
+        (when (interruption/interruption? e)
+          (.interrupt (Thread/currentThread)))
+        (throw e))))
 
   nemesis/Reflection
   (fs [_]

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -6,6 +6,7 @@
              [random :as random]]
             [jepsen.nemesis.combined :as combined]
             [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.checker :as openraft-checker]
             [jepsen.openraft.interruption :as interruption]
             [jepsen.openraft.nemesis.outcome :as outcome]
             [jepsen.openraft.quorum :as quorum]
@@ -495,7 +496,8 @@
    :generator (process-generator)
    :final-generator {:type :info
                      :f :restart-process}
-   :checker (coverage-checker)})
+   :checker (openraft-checker/reject-checker-exceptions
+             (coverage-checker))})
 
 (defn- next-pause-state [expected-nodes state op]
   (let [error? (operation-error? op)
@@ -548,4 +550,5 @@
    :generator (pause-generator)
    :final-generator {:type :info
                      :f :resume-process}
-   :checker (pause-coverage-checker)})
+   :checker (openraft-checker/reject-checker-exceptions
+             (pause-coverage-checker))})

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -1,5 +1,5 @@
 (ns jepsen.openraft.nemesis.process
-  (:require [clojure.tools.logging :refer [info warn]]
+  (:require [clojure.tools.logging :refer [info]]
             [jepsen [checker :as checker]
              [generator :as gen]
              [nemesis :as nemesis]
@@ -8,7 +8,8 @@
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.interruption :as interruption]
             [jepsen.openraft.nemesis.outcome :as outcome]
-            [jepsen.openraft.quorum :as quorum]))
+            [jepsen.openraft.quorum :as quorum]
+            [jepsen.openraft.worker :as worker]))
 
 (def downtime-seconds 10)
 (def required-process-modes
@@ -305,16 +306,16 @@
                        {:type :info
                         :f :resume
                         :value (:nodes test)})
-      (catch Exception e
-        (if (interruption/interruption? e)
-          (do
-            (.interrupt (Thread/currentThread))
-            (throw e))
-          (warn e
-                "Failed to resume OpenRaft processes during teardown"
-                {:nodes (:nodes test)})))
-      (finally
-        (nemesis/teardown! delegate test))))
+      (catch Throwable throwable
+        (worker/handle-teardown-failure!
+         {:action :resume-processes}
+         throwable)))
+    (try
+      (nemesis/teardown! delegate test)
+      (catch Throwable throwable
+        (worker/handle-teardown-failure!
+         {:action :delegate-teardown}
+         throwable))))
 
   nemesis/Reflection
   (fs [_]

--- a/jepsen/src/jepsen/openraft/worker.clj
+++ b/jepsen/src/jepsen/openraft/worker.clj
@@ -1,6 +1,7 @@
 (ns jepsen.openraft.worker
   (:require [clojure.tools.logging :refer [error]]
             [jepsen [client :as client]
+             [db :as db]
              [nemesis :as nemesis]]
             [jepsen.openraft.harness :as harness]
             [jepsen.openraft.interruption :as interruption]))
@@ -10,7 +11,9 @@
   (try
     (f)
     (catch Throwable throwable
-      (harness/record-failure! failure-state source context throwable)
+      (if (interruption/interruption? throwable)
+        (.interrupt (Thread/currentThread))
+        (harness/record-failure! failure-state source context throwable))
       (throw throwable))))
 
 (def ^:dynamic ^:private *teardown-failure-handler* nil)
@@ -81,7 +84,12 @@
                                #(client/open! delegate test node))))
 
     (setup! [_ test]
-      (wrap-client failure-state (client/setup! delegate test)))
+      (wrap-client
+       failure-state
+       (call-recording-failure failure-state
+                               :client
+                               {:phase :setup}
+                               #(client/setup! delegate test))))
 
     (invoke! [_ test op]
       (call-recording-failure failure-state
@@ -108,7 +116,12 @@
   [failure-state delegate]
   (reify nemesis/Nemesis
     (setup! [_ test]
-      (wrap-nemesis failure-state (nemesis/setup! delegate test)))
+      (wrap-nemesis
+       failure-state
+       (call-recording-failure failure-state
+                               :nemesis
+                               {:phase :setup}
+                               #(nemesis/setup! delegate test))))
 
     (invoke! [_ test op]
       (call-recording-failure failure-state
@@ -123,6 +136,42 @@
                                 :component :composed-nemesis
                                 :nodes (:nodes test)}
                                #(nemesis/teardown! delegate test)))))
+
+(defn wrap-db
+  "Records failures from the OpenRaft DB lifecycle and control boundaries."
+  [failure-state delegate]
+  (reify db/DB
+    (setup! [_ test node]
+      (call-recording-failure failure-state
+                              :db
+                              {:phase :setup
+                               :node node}
+                              #(db/setup! delegate test node)))
+
+    (teardown! [_ test node]
+      (call-recording-failure failure-state
+                              :db
+                              {:phase :teardown
+                               :node node}
+                              #(db/teardown! delegate test node)))
+
+    db/Kill
+    (kill! [_ test node]
+      (db/kill! delegate test node))
+
+    (start! [_ test node]
+      (db/start! delegate test node))
+
+    db/Pause
+    (pause! [_ test node]
+      (db/pause! delegate test node))
+
+    (resume! [_ test node]
+      (db/resume! delegate test node))
+
+    db/LogFiles
+    (log-files [_ test node]
+      (db/log-files delegate test node))))
 
 (defn wrap-nemesis-teardown
   "Records and contains a package's non-interruption teardown failures."

--- a/jepsen/src/jepsen/openraft/worker.clj
+++ b/jepsen/src/jepsen/openraft/worker.clj
@@ -1,7 +1,9 @@
 (ns jepsen.openraft.worker
-  (:require [jepsen [client :as client]
+  (:require [clojure.tools.logging :refer [error]]
+            [jepsen [client :as client]
              [nemesis :as nemesis]]
-            [jepsen.openraft.harness :as harness]))
+            [jepsen.openraft.harness :as harness]
+            [jepsen.openraft.interruption :as interruption]))
 
 (defn- call-recording-failure
   [failure-state source context f]
@@ -10,6 +12,60 @@
     (catch Throwable throwable
       (harness/record-failure! failure-state source context throwable)
       (throw throwable))))
+
+(def ^:dynamic ^:private *teardown-failure-handler* nil)
+
+(defn- fatal-throwable? [throwable]
+  (or (instance? ThreadDeath throwable)
+      (instance? VirtualMachineError throwable)))
+
+(defn handle-teardown-failure!
+  "Records a teardown stage failure when a package guard is active.
+
+  Outside guarded package teardown, the original Throwable is rethrown."
+  [context throwable]
+  (cond
+    (interruption/interruption? throwable)
+    (do
+      (.interrupt (Thread/currentThread))
+      (throw throwable))
+
+    (fatal-throwable? throwable)
+    (throw throwable)
+
+    *teardown-failure-handler*
+    (*teardown-failure-handler* context throwable)
+
+    :else
+    (throw throwable)))
+
+(defn- log-teardown-failure [context throwable]
+  (error throwable "OpenRaft Nemesis teardown failed" context))
+
+(defn- call-recording-teardown
+  [failure-state context f]
+  (binding [*teardown-failure-handler*
+            (fn [stage-context throwable]
+              (let [context (merge context stage-context)]
+                (harness/record-failure! failure-state
+                                         :nemesis
+                                         context
+                                         throwable)
+                (try
+                  (log-teardown-failure context throwable)
+                  (catch Throwable logging-failure
+                    (if (or (interruption/interruption? logging-failure)
+                            (fatal-throwable? logging-failure))
+                      (handle-teardown-failure! {} logging-failure)
+                      (harness/record-failure!
+                       failure-state
+                       :nemesis
+                       (assoc context :diagnostic :failure-log)
+                       logging-failure))))))]
+    (try
+      (f)
+      (catch Throwable throwable
+        (handle-teardown-failure! {} throwable)))))
 
 (defn wrap-client
   "Records failures from Client worker lifecycle and invocation boundaries."
@@ -48,7 +104,7 @@
       (client/is-reusable? delegate test))))
 
 (defn wrap-nemesis
-  "Records failures from the Nemesis worker invocation boundary."
+  "Records failures from Nemesis worker and teardown boundaries."
   [failure-state delegate]
   (reify nemesis/Nemesis
     (setup! [_ test]
@@ -62,4 +118,31 @@
                               #(nemesis/invoke! delegate test op)))
 
     (teardown! [_ test]
-      (nemesis/teardown! delegate test))))
+      (call-recording-teardown failure-state
+                               {:phase :teardown
+                                :component :composed-nemesis
+                                :nodes (:nodes test)}
+                               #(nemesis/teardown! delegate test)))))
+
+(defn wrap-nemesis-teardown
+  "Records and contains a package's non-interruption teardown failures."
+  [failure-state component delegate]
+  (reify nemesis/Nemesis
+    (setup! [_ test]
+      (wrap-nemesis-teardown failure-state
+                             component
+                             (nemesis/setup! delegate test)))
+
+    (invoke! [_ test op]
+      (nemesis/invoke! delegate test op))
+
+    (teardown! [_ test]
+      (call-recording-teardown failure-state
+                               {:phase :teardown
+                                :component component
+                                :nodes (:nodes test)}
+                               #(nemesis/teardown! delegate test)))
+
+    nemesis/Reflection
+    (fs [_]
+      (nemesis/fs delegate))))

--- a/jepsen/src/jepsen/openraft/workload.clj
+++ b/jepsen/src/jepsen/openraft/workload.clj
@@ -6,6 +6,7 @@
              [independent :as independent]
              [random :as random]]
             [jepsen.openraft.client :as http]
+            [jepsen.openraft.checker :as openraft-checker]
             [jepsen.openraft.interruption :as interruption]
             [knossos.model :as model]))
 
@@ -304,11 +305,19 @@
                   bootstrap
                   (gen/stagger 0.1 operations)))
      :final-generator (gen/clients final)
-     :checker (checker/compose
-               {:linearizable (independent/checker
-                               (checker/linearizable
-                                {:model (model/cas-register)}))
-                :meaningful-operations (meaningful-operations-checker)
-                :final-workload (final-workload-checker)
-                :unexpected-sut-responses
-                (unexpected-sut-responses-checker)})}))
+     :checker (openraft-checker/reject-checker-exceptions
+               (checker/compose
+                {:linearizable
+                 (openraft-checker/reject-checker-exceptions
+                  (independent/checker
+                   (checker/linearizable
+                    {:model (model/cas-register)})))
+                 :meaningful-operations
+                 (openraft-checker/reject-checker-exceptions
+                  (meaningful-operations-checker))
+                 :final-workload
+                 (openraft-checker/reject-checker-exceptions
+                  (final-workload-checker))
+                 :unexpected-sut-responses
+                 (openraft-checker/reject-checker-exceptions
+                  (unexpected-sut-responses-checker))}))}))

--- a/jepsen/test/jepsen/openraft/checker_test.clj
+++ b/jepsen/test/jepsen/openraft/checker_test.clj
@@ -14,6 +14,11 @@
       (swap! calls inc)
       result)))
 
+(defn- throwing-checker [throwable]
+  (reify checker/Checker
+    (check [_ _test _history _opts]
+      (throw throwable))))
+
 (def ^:private escaped-worker-op
   {:type :info
    :f :read
@@ -26,6 +31,37 @@
                         {:seed 41}
                         (history/history [])
                         {}))))
+
+(deftest checker-exceptions-reject-standalone-and-composed-checkers
+  (let [throwable (RuntimeException. "checker failed")
+        subject (openraft-checker/reject-checker-exceptions
+                 (throwing-checker throwable))
+        expected {:valid? false
+                  :checker-exception
+                  {:class "java.lang.RuntimeException"
+                   :message "checker failed"}}
+        standalone (checker/check subject {} (history/history []) {})
+        composed (checker/check (checker/compose {:subject subject})
+                                {}
+                                (history/history [])
+                                {})]
+    (is (= expected standalone))
+    (is (= expected (:subject composed)))
+    (is (false? (:valid? composed)))))
+
+(deftest checker-interruptions-propagate
+  (let [throwable (InterruptedException. "cancelled")
+        subject (openraft-checker/reject-checker-exceptions
+                 (throwing-checker throwable))]
+    (try
+      (let [thrown (try
+                     (checker/check subject {} (history/history []) {})
+                     nil
+                     (catch Throwable throwable
+                       throwable))]
+        (is (identical? throwable thrown)))
+      (finally
+        (Thread/interrupted)))))
 
 (deftest reports-unhandled-worker-exceptions
   (let [subject (openraft-checker/strict-unhandled-exceptions)

--- a/jepsen/test/jepsen/openraft/checker_test.clj
+++ b/jepsen/test/jepsen/openraft/checker_test.clj
@@ -1,10 +1,23 @@
 (ns jepsen.openraft.checker-test
-  (:require [clojure.java.io :as io]
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.test :refer [deftest is testing]]
             [jepsen.checker :as checker]
             [jepsen.history :as history]
             [jepsen.openraft.checker :as openraft-checker]
+            [jepsen.openraft.harness :as harness]
             [jepsen.store :as store]))
+
+(defn- result-checker [calls result]
+  (reify checker/Checker
+    (check [_ _test _history _opts]
+      (swap! calls inc)
+      result)))
+
+(def ^:private escaped-worker-op
+  {:type :info
+   :f :read
+   :exception {:via [{:type 'java.lang.IllegalStateException}]}})
 
 (deftest records-the-random-seed
   (is (= {:valid? true
@@ -16,19 +29,183 @@
 
 (deftest reports-unhandled-worker-exceptions
   (let [subject (openraft-checker/strict-unhandled-exceptions)
-        op {:type :info
-            :f :read
-            :exception {:via [{:type 'java.lang.IllegalStateException}]}}
-        result (checker/check subject {} (history/history [op]) {})
+        result (checker/check subject
+                              {}
+                              (history/history [escaped-worker-op])
+                              {})
         exception (first (:exceptions result))]
-    (is (= :unknown (:valid? result)))
+    (is (false? (:valid? result)))
     (is (= {:count 1
             :class 'java.lang.IllegalStateException}
            (select-keys exception [:count :class])))
-    (is (true? (:valid? (checker/check subject
-                                       {}
-                                       (history/history [])
-                                       {}))))))
+    (let [escaped (:escaped-worker-exceptions result)]
+      (is (= (select-keys exception [:count :class])
+             (select-keys (first escaped) [:count :class])))
+      (is (= escaped (edn/read-string (pr-str escaped)))))
+    (let [clean-result (checker/check subject
+                                      {}
+                                      (history/history [])
+                                      {})]
+      (is (true? (:valid? clean-result)))
+      (is (not (contains? clean-result :escaped-worker-exceptions))))))
+
+(deftest preserves-results-without-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        calls (atom 0)
+        expected {:valid? :unknown
+                  :workload {:valid? true}
+                  :nemesis {:valid? :unknown}}
+        subject (openraft-checker/reject-harness-failures
+                 failure-state
+                 (result-checker calls expected))
+        result (checker/check subject {} (history/history []) {})]
+    (is (identical? expected result))
+    (is (= 1 @calls))
+    (is (not (contains? result :harness-failure)))))
+
+(deftest rejects-recorded-harness-failures-after-analysis
+  (doseq [delegate-verdict [true :unknown]]
+    (testing (str "delegate verdict " delegate-verdict)
+      (let [failure-state (harness/failure-state)
+            primary (ex-info "teardown failed" {:unsafe (Object.)})
+            secondary (RuntimeException. "logging failed")
+            calls (atom 0)
+            nested {:workload {:valid? false
+                               :counterexample [{:f :write}]}
+                    :nemesis {:valid? true
+                              :observed-modes [:partition]}}
+            delegate-result (assoc nested :valid? delegate-verdict)
+            _ (harness/record-failure!
+               failure-state
+               :nemesis
+               {:phase :teardown
+                :component :partition}
+               primary)
+            _ (harness/record-failure!
+               failure-state
+               :nemesis
+               {:phase :teardown
+                :diagnostic :failure-log}
+               secondary)
+            result (checker/check
+                    (openraft-checker/reject-harness-failures
+                     failure-state
+                     (result-checker calls delegate-result))
+                    {}
+                    (history/history [])
+                    {})
+            evidence (:harness-failure result)]
+        (is (false? (:valid? result)))
+        (is (= nested (select-keys result [:workload :nemesis])))
+        (is (= 1 @calls))
+        (is (= {:valid? false
+                :primary
+                {:source :nemesis
+                 :context {:phase :teardown
+                           :component :partition}
+                 :exception
+                 {:class "clojure.lang.ExceptionInfo"
+                  :message "teardown failed"}}
+                :secondary
+                [{:source :nemesis
+                  :context {:phase :teardown
+                            :diagnostic :failure-log}
+                  :exception
+                  {:class "java.lang.RuntimeException"
+                   :message "logging failed"}}]}
+               evidence))
+        (is (= evidence (edn/read-string (pr-str evidence))))))))
+
+(deftest rejects-strict-fallback-without-mutating-runtime-state
+  (let [failure-state (harness/failure-state)
+        workload-result {:valid? true
+                         :details {:reads 4}}
+        aggregate (checker/compose
+                   {:exceptions
+                    (openraft-checker/strict-unhandled-exceptions)
+                    :workload (result-checker (atom 0) workload-result)})
+        result (checker/check
+                (openraft-checker/reject-harness-failures
+                 failure-state
+                 aggregate
+                 :exceptions)
+                {}
+                (history/history [escaped-worker-op])
+                {})
+        strict-result (:exceptions result)
+        escaped (:escaped-worker-exceptions strict-result)]
+    (is (false? (:valid? result)))
+    (is (= workload-result (:workload result)))
+    (is (false? (:valid? strict-result)))
+    (is (seq escaped))
+    (is (= {:valid? false
+            :strict-fallback {:escaped-worker-exceptions escaped}}
+           (:harness-failure result)))
+    (is (nil? (harness/primary-failure failure-state)))
+    (is (empty? (harness/secondary-failures failure-state)))))
+
+(deftest preserves-direct-and-strict-harness-diagnostics
+  (let [failure-state (harness/failure-state)
+        primary (RuntimeException. "client failed")
+        secondary (RuntimeException. "cleanup failed")
+        workload-result {:valid? false
+                         :counterexample [{:f :write :value 1}]}
+        aggregate (checker/compose
+                   {:exceptions
+                    (openraft-checker/strict-unhandled-exceptions)
+                    :workload (result-checker (atom 0) workload-result)})
+        _ (harness/record-failure!
+           failure-state :client {:operation :write} primary)
+        _ (harness/record-failure!
+           failure-state :nemesis {:phase :teardown} secondary)
+        result (checker/check
+                (openraft-checker/reject-harness-failures
+                 failure-state
+                 aggregate
+                 :exceptions)
+                {}
+                (history/history [escaped-worker-op])
+                {})
+        strict-result (:exceptions result)
+        evidence (:harness-failure result)]
+    (is (false? (:valid? result)))
+    (is (= workload-result (:workload result)))
+    (is (= {:source :client
+            :context {:operation :write}
+            :exception {:class "java.lang.RuntimeException"
+                        :message "client failed"}}
+           (:primary evidence)))
+    (is (= [{:source :nemesis
+             :context {:phase :teardown}
+             :exception {:class "java.lang.RuntimeException"
+                         :message "cleanup failed"}}]
+           (:secondary evidence)))
+    (is (= {:escaped-worker-exceptions
+            (:escaped-worker-exceptions strict-result)}
+           (:strict-fallback evidence)))
+    (is (false? (:valid? strict-result)))
+    (is (= (select-keys (first (:exceptions strict-result)) [:count :class])
+           (select-keys
+            (first (:escaped-worker-exceptions strict-result))
+            [:count :class])))
+    (is (= evidence (edn/read-string (pr-str evidence))))))
+
+(deftest does-not-reject-interruption
+  (let [failure-state (harness/failure-state)
+        expected {:valid? true}]
+    (is (false? (harness/record-failure!
+                 failure-state
+                 :nemesis
+                 {:phase :teardown}
+                 (InterruptedException. "cancelled"))))
+    (is (= expected
+           (checker/check
+            (openraft-checker/reject-harness-failures
+             failure-state
+             (result-checker (atom 0) expected))
+            {}
+            (history/history [])
+            {})))))
 
 (deftest checks-downloaded-logs-for-node-panics
   (let [^java.io.File temp-dir

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -103,6 +103,7 @@
                   (fn [state packages]
                     (swap! composition-states conj state)
                     (compose-packages state packages))
+                  worker/wrap-db (wrap :db)
                   worker/wrap-client (wrap :client)
                   worker/wrap-nemesis (wrap :nemesis)
                   openraft-checker/reject-harness-failures
@@ -118,7 +119,7 @@
       (cli/openraft-test {:nemesis :partition
                           :nodes ["n1" "n2" "n3"]
                           :time-limit 10}))
-    (is (= [:client :nemesis] (mapv first @wrapped-states)))
+    (is (= [:db :client :nemesis] (mapv first @wrapped-states)))
     (is (every? #(identical? failure-state (second %))
                 @wrapped-states))
     (is (= 1 (count @stopped-states)))

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -3,10 +3,12 @@
             [clojure.tools.cli :as tools-cli]
             [jepsen.generator :as gen]
             [jepsen.generator.test :as gen-test]
+            [jepsen.openraft.checker :as openraft-checker]
             [jepsen.openraft.cli :as cli]
             [jepsen.openraft.db :as openraft-db]
             [jepsen.openraft.generator :as openraft-generator]
             [jepsen.openraft.harness :as harness]
+            [jepsen.openraft.nemesis :as openraft-nemesis]
             [jepsen.openraft.worker :as worker]
             [jepsen.random :as random]))
 
@@ -74,7 +76,7 @@
   (let [test (cli/openraft-test {:nemesis [:membership :partition]
                                  :nodes ["n1" "n2" "n3" "n4" "n5"]
                                  :time-limit 10})
-        checkers (get-in test [:checker :checkers])
+        checkers (get-in test [:checker :delegate :checkers])
         nemesis-checkers (get-in checkers [:nemesis :checkers])]
     (is (= #{:seed :stats :exceptions :crash :nemesis :workload}
            (set (keys checkers))))
@@ -86,6 +88,9 @@
         wrapped-states (atom [])
         stopped-states (atom [])
         pending-states (atom [])
+        composition-states (atom [])
+        checker-states (atom [])
+        compose-packages openraft-nemesis/compose-packages
         wrap (fn [source]
                (fn [state delegate]
                  (swap! wrapped-states conj [source state])
@@ -94,8 +99,17 @@
                (swap! stopped-states conj state)
                generator)]
     (with-redefs [harness/failure-state (constantly failure-state)
+                  openraft-nemesis/compose-packages
+                  (fn [state packages]
+                    (swap! composition-states conj state)
+                    (compose-packages state packages))
                   worker/wrap-client (wrap :client)
                   worker/wrap-nemesis (wrap :nemesis)
+                  openraft-checker/reject-harness-failures
+                  (fn [state delegate strict-checker-key]
+                    (swap! checker-states conj
+                           [state strict-checker-key])
+                    delegate)
                   openraft-generator/stop-on-harness-failure stop
                   openraft-generator/pending-on-harness-failure
                   (fn [state generator]
@@ -110,7 +124,12 @@
     (is (= 1 (count @stopped-states)))
     (is (identical? failure-state (first @stopped-states)))
     (is (= 1 (count @pending-states)))
-    (is (identical? failure-state (first @pending-states)))))
+    (is (identical? failure-state (first @pending-states)))
+    (is (= 1 (count @composition-states)))
+    (is (identical? failure-state (first @composition-states)))
+    (is (= 1 (count @checker-states)))
+    (is (identical? failure-state (ffirst @checker-states)))
+    (is (= :exceptions (second (first @checker-states))))))
 
 (defn- lifecycle-test-generator [failure-state]
   (#'cli/lifecycle-generator

--- a/jepsen/test/jepsen/openraft/harness_test.clj
+++ b/jepsen/test/jepsen/openraft/harness_test.clj
@@ -3,14 +3,20 @@
             [jepsen.openraft.harness :as harness]))
 
 (deftest starts-without-a-primary-failure
-  (is (nil? (harness/primary-failure (harness/failure-state)))))
+  (let [state (harness/failure-state)]
+    (is (nil? (harness/primary-failure state)))
+    (is (empty? (harness/secondary-failures state)))))
 
 (deftest records-the-first-failure
   (let [state (harness/failure-state)
         context {:operation :write
                  :node :n1}
         throwable (ex-info "Client failed" {:kind :client-error})]
-    (harness/record-failure! state :client context throwable)
+    (is (true? (harness/record-failure!
+                state
+                :client
+                context
+                throwable)))
     (let [failure (harness/primary-failure state)]
       (is (= :client (:source failure)))
       (is (= context (:context failure)))
@@ -19,19 +25,59 @@
 (deftest retains-the-first-failure
   (let [state (harness/failure-state)
         first-throwable (RuntimeException. "first")
-        later-throwable (RuntimeException. "later")]
+        later-throwable (RuntimeException. "later")
+        last-throwable (RuntimeException. "last")]
     (harness/record-failure! state
                              :nemesis
                              {:operation :partition}
                              first-throwable)
-    (harness/record-failure! state
-                             :teardown
-                             {:operation :heal}
-                             later-throwable)
+    (is (false? (harness/record-failure!
+                 state
+                 :nemesis
+                 {:phase :teardown
+                  :operation :heal}
+                 later-throwable)))
+    (is (false? (harness/record-failure!
+                 state
+                 :nemesis
+                 {:phase :teardown
+                  :operation :resume}
+                 last-throwable)))
     (let [failure (harness/primary-failure state)]
       (is (= :nemesis (:source failure)))
       (is (= {:operation :partition} (:context failure)))
-      (is (identical? first-throwable (:throwable failure))))))
+      (is (identical? first-throwable (:throwable failure))))
+    (let [[later last] (harness/secondary-failures state)]
+      (is (= {:phase :teardown
+              :operation :heal}
+             (:context later)))
+      (is (identical? later-throwable (:throwable later)))
+      (is (= {:phase :teardown
+              :operation :resume}
+             (:context last)))
+      (is (identical? last-throwable (:throwable last))))))
+
+(deftest records-concurrent-failures-once
+  (let [state (harness/failure-state)
+        start (promise)
+        errors (mapv #(RuntimeException. (str "failure " %)) (range 16))
+        workers (mapv (fn [id throwable]
+                        (future
+                          @start
+                          (harness/record-failure! state
+                                                   :nemesis
+                                                   {:id id}
+                                                   throwable)))
+                      (range 16)
+                      errors)]
+    (deliver start true)
+    (let [results (mapv deref workers)
+          primary (harness/primary-failure state)
+          recorded (cons primary (harness/secondary-failures state))]
+      (is (= 1 (count (filter true? results))))
+      (is (= (count errors) (count recorded)))
+      (is (= (set (range 16)) (set (map (comp :id :context) recorded))))
+      (is (= (set errors) (set (map :throwable recorded)))))))
 
 (deftest ignores-interruptions
   (doseq [[description throwable]
@@ -43,9 +89,21 @@
            ["interrupted ex-info"
             (ex-info "interrupted" {:kind :interrupted})]]]
     (testing description
-      (let [state (harness/failure-state)]
-        (harness/record-failure! state
-                                 :client
-                                 {:operation :read}
-                                 throwable)
-        (is (nil? (harness/primary-failure state)))))))
+      (let [state (harness/failure-state)
+            primary (RuntimeException. "primary")]
+        (is (false? (harness/record-failure!
+                     state
+                     :client
+                     {:operation :read}
+                     throwable)))
+        (is (nil? (harness/primary-failure state)))
+        (is (empty? (harness/secondary-failures state)))
+        (harness/record-failure! state :client {:operation :write} primary)
+        (is (false? (harness/record-failure!
+                     state
+                     :nemesis
+                     {:phase :teardown}
+                     throwable)))
+        (is (identical? primary
+                        (:throwable (harness/primary-failure state))))
+        (is (empty? (harness/secondary-failures state)))))))

--- a/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/partition_test.clj
@@ -107,16 +107,28 @@
           (is (= :no-safe-partition-target (:reason value)))
           (is (empty? @invocations)))))))
 
-(deftest partition-cleanup-failure-does-not-mask-analysis
-  (let [attempted? (atom false)
+(deftest partition-cleanup-failure-records-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        error (ex-info "unreachable" {:kind :unreachable})
+        attempted? (atom false)
         partitioner (teardown-partitioner
                      #(do
                         (reset! attempted? true)
-                        (throw (ex-info "unreachable"
-                                        {:kind :unreachable}))))]
-    (nemesis/teardown! (partition/->PartitionNemesis partitioner)
+                        (throw error)))
+        subject (worker/wrap-nemesis-teardown
+                 failure-state
+                 :partition
+                 (partition/->PartitionNemesis partitioner))]
+    (nemesis/teardown! subject
                        {:nodes nodes})
-    (is @attempted?)))
+    (is @attempted?)
+    (let [failure (harness/primary-failure failure-state)]
+      (is (= :nemesis (:source failure)))
+      (is (= {:phase :teardown
+              :component :partition
+              :nodes nodes}
+             (:context failure)))
+      (is (identical? error (:throwable failure))))))
 
 (deftest partition-control-failures-take-the-harness-path
   (let [error (ex-info "SSH failed" {:kind :ssh})

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -5,9 +5,11 @@
              [nemesis :as nemesis]
              [random :as random]]
             [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.harness :as harness]
             [jepsen.openraft.nemesis :as openraft-nemesis]
             [jepsen.openraft.nemesis.process :as process]
-            [jepsen.openraft.quorum :as quorum]))
+            [jepsen.openraft.quorum :as quorum]
+            [jepsen.openraft.worker :as worker]))
 
 (def voters ["n1" "n2" "n3" "n4" "n5"])
 
@@ -51,16 +53,32 @@
     (teardown! [this _test]
       this)))
 
-(defn- failing-resume-nemesis [events error]
+(defn- failing-resume-nemesis
+  ([events resume-error]
+   (failing-resume-nemesis events resume-error nil))
+  ([events resume-error teardown-error]
+   (reify nemesis/Nemesis
+     (setup! [this _test]
+       this)
+     (invoke! [_ _test op]
+       (swap! events conj [(:f op) (:value op)])
+       (throw resume-error))
+     (teardown! [this _test]
+       (swap! events conj :teardown)
+       (when teardown-error
+         (throw teardown-error))
+       this))))
+
+(defn- failing-teardown-nemesis [events error]
   (reify nemesis/Nemesis
     (setup! [this _test]
       this)
     (invoke! [_ _test op]
       (swap! events conj [(:f op) (:value op)])
-      (throw error))
-    (teardown! [this _test]
+      (delegate-completion op))
+    (teardown! [_ _test]
       (swap! events conj :teardown)
-      this)))
+      (throw error))))
 
 (deftest selects-fault-set-for-leader-mode
   (let [configs [(set voters)]
@@ -613,16 +631,52 @@
         (is (empty? @invocations))
         (is (empty? (:observed-modes result)))))))
 
-(deftest teardown-cleanup-failure-does-not-mask-analysis
-  (let [events (atom [])
+(deftest teardown-cleanup-failure-records-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        events (atom [])
+        error (ex-info "unreachable" {:kind :unreachable})
         delegate (failing-resume-nemesis
                   events
-                  (ex-info "unreachable" {:kind :unreachable}))
-        subject (process/->PauseNemesis delegate (atom nil))
+                  error)
+        subject (worker/wrap-nemesis-teardown
+                 failure-state
+                 :pause
+                 (process/->PauseNemesis delegate (atom nil)))
         test {:nodes ["n1" "n2" "n3"]}]
     (nemesis/teardown! subject test)
     (is (= [[:resume (:nodes test)] :teardown]
-           @events))))
+           @events))
+    (let [failure (harness/primary-failure failure-state)]
+      (is (= :nemesis (:source failure)))
+      (is (= {:phase :teardown
+              :component :pause
+              :action :resume-processes
+              :nodes (:nodes test)}
+             (:context failure)))
+      (is (identical? error (:throwable failure))))))
+
+(deftest teardown-retains-each-stage-failure
+  (let [failure-state (harness/failure-state)
+        events (atom [])
+        resume-error (RuntimeException. "resume failed")
+        teardown-error (RuntimeException. "delegate teardown failed")
+        delegate (failing-resume-nemesis
+                  events
+                  resume-error
+                  teardown-error)
+        subject (worker/wrap-nemesis-teardown
+                 failure-state
+                 :pause
+                 (process/->PauseNemesis delegate (atom nil)))
+        test {:nodes ["n1" "n2" "n3"]}]
+    (nemesis/teardown! subject test)
+    (is (= [[:resume (:nodes test)] :teardown] @events))
+    (let [primary (harness/primary-failure failure-state)
+          [secondary] (harness/secondary-failures failure-state)]
+      (is (= :resume-processes (get-in primary [:context :action])))
+      (is (identical? resume-error (:throwable primary)))
+      (is (= :delegate-teardown (get-in secondary [:context :action])))
+      (is (identical? teardown-error (:throwable secondary))))))
 
 (deftest teardown-preserves-interruptions
   (doseq [[label error]
@@ -649,8 +703,42 @@
                 interrupted? (.isInterrupted (Thread/currentThread))]
             (is (identical? error thrown))
             (is interrupted?)
-            (is (= [[:resume (:nodes test)] :teardown]
+            (is (= [[:resume (:nodes test)]]
                    @events)))
+          (finally
+            (Thread/interrupted)))))))
+
+(deftest delegate-teardown-preserves-interruptions
+  (doseq [[label error]
+          [[:interrupted-exception
+            (InterruptedException. "interrupted")]
+           [:interrupted-io
+            (java.io.InterruptedIOException. "interrupted")]
+           [:closed-by-interrupt
+            (java.nio.channels.ClosedByInterruptException.)]
+           [:wrapped
+            (ex-info "interrupted" {:kind :interrupted})]]]
+    (testing (name label)
+      (Thread/interrupted)
+      (let [failure-state (harness/failure-state)
+            events (atom [])
+            delegate (failing-teardown-nemesis events error)
+            subject (worker/wrap-nemesis-teardown
+                     failure-state
+                     :pause
+                     (process/->PauseNemesis delegate (atom nil)))
+            test {:nodes ["n1" "n2" "n3"]}]
+        (try
+          (let [[thrown interrupted?]
+                (try
+                  (nemesis/teardown! subject test)
+                  [nil (.isInterrupted (Thread/currentThread))]
+                  (catch Throwable throwable
+                    [throwable (.isInterrupted (Thread/currentThread))]))]
+            (is (identical? error thrown))
+            (is interrupted?)
+            (is (= [[:resume (:nodes test)] :teardown] @events))
+            (is (nil? (harness/primary-failure failure-state))))
           (finally
             (Thread/interrupted)))))))
 

--- a/jepsen/test/jepsen/openraft/nemesis_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis_test.clj
@@ -65,8 +65,10 @@
                 (+ (:time retry) (gen/secs->nanos 15))))))))
 
 (deftest cleans-up-all-faults-before-confirming-recovery
-  (let [database (db/db {})
+  (let [failure-state (harness/failure-state)
+        database (db/db {})
         package (openraft-nemesis/compose-packages
+                 failure-state
                  [(membership/membership-package
                    database
                    test-config)
@@ -81,10 +83,12 @@
            (mapv :f (:final-generator package))))))
 
 (deftest requires-each-composed-fault-class-to-execute
-  (let [database (db/db {})
+  (let [failure-state (harness/failure-state)
+        database (db/db {})
         all-voters (set (:nodes test-config))
         fewer-voters (disj all-voters "n5")
         package (openraft-nemesis/compose-packages
+                 failure-state
                  [(partition/partition-package)
                   (process/pause-package database)
                   (membership/membership-package database test-config)])
@@ -143,6 +147,115 @@
                                 history))]
         (is (false? (:valid? result)))
         (is (false? (get-in result [:pause :fault-class-executed?])))))))
+
+(defn- teardown-package [package-name events throwable]
+  {:name package-name
+   :interval 1
+   :nemesis
+   (reify nemesis/Nemesis
+     (setup! [this _test]
+       this)
+
+     (invoke! [_ _test op]
+       op)
+
+     (teardown! [this _test]
+       (swap! events conj package-name)
+       (when throwable
+         (throw throwable))
+       this)
+
+     nemesis/Reflection
+     (fs [_]
+       #{package-name}))
+   :generator {:type :info
+               :f package-name}
+   :final-generator nil
+   :checker (reify checker/Checker
+              (check [_ _test _history _opts]
+                {:valid? true}))
+   :perf #{}})
+
+(deftest composed-teardown-records-failures-and-continues
+  (let [failure-state (harness/failure-state)
+        events (atom [])
+        first-error (RuntimeException. "partition cleanup failed")
+        second-error (RuntimeException. "pause cleanup failed")
+        package (openraft-nemesis/compose-packages
+                 failure-state
+                 [(teardown-package :partition events first-error)
+                  (teardown-package :pause events second-error)
+                  (teardown-package :process events nil)])
+        subject (nemesis/setup! (:nemesis package) test-config)]
+    (nemesis/teardown! subject test-config)
+    (swap! events conj :analysis)
+    (is (= [:partition :pause :process :analysis] @events))
+    (let [primary (harness/primary-failure failure-state)
+          [secondary] (harness/secondary-failures failure-state)]
+      (is (= :nemesis (:source primary)))
+      (is (= {:phase :teardown
+              :component :partition
+              :nodes (:nodes test-config)}
+             (:context primary)))
+      (is (identical? first-error (:throwable primary)))
+      (is (= :nemesis (:source secondary)))
+      (is (= {:phase :teardown
+              :component :pause
+              :nodes (:nodes test-config)}
+             (:context secondary)))
+      (is (identical? second-error (:throwable secondary))))))
+
+(deftest retains-legacy-compose-packages-arity
+  (let [events (atom [])
+        failure (RuntimeException. "legacy teardown failure")
+        package (openraft-nemesis/compose-packages
+                 [(teardown-package :partition events failure)])
+        subject (nemesis/setup! (:nemesis package) test-config)
+        thrown (try
+                 (nemesis/teardown! subject test-config)
+                 nil
+                 (catch Throwable throwable
+                   throwable))]
+    (is (identical? failure thrown))
+    (is (= [:partition] @events))))
+
+(deftest composed-teardown-preserves-clean-behavior
+  (let [failure-state (harness/failure-state)
+        events (atom [])
+        package (openraft-nemesis/compose-packages
+                 failure-state
+                 [(teardown-package :partition events nil)
+                  (teardown-package :process events nil)])
+        subject (nemesis/setup! (:nemesis package) test-config)]
+    (nemesis/teardown! subject test-config)
+    (is (= [:partition :process] @events))
+    (is (nil? (harness/primary-failure failure-state)))
+    (is (empty? (harness/secondary-failures failure-state)))))
+
+(deftest composed-teardown-propagates-interruption
+  (Thread/interrupted)
+  (let [failure-state (harness/failure-state)
+        events (atom [])
+        interruption (InterruptedException. "stop teardown")
+        package (openraft-nemesis/compose-packages
+                 failure-state
+                 [(teardown-package :partition events interruption)
+                  (teardown-package :process events nil)])
+        subject (nemesis/setup! (:nemesis package) test-config)]
+    (try
+      (let [[thrown interrupted?]
+            (try
+              (nemesis/teardown! subject test-config)
+              [nil (.isInterrupted (Thread/currentThread))]
+              (catch Throwable throwable
+                [throwable (.isInterrupted (Thread/currentThread))]))]
+        (is (identical? interruption thrown))
+        (is interrupted?)
+        (is (= [:partition] @events))
+        (is (nil? (harness/primary-failure failure-state)))
+        (is (empty? (harness/secondary-failures failure-state))))
+      (finally
+        (Thread/interrupted)))))
 
 (defn- condition-timeout [condition]
   (try

--- a/jepsen/test/jepsen/openraft/worker_test.clj
+++ b/jepsen/test/jepsen/openraft/worker_test.clj
@@ -1,21 +1,23 @@
 (ns jepsen.openraft.worker-test
   (:require [clojure.test :refer [deftest is testing]]
             [jepsen [client :as client]
+             [db :as db]
              [nemesis :as nemesis]]
             [jepsen.openraft [harness :as harness]
              [worker :as worker]]))
 
 (defn- test-client
-  [{:keys [open-f invoke-f close-f]
+  [{:keys [open-f setup-f invoke-f close-f]
     :or {open-f (fn [this _test _node] this)
+         setup-f (fn [this _test] this)
          invoke-f (fn [_test op] (assoc op :type :ok))
          close-f (fn [_test])}}]
   (reify client/Client
     (open! [this test node]
       (open-f this test node))
 
-    (setup! [this _test]
-      this)
+    (setup! [this test]
+      (setup-f this test))
 
     (invoke! [_ test op]
       (invoke-f test op))
@@ -27,17 +29,39 @@
 
 (defn- test-nemesis
   ([invoke-f]
-   (test-nemesis invoke-f (fn [_test])))
+   (test-nemesis invoke-f (fn [this _test] this) (fn [_test])))
   ([invoke-f teardown-f]
+   (test-nemesis invoke-f (fn [this _test] this) teardown-f))
+  ([invoke-f setup-f teardown-f]
    (reify nemesis/Nemesis
-     (setup! [this _test]
-       this)
+     (setup! [this test]
+       (setup-f this test))
 
      (invoke! [_ test op]
        (invoke-f test op))
 
      (teardown! [_ test]
        (teardown-f test)))))
+
+(defn- test-db
+  [setup-f]
+  (reify db/DB
+    (setup! [_ test node]
+      (setup-f test node))
+
+    (teardown! [_ _test _node])
+
+    db/Kill
+    (kill! [_ _test _node])
+    (start! [_ _test _node])
+
+    db/Pause
+    (pause! [_ _test _node])
+    (resume! [_ _test _node])
+
+    db/LogFiles
+    (log-files [_ _test _node]
+      {})))
 
 (defn- thrown-by [f]
   (try
@@ -54,6 +78,19 @@
     (is (identical? throwable (:throwable failure)))))
 
 (deftest records-client-worker-failures
+  (testing "setup"
+    (let [failure-state (harness/failure-state)
+          throwable (RuntimeException. "setup failed")
+          subject (worker/wrap-client
+                   failure-state
+                   (test-client {:setup-f (fn [& _] (throw throwable))}))
+          thrown (thrown-by #(client/setup! subject {}))]
+      (is (identical? throwable thrown))
+      (assert-primary-failure failure-state
+                              :client
+                              {:phase :setup}
+                              throwable)))
+
   (testing "open"
     (let [failure-state (harness/failure-state)
           throwable (RuntimeException. "open failed")
@@ -100,6 +137,21 @@
                               throwable))))
 
 (deftest records-nemesis-worker-failures
+  (testing "setup"
+    (let [failure-state (harness/failure-state)
+          throwable (RuntimeException. "nemesis setup failed")
+          subject (worker/wrap-nemesis
+                   failure-state
+                   (test-nemesis (fn [& _] nil)
+                                 (fn [& _] (throw throwable))
+                                 (fn [& _] nil)))
+          thrown (thrown-by #(nemesis/setup! subject {}))]
+      (is (identical? throwable thrown))
+      (assert-primary-failure failure-state
+                              :nemesis
+                              {:phase :setup}
+                              throwable)))
+
   (let [failure-state (harness/failure-state)
         throwable (RuntimeException. "nemesis failed")
         op {:type :info
@@ -115,6 +167,20 @@
                             :nemesis
                             {:phase :invoke
                              :operation op}
+                            throwable)))
+
+(deftest records-db-setup-failures
+  (let [failure-state (harness/failure-state)
+        throwable (RuntimeException. "database setup failed")
+        subject (worker/wrap-db
+                 failure-state
+                 (test-db (fn [& _] (throw throwable))))
+        thrown (thrown-by #(db/setup! subject {} "n1"))]
+    (is (identical? throwable thrown))
+    (assert-primary-failure failure-state
+                            :db
+                            {:phase :setup
+                             :node "n1"}
                             throwable)))
 
 (deftest modeled-outcomes-do-not-record-failures

--- a/jepsen/test/jepsen/openraft/worker_test.clj
+++ b/jepsen/test/jepsen/openraft/worker_test.clj
@@ -25,15 +25,19 @@
     (close! [_ test]
       (close-f test))))
 
-(defn- test-nemesis [invoke-f]
-  (reify nemesis/Nemesis
-    (setup! [this _test]
-      this)
+(defn- test-nemesis
+  ([invoke-f]
+   (test-nemesis invoke-f (fn [_test])))
+  ([invoke-f teardown-f]
+   (reify nemesis/Nemesis
+     (setup! [this _test]
+       this)
 
-    (invoke! [_ test op]
-      (invoke-f test op))
+     (invoke! [_ test op]
+       (invoke-f test op))
 
-    (teardown! [_ _test])))
+     (teardown! [_ test]
+       (teardown-f test)))))
 
 (defn- thrown-by [f]
   (try
@@ -167,3 +171,36 @@
             thrown (thrown-by #(invoke failure-state throwable))]
         (is (identical? throwable thrown))
         (is (nil? (harness/primary-failure failure-state)))))))
+
+(deftest teardown-logging-failures-do-not-escape
+  (let [failure-state (harness/failure-state)
+        teardown-error (RuntimeException. "teardown failed")
+        logging-error (RuntimeException. "logging failed")
+        subject (worker/wrap-nemesis-teardown
+                 failure-state
+                 :partition
+                 (test-nemesis identity
+                               (fn [_test] (throw teardown-error))))]
+    (with-redefs-fn {#'worker/log-teardown-failure
+                     (fn [_context _throwable]
+                       (throw logging-error))}
+      #(nemesis/teardown! subject {:nodes ["n1" "n2" "n3"]}))
+    (is (identical? teardown-error
+                    (:throwable
+                     (harness/primary-failure failure-state))))
+    (let [[failure] (harness/secondary-failures failure-state)]
+      (is (= :failure-log (get-in failure [:context :diagnostic])))
+      (is (identical? logging-error (:throwable failure))))))
+
+(deftest fatal-teardown-errors-propagate
+  (let [failure-state (harness/failure-state)
+        fatal-error (StackOverflowError. "fatal")
+        subject (worker/wrap-nemesis-teardown
+                 failure-state
+                 :partition
+                 (test-nemesis identity
+                               (fn [_test] (throw fatal-error))))
+        thrown (thrown-by #(nemesis/teardown! subject {}))]
+    (is (identical? fatal-error thrown))
+    (is (nil? (harness/primary-failure failure-state)))
+    (is (empty? (harness/secondary-failures failure-state)))))


### PR DESCRIPTION
## Summary

This PR closes the remaining lifecycle and verdict path for the Jepsen
error-handling model. Once the test Harness itself becomes unreliable, the run
must be rejected without turning that failure into a fabricated SUT Outcome or
discarding independent cleanup and analysis evidence.

- retain one run-scoped primary Harness failure plus later diagnostic failures
- record setup and teardown failures while allowing independent cleanup to
  continue where it remains safe
- stop normal work after a Harness failure, while preserving the required
  recovery and analysis paths
- make the aggregate checker reject any recorded Harness failure while
  retaining its nested checker results
- turn escaped worker exceptions found post-hoc in history into explicit
  strict-fallback Harness evidence rather than an ambiguous `:unknown` result
- give checker implementation failures the same explicit rejection semantics
  whether a checker runs alone or inside a composition

Modeled SUT Outcomes remain in history for workload and Nemesis checkers.
Harness failures instead make the overall result unusable and produce a
nonzero exit after the applicable cleanup and analysis work has completed.

## Verification

- `JAVA_CMD=/opt/homebrew/opt/openjdk@26/bin/java make -C jepsen unit-test`
  — 174 tests, 1222 assertions, 0 failures/errors
- `JAVA_CMD=/opt/homebrew/opt/openjdk@26/bin/java make -C jepsen clojure-lint`
  — clj-kondo and cljfmt passed
- `git diff --check upstream/main...HEAD`

Closes #1975

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2018)
<!-- Reviewable:end -->
