### PR TITLE
perf: replication: drop the duplicate commit-only AppendEntries

### DIFF
--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -144,7 +144,6 @@ where
                 log_reader,
                 payload: None,
                 inflight_id: None,
-                leader_committed: None,
                 backoff_consumer: backoff_state.consumer(),
             })),
             inflight_id: None,
@@ -296,7 +295,6 @@ where
             let mut stream_state = self.stream_state.lock().await;
             stream_state.payload = Some(payload.clone());
             stream_state.inflight_id = self.inflight_id;
-            stream_state.leader_committed = self.event_watcher.committed_rx.borrow_watched().clone()
         }
 
         let inflight_queue = InflightAppendQueue::new();

--- a/openraft/src/replication/stream_state.rs
+++ b/openraft/src/replication/stream_state.rs
@@ -49,9 +49,6 @@ where
 
     pub(crate) inflight_id: Option<InflightId>,
 
-    /// The leader_commit value to send in AppendEntries requests.
-    pub(crate) leader_committed: Option<LogIdOf<C>>,
-
     /// Read-only handle to the shared backoff state, sampled before each request.
     ///
     /// The consumer can only query the next delay; only `ReplicationCore` (via its
@@ -97,7 +94,10 @@ where
         let payload: AppendEntriesRequest<C> = AppendEntriesRequest {
             vote: self.replication_context.leader_vote.clone().into_vote(),
             prev_log_id: sending_range.prev.clone(),
-            leader_commit: self.event_watcher.committed_rx.borrow_watched().clone(),
+            // Marking the commit as seen keeps the pending `committed_rx.changed()` from forcing a
+            // second, entry-less request that carries this same commit. A commit that advances
+            // after this read stays unseen and gets a request of its own.
+            leader_commit: self.event_watcher.committed_rx.borrow_and_update().clone(),
             entries,
         };
 
@@ -138,16 +138,12 @@ where
             let current: IOId<C> = self.event_watcher.io_submitted_rx.borrow_watched().clone();
             let last_log_id = current.last_log_id().cloned();
 
-            let committed: Option<LogIdOf<C>> = self.event_watcher.committed_rx.borrow_watched().clone();
-
             tracing::debug!(
-                "building next entries range to replicate: current last_log_id: {}, current committed: {}",
-                last_log_id.display(),
-                committed.display()
+                "building next entries range to replicate: current last_log_id: {}",
+                last_log_id.display()
             );
 
-            if last_log_id > prev || committed > self.leader_committed {
-                self.leader_committed = committed;
+            if last_log_id > prev {
                 return Some(non_reversed_log_id_range(prev, last_log_id));
             } else {
                 let data_change = self.event_watcher.replicate_rx.changed();
@@ -169,9 +165,9 @@ where
                     }
                     _committed_change = committed_change.fuse() => {
                         tracing::debug!("committed_rx changed");
-                        // A notification may force an RPC even if no new readable logs are available.
-                        // This read delivers the event, thus it marks the value as seen.
-                        self.leader_committed = self.event_watcher.committed_rx.borrow_and_update().clone();
+                        // Only a commit that no request has carried is still unseen here, because
+                        // `next_request()` marks every commit it sends. With no new logs to
+                        // piggyback on, an entry-less request is the only way to deliver it.
                         return Some(non_reversed_log_id_range(prev, last_log_id));
                     }
                     cancel_res = cancel.fuse() => {

--- a/tests/tests/replication/main.rs
+++ b/tests/tests/replication/main.rs
@@ -14,3 +14,4 @@ mod t61_allow_follower_log_revert;
 mod t62_follower_clear_restart_recover;
 mod t99_issue_1500_heartbeat_cause_reversion_panic;
 mod t99_issue_1795_storage_error_stops_replication;
+mod t99_issue_2004_redundant_commit_only_append;

--- a/tests/tests/replication/t99_issue_2004_redundant_commit_only_append.rs
+++ b/tests/tests/replication/t99_issue_2004_redundant_commit_only_append.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::RPCTypes;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::rpc_request::RpcRequest;
+use crate::fixtures::ut_harness;
+
+/// The number of client writes issued one after another, each awaited before the next.
+const WRITES: usize = 100;
+
+/// A commit that an AppendEntries already carried must not trigger a second, entry-less
+/// AppendEntries.
+///
+/// Issue 2004: `next_request()` used to read the commit watch without marking it seen, so the
+/// pending `committed_rx.changed()` woke the replication stream once more and produced an extra
+/// AppendEntries with no entries and the same `leader_commit`.
+///
+/// Every commit still needs to reach the follower, so one entry-less AppendEntries per
+/// log-carrying one remains expected: a sequential writer leaves no later write to piggyback the
+/// commit on.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn no_redundant_commit_only_append_entries() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            // Heartbeats send entry-less AppendEntries of their own, which would blur the count.
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    let mut log_index = router.new_cluster(btreeset! {0, 1, 2}, btreeset! {}).await?;
+
+    let entry_less = Arc::new(AtomicU64::new(0));
+    let with_entries = Arc::new(AtomicU64::new(0));
+
+    tracing::info!(log_index, "--- count AppendEntries sent from now on");
+    {
+        let entry_less = entry_less.clone();
+        let with_entries = with_entries.clone();
+
+        router
+            .set_rpc_pre_hook(RPCTypes::AppendEntries, move |_router, req, _from, _to| {
+                if let RpcRequest::AppendEntries(append) = &req {
+                    if append.entries.is_empty() {
+                        entry_less.fetch_add(1, Ordering::Relaxed);
+                    } else {
+                        with_entries.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+                Box::pin(async move { Ok(()) })
+            })
+            .await;
+    }
+
+    tracing::info!(log_index, "--- write {} logs, one at a time", WRITES);
+    {
+        log_index += router.client_request_many(0, "foo", WRITES).await?;
+
+        router.wait(&1, timeout()).applied_index(Some(log_index), "node 1 applied").await?;
+        router.wait(&2, timeout()).applied_index(Some(log_index), "node 2 applied").await?;
+    }
+
+    let entry_less = entry_less.load(Ordering::Relaxed);
+    let with_entries = with_entries.load(Ordering::Relaxed);
+
+    tracing::info!(entry_less, with_entries, "--- AppendEntries counts");
+
+    assert!(
+        entry_less <= with_entries,
+        "expect at most one entry-less AppendEntries per log-carrying one, \
+         but got {} entry-less and {} with entries",
+        entry_less,
+        with_entries
+    );
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(5_000))
+}


### PR DESCRIPTION

## Changelog

##### perf: replication: drop the duplicate commit-only AppendEntries
# Summary

`next_request()` now reads `committed_rx` with `borrow_and_update()`
instead of `borrow_watched()`, so the leader stops sending a second,
entry-less AppendEntries that repeats a commit the previous request
already delivered.

# Details

`borrow_watched()` does not mark the value as seen. A request could
therefore stamp `leader_commit = C` and leave `committed_rx.changed()`
pending for that same `C`. The `_committed_change` arm of
`get_log_id_range()` then woke on it and returned an empty range,
producing an extra RPC that told the follower nothing new.

`StreamState::leader_committed` tracked by hand what the watch's
seen-marker now records exactly, so the field and its top-of-loop test
`committed > self.leader_committed` both go. When the commit is ahead,
`committed_rx.changed()` is already resolved and the `select!` returns at
once through the same arm.

One behavior difference follows from reaching the `select!` instead of
returning at the top of the loop: `futures_util::select!` picks randomly
among ready arms, so a ready `replicate_rx` carrying a different
`inflight_id` can win and end the stream. That skips one last request for
a payload already known to be obsolete.

Measured on 3 nodes with heartbeats off and 100 sequential writes:
entry-less AppendEntries drop from 251 to 200, while log-carrying ones
stay at 200. The remaining 200 are inherent — a sequential writer leaves
no later write for the commit to ride along with.

`no_redundant_commit_only_append_entries` pins the ratio that the old
code broke: at most one entry-less AppendEntries per log-carrying one.

- Fix: #2004

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2027)
<!-- Reviewable:end -->
