### PR TITLE
test: jepsen: simplify suite boundaries

### DIFF
--- a/jepsen/error-handling-semantics.md
+++ b/jepsen/error-handling-semantics.md
@@ -111,9 +111,9 @@ recovery belongs in final Nemesis operations.
 
 Other Nemeses may perform cleanup during teardown. A failure in a non-empty
 suite-controlled teardown is a Harness failure. Record it, then continue
-independent cleanup,
-artifact collection, and applicable analysis. Teardown must not exit early
-because one cleanup failed, and the failure must not be reduced to a warning.
+independent cleanup, artifact collection, and applicable analysis. Teardown
+must not exit early because one cleanup failed, and the failure must not be
+reduced to a warning.
 
 A modeled final-recovery outcome remains a Nemesis outcome, and a failed
 recovery postcondition remains a checker verdict. An unexpected execution

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -127,7 +127,7 @@
            opts
            {:name (str "openraft linearizable registers "
                        (str/join "," (map name nemesis-types)))
-            :db (worker/wrap-db failure-state database)
+            :db database
             :client (worker/wrap-client failure-state (:client workload))
             :nemesis (worker/wrap-nemesis failure-state
                                           (:nemesis nemesis-package))

--- a/jepsen/src/jepsen/openraft/nemesis.clj
+++ b/jepsen/src/jepsen/openraft/nemesis.clj
@@ -198,15 +198,14 @@
     (throw (ex-info "At least one nemesis package is required" {})))
   (let [packages (->> packages
                       (mapv (fn [{:keys [name] :as package}]
-                              (cond-> (assoc package
+                              (update (assoc package
                                              :perf
                                              (or (:perf package) #{}))
-                                failure-state
-                                (update :nemesis
-                                        #(worker/wrap-nemesis-teardown
-                                          failure-state
-                                          name
-                                          %)))))
+                                      :nemesis
+                                      #(worker/wrap-nemesis-teardown
+                                        failure-state
+                                        name
+                                        %))))
                       cleanup-order
                       (mapv schedule-package))
         composed (combined/compose-packages

--- a/jepsen/src/jepsen/openraft/worker.clj
+++ b/jepsen/src/jepsen/openraft/worker.clj
@@ -1,7 +1,6 @@
 (ns jepsen.openraft.worker
   (:require [clojure.tools.logging :refer [error]]
             [jepsen [client :as client]
-             [db :as db]
              [nemesis :as nemesis]]
             [jepsen.openraft.harness :as harness]
             [jepsen.openraft.interruption :as interruption]))
@@ -119,34 +118,6 @@
                                 :component :composed-nemesis
                                 :nodes (:nodes test)}
                                #(nemesis/teardown! delegate test)))))
-
-(defn wrap-db
-  "Delegates Jepsen-managed DB lifecycle and control boundaries."
-  [_failure-state delegate]
-  (reify db/DB
-    (setup! [_ test node]
-      (db/setup! delegate test node))
-
-    (teardown! [_ test node]
-      (db/teardown! delegate test node))
-
-    db/Kill
-    (kill! [_ test node]
-      (db/kill! delegate test node))
-
-    (start! [_ test node]
-      (db/start! delegate test node))
-
-    db/Pause
-    (pause! [_ test node]
-      (db/pause! delegate test node))
-
-    (resume! [_ test node]
-      (db/resume! delegate test node))
-
-    db/LogFiles
-    (log-files [_ test node]
-      (db/log-files delegate test node))))
 
 (defn wrap-nemesis-teardown
   "Records and contains a package's non-interruption teardown failures."

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -1,8 +1,10 @@
 (ns jepsen.openraft.cli-test
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.tools.cli :as tools-cli]
+            [jepsen.checker :as checker]
             [jepsen.generator :as gen]
             [jepsen.generator.test :as gen-test]
+            [jepsen.history :as history]
             [jepsen.openraft.checker :as openraft-checker]
             [jepsen.openraft.cli :as cli]
             [jepsen.openraft.db :as openraft-db]
@@ -92,7 +94,6 @@
                   (fn [state packages]
                     (swap! composition-states conj state)
                     (compose-packages state packages))
-                  worker/wrap-db (wrap :db)
                   worker/wrap-client (wrap :client)
                   worker/wrap-nemesis (wrap :nemesis)
                   openraft-checker/reject-harness-failures
@@ -108,7 +109,7 @@
       (cli/openraft-test {:nemesis :partition
                           :nodes ["n1" "n2" "n3"]
                           :time-limit 10}))
-    (is (= [:db :client :nemesis] (mapv first @wrapped-states)))
+    (is (= [:client :nemesis] (mapv first @wrapped-states)))
     (is (every? #(identical? failure-state (second %))
                 @wrapped-states))
     (is (= 1 (count @stopped-states)))
@@ -120,6 +121,16 @@
     (is (= 1 (count @checker-states)))
     (is (identical? failure-state (ffirst @checker-states)))
     (is (= :exceptions (second (first @checker-states))))))
+
+(deftest reports-every-configured-checker
+  (let [test (cli/openraft-test {:nemesis [:membership :partition]
+                                 :nodes ["n1" "n2" "n3" "n4" "n5"]
+                                 :time-limit 10})
+        result (checker/check (:checker test) test (history/history []) {})]
+    (is (every? #(contains? result %)
+                #{:seed :stats :exceptions :crash :nemesis :workload}))
+    (is (every? #(contains? (:nemesis result) %)
+                #{:partition :membership}))))
 
 (defn- lifecycle-test-generator [failure-state]
   (#'cli/lifecycle-generator

--- a/jepsen/test/jepsen/openraft/worker_test.clj
+++ b/jepsen/test/jepsen/openraft/worker_test.clj
@@ -1,7 +1,6 @@
 (ns jepsen.openraft.worker-test
   (:require [clojure.test :refer [deftest is testing]]
             [jepsen [client :as client]
-             [db :as db]
              [nemesis :as nemesis]]
             [jepsen.openraft [harness :as harness]
              [worker :as worker]]))
@@ -42,29 +41,6 @@
 
      (teardown! [_ test]
        (teardown-f test)))))
-
-(defn- test-db
-  [{:keys [setup-f teardown-f]
-    :or {setup-f (fn [& _])
-         teardown-f (fn [& _])}}]
-  (reify db/DB
-    (setup! [_ test node]
-      (setup-f test node))
-
-    (teardown! [_ test node]
-      (teardown-f test node))
-
-    db/Kill
-    (kill! [_ _test _node])
-    (start! [_ _test _node])
-
-    db/Pause
-    (pause! [_ _test _node])
-    (resume! [_ _test _node])
-
-    db/LogFiles
-    (log-files [_ _test _node]
-      {})))
 
 (defn- thrown-by [f]
   (try
@@ -140,17 +116,7 @@
             (test-nemesis (fn [& _] nil)
                           (fn [& _]
                             (throw (RuntimeException. "setup failed")))
-                          (fn [& _] nil))]
-           [:db-setup
-            worker/wrap-db
-            #(db/setup! % {} "n1")
-            (test-db {:setup-f (fn [& _]
-                                 (throw (RuntimeException. "setup failed")))})]
-           [:db-teardown
-            worker/wrap-db
-            #(db/teardown! % {} "n1")
-            (test-db {:teardown-f (fn [& _]
-                                    (throw (RuntimeException. "teardown failed")))})]]]
+                          (fn [& _] nil))]]]
     (testing (name label)
       (let [failure-state (harness/failure-state)
             subject (wrapper failure-state delegate)


### PR DESCRIPTION
## Summary

This follow-up removes an obsolete suite-level DB wrapper and keeps the
Jepsen harness boundary aligned with core lifecycle ownership.

- pass the original DB directly to Jepsen instead of forwarding a fixed set
  of DB protocols
- always install the Nemesis teardown guard, because every package composition
  now receives shared failure state
- verify the final checker through its returned analysis result, without
  inspecting wrapper or `checker/compose` internals
- fix the remaining error-semantics Markdown wrapping

The real-process Docker smoke test is intentionally not added. As explained
in #2021, it would either move Docker integration work into PR CI or provide
no earlier signal than the existing post-merge Jepsen matrix.

## Verification

- `make -C jepsen unit-test` — 171 tests, 1,183 assertions
- `make -C jepsen clojure-lint`
- `git diff --check`

Closes #2021

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2023)
<!-- Reviewable:end -->
