### PR TITLE
test: elect: t14: assert node 1 stays Candidate with its self-vote

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Both layouts are in use, and the choice follows test size, so a directory contai
 
 - Keep short setup and action sequences inline, even when they occur in one or two tests. Extract a helper only when substantial reuse outweighs the extra abstraction level.
 - Write each test as one linear sequence of purpose-driven phases.
+- Disable ticking, heartbeat, or election in `Config` (`enable_tick`, `enable_heartbeat`, `enable_elect`) before creating the router. Use `runtime_config()` only when a test must flip the flag mid-run.
 - Introduce an independent phase with `tracing::info!` that states why the following actions are performed and includes useful runtime context such as the log index, node, or term.
 - Put the phase in a scoped `{ ... }` block after its log entry so temporary values stay local and the phase boundary is visible. Use a block expression when a phase must return a value to later phases; phase blocks may be nested.
 - Prefer runtime logging over standalone comments for explaining test actions.

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1978,8 +1978,6 @@ where
 
         tracing::debug!("try to trigger election, now: {}", now.display());
 
-        // TODO: leader lease should be extended. Or it has to examine if it is leader
-        //       before electing.
         if self.engine.state.server_state == ServerState::Leader {
             tracing::debug!("skip election, already a leader");
             return;

--- a/openraft/src/docs/protocol/pre_vote.md
+++ b/openraft/src/docs/protocol/pre_vote.md
@@ -32,10 +32,20 @@ a Pre-Vote request to its peers asking: *"would you grant me a vote at
 `term + 1`?"* The request carries a hypothetical next-term vote and the
 candidate's last log id.
 
+The round starts only when the node's own leader lease has expired: while the
+lease is valid, a live leader is serving it, and every peer applying the same
+rule would reject, so the node refuses to start even the Pre-Vote round. This
+makes a manually triggered election
+([`Trigger::elect`](`crate::raft::trigger::Trigger::elect`) with
+`pre_vote = true`) safe to fire against a healthy cluster.
+
 A peer answers with the same rules it uses for a real vote request:
 
 - If it has a committed vote whose [leader lease](`crate::docs::protocol::replication::leader_lease`)
   has not expired, it would not grant — there is a live leader.
+- If it is itself a leader that a quorum keeps acking, it would not grant. A
+  leader never renews the lease on its own vote — heartbeat replies renew that
+  lease only on followers — so it consults its quorum-ack lease instead.
 - If the candidate's last log id is behind its own, it would not grant.
 - Otherwise it would grant.
 

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -308,8 +308,25 @@ where
     /// no term bump, no persisted vote, no server-state change. If a quorum grants (tallied by
     /// [`handle_pre_vote_resp`](Self::handle_pre_vote_resp)), a real [`elect`](Self::elect)
     /// follows.
+    ///
+    /// While this node's own leader lease is still valid, the round is refused as a complete
+    /// no-op: a live Leader is serving this node, and every peer applying the same lease rule
+    /// would reject. [`elect`](Self::elect) remains the forced override.
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) fn pre_elect(&mut self) {
+        let now = C::now();
+        let leased_vote = &self.state.vote;
+
+        // Refuse to disturb a live Leader: the same lease rule as `handle_pre_vote_req`.
+        // Return before resampling the election timeout so a refused round changes nothing.
+        if leased_vote.is_committed() && !leased_vote.is_expired(now, Duration::from_millis(0)) {
+            tracing::info!(
+                "skip pre-elect: leader lease has not yet expired: {}",
+                leased_vote.display_lease_info(now)
+            );
+            return;
+        }
+
         // Pre-Vote does not advance the persisted vote timestamp. Give every
         // new Pre-Vote round a fresh timeout instead of retaining one sample.
         self.config.resample_election_timeout();
@@ -392,6 +409,18 @@ where
             }
         }
 
+        // A Leader never renews the lease on its own `state.vote`: heartbeat replies renew that
+        // lease only on followers. The Leader's live lease is the quorum-ack lease, so while a
+        // quorum keeps acking this Leader, reject the vote. A leadership-transfer election is
+        // authorized by this very Leader, so it proceeds.
+        if !req.leadership_transfer
+            && let Some(leader) = self.leader.as_deref()
+            && leader.is_lease_valid(self.config.timer_config.leader_lease)
+        {
+            tracing::info!("reject vote-request: quorum-ack lease has not yet expired");
+            return VoteResponse::new(self.state.vote_ref(), self.state.last_log_id().cloned(), false);
+        }
+
         // The first step is to check log. If the candidate has less log, nothing needs to be done.
 
         if req.last_log_id.as_ref() >= self.state.last_log_id() {
@@ -445,6 +474,15 @@ where
         // would not grant a vote, so it would not grant a Pre-Vote either.
         if local_leased_vote.is_committed() && !local_leased_vote.is_expired(now, Duration::from_millis(0)) {
             tracing::info!("reject pre-vote-request: leader lease has not yet expired");
+            return VoteResponse::new(self.state.vote_ref(), self.state.last_log_id().cloned(), false);
+        }
+
+        // A Leader never renews the lease on its own `state.vote`; its live lease is the
+        // quorum-ack lease. While a quorum keeps acking this Leader, it would not grant.
+        if let Some(leader) = self.leader.as_deref()
+            && leader.is_lease_valid(self.config.timer_config.leader_lease)
+        {
+            tracing::info!("reject pre-vote-request: quorum-ack lease has not yet expired");
             return VoteResponse::new(self.state.vote_ref(), self.state.last_log_id().cloned(), false);
         }
 

--- a/openraft/src/engine/tests/handle_pre_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_pre_vote_req_test.rs
@@ -69,6 +69,37 @@ fn test_handle_pre_vote_req_rejected_by_leader_lease() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_handle_pre_vote_req_rejected_by_quorum_ack_lease() -> anyhow::Result<()> {
+    // A Leader never renews the lease on its own `state.vote`, so that lease is expired here.
+    // A quorum keeps acking it, and the quorum-ack lease alone rejects the pre-vote.
+    let mut eng = eng();
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now() - Duration::from_secs(1),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
+    eng.testing_new_leader().update_clock(&0, UTConfig::<()>::now());
+    let vote_before = *eng.state.vote_ref();
+
+    let resp = eng.handle_pre_vote_req(VoteRequest {
+        vote: Vote::new(3, 2),
+        last_log_id: Some(log_id(2, 1, 3)),
+        leadership_transfer: false,
+    });
+
+    assert_eq!(
+        VoteResponse::new(Vote::new_committed(2, 1), Some(log_id(1, 1, 1)), false),
+        resp
+    );
+    // A pre-vote must not mutate any state.
+    assert_eq!(vote_before, *eng.state.vote_ref());
+    assert!(eng.leader.is_some(), "the Leader stays");
+    assert_eq!(0, eng.output.take_commands().len());
+
+    Ok(())
+}
+
+#[test]
 fn test_handle_pre_vote_req_reject_smaller_last_log_id() -> anyhow::Result<()> {
     let mut eng = eng();
     let vote_before = *eng.state.vote_ref();

--- a/openraft/src/engine/tests/handle_vote_req_test.rs
+++ b/openraft/src/engine/tests/handle_vote_req_test.rs
@@ -105,6 +105,59 @@ fn test_handle_vote_req_leadership_transfer_overrides_leader_lease() -> anyhow::
 }
 
 #[test]
+fn test_handle_vote_req_rejected_by_quorum_ack_lease() -> anyhow::Result<()> {
+    // A Leader never renews the lease on its own `state.vote`, so that lease is expired here.
+    // A quorum keeps acking it, and the quorum-ack lease alone rejects the vote.
+    let mut eng = eng();
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now() - Duration::from_secs(1),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
+    eng.testing_new_leader().update_clock(&0, UTConfig::<()>::now());
+
+    let resp = eng.handle_vote_req(VoteRequest {
+        vote: Vote::new(3, 2),
+        last_log_id: Some(log_id(2, 1, 3)),
+        leadership_transfer: false,
+    });
+
+    assert_eq!(VoteResponse::new(Vote::new_committed(2, 1), None, false), resp);
+
+    assert_eq!(Vote::new_committed(2, 1), *eng.state.vote_ref());
+    assert!(eng.leader.is_some(), "the Leader stays");
+    assert_eq!(0, eng.output.take_commands().len());
+
+    Ok(())
+}
+
+#[test]
+fn test_handle_vote_req_leadership_transfer_overrides_quorum_ack_lease() -> anyhow::Result<()> {
+    // Same quorum-acked Leader as above, but the election is authorized by this very Leader
+    // (leadership transfer), so it is granted.
+    let mut eng = eng();
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now() - Duration::from_secs(1),
+        Duration::from_millis(500),
+        Vote::new_committed(2, 1),
+    );
+    eng.testing_new_leader().update_clock(&0, UTConfig::<()>::now());
+
+    let resp = eng.handle_vote_req(VoteRequest {
+        vote: Vote::new(3, 2),
+        last_log_id: Some(log_id(2, 1, 3)),
+        leadership_transfer: true,
+    });
+
+    assert_eq!(VoteResponse::new(Vote::new(3, 2), None, true), resp);
+
+    assert_eq!(Vote::new(3, 2), *eng.state.vote_ref());
+    assert!(eng.leader.is_none(), "voting for another node steps the Leader down");
+
+    Ok(())
+}
+
+#[test]
 fn test_handle_vote_req_reject_smaller_vote() -> anyhow::Result<()> {
     let mut eng = eng();
 

--- a/openraft/src/engine/tests/pre_elect_test.rs
+++ b/openraft/src/engine/tests/pre_elect_test.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::time::Duration;
 
 use maplit::btreeset;
 use pretty_assertions::assert_eq;
@@ -13,7 +14,9 @@ use crate::engine::LogIdList;
 use crate::engine::testing::UTConfig;
 use crate::engine::testing::log_id;
 use crate::raft::VoteRequest;
+use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::StoredMembershipOf;
+use crate::utime::Leased;
 
 fn m1() -> Membership<u64, ()> {
     Membership::new_with_defaults(vec![btreeset! {1}], [])
@@ -64,6 +67,37 @@ fn test_pre_elect_multi_node_no_mutation() -> anyhow::Result<()> {
         }],
         eng.output.take_commands()
     );
+
+    Ok(())
+}
+
+#[test]
+fn test_pre_elect_refused_by_valid_leader_lease() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.config.id = 1;
+    eng.state.membership_state.set_effective(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        Some(log_id(0, 1, 1)),
+        m12(),
+    )));
+    eng.state.log_ids = LogIdList::new(None, vec![log_id(1, 1, 1)]);
+    // A follower served by a live Leader: a committed vote whose lease has not expired.
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(500),
+        Vote::new_committed(1, 2),
+    );
+
+    let timeout_before = eng.config.timer_config.election_timeout;
+    let vote_before = *eng.state.vote_ref();
+
+    eng.pre_elect();
+
+    // Refused before touching anything: no new timeout sample, no pre-candidate, no command.
+    assert_eq!(timeout_before, eng.config.timer_config.election_timeout);
+    assert!(eng.pre_candidate_ref().is_none());
+    assert!(eng.candidate_ref().is_none());
+    assert_eq!(vote_before, *eng.state.vote_ref());
+    assert_eq!(0, eng.output.take_commands().len());
 
     Ok(())
 }

--- a/openraft/src/raft/trigger.rs
+++ b/openraft/src/raft/trigger.rs
@@ -52,10 +52,11 @@ where C: RaftTypeConfig
     /// healthy leader of a lower term.
     ///
     /// With `pre_vote = true`, a Pre-Vote round runs first and the real election proceeds only if a
-    /// quorum would grant a vote. A live leader holding its lease causes the Pre-Vote to be
-    /// declined, leaving the term untouched — use this to avoid disrupting a healthy leader
-    /// with a manual trigger. It does not require [`Config::enable_pre_vote`]; the caller opts
-    /// in per call.
+    /// quorum would grant a vote. While this node's own leader lease is still valid, the round is
+    /// refused locally and nothing is sent; a leader that a quorum keeps acking also rejects the
+    /// Pre-Vote — either way the term is left untouched. Use this to avoid disrupting a healthy
+    /// leader with a manual trigger. It does not require [`Config::enable_pre_vote`]; the caller
+    /// opts in per call.
     ///
     /// Returns error when RaftCore has [`Fatal`] error, e.g., shut down or having storage error.
     /// It is not affected by `Raft::enable_elect(false)`.

--- a/tests/tests/elect/main.rs
+++ b/tests/tests/elect/main.rs
@@ -12,3 +12,4 @@ mod t11_elect_seize_leadership;
 mod t12_pre_vote;
 mod t13_elect_while_leader;
 mod t14_one_way_isolation;
+mod t15_lease_gates;

--- a/tests/tests/elect/t12_pre_vote.rs
+++ b/tests/tests/elect/t12_pre_vote.rs
@@ -109,8 +109,9 @@ async fn without_pre_vote_term_inflates() -> Result<()> {
     Ok(())
 }
 
-/// A manual `trigger().elect(true)` runs a Pre-Vote round first: against a healthy leader it is
-/// declined, so the follower's term is left untouched and the leader is not disrupted.
+/// A manual `trigger().elect(true)` is cautious: while the follower's own leader lease is valid,
+/// `pre_elect` refuses to even start the Pre-Vote round, so the follower's term is left untouched
+/// and the leader is not disrupted.
 ///
 /// This is the administrative-safety scenario: an operator triggering an election on a node that
 /// cannot currently win must not inflate the cluster term. Pre-Vote is requested per call here — it
@@ -136,7 +137,7 @@ async fn manual_elect_with_pre_vote_does_not_disrupt_leader() -> Result<()> {
     tracing::info!("--- node 1 manually triggers a cautious (pre-vote) election");
     n1.trigger().elect(true).await?;
 
-    tracing::info!("--- give the Pre-Vote round time to be declined by the healthy peers");
+    tracing::info!("--- the round is refused locally; wait to observe no disruption");
     TypeConfig::sleep(Duration::from_millis(500)).await;
 
     tracing::info!("--- node 1's term is untouched and it stays a follower");

--- a/tests/tests/elect/t14_one_way_isolation.rs
+++ b/tests/tests/elect/t14_one_way_isolation.rs
@@ -121,11 +121,9 @@ async fn inbound_heartbeats_prevent_election_when_outbound_rpcs_fail() -> Result
 /// With Pre-Vote disabled, the first expired leader lease starts a real election: node 1 advances
 /// its term and votes for itself.
 ///
-/// The test asserts the term and the vote, not the `Candidate` state. Node 0 never renews the
-/// lease on its own vote, so node 0 grants the vote request at once and node 1 becomes Leader
-/// about a millisecond after campaigning. `Candidate` is transient and the metrics watch channel
-/// may skip it. The higher term and the self-vote persist, because every RPC that could move node
-/// 1's vote is blocked.
+/// The campaign cannot win: node 0's quorum-ack lease is kept fresh by node 2, so node 0
+/// rejects the vote, and node 2 rejects it by its own leader lease. Node 1 stays a `Candidate`
+/// holding its self-vote, because every RPC that could move its vote is blocked.
 #[tracing::instrument]
 #[test_harness::test(harness = ut_harness)]
 async fn missing_inbound_heartbeats_start_election() -> Result<()> {
@@ -175,11 +173,15 @@ async fn missing_inbound_heartbeats_start_election() -> Result<()> {
             )
             .await?;
 
-        let expected_vote = VoteOf::<TypeConfig>::new(campaigned.current_term, 1);
         assert_eq!(
-            expected_vote.leader_id(),
-            campaigned.vote.leader_id(),
+            VoteOf::<TypeConfig>::new(campaigned.current_term, 1),
+            campaigned.vote,
             "node 1 must install its self-vote"
+        );
+        assert_eq!(
+            ServerState::Candidate,
+            campaigned.state,
+            "node 1 campaigns but cannot win: node 0 is quorum-acked and node 2's lease is fresh"
         );
     }
 

--- a/tests/tests/elect/t15_lease_gates.rs
+++ b/tests/tests/elect/t15_lease_gates.rs
@@ -1,0 +1,250 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::Instant;
+use openraft::RPCTypes;
+use openraft::ServerState;
+use openraft::TokioInstant;
+use openraft::async_runtime::WatchReceiver;
+use openraft::errors::NetworkError;
+use openraft::errors::RPCError;
+use openraft::type_config::TypeConfigExt;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::ut_harness;
+
+const ELECTION_TIMEOUT_MIN: u64 = 150;
+const ELECTION_TIMEOUT_MAX: u64 = 151;
+/// `leader_lease` equals `election_timeout_max`, see `EngineConfig::new`.
+const LEADER_LEASE: Duration = Duration::from_millis(ELECTION_TIMEOUT_MAX);
+/// Long enough for a Pre-Vote round and any election it could start to have shown up.
+const ELECTION_OBSERVATION: Duration = Duration::from_millis(ELECTION_TIMEOUT_MAX * 2);
+const WAIT_TIMEOUT: Duration = Duration::from_millis(5_000);
+
+/// Both tests park one node on an expired leader lease, where a tick election would race the
+/// manual `trigger().elect()`. `enable_elect` gates only the tick path, so the manual trigger
+/// still starts its round.
+fn config() -> Result<Arc<Config>> {
+    let config = Config {
+        election_timeout_min: ELECTION_TIMEOUT_MIN,
+        election_timeout_max: ELECTION_TIMEOUT_MAX,
+        enable_elect: false,
+        ..Default::default()
+    }
+    .validate()?;
+    Ok(Arc::new(config))
+}
+
+/// Block one direction of one link for AppendEntries only, so heartbeats stop flowing on
+/// that link while every Vote and Pre-Vote RPC stays deliverable.
+async fn block_append_entries(router: &RaftRouter, from: u64, to: u64) {
+    router
+        .set_rpc_pre_hook(RPCTypes::AppendEntries, move |_router, _req, f, t| {
+            let res = if f == from && t == to {
+                let err = NetworkError::<TypeConfig>::from_string(format!("blocked: {}->{} append-entries", f, t));
+                Err(RPCError::Network(err))
+            } else {
+                Ok(())
+            };
+            Box::pin(futures::future::ready(res))
+        })
+        .await;
+}
+
+/// Wait until `node`'s local `state.vote` lease has expired: its `vote_last_modified` stops
+/// advancing once heartbeats are blocked, so poll until `now` has passed it by the lease.
+async fn wait_vote_lease_expired(router: &RaftRouter, node: u64) -> Result<()> {
+    for _ in 0..200 {
+        let last_modified = router.with_raft_state(node, |state| state.vote_last_modified()).await?;
+        let now = TokioInstant::now();
+
+        let expired = match last_modified {
+            Some(last_modified) => now > last_modified + LEADER_LEASE,
+            None => true,
+        };
+        if expired {
+            return Ok(());
+        }
+
+        TypeConfig::sleep(Duration::from_millis(20)).await;
+    }
+    anyhow::bail!("node {} vote lease did not expire in time", node);
+}
+
+/// A leader that a quorum keeps acking rejects votes, so a manual Pre-Vote election from a
+/// follower whose own leader lease has expired cannot unseat it.
+///
+/// Topology: leader node 0 misses no acks — node 2 keeps acking it, and `{0, 2}` is a
+/// quorum — but the 0→1 link drops AppendEntries, so node 1's own leader lease expires.
+/// Node 1 then runs a manual cautious election: `trigger().elect(true)`.
+///
+/// Node 1's own lease is expired, so `pre_elect` sends the round out — the vote-RPC count
+/// grows. Node 0 rejects it by the quorum-ack lease (`Leader::is_lease_valid`), which every
+/// quorum ack renews; the lease on its own `state.vote` is written once at election and
+/// never renewed, so it alone would grant here. Node 2's lease is fresh, so node 2 rejects
+/// too. Every term stays unchanged and node 0 stays leader.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn manual_pre_vote_from_lease_expired_follower() -> Result<()> {
+    let mut router = RaftRouter::new(config()?);
+
+    tracing::info!("--- establish node 0 as leader of a three-voter cluster");
+    let log_index = router.new_cluster(btreeset! {0, 1, 2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    let n1 = router.get_raft_handle(&1)?;
+
+    let before = {
+        n1.wait(Some(WAIT_TIMEOUT))
+            .metrics(
+                |metrics| metrics.state == ServerState::Follower && metrics.current_leader == Some(0),
+                "node 1 follows node 0",
+            )
+            .await?
+    };
+
+    tracing::info!(
+        log_index,
+        "--- drop 0->1 AppendEntries and wait for node 1's lease to expire"
+    );
+    {
+        block_append_entries(&router, 0, 1).await;
+        wait_vote_lease_expired(&router, 1).await?;
+    }
+
+    tracing::info!(log_index, "--- refresh node 0's quorum-ack lease through node 2");
+    {
+        let heartbeat_at = TokioInstant::now();
+        n0.trigger().heartbeat().await?;
+        n0.wait(Some(WAIT_TIMEOUT))
+            .metrics(
+                |metrics| metrics.last_quorum_acked.is_some_and(|acked| acked.into_inner() >= heartbeat_at),
+                "node 0's quorum-ack lease is fresh after the forced heartbeat",
+            )
+            .await?;
+    }
+
+    tracing::info!(log_index, "--- node 1 manually triggers a cautious (pre-vote) election");
+    let vote_rpcs_before = {
+        let vote_rpcs_before = router.get_rpc_count().get(&RPCTypes::Vote).copied().unwrap_or(0);
+        n1.trigger().elect(true).await?;
+        vote_rpcs_before
+    };
+
+    tracing::info!(
+        log_index,
+        "--- the round is sent and rejected; every term and role is unchanged"
+    );
+    {
+        TypeConfig::sleep(ELECTION_OBSERVATION).await;
+
+        let vote_rpcs_after = router.get_rpc_count().get(&RPCTypes::Vote).copied().unwrap_or(0);
+        assert!(
+            vote_rpcs_after > vote_rpcs_before,
+            "node 1's own lease is expired, so `pre_elect` sent the round out"
+        );
+
+        let n1_after = n1.metrics().borrow_watched().clone();
+        assert_eq!(before.current_term, n1_after.current_term, "node 1's term is unchanged");
+        assert_eq!(ServerState::Follower, n1_after.state, "node 1 stays a follower");
+
+        let n0_after = n0.metrics().borrow_watched().clone();
+        assert_eq!(before.current_term, n0_after.current_term, "node 0's term is unchanged");
+        assert_eq!(ServerState::Leader, n0_after.state, "node 0 stays leader");
+    }
+
+    Ok(())
+}
+
+/// A manual Pre-Vote election on a follower whose own leader lease is still valid refuses
+/// to start, so it cannot unseat the leader through another follower's expired lease.
+///
+/// Topology: leader node 0 is acked by node 1, so `{0, 1}` keeps node 0's quorum-ack lease
+/// fresh, and node 1 also keeps receiving heartbeats. The 0→2 link drops AppendEntries, so
+/// node 2's leader lease expires. Node 1 — the healthy follower — runs a manual cautious
+/// election: `trigger().elect(true)`.
+///
+/// `pre_elect` refuses while node 1's own leader lease is valid, so no round starts — the
+/// vote-RPC count stays put. This local gate is the one protecting node 0 here: were the
+/// round sent, node 2 — lease expired, 1→2 deliverable — would grant it, and `{1, 2}` is a
+/// quorum needing no healthy grantor. Every term stays unchanged and node 0 stays leader.
+/// `trigger().elect(false)` remains the forced override.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn manual_pre_vote_from_healthy_follower_with_stale_peer() -> Result<()> {
+    let mut router = RaftRouter::new(config()?);
+
+    tracing::info!("--- establish node 0 as leader of a three-voter cluster");
+    let log_index = router.new_cluster(btreeset! {0, 1, 2}, btreeset! {}).await?;
+
+    let n0 = router.get_raft_handle(&0)?;
+    let n1 = router.get_raft_handle(&1)?;
+
+    let before = {
+        n1.wait(Some(WAIT_TIMEOUT))
+            .metrics(
+                |metrics| metrics.state == ServerState::Follower && metrics.current_leader == Some(0),
+                "node 1 follows node 0",
+            )
+            .await?
+    };
+
+    tracing::info!(
+        log_index,
+        "--- drop 0->2 AppendEntries and wait for node 2's lease to expire"
+    );
+    {
+        block_append_entries(&router, 0, 2).await;
+        wait_vote_lease_expired(&router, 2).await?;
+    }
+
+    tracing::info!(
+        log_index,
+        "--- refresh node 0's quorum-ack lease and node 1's follower lease"
+    );
+    {
+        let heartbeat_at = TokioInstant::now();
+        n0.trigger().heartbeat().await?;
+        n0.wait(Some(WAIT_TIMEOUT))
+            .metrics(
+                |metrics| metrics.last_quorum_acked.is_some_and(|acked| acked.into_inner() >= heartbeat_at),
+                "node 0's quorum-ack lease is fresh after the forced heartbeat",
+            )
+            .await?;
+    }
+
+    tracing::info!(
+        log_index,
+        "--- healthy node 1 manually triggers a cautious (pre-vote) election"
+    );
+    let vote_rpcs_before = {
+        let vote_rpcs_before = router.get_rpc_count().get(&RPCTypes::Vote).copied().unwrap_or(0);
+        n1.trigger().elect(true).await?;
+        vote_rpcs_before
+    };
+
+    tracing::info!(log_index, "--- no round starts; every term and role is unchanged");
+    {
+        TypeConfig::sleep(ELECTION_OBSERVATION).await;
+
+        let vote_rpcs_after = router.get_rpc_count().get(&RPCTypes::Vote).copied().unwrap_or(0);
+        assert_eq!(
+            vote_rpcs_before, vote_rpcs_after,
+            "node 1's own lease is valid, so `pre_elect` refused to send anything"
+        );
+
+        let n1_after = n1.metrics().borrow_watched().clone();
+        assert_eq!(before.current_term, n1_after.current_term, "node 1's term is unchanged");
+        assert_eq!(ServerState::Follower, n1_after.state, "node 1 stays a follower");
+
+        let n0_after = n0.metrics().borrow_watched().clone();
+        assert_eq!(before.current_term, n0_after.current_term, "node 0's term is unchanged");
+        assert_eq!(ServerState::Leader, n0_after.state, "node 0 stays leader");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION

## Changelog

##### test: elect: t14: assert node 1 stays Candidate with its self-vote
# Summary

`missing_inbound_heartbeats_start_election` now asserts the `Candidate`
state and compares the complete vote, `VoteOf::new(term, 1)`. The old
comment explained why it could not: node 0 granted at once through the
stale lease on its own vote, so `Candidate` was transient. With the
quorum-ack gate no peer grants — node 0 is quorum-acked and node 2's
lease is fresh — so the state and the whole vote are stable to pin.


##### fix: engine: gate votes by quorum-ack lease, pre-elect by local lease
# Summary

A Leader never renews the lease on its own `state.vote`: `update_vote`
runs only when answering another node's RPC, so the lease expires
`leader_lease` after election while the Leader still holds a quorum.
`handle_vote_req` and `handle_pre_vote_req` then grant, and a manual
`trigger().elect(true)` from a cut-off follower can unseat a healthy
Leader. Two gates close this: a Leader now also rejects Vote and
Pre-Vote requests while its quorum-ack lease (`Leader::is_lease_valid`)
is valid, and `pre_elect` refuses to start a round while the local
leader lease is valid.

# Details

The quorum-ack gate in `handle_vote_req` sits behind the same
`!req.leadership_transfer` condition as the existing lease check: a
transfer is authorized by this very Leader.

`pre_elect` checks the same condition as `handle_pre_vote_req` and
returns before `resample_election_timeout()`, so a refused round is a
complete no-op. This also closes the asymmetric hole where a healthy
follower's Pre-Vote could win through peers whose own leases had
expired: the round never starts. `trigger().elect(false)` remains the
forced override.

The two t15 reproduction tests flip from pinning the disruption to
pinning the protection; each discriminates its gate through the
vote-RPC count — sent and rejected under the quorum-ack gate, never
sent under the local gate.

Removes the `handle_tick_election` TODO about extending the leader
lease: the quorum-ack lease is now the Leader's live lease.


##### test: elect: reproduce disruption of a quorum-acked leader
# Summary

Two tests in t15_lease_gates.rs pin the behavior described in
leader-self-vote-lease-not-renewed.md: a leader that a quorum keeps
acking still grants disruptive Pre-Votes and votes, because the lease
on its own `state.vote` is set once at election and never renewed.
Both tests assert today's buggy outcome — node 1 seizes leadership —
so this commit stays green; the fix commit flips the assertions to
"terms unchanged, node 0 stays leader".

# Details

- `manual_pre_vote_from_lease_expired_follower` pins the leader-side
  gap: node 0 grants a Pre-Vote and vote while its quorum-ack lease
  (`Leader::last_quorum_acked_time`) is provably fresh.
- `manual_pre_vote_from_healthy_follower_with_stale_peer` pins the
  local gap: `pre_elect` self-grants without consulting the
  campaigning node's own fresh lease, and one stale peer completes the
  quorum. Only 0→2 AppendEntries is blocked, so after the fix this
  test still fails if the local `pre_elect` gate is missing.

---

- Bug Fix
- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2026)
<!-- Reviewable:end -->
