### PR TITLE
chore: deps: bump validit to 0.2.6, set rust-version 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace.package]
 version = "0.10.0-alpha.34"
 edition = "2024"
+rust-version = "1.88"
 authors = [
     "Databend Authors <opensource@datafuselabs.com>",
     "Anthony Dodd <Dodd.AnthonyJosiah@gmail.com>",
@@ -59,7 +60,7 @@ tokio              = { version = "1.39", default-features = false, features = [
 tracing            = { version = "0.1.40" }
 tracing-appender   = { version = "0.2.0" }
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
-validit            = { version = "0.2.5" }
+validit            = { version = "0.2.6" }
 
 
 [profile.release]


### PR DESCRIPTION

## Changelog

##### chore: deps: bump validit to 0.2.6, set rust-version 1.88
# Summary

The workspace dependency `validit` moves from 0.2.5 to 0.2.6, and
`[workspace.package]` gains `rust-version = "1.88"`.

# Details

validit 0.2.6 declares `rust-version = "1.88"` itself, so the workspace
records the same minimum toolchain instead of leaving it implicit.

The field documents the requirement only. No member crate inherits it
with `rust-version = { workspace = true }`, and no CI job checks an MSRV,
so cargo does not enforce 1.88 for openraft yet.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2022)
<!-- Reviewable:end -->
