### PR TITLE
test: tests: use new_cluster for setup and document the conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ A moved test module stays a child of the module it tests, so it keeps access to 
 
 Both layouts are in use, and the choice follows test size, so a directory containing a mix of inline and separate test modules is expected rather than something to normalize.
 
+Integration tests live in `tests/tests/`, one test binary per directory. Read `tests/tests/README.md` before writing one; it defines the file naming, the `RaftRouter` cluster setup, and the waiting rules.
+
 ## Test Style
 
 - Keep short setup and action sequences inline, even when they occur in one or two tests. Extract a helper only when substantial reuse outweighs the extra abstraction level.

--- a/tests-turmoil/Cargo.lock
+++ b/tests-turmoil/Cargo.lock
@@ -1329,9 +1329,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "validit"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efba0434d5a0a62d4f22070b44ce055dc18cb64d4fa98276aa523dadfaba0e7"
+checksum = "4417835826b78aa6265724624d424df2b1e6e71a33329227d8b04a88950780dc"
 dependencies = [
  "anyerror",
 ]

--- a/tests/tests/README.md
+++ b/tests/tests/README.md
@@ -21,3 +21,155 @@ A test file name starts with `t[\d\d]_`, where `\d\d` is the test case number in
 - `t70`: not used.
 - `t80`: not used.
 - `t90`: issue fixes. 
+
+
+## Adding a test case
+
+Every directory here, such as `metrics/`, builds one test binary. Put the new
+file in the directory that owns the behavior under test, then declare it in
+that directory's `main.rs`:
+
+```rust
+mod t10_my_case;
+```
+
+Keep the `mod` list in file-name order. The numeric prefix describes the
+behavior's logical layer. Lower numbers cover basic behavior, while higher
+numbers cover higher-level behavior built from those basics.
+
+`custom_type_config_test.rs` and `public_api_test.rs` sit at the top level
+instead of in a directory. Each is a single-file binary that only has to
+compile, so neither needs a directory of its own.
+
+
+## Test case skeleton
+
+A test case is one async function that carries both attributes, returns
+`Result<()>`, and builds its own `Config` and `RaftRouter`:
+
+```rust
+/// One line stating what this case proves.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn my_case() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+
+    let mut router = RaftRouter::new(config.clone());
+
+    tracing::info!("--- bring up a 3-node cluster");
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {}).await?;
+
+    tracing::info!(log_index, "--- write one log");
+    {
+        router.client_request(0, "foo", 1).await?;
+        log_index += 1;
+
+        router.wait(&0, timeout()).applied_index(Some(log_index), "write one log").await?;
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1_000))
+}
+```
+
+Turn off `enable_tick`, `enable_heartbeat`, or `enable_elect` in `Config` when
+a background timer would disturb what the case observes. Set the flag before
+creating the router, and use `Raft::runtime_config()` only when the case must
+flip it in the middle of a run.
+
+Each file defines its own finite `timeout()` at the bottom and uses it for
+every `wait()` that expects progress. One second suits most cases.
+
+`ut_harness` installs the tracing subscriber and the panic hook, and runs the
+test body on the async runtime. It writes every log line to `tests/_log/`,
+which is the first place to look when a case fails.
+
+A case that touches no cluster, such as the serialization checks in
+`snapshot_streaming/t10_wire_compat_09.rs`, is a plain `#[test]` function
+with neither attribute. It needs no async runtime, so it needs no harness.
+
+
+## Set up the cluster with `new_cluster`
+
+`RaftRouter::new_cluster(voter_ids, learner_ids)` creates every node,
+initializes the cluster, turns the remaining voters into voters, adds the
+learners, waits for all of them to catch up, and returns the last log index:
+
+```rust
+let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3}).await?;
+```
+
+Use it in every case that only needs a running cluster. Call
+`Raft::initialize()` by hand only when the case observes initialization
+itself, for example an uninitialized node or an `initialize()` error.
+
+A case that drives one Raft API directly, such as
+`append_entries/t11_append_conflicts.rs` calling `Raft::append_entries()`,
+creates its nodes with `new_raft_node()` and forms no cluster at all.
+
+A hand-written setup must wait for the leader to apply log index 1 before it
+calls `add_learner()` or `change_membership()`:
+
+```rust
+n0.initialize(btreeset! {0}).await?;
+router.wait(&0, timeout()).applied_index(Some(1), "init").await?;
+```
+
+`Raft::initialize()` returns once the membership entry at index 0 is flushed,
+not once it is committed. A node also reports `ServerState::Leader` before it
+commits its own blank log at index 1. A membership call that arrives in that
+window is rejected with `ChangeMembershipError::InProgress`, which surfaces as
+a test that fails only now and then on CI.
+
+
+## Track the expected log index
+
+Keep one `log_index` variable that mirrors the last log index the cluster
+should hold, and update it right after each write:
+
+- cluster init: 2 logs, the membership entry at index 0 and the leader blank
+  log at index 1.
+- `add_learner()`: 1 log.
+- `change_membership()`: 2 logs, the joint config and then the uniform config.
+- `client_request()`: 1 log. `client_request_many()` returns how many it wrote.
+
+Assert progress with a wait, never with a sleep:
+
+```rust
+router.wait(&node_id, timeout()).applied_index(Some(log_index), "write one log").await?;
+```
+
+`Wait` also offers `committed_index()`, `state()`, `vote()`, `members()`,
+`voter_ids()`, `snapshot()`, `purged()`, and `current_leader()`. Passing
+`None` creates a 100-year timeout. Use it only when an explicit finite
+`TypeConfig::timeout()` bounds the whole wait.
+
+Sleep only to show that something does not happen. A `TypeConfig::sleep()`
+followed by an assertion that the term did not grow, or that the node is
+still the leader, is the one correct use. Await everything a case expects to
+happen with `wait()` instead, because a sleep long enough to be safe on a
+loaded CI runner also slows down every green run.
+
+
+## Fault injection
+
+The router owns the simulated network, so a case shapes failures through it:
+
+- `set_network_error(id, bool)` and `set_unreachable(id, bool)` cut a node off.
+- `set_rpc_failure(id, direction, error_type)` fails one direction of one node.
+- `set_rpc_pre_hook()` and `set_rpc_post_hook()` block or inspect one RPC type.
+- `network_send_delay(ms)` delays every send.
+- `get_rpc_count()` reports how many RPCs of each type were sent.
+
+CI runs the whole suite a second time with `OPENRAFT_NETWORK_SEND_DELAY=30`,
+which delays every RPC by 30 ms. A case must therefore never assume an RPC
+completes quickly.

--- a/tests/tests/elect/t12_pre_vote.rs
+++ b/tests/tests/elect/t12_pre_vote.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
+use openraft::RaftMetrics;
 use openraft::ServerState;
 use openraft::Vote;
 use openraft::async_runtime::WatchReceiver;
@@ -96,15 +97,11 @@ async fn without_pre_vote_term_inflates() -> Result<()> {
 
     tracing::info!("--- isolate node 1 and let many election timeouts pass");
     router.set_network_error(1, true);
-    TypeConfig::sleep(Duration::from_secs(2)).await;
 
-    let follower_term_after = n1.metrics().borrow_watched().current_term;
-    assert!(
-        follower_term_after > follower_term_before,
-        "without Pre-Vote the isolated follower inflates its term, was {}, now {}",
-        follower_term_before,
-        follower_term_after
-    );
+    let inflated = |x: &RaftMetrics<TypeConfig>| x.current_term > follower_term_before;
+    n1.wait(Some(Duration::from_secs(2)))
+        .metrics(inflated, "without Pre-Vote the isolated follower inflates its term")
+        .await?;
 
     Ok(())
 }

--- a/tests/tests/membership/t12_concurrent_write_and_add_learner.rs
+++ b/tests/tests/membership/t12_concurrent_write_and_add_learner.rs
@@ -7,7 +7,6 @@ use maplit::btreeset;
 use openraft::Config;
 use openraft::LogIdOptionExt;
 use openraft::ServerState;
-use openraft::Vote;
 use openraft::type_config::TypeConfigExt;
 use openraft_memstore::TypeConfig;
 use tracing::Instrument;
@@ -53,38 +52,8 @@ async fn concurrent_write_and_add_learner() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    router.new_raft_node(0).await;
-
-    let mut log_index;
-
-    tracing::info!("--- initializing cluster of 1 node");
-    {
-        router.initialize(0).await?;
-        log_index = 1;
-
-        wait_log(&router, &btreeset![0], log_index).await?;
-    }
-
-    tracing::info!(log_index, "--- adding two candidate nodes");
-    {
-        // Sync some new nodes.
-        router.new_raft_node(1).await;
-        router.new_raft_node(2).await;
-        router.add_learner(0, 1).await?;
-        router.add_learner(0, 2).await?;
-        log_index += 2; // two add_learner logs
-
-        tracing::info!(log_index, "--- changing cluster config");
-
-        let node = router.get_raft_handle(&0)?;
-        node.change_membership(candidates.clone(), false).await?;
-        log_index += 2; // Tow member change logs
-
-        wait_log(&router, &candidates, log_index).await?;
-        for id in [0, 1, 2] {
-            router.wait(&id, timeout()).vote(Vote::new_committed(1, 0), "after changing membership").await?;
-        }
-    }
+    tracing::info!("--- bring up a cluster of the 3 candidates");
+    let mut log_index = router.new_cluster(candidates.clone(), btreeset! {}).await?;
 
     let leader = router.leader().unwrap();
 

--- a/tests/tests/membership/t30_commit_joint_config.rs
+++ b/tests/tests/membership/t30_commit_joint_config.rs
@@ -32,28 +32,9 @@ async fn commit_joint_config_during_0_to_012() -> Result<()> {
     );
 
     let mut router = RaftRouter::new(config.clone());
-    router.new_raft_node(0).await;
 
-    // Initialize the cluster, then assert that a stable cluster was formed & held.
-    tracing::info!("--- initializing cluster");
-    router.initialize(0).await?;
-    // Assert all nodes are in learner state & have no entries.
-    let mut log_index = 1;
-
-    router.wait(&0, timeout()).applied_index(Some(log_index), "init node 0").await?;
-
-    // Sync some new nodes.
-    router.new_raft_node(1).await;
-    router.new_raft_node(2).await;
-
-    tracing::info!(log_index, "--- adding new nodes 1,2 to cluster");
-    {
-        router.add_learner(0, 1).await?;
-        router.add_learner(0, 2).await?;
-    }
-    log_index += 2;
-
-    router.wait(&0, timeout()).applied_index(Some(log_index), "init node 0").await?;
+    tracing::info!("--- bring up node 0 as leader, with node 1,2 as learners");
+    let log_index = router.new_cluster(btreeset! {0}, btreeset! {1,2}).await?;
 
     tracing::info!(
         log_index,

--- a/tests/tests/metrics/t20_metrics_state_machine_consistency.rs
+++ b/tests/tests/metrics/t20_metrics_state_machine_consistency.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
-use openraft::ServerState;
 
 use crate::fixtures::RaftRouter;
 use crate::fixtures::ut_harness;
@@ -30,23 +29,8 @@ async fn metrics_state_machine_consistency() -> Result<()> {
 
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = 0;
-
-    router.new_raft_node(0).await;
-    router.new_raft_node(1).await;
-
-    tracing::info!(log_index, "--- initializing single node cluster");
-    {
-        let n0 = router.get_raft_handle(&0)?;
-        n0.initialize(btreeset! {0}).await?;
-        log_index += 1;
-
-        router.wait(&0, timeout()).state(ServerState::Leader, "n0 -> leader").await?;
-    }
-
-    tracing::info!(log_index, "--- add one learner");
-    router.add_learner(0, 1).await?;
-    log_index += 1;
+    tracing::info!("--- bring up one leader and one learner");
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
     tracing::info!(log_index, "--- write one log");
     router.client_request(0, "foo", 1).await?;
@@ -56,7 +40,7 @@ async fn metrics_state_machine_consistency() -> Result<()> {
     tracing::info!(log_index, "--- wait for log to sync");
     log_index += 1;
     for node_id in 0..2 {
-        router.wait(&node_id, None).applied_index(Some(log_index), "write one log").await?;
+        router.wait(&node_id, timeout()).applied_index(Some(log_index), "write one log").await?;
         let (_sto, sm) = router.get_storage_handle(&node_id)?;
         assert!(sm.get_state_machine().await.client_status.contains_key("foo"));
     }
@@ -65,5 +49,5 @@ async fn metrics_state_machine_consistency() -> Result<()> {
 }
 
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_millis(1000))
+    Some(Duration::from_millis(1_000))
 }

--- a/tests/tests/metrics/t40_metrics_wait.rs
+++ b/tests/tests/metrics/t40_metrics_wait.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
-use openraft::ServerState;
 use openraft::metrics::WaitError;
 
 use crate::fixtures::RaftRouter;
@@ -30,21 +29,14 @@ async fn metrics_wait() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let cluster = btreeset![0];
-    router.new_raft_node(0).await;
-    {
-        let n0 = router.get_raft_handle(&0)?;
-        n0.initialize(cluster.clone()).await?;
+    tracing::info!("--- bring up a single node cluster");
+    let log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
-        router.wait(&0, timeout()).state(ServerState::Leader, "n0 -> leader").await?;
-    }
+    tracing::info!(log_index, "--- wait for a log that is never written, expect timeout");
 
-    router.wait(&0, None).current_leader(0, "become leader").await?;
-    router.wait(&0, None).applied_index(Some(1), "initial log").await?;
-
-    tracing::info!("--- wait and timeout");
-
-    let rst = router.wait(&0, timeout()).applied_index(Some(2), "timeout waiting for log 2").await;
+    let never_written = log_index + 1;
+    let msg = format!("timeout waiting for log {}", never_written);
+    let rst = router.wait(&0, timeout()).applied_index(Some(never_written), msg).await;
 
     match rst {
         Ok(_) => {

--- a/tests/tests/snapshot_streaming/t60_snapshot_chunk_size.rs
+++ b/tests/tests/snapshot_streaming/t60_snapshot_chunk_size.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
+use maplit::btreeset;
 use openraft::Config;
 use openraft::RaftLogReader;
-use openraft::ServerState;
 use openraft::SnapshotPolicy;
 use openraft::Vote;
 use openraft::storage::RaftLogStorage;
@@ -38,20 +38,8 @@ async fn snapshot_chunk_size() -> Result<()> {
     );
     let mut router = RaftRouter::new(config.clone());
 
-    let mut log_index = 0;
-
-    tracing::info!(log_index, "--- initializing cluster");
-    {
-        router.new_raft_node(0).await;
-
-        router.wait(&0, timeout()).applied_index(None, "empty").await?;
-        router.wait(&0, timeout()).state(ServerState::Learner, "empty").await?;
-
-        router.initialize(0).await?;
-        log_index += 1;
-
-        router.wait(&0, timeout()).applied_index(Some(log_index), "init leader").await?;
-    }
+    tracing::info!("--- bring up a single node cluster");
+    let mut log_index = router.new_cluster(btreeset! {0}, btreeset! {}).await?;
 
     tracing::info!(log_index, "--- send just enough logs to trigger snapshot");
     {

--- a/tests/tests/state_machine/t10_total_order_apply.rs
+++ b/tests/tests/state_machine/t10_total_order_apply.rs
@@ -5,7 +5,6 @@ use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::LogIdOptionExt;
-use openraft::ServerState;
 use openraft::async_runtime::WatchReceiver;
 use openraft::async_runtime::WatchSender;
 use openraft::storage::RaftStateMachine;
@@ -30,19 +29,8 @@ async fn total_order_apply() -> Result<()> {
 
     let mut router = RaftRouter::new(config.clone());
 
-    router.new_raft_node(0).await;
-    router.new_raft_node(1).await;
-
-    tracing::info!("--- initializing single node cluster");
-    {
-        let n0 = router.get_raft_handle(&0)?;
-        n0.initialize(btreeset! {0}).await?;
-
-        router.wait(&0, timeout()).state(ServerState::Leader, "n0 -> leader").await?;
-    }
-
-    tracing::info!("--- add one learner");
-    router.add_learner(0, 1).await?;
+    tracing::info!("--- bring up one leader and one learner");
+    router.new_cluster(btreeset! {0}, btreeset! {1}).await?;
 
     let (tx, rx) = TypeConfig::watch_channel(false);
 


### PR DESCRIPTION

## Changelog

##### test: tests: use new_cluster for setup and document the conventions
# Summary

Six integration test cases that built a cluster by hand now call
`RaftRouter::new_cluster()`, and `tests/tests/README.md` states the
conventions every case follows.

# Details

`metrics_state_machine_consistency` and `total_order_apply` both called
`add_learner()` after waiting only for `ServerState::Leader`, so the
membership call could fail with `ChangeMembershipError::InProgress`.
`Raft::initialize()` returns once the membership entry at index 0 is
flushed, not once it is committed, and a node reports `Leader` before it
commits its own blank log at index 1. `new_cluster` waits for that
commit before it adds a learner.

`metrics_state_machine_consistency` failed this way on CI:
https://github.com/databendlabs/openraft/actions/runs/32617209041/job/97139737338
`total_order_apply` is `#[ignore]`d, so CI never ran into it. It passes
under `--ignored` after the change. The other four cases repeated what
`new_cluster` already does, waits included.

`without_pre_vote_term_inflates` slept a fixed two seconds and then
asserted that the isolated follower's term had grown. Waiting on that
condition ends the case as soon as the term grows, and no longer depends
on two seconds being enough on a loaded runner.

The README covers where a case file goes, the case skeleton, cluster
setup with `new_cluster`, log index tracking, and the router's fault
injection knobs. The numeric file prefix marks the behavior's logical
layer. A wait that expects progress carries a finite timeout, and sleep
is left for one job only: showing that something does not happen.
`CLAUDE.md` points at the README so the rules are read before a new case
is written.

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2028)
<!-- Reviewable:end -->
