### PR TITLE
test: jepsen: assert the checker key set, not containment

### DIFF
--- a/jepsen/docker/control.Dockerfile
+++ b/jepsen/docker/control.Dockerfile
@@ -12,6 +12,18 @@ RUN mkdir -p /root/.ssh \
 WORKDIR /openraft/jepsen
 
 COPY jepsen/project.clj ./project.clj
-RUN lein deps
+
+# repo1.maven.org sometimes answers 403 to a whole runner IP, so a single
+# pass fails every Central artifact at once. The 2026-08-23 `pause` job died
+# that way while its four sibling matrix jobs fetched the same artifacts
+# cleanly. Retry the resolution so one Central hiccup does not cost a
+# 30-minute Jepsen job.
+RUN attempt=1; \
+    until lein deps; do \
+      if [ "$attempt" -ge 3 ]; then exit 1; fi; \
+      echo "[control] lein deps attempt $attempt failed; retrying in 60s"; \
+      attempt=$((attempt + 1)); \
+      sleep 60; \
+    done
 
 CMD ["sleep", "infinity"]

--- a/jepsen/docker/node.Dockerfile
+++ b/jepsen/docker/node.Dockerfile
@@ -40,6 +40,23 @@ FROM ubuntu:24.04
 # The binary links librocksdb dynamically, so the runtime image needs it too.
 # Use the -dev package: its name is stable across RocksDB version bumps, while
 # the versioned runtime package name is not.
+#
+# `jepsen.openraft.db` controls the test app through the process tools below
+# and depends on three of their behaviors. `db_test.clj` redefines `c/exec`,
+# so it covers the Clojure decision logic and never these behaviors; the only
+# real check is the post-merge `process` job in .github/workflows/jepsen.yml,
+# which reports a break as a Jepsen run failure rather than a named test.
+# Re-verify all three when moving off Ubuntu 24.04:
+#
+# - `pgrep --ignore-ancestors` needs procps-ng 4.0 or later; this image has
+#   procps 4.0.4. Under procps 3.3.17, as in Debian bullseye, every process
+#   probe exits non-zero.
+# - psmisc's `killall` reports a missing target as `<name>: no process found`.
+#   `no-such-process-race?` matches that exact wording, so a reworded message
+#   turns a benign exit race into a Harness failure.
+# - `start-stop-daemon --oknodo`, which the base image provides rather than
+#   the list below, converts only the nothing-to-do case to exit 0, so a real
+#   start failure still exits non-zero.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       ca-certificates \

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -127,10 +127,10 @@
                                  :nodes ["n1" "n2" "n3" "n4" "n5"]
                                  :time-limit 10})
         result (checker/check (:checker test) test (history/history []) {})]
-    (is (every? #(contains? result %)
-                #{:seed :stats :exceptions :crash :nemesis :workload}))
-    (is (every? #(contains? (:nemesis result) %)
-                #{:partition :membership}))))
+    (is (= #{:valid? :seed :stats :exceptions :crash :nemesis :workload}
+           (set (keys result))))
+    (is (= #{:valid? :partition :membership}
+           (set (keys (:nemesis result)))))))
 
 (defn- lifecycle-test-generator [failure-state]
   (#'cli/lifecycle-generator


### PR DESCRIPTION

## Changelog

##### test: jepsen: assert the checker key set, not containment
# Summary

`reports-every-configured-checker` compares the key set of the
`checker/check` result with `=`, replacing the `every? contains?`
checks that only reported whether some key was missing.

# Details

`every?` prints its predicate as a function object when it fails, so the
failure never named the missing key. Deleting the `:crash` entry from
`openraft-test`'s `checker/compose` map used to report only that the
containment check failed. Set equality prints both sets, so the reader
sees the key by name. `:valid?` joins each expected set because
`checker/compose` adds it to the result and to the nested `:nemesis`
result.

`node.Dockerfile` now records the three process-tool behaviors that
`jepsen.openraft.db` relies on: `pgrep --ignore-ancestors` needs
procps-ng 4.0 or later, `no-such-process-race?` matches psmisc's
`<name>: no process found` wording, and `start-stop-daemon --oknodo`
converts only the nothing-to-do case to exit 0. `db_test.clj` reaches
all three only through a redefined `c/exec`, so a base-image change that
breaks one surfaces as a post-merge Jepsen run failure instead of a
named test. The note sits next to the base image and package list such
a change would edit.

Closes #2024

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2025)
<!-- Reviewable:end -->
