### PR TITLE
test: jepsen: add a quorum-aware Packet Nemesis

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -61,7 +61,7 @@ jobs:
         run: make -C jepsen unit-test
 
   jepsen:
-    name: Jepsen (${{ matrix.nemesis }})
+    name: Jepsen (${{ matrix.name }})
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -69,19 +69,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nemesis:
-          - membership
-          - partition
-          - pause
-          - process
-          - chaos
+        include:
+          - name: membership
+            nemesis: membership
+          - name: partition
+            nemesis: partition
+          - name: pause
+            nemesis: pause
+          - name: process
+            nemesis: process
+          - name: packet-slow
+            nemesis: packet
+            packet_mode: slow
+          - name: packet-flaky
+            nemesis: packet
+            packet_mode: flaky
+          - name: chaos
+            nemesis: chaos
 
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v4
 
       - name: Test | Jepsen
-        run: make -C jepsen jepsen NEMESIS=${{ matrix.nemesis }}
+        run: >-
+          make -C jepsen jepsen
+          NEMESIS=${{ matrix.nemesis }}
+          PACKET_MODE=${{ matrix.packet_mode }}
 
       - name: Debug | Docker logs
         if: failure()
@@ -93,7 +107,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jepsen-results-${{ matrix.nemesis }}
+          name: jepsen-results-${{ matrix.name }}
           path: jepsen/store/**/results.edn
           if-no-files-found: ignore
 
@@ -101,7 +115,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: jepsen-debug-${{ matrix.nemesis }}
+          name: jepsen-debug-${{ matrix.name }}
           path: |
             jepsen/store/
             jepsen/docker-compose.log

--- a/jepsen/Makefile
+++ b/jepsen/Makefile
@@ -14,6 +14,10 @@ ifneq ($(SNAPSHOT_THRESHOLD),)
 override ARGS += --snapshot-threshold $(SNAPSHOT_THRESHOLD)
 endif
 
+ifneq ($(PACKET_MODE),)
+override ARGS += --packet-mode $(PACKET_MODE)
+endif
+
 app-lint:
 	cargo fmt --check --manifest-path $(APP_MANIFEST)
 	cargo clippy --no-deps --manifest-path $(APP_MANIFEST) --all-targets -- -D warnings

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -148,32 +148,126 @@ as its OpenRaft node ID.
 This starts the five-node Docker environment, then runs the Jepsen control
 process from the control container. Every test checks a concurrent mix of
 linearizable reads, writes, and compare-and-set operations across independent
-registers with Knossos. The default `chaos` profile independently
-schedules partition, process, pause, and membership faults, so their active
-intervals can overlap. `NEMESIS` accepts a comma-separated subset when a
+registers with Knossos. `NEMESIS` accepts a comma-separated subset when a
 narrower combination is needed.
 
-The partition nemesis alternates between partitions where the current leader is
-in the majority and in the minority. A focused partition run requires both
-modes to occur.
+### Nemesis Design
 
-The process nemesis reads the effective voter configs from OpenRaft metrics and
-randomly stops a non-empty voter subset whose survivors still form a quorum. It
-supports both stable and joint membership and covers leader and follower-only
-crashes.
+A standalone Nemesis selects each target so the surviving voters still contain
+a quorum in every effective voter configuration. This applies to both stable
+and joint membership. A focused run can therefore exercise one fault class and
+its recovery while retaining a component that can make progress.
 
-The pause nemesis uses the same quorum-safe target selection, but suspends the
-selected processes without terminating them. Their in-memory state and open TCP
-connections remain in place, so peers observe an unresponsive process rather
-than a closed connection. It covers pauses that include and exclude the current
-leader. Resume operations target every test node as an idempotent cleanup and
-record both the preceding disruption and the complete resumed node set in the
-Jepsen history.
+The `chaos` profile composes individually quorum-safe faults without reserving
+one common survivor quorum across fault classes. Their active intervals may
+overlap and temporarily remove the global quorum. Safety and eventual recovery
+remain mandatory in that case, but continuous availability does not.
 
-The membership nemesis starts with a shrink and grow for deterministic coverage,
-then randomly mixes additional membership changes. Removed nodes are stopped
-and wiped only after the new voter set is committed. The final recovery restores
-all five nodes as voters and waits for every node to agree on a leader.
+#### Network Partition Nemesis
+
+The partition Nemesis installs a hard network partition between two components.
+It exercises two leader-aware cases:
+
+- `leader-in-majority`: the current quorum-supported leader remains with a
+  majority of the voters;
+- `leader-in-minority`: the leader is isolated with a minority while the other
+  component retains a quorum and can elect a replacement.
+
+A focused partition run requires both cases to be installed and healed. If no
+quorum-supported leader or safe partition target is observable, the operation
+is skipped and retried later without counting as coverage.
+
+#### Process Kill Nemesis
+
+The process Nemesis reads the effective voter configurations from OpenRaft
+metrics and randomly stops a non-empty voter subset whose survivors still form
+a quorum. It exercises two target cases:
+
+- `leader-killed`: the selected processes include the current
+  quorum-supported leader, so the survivors must elect a replacement;
+- `leader-survives`: only non-leader voters are selected, so the existing leader
+  remains with a quorum.
+
+The target set is fixed for one fault episode. Recovery restarts the selected
+processes and waits for them to rejoin the healthy cluster.
+
+#### Process Pause Nemesis
+
+The pause Nemesis uses the same quorum-safe target selection as process kill,
+but suspends the selected processes without terminating them. It covers:
+
+- `leader-paused`: the selected set includes the supported leader;
+- `leader-unpaused`: only non-leader voters are suspended.
+
+Paused processes retain their memory and open TCP connections, so peers observe
+unresponsive processes rather than closed connections. Resume operations target
+every test node as an idempotent cleanup and record the complete resumed node
+set in history.
+
+#### Membership Nemesis
+
+The membership Nemesis exercises two membership-change cases:
+
+- `shrink`: remove a voter only when the resulting configuration retains a
+  quorum;
+- `grow`: add a non-voter back through learner initialization and committed
+  membership change.
+
+It starts with one shrink and grow for deterministic coverage, then randomly
+mixes additional membership changes. Removed nodes are stopped and wiped only
+after the new voter set is committed. Final recovery restores all five nodes as
+voters and waits for every node to agree on a leader.
+
+#### Packet Nemesis
+
+The planned packet Nemesis models traffic that remains reachable but is
+degraded. Hard packet drops that create a partition remain the responsibility
+of the Network Partition Nemesis. Packet provides two mutually exclusive
+modes:
+
+- `slow`: 300 ms latency with 50 ms jitter;
+- `flaky`: Jepsen's default 20% packet loss with 75% correlation.
+
+The `slow` parameters are derived from the test application's timing
+configuration. Its election timeout is approximately 299 ms and its heartbeat
+interval is 50 ms. A 300 ms base delay with 50 ms jitter therefore spans roughly
+250--350 ms: from about one heartbeat interval before the election threshold to
+about one heartbeat interval after it. This deliberately exercises the boundary
+where some messages arrive before an election timeout and others arrive after
+it, without requiring every fault episode to trigger an election.
+
+A focused run explicitly selects one mode. Within that mode it exercises two
+quorum-safe target cases:
+
+- `leader-included`: the fixed target set includes the quorum-supported leader;
+- `leader-excluded`: the fixed target set contains only non-leader voters.
+
+Targets are selected once per fault episode and do not follow a newly elected
+leader. If no supported leader or safe target for the requested case is
+observable, the operation is skipped and retried without counting as coverage.
+
+Both modes use Jepsen's `shape!` wrapper around Linux `tc netem`. The first
+version applies one mode in both directions across the selected target boundary,
+at node-IP granularity and across DB-to-DB ports. It does not provide one-way,
+per-RPC, or per-port shaping. Because both modes own the same root qdisc, they
+are never active at the same time.
+
+The same Packet package and checker are used in focused and chaos runs. Packet
+coverage requires the selected mode and both leader-target cases to be installed
+and later cleared successfully. It does not require an election, timeout, or
+indeterminate mutation, because those observations depend on timing, TCP
+retransmission, and kernel packet selection. Partial installation or cleanup is
+a Harness failure; final recovery and teardown must attempt idempotent cleanup
+on every node.
+
+#### Chaos Composition
+
+The default `chaos` profile independently schedules partition, process, pause,
+membership, and, once implemented, packet faults. It composes the package,
+generator, final recovery, and checker supplied by each Nemesis rather than
+defining separate Chaos-only checker semantics. Packet chooses one of `slow` or
+`flaky` for each independent Packet episode, and never overlaps those two modes
+with each other. Different fault classes may remain active at the same time.
 
 Every Jepsen node builds a snapshot after 100 newly committed logs by default.
 The regular write workload therefore exercises snapshot construction during

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -225,16 +225,18 @@ degraded. Hard packet drops that create a partition remain the responsibility
 of the Network Partition Nemesis. Packet provides two mutually exclusive
 modes:
 
-- `slow`: 300 ms latency with 50 ms jitter;
+- `slow`: 300 ms latency with 50 ms normally distributed jitter;
 - `flaky`: Jepsen's default 20% packet loss with 75% correlation.
 
 The `slow` parameters are derived from the test application's timing
 configuration. Its election timeout is approximately 299 ms and its heartbeat
-interval is 50 ms. A 300 ms base delay with 50 ms jitter therefore spans roughly
-250--350 ms: from about one heartbeat interval before the election threshold to
-about one heartbeat interval after it. This deliberately exercises the boundary
-where some messages arrive before an election timeout and others arrive after
-it, without requiring every fault episode to trigger an election.
+interval is 50 ms. A 300 ms base delay with a 50 ms normal jitter scale therefore
+concentrates delays around the election threshold, with substantial probability
+on either side of it. This deliberately exercises the boundary where some
+messages arrive before an election timeout and others arrive after it, without
+requiring every fault episode to trigger an election. The distribution is not
+bounded to 250--350 ms; values farther from the base delay are less likely but
+possible.
 
 A focused run explicitly selects one mode. Within that mode it exercises two
 quorum-safe target cases:

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -22,7 +22,7 @@
   [:partition :process :pause :membership :packet])
 
 (def ^:private chaos-nemesis-types
-  [:partition :process :pause :membership])
+  concrete-nemesis-types)
 
 (def nemesis-types
   (conj (set concrete-nemesis-types) :chaos))
@@ -51,6 +51,13 @@
     true
     (catch Exception _
       false)))
+
+(defn- chaos-selection? [selection]
+  (or (nil? selection)
+      (contains? (set (if (coll? selection)
+                        selection
+                        [selection]))
+                 :chaos)))
 
 (def cli-opts
   [[nil "--api-port PORT" "OpenRaft application HTTP port."
@@ -113,6 +120,7 @@
   (let [failure-state (harness/failure-state)
         database (openraft-db/db opts)
         workload (workload/workload opts)
+        chaos? (chaos-selection? (:nemesis opts))
         nemesis-types (normalize-nemeses (:nemesis opts))
         nemesis-package
         (openraft-nemesis/compose-packages
@@ -132,8 +140,9 @@
                    (membership/membership-package database opts)
 
                    :packet
-                   (let [packet-mode (:packet-mode opts)]
-                     (when-not packet-mode
+                   (let [packet-mode (when-not chaos?
+                                       (:packet-mode opts))]
+                     (when-not (or chaos? packet-mode)
                        (throw (ex-info
                                "--packet-mode is required for Packet Nemesis"
                                {:nemesis nemesis-types})))

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -14,10 +14,14 @@
              [worker :as worker]
              [workload :as workload]]
             [jepsen.openraft.nemesis [membership :as membership]
+             [packet :as packet]
              [partition :as partition]
              [process :as process]]))
 
 (def ^:private concrete-nemesis-types
+  [:partition :process :pause :membership :packet])
+
+(def ^:private chaos-nemesis-types
   [:partition :process :pause :membership])
 
 (def nemesis-types
@@ -38,7 +42,7 @@
                        :unknown (vec unknown)})))
     (let [expanded (cond-> (disj requested :chaos)
                      (contains? requested :chaos)
-                     (into concrete-nemesis-types))]
+                     (into chaos-nemesis-types))]
       (filterv expanded concrete-nemesis-types))))
 
 (defn- valid-nemeses? [selection]
@@ -65,10 +69,14 @@
                "Must be a positive integer."]]
 
    [nil "--nemesis TYPES"
-    "Comma-separated faults: membership, partition, process, pause, or chaos."
+    "Comma-separated faults: membership, packet, partition, process, pause, or chaos."
     :default [:chaos]
     :parse-fn parse-nemeses
     :validate [valid-nemeses? "Unknown fault."]]
+
+   [nil "--packet-mode MODE" "Packet mode: slow or flaky."
+    :parse-fn keyword
+    :validate [packet/packet-modes "Must be slow or flaky."]]
 
    [nil "--seed SEED" "Seed for Jepsen random choices."
     :parse-fn parse-long
@@ -121,7 +129,15 @@
                    (process/pause-package database)
 
                    :membership
-                   (membership/membership-package database opts)))
+                   (membership/membership-package database opts)
+
+                   :packet
+                   (let [packet-mode (:packet-mode opts)]
+                     (when-not packet-mode
+                       (throw (ex-info
+                               "--packet-mode is required for Packet Nemesis"
+                               {:nemesis nemesis-types})))
+                     (packet/packet-package database packet-mode))))
                nemesis-types))]
     (merge tests/noop-test
            opts

--- a/jepsen/src/jepsen/openraft/nemesis.clj
+++ b/jepsen/src/jepsen/openraft/nemesis.clj
@@ -17,6 +17,7 @@
 (def ^:private retryable-skip-reasons
   #{:no-quorum-safe-process-target
     :no-reachable-pause-target
+    :no-safe-packet-target
     :no-safe-partition-target
     :no-supported-leader})
 

--- a/jepsen/src/jepsen/openraft/nemesis/packet.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/packet.clj
@@ -60,12 +60,16 @@
       (if-let [{:keys [leader] :as status}
                (cluster/membership-status test)]
         (let [configs (cluster/voter-configs test status)
-              target-role (:value op)]
+              request (:value op)
+              mode (or (:mode request) packet-mode)
+              target-role (or (:target-role request) request)]
+          (when-not (packet-modes mode)
+            (throw (ex-info "Unknown packet mode" {:mode mode})))
           (if-let [targets (packet-targets configs leader target-role)]
             (let [targets (vec (filter targets (:nodes test)))
-                  behavior (get packet-behaviors packet-mode)]
+                  behavior (get packet-behaviors mode)]
               (info "Degrading OpenRaft packet delivery"
-                    {:mode packet-mode
+                    {:mode mode
                      :target-role target-role
                      :leader leader
                      :targets targets
@@ -76,7 +80,7 @@
                                        :value [targets behavior]))
               (assoc op
                      :value (outcome/installed
-                             {:mode packet-mode
+                             {:mode mode
                               :target-role target-role
                               :leader leader
                               :voter-configs configs
@@ -84,14 +88,14 @@
                               :behavior behavior})))
             (do
               (info "Skipping packet degradation without a safe target"
-                    {:mode packet-mode
+                    {:mode mode
                      :target-role target-role
                      :leader leader
                      :voter-configs configs})
               (assoc op
                      :value (outcome/skipped
                              :no-safe-packet-target
-                             {:mode packet-mode
+                             {:mode mode
                               :target-role target-role
                               :leader leader
                               :voter-configs configs})))))
@@ -100,8 +104,9 @@
           (assoc op
                  :value (outcome/skipped
                          :no-supported-leader
-                         {:mode packet-mode
-                          :target-role (:value op)}))))
+                         {:mode (or (:mode (:value op)) packet-mode)
+                          :target-role (or (:target-role (:value op))
+                                           (:value op))}))))
 
       :stop-packet
       (do
@@ -122,7 +127,8 @@
     #{:start-packet :stop-packet}))
 
 (defn packet-nemesis [database packet-mode]
-  (when-not (packet-modes packet-mode)
+  (when-not (or (nil? packet-mode)
+                (packet-modes packet-mode))
     (throw (ex-info "Unknown packet mode" {:mode packet-mode})))
   (PacketNemesis. (combined/packet-nemesis database) packet-mode))
 
@@ -138,19 +144,25 @@
   (and (= :installed (:status value))
        (:leader value)))
 
-(defn- packet-generator []
-  (gen/cycle
-   (gen/phases
-    {:type :info
-     :f :start-packet
-     :value :leader-included}
-    {:type :info
-     :f :stop-packet}
-    {:type :info
-     :f :start-packet
-     :value :leader-excluded}
-    {:type :info
-     :f :stop-packet})))
+(defn- select-packet-mode [packet-mode]
+  (or packet-mode
+      (first (random/shuffle packet-modes))))
+
+(defn- packet-generator [packet-mode]
+  (let [start (fn [target-role]
+                (fn [_test _context]
+                  {:type :info
+                   :f :start-packet
+                   :value {:mode (select-packet-mode packet-mode)
+                           :target-role target-role}}))
+        stop {:type :info
+              :f :stop-packet}]
+    (gen/cycle
+     (gen/phases
+      (gen/once (start :leader-included))
+      stop
+      (gen/once (start :leader-excluded))
+      stop))))
 
 (defn- next-cluster-state [state op]
   (let [status (get-in op [:value :status])
@@ -187,8 +199,9 @@
       (let [observed-roles (->> history
                                 (filter #(= :start-packet (:f %)))
                                 (filter #(packet-start-installed? (:value %)))
-                                (filter #(= packet-mode
-                                            (get-in % [:value :mode])))
+                                (filter #(or (nil? packet-mode)
+                                             (= packet-mode
+                                                (get-in % [:value :mode]))))
                                 (keep #(get-in % [:value :target-role]))
                                 set)
             missing-roles (remove observed-roles required-target-roles)
@@ -199,7 +212,7 @@
                      (= :recovery-pending cluster-state) false
                      :else :unknown)]
         {:valid? valid?
-         :mode packet-mode
+         :mode (or packet-mode :mixed)
          :observed-modes (vec (sort observed-roles))
          :missing-modes (vec (sort missing-roles))
          :cluster-state cluster-state}))))
@@ -208,7 +221,7 @@
   {:name :packet
    :interval packet-seconds
    :nemesis (packet-nemesis database packet-mode)
-   :generator (packet-generator)
+   :generator (packet-generator packet-mode)
    :final-generator {:type :info
                      :f :stop-packet}
    :checker (openraft-checker/reject-checker-exceptions

--- a/jepsen/src/jepsen/openraft/nemesis/packet.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/packet.clj
@@ -1,0 +1,215 @@
+(ns jepsen.openraft.nemesis.packet
+  (:require [clojure.tools.logging :refer [info]]
+            [jepsen [checker :as checker]
+             [generator :as gen]
+             [nemesis :as nemesis]
+             [random :as random]]
+            [jepsen.nemesis.combined :as combined]
+            [jepsen.openraft.checker :as openraft-checker]
+            [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.interruption :as interruption]
+            [jepsen.openraft.nemesis.outcome :as outcome]
+            [jepsen.openraft.quorum :as quorum]))
+
+(def packet-seconds 10)
+(def packet-modes #{:slow :flaky})
+(def required-target-roles #{:leader-included :leader-excluded})
+
+(def ^:private packet-behaviors
+  {:slow {:delay {:time :300ms
+                  :jitter :50ms
+                  :correlation :25%
+                  :distribution :normal}}
+   :flaky {:loss {}}})
+
+(defn- packet-targets [configs leader target-role]
+  (let [voters (quorum/voter-set configs)]
+    (when-not (contains? voters leader)
+      (throw (ex-info "The current leader is not a voter"
+                      {:leader leader
+                       :configs configs})))
+    (let [candidates (case target-role
+                       :leader-included
+                       (filter #(contains? % leader)
+                               (quorum/fault-sets configs))
+
+                       :leader-excluded
+                       (remove #(contains? % leader)
+                               (quorum/fault-sets configs))
+
+                       (throw (ex-info "Unknown packet target role"
+                                       {:target-role target-role})))]
+      (first (random/shuffle candidates)))))
+
+(defn- invoke-delegate! [delegate test op]
+  (try
+    (nemesis/invoke! delegate test op)
+    (catch Exception e
+      (when (interruption/interruption? e)
+        (.interrupt (Thread/currentThread)))
+      (throw e))))
+
+(defrecord PacketNemesis [delegate packet-mode]
+  nemesis/Nemesis
+  (setup! [_ test]
+    (PacketNemesis. (nemesis/setup! delegate test) packet-mode))
+
+  (invoke! [_ test op]
+    (case (:f op)
+      :start-packet
+      (if-let [{:keys [leader] :as status}
+               (cluster/membership-status test)]
+        (let [configs (cluster/voter-configs test status)
+              target-role (:value op)]
+          (if-let [targets (packet-targets configs leader target-role)]
+            (let [targets (vec (filter targets (:nodes test)))
+                  behavior (get packet-behaviors packet-mode)]
+              (info "Degrading OpenRaft packet delivery"
+                    {:mode packet-mode
+                     :target-role target-role
+                     :leader leader
+                     :targets targets
+                     :behavior behavior})
+              (invoke-delegate! delegate
+                                test
+                                (assoc op
+                                       :value [targets behavior]))
+              (assoc op
+                     :value (outcome/installed
+                             {:mode packet-mode
+                              :target-role target-role
+                              :leader leader
+                              :voter-configs configs
+                              :targets targets
+                              :behavior behavior})))
+            (do
+              (info "Skipping packet degradation without a safe target"
+                    {:mode packet-mode
+                     :target-role target-role
+                     :leader leader
+                     :voter-configs configs})
+              (assoc op
+                     :value (outcome/skipped
+                             :no-safe-packet-target
+                             {:mode packet-mode
+                              :target-role target-role
+                              :leader leader
+                              :voter-configs configs})))))
+        (do
+          (info "Skipping packet degradation without a supported leader")
+          (assoc op
+                 :value (outcome/skipped
+                         :no-supported-leader
+                         {:mode packet-mode
+                          :target-role (:value op)}))))
+
+      :stop-packet
+      (do
+        (info "Restoring reliable OpenRaft packet delivery")
+        (invoke-delegate! delegate test (assoc op :value nil))
+        (assoc op :value (outcome/installed {:mode packet-mode})))))
+
+  (teardown! [_ test]
+    (try
+      (nemesis/teardown! delegate test)
+      (catch Exception e
+        (when (interruption/interruption? e)
+          (.interrupt (Thread/currentThread)))
+        (throw e))))
+
+  nemesis/Reflection
+  (fs [_]
+    #{:start-packet :stop-packet}))
+
+(defn packet-nemesis [database packet-mode]
+  (when-not (packet-modes packet-mode)
+    (throw (ex-info "Unknown packet mode" {:mode packet-mode})))
+  (PacketNemesis. (combined/packet-nemesis database) packet-mode))
+
+(defn- packet-start-installed? [value]
+  (and (= :installed (:status value))
+       (packet-modes (:mode value))
+       (required-target-roles (:target-role value))))
+
+(defn- packet-stop-installed? [value]
+  (= :installed (:status value)))
+
+(defn- recovery-installed? [value]
+  (and (= :installed (:status value))
+       (:leader value)))
+
+(defn- packet-generator []
+  (gen/cycle
+   (gen/phases
+    {:type :info
+     :f :start-packet
+     :value :leader-included}
+    {:type :info
+     :f :stop-packet}
+    {:type :info
+     :f :start-packet
+     :value :leader-excluded}
+    {:type :info
+     :f :stop-packet})))
+
+(defn- next-cluster-state [state op]
+  (let [status (get-in op [:value :status])
+        operation-error? (boolean (or (:error op)
+                                      (:exception op)
+                                      (= :indeterminate status)))]
+    (case (:f op)
+      :start-packet
+      (cond
+        operation-error? :unknown
+        (packet-start-installed? (:value op)) :recovery-pending
+        :else state)
+
+      :stop-packet
+      (cond
+        operation-error? :unknown
+        (packet-stop-installed? (:value op)) :recovery-pending
+        :else state)
+
+      :await-recovery
+      (cond
+        operation-error? (if (= :recovery-pending state)
+                           :recovery-pending
+                           :unknown)
+        (= :unknown state) :unknown
+        (recovery-installed? (:value op)) :intact
+        :else state)
+
+      state)))
+
+(defn- coverage-checker [packet-mode]
+  (reify checker/Checker
+    (check [_ _test history _opts]
+      (let [observed-roles (->> history
+                                (filter #(= :start-packet (:f %)))
+                                (filter #(packet-start-installed? (:value %)))
+                                (filter #(= packet-mode
+                                            (get-in % [:value :mode])))
+                                (keep #(get-in % [:value :target-role]))
+                                set)
+            missing-roles (remove observed-roles required-target-roles)
+            cluster-state (reduce next-cluster-state :intact history)
+            valid? (cond
+                     (seq missing-roles) false
+                     (= :intact cluster-state) true
+                     (= :recovery-pending cluster-state) false
+                     :else :unknown)]
+        {:valid? valid?
+         :mode packet-mode
+         :observed-modes (vec (sort observed-roles))
+         :missing-modes (vec (sort missing-roles))
+         :cluster-state cluster-state}))))
+
+(defn packet-package [database packet-mode]
+  {:name :packet
+   :interval packet-seconds
+   :nemesis (packet-nemesis database packet-mode)
+   :generator (packet-generator)
+   :final-generator {:type :info
+                     :f :stop-packet}
+   :checker (openraft-checker/reject-checker-exceptions
+             (coverage-checker packet-mode))})

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -72,7 +72,39 @@
            (#'cli/normalize-nemeses [:chaos :partition]))))
 
   (testing "membership can be combined with another fault"
-    (is (#'cli/valid-nemeses? [:membership :partition]))))
+    (is (#'cli/valid-nemeses? [:membership :partition])))
+
+  (testing "packet is selectable without joining chaos yet"
+    (is (= [:packet]
+           (#'cli/normalize-nemeses :packet)))))
+
+(deftest validates-focused-packet-mode
+  (testing "slow and flaky are accepted"
+    (doseq [mode ["slow" "flaky"]]
+      (is (empty? (:errors
+                   (tools-cli/parse-opts ["--packet-mode" mode]
+                                         cli/cli-opts))))))
+
+  (testing "unknown packet modes are rejected"
+    (let [parsed (tools-cli/parse-opts ["--packet-mode" "drop"]
+                                       cli/cli-opts)]
+      (is (some #(re-find #"Must be slow or flaky" %)
+                (:errors parsed)))))
+
+  (testing "focused packet runs require an explicit mode"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"--packet-mode is required"
+         (cli/openraft-test {:nemesis :packet
+                             :nodes ["n1" "n2" "n3"]
+                             :time-limit 10}))))
+
+  (testing "focused packet runs accept an explicit mode"
+    (is (= "openraft linearizable registers packet"
+           (:name (cli/openraft-test {:nemesis :packet
+                                      :packet-mode :slow
+                                      :nodes ["n1" "n2" "n3"]
+                                      :time-limit 10}))))))
 
 (deftest shares-one-harness-state-across-workers-and-generators
   (let [failure-state (harness/failure-state)

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -59,7 +59,7 @@
 
 (deftest selects-composable-nemeses
   (testing "chaos is the default"
-    (is (= [:partition :process :pause :membership]
+    (is (= [:partition :process :pause :membership :packet]
            (#'cli/normalize-nemeses nil))))
 
   (testing "comma-separated faults are parsed and canonically ordered"
@@ -68,13 +68,13 @@
             (#'cli/parse-nemeses "process, partition")))))
 
   (testing "chaos expands to every composable fault without duplicates"
-    (is (= [:partition :process :pause :membership]
+    (is (= [:partition :process :pause :membership :packet]
            (#'cli/normalize-nemeses [:chaos :partition]))))
 
   (testing "membership can be combined with another fault"
     (is (#'cli/valid-nemeses? [:membership :partition])))
 
-  (testing "packet is selectable without joining chaos yet"
+  (testing "packet is selectable by itself"
     (is (= [:packet]
            (#'cli/normalize-nemeses :packet)))))
 
@@ -104,6 +104,19 @@
            (:name (cli/openraft-test {:nemesis :packet
                                       :packet-mode :slow
                                       :nodes ["n1" "n2" "n3"]
+                                      :time-limit 10}))))))
+
+(deftest chaos-selects-packet-modes-internally
+  (testing "the default chaos profile does not require --packet-mode"
+    (is (= "openraft linearizable registers partition,process,pause,membership,packet"
+           (:name (cli/openraft-test {:nodes ["n1" "n2" "n3" "n4" "n5"]
+                                      :time-limit 10})))))
+
+  (testing "an explicit packet mode does not lock chaos"
+    (is (= "openraft linearizable registers partition,process,pause,membership,packet"
+           (:name (cli/openraft-test {:nemesis :chaos
+                                      :packet-mode :slow
+                                      :nodes ["n1" "n2" "n3" "n4" "n5"]
                                       :time-limit 10}))))))
 
 (deftest shares-one-harness-state-across-workers-and-generators

--- a/jepsen/test/jepsen/openraft/nemesis/packet_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/packet_test.clj
@@ -1,0 +1,211 @@
+(ns jepsen.openraft.nemesis.packet-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen [checker :as checker]
+             [nemesis :as nemesis]]
+            [jepsen.openraft [cluster :as cluster]
+             [harness :as harness]
+             [worker :as worker]]
+            [jepsen.openraft.nemesis.packet :as packet]
+            [jepsen.openraft.quorum :as quorum]))
+
+(def nodes ["n1" "n2" "n3" "n4" "n5"])
+
+(defn- recording-nemesis [invocations teardown]
+  (reify nemesis/Nemesis
+    (setup! [this _test]
+      this)
+    (invoke! [_ _test op]
+      (swap! invocations conj op)
+      op)
+    (teardown! [_ _test]
+      (teardown))))
+
+(defn- installed [details]
+  (assoc details :status :installed))
+
+(deftest selects-quorum-safe-leader-aware-targets
+  (let [stable [(set nodes)]
+        joint [#{"n1" "n2" "n3"}
+               #{"n3" "n4" "n5"}]]
+    (doseq [configs [stable joint]
+            target-role [:leader-included :leader-excluded]]
+      (testing (str configs " " target-role)
+        (let [targets (#'packet/packet-targets configs
+                                               "n1"
+                                               target-role)
+              survivors (remove targets (quorum/voter-set configs))]
+          (is (seq targets))
+          (is (quorum/quorum? configs survivors))
+          (is (= (= :leader-included target-role)
+                 (contains? targets "n1"))))))))
+
+(deftest starts-packet-degradation-with-structured-evidence
+  (let [invocations (atom [])
+        delegate (recording-nemesis invocations (constantly nil))
+        subject (packet/->PacketNemesis delegate :slow)
+        op {:type :info
+            :process :nemesis
+            :f :start-packet
+            :value :leader-included}]
+    (with-redefs [cluster/membership-status
+                  (constantly {:leader "n1"})
+                  cluster/voter-configs
+                  (constantly [(set nodes)])
+                  packet/packet-targets
+                  (constantly #{"n1" "n2"})]
+      (let [result (nemesis/invoke! subject {:nodes nodes} op)
+            delegated (first @invocations)
+            value (:value result)]
+        (is (= :installed (:status value)))
+        (is (= :slow (:mode value)))
+        (is (= :leader-included (:target-role value)))
+        (is (= "n1" (:leader value)))
+        (is (= ["n1" "n2"] (:targets value)))
+        (is (= {:delay {:time :300ms
+                        :jitter :50ms
+                        :correlation :25%
+                        :distribution :normal}}
+               (:behavior value)))
+        (is (= :start-packet (:f delegated)))
+        (is (= [["n1" "n2"] (:behavior value)]
+               (:value delegated)))))))
+
+(deftest uses-jepsen-default-loss-options-for-flaky-mode
+  (let [invocations (atom [])
+        subject (packet/->PacketNemesis
+                 (recording-nemesis invocations (constantly nil))
+                 :flaky)]
+    (with-redefs [cluster/membership-status
+                  (constantly {:leader "n1"})
+                  cluster/voter-configs
+                  (constantly [(set nodes)])
+                  packet/packet-targets
+                  (constantly #{"n2"})]
+      (let [result (nemesis/invoke!
+                    subject
+                    {:nodes nodes}
+                    {:type :info
+                     :process :nemesis
+                     :f :start-packet
+                     :value :leader-excluded})]
+        (is (= {:loss {}} (get-in result [:value :behavior])))
+        (is (= [["n2"] {:loss {}}]
+               (:value (first @invocations))))))))
+
+(deftest skips-packet-degradation-without-a-safe-target
+  (let [invocations (atom [])
+        subject (packet/->PacketNemesis
+                 (recording-nemesis invocations (constantly nil))
+                 :slow)
+        op {:type :info
+            :process :nemesis
+            :f :start-packet
+            :value :leader-excluded}]
+    (testing "no supported leader"
+      (with-redefs [cluster/membership-status (constantly nil)]
+        (let [value (:value (nemesis/invoke! subject {:nodes nodes} op))]
+          (is (= :skipped (:status value)))
+          (is (= :no-supported-leader (:reason value)))
+          (is (empty? @invocations)))))
+
+    (testing "no target for the requested role"
+      (with-redefs [cluster/membership-status
+                    (constantly {:leader "n1"})
+                    cluster/voter-configs
+                    (constantly [#{"n1"}])]
+        (let [value (:value (nemesis/invoke!
+                             subject
+                             {:nodes ["n1"]}
+                             op))]
+          (is (= :skipped (:status value)))
+          (is (= :no-safe-packet-target (:reason value)))
+          (is (empty? @invocations)))))))
+
+(deftest stop-and-teardown-clear-packet-shaping
+  (let [invocations (atom [])
+        teardown-count (atom 0)
+        subject (packet/->PacketNemesis
+                 (recording-nemesis invocations
+                                    #(swap! teardown-count inc))
+                 :slow)
+        result (nemesis/invoke! subject
+                                {:nodes nodes}
+                                {:type :info
+                                 :process :nemesis
+                                 :f :stop-packet})]
+    (is (= (installed {:mode :slow}) (:value result)))
+    (is (= nil (:value (first @invocations))))
+    (nemesis/teardown! subject {:nodes nodes})
+    (is (= 1 @teardown-count))))
+
+(deftest packet-cleanup-failure-records-a-harness-failure
+  (let [failure-state (harness/failure-state)
+        error (ex-info "tc failed" {:kind :control-error})
+        subject (worker/wrap-nemesis-teardown
+                 failure-state
+                 :packet
+                 (packet/->PacketNemesis
+                  (recording-nemesis (atom []) #(throw error))
+                  :slow))]
+    (nemesis/teardown! subject {:nodes nodes})
+    (let [failure (harness/primary-failure failure-state)]
+      (is (= :nemesis (:source failure)))
+      (is (= :packet (get-in failure [:context :component])))
+      (is (identical? error (:throwable failure))))))
+
+(deftest packet-checker-requires-both-target-roles-and-recovery
+  (let [subject (#'packet/coverage-checker :slow)
+        start (fn [target-role]
+                {:type :info
+                 :process :nemesis
+                 :f :start-packet
+                 :value (installed {:mode :slow
+                                    :target-role target-role})})
+        stop {:type :info
+              :process :nemesis
+              :f :stop-packet
+              :value (installed {:mode :slow})}
+        recovered {:type :info
+                   :process :nemesis
+                   :f :await-recovery
+                   :value (installed {:leader "n1"})}]
+    (testing "one target role is insufficient"
+      (let [result (checker/check subject
+                                  {}
+                                  [(start :leader-included)
+                                   stop
+                                   recovered]
+                                  {})]
+        (is (false? (:valid? result)))
+        (is (= [:leader-excluded] (:missing-modes result)))
+        (is (= :intact (:cluster-state result)))))
+
+    (testing "both target roles and final recovery pass"
+      (let [result (checker/check subject
+                                  {}
+                                  [(start :leader-included)
+                                   stop
+                                   (start :leader-excluded)
+                                   stop
+                                   recovered]
+                                  {})]
+        (is (true? (:valid? result)))
+        (is (empty? (:missing-modes result)))
+        (is (= [:leader-excluded :leader-included]
+               (:observed-modes result)))))
+
+    (testing "cleanup without confirmed recovery fails"
+      (let [result (checker/check subject
+                                  {}
+                                  [(start :leader-included)
+                                   stop
+                                   (start :leader-excluded)
+                                   stop]
+                                  {})]
+        (is (false? (:valid? result)))
+        (is (= :recovery-pending (:cluster-state result)))))))
+
+(deftest rejects-unknown-packet-modes
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                        #"Unknown packet mode"
+                        (packet/packet-nemesis nil :drop))))

--- a/jepsen/test/jepsen/openraft/nemesis/packet_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/packet_test.clj
@@ -1,7 +1,9 @@
 (ns jepsen.openraft.nemesis.packet-test
   (:require [clojure.test :refer [deftest is testing]]
             [jepsen [checker :as checker]
+             [generator :as gen]
              [nemesis :as nemesis]]
+            [jepsen.generator.test :as gen-test]
             [jepsen.openraft [cluster :as cluster]
              [harness :as harness]
              [worker :as worker]]
@@ -209,3 +211,25 @@
   (is (thrown-with-msg? clojure.lang.ExceptionInfo
                         #"Unknown packet mode"
                         (packet/packet-nemesis nil :drop))))
+
+(deftest chaos-packet-generator-selects-one-mode-per-episode
+  (is (= :slow (#'packet/select-packet-mode :slow)))
+  (is (every? packet/packet-modes
+              (repeatedly 20
+                          (fn []
+                            (#'packet/select-packet-mode nil))))))
+
+(deftest packet-generator-advances-through-an-episode
+  (let [invocations (atom [])]
+    (gen-test/simulate
+     (gen/limit 4 (#'packet/packet-generator :slow))
+     (fn [_context operation]
+       (swap! invocations conj operation)
+       (assoc operation :type :info)))
+    (is (= [[:start-packet :leader-included]
+            [:stop-packet nil]
+            [:start-packet :leader-excluded]
+            [:stop-packet nil]]
+           (mapv (fn [op]
+                   [(:f op) (get-in op [:value :target-role])])
+                 @invocations)))))

--- a/jepsen/test/jepsen/openraft/nemesis_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis_test.clj
@@ -11,6 +11,7 @@
              [nemesis :as openraft-nemesis]
              [worker :as worker]]
             [jepsen.openraft.nemesis.membership :as membership]
+            [jepsen.openraft.nemesis.packet :as packet]
             [jepsen.openraft.nemesis.partition :as partition]
             [jepsen.openraft.nemesis.process :as process]))
 
@@ -24,6 +25,7 @@
                                :reason reason})
                             [:no-quorum-safe-process-target
                              :no-reachable-pause-target
+                             :no-safe-packet-target
                              :no-safe-partition-target
                              :no-supported-leader])
                        [{:status :no-supported-leader}
@@ -74,10 +76,12 @@
                    test-config)
                   (partition/partition-package)
                   (process/process-package database)
-                  (process/pause-package database)])]
+                  (process/pause-package database)
+                  (packet/packet-package database nil)])]
     (is (= [:stop-partition
             :restart-process
             :resume-process
+            :stop-packet
             :restore-membership
             :await-recovery]
            (mapv :f (:final-generator package))))))


### PR DESCRIPTION
## Summary

Add a quorum-aware Packet Nemesis to the OpenRaft Jepsen suite. Packet models
degraded-but-reachable links and remains separate from the existing hard
Network Partition Nemesis.

- Add focused `slow` and `flaky` Packet modes.
- Select fixed, quorum-safe voter targets for each fault episode.
- Cover both leader-included and leader-excluded target sets.
- Compose Packet with the existing Chaos profile.
- Run focused Slow and Flaky jobs in the post-merge/manual Jepsen matrix.

## Design

Slow applies a 300 ms base delay with a 50 ms normally distributed jitter
scale and 25% correlation. Flaky uses Jepsen's default 20% loss with 75%
correlation. The two modes are mutually exclusive because they share the same
root qdisc; focused runs select one explicitly, while Chaos selects one per
Packet episode.

For stable and joint voter configurations, each focused target set leaves a
quorum alive. If there is no quorum-supported leader or no safe target for the
requested role, the operation is recorded as skipped and retried. Installation
and cleanup errors remain Harness failures. Stop, final recovery, and teardown
all clear packet shaping before the suite confirms that the cluster is intact.

The Packet checker verifies role coverage, cleanup, and final recovery. The
workload checker remains responsible for linearizability; Packet does not
require every episode to trigger an election, timeout, or indeterminate
mutation.

## Verification

- `make -C jepsen unit-test` — 183 tests, 1241 assertions
- `make -C jepsen clojure-lint`
- `git diff --check upstream/main...HEAD`
- `make -C jepsen test NEMESIS=packet PACKET_MODE=slow` — valid

Closes #2029
Refs #1597

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2030)
<!-- Reviewable:end -->
