### PR TITLE
fix(jepsen): validate packet mode selection

### DIFF
--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -223,10 +223,9 @@ voters and waits for every node to agree on a leader.
 
 #### Packet Nemesis
 
-The Packet Nemesis models traffic that remains reachable but is
-degraded. Hard packet drops that create a partition remain the responsibility
-of the Network Partition Nemesis. Packet provides two mutually exclusive
-modes:
+The Packet Nemesis models traffic that remains reachable but is degraded. Hard
+packet drops that create a partition remain the responsibility of the Network
+Partition Nemesis. Packet provides two mutually exclusive modes:
 
 - `slow`: 300 ms latency with 50 ms normally distributed jitter;
 - `flaky`: Jepsen's default 20% packet loss with 75% correlation.
@@ -268,11 +267,11 @@ on every node.
 #### Chaos Composition
 
 The default `chaos` profile independently schedules partition, process, pause,
-membership, and packet faults. It composes the package,
-generator, final recovery, and checker supplied by each Nemesis rather than
-defining separate Chaos-only checker semantics. Packet chooses one of `slow` or
-`flaky` for each independent Packet episode, and never overlaps those two modes
-with each other. Different fault classes may remain active at the same time.
+membership, and packet faults. It composes the package, generator, final
+recovery, and checker supplied by each Nemesis rather than defining separate
+Chaos-only checker semantics. Packet chooses one of `slow` or `flaky` for each
+independent Packet episode, and never overlaps those two modes with each other.
+Different fault classes may remain active at the same time.
 
 Every Jepsen node builds a snapshot after 100 newly committed logs by default.
 The regular write workload therefore exercises snapshot construction during
@@ -307,10 +306,10 @@ The `final-workload` checker separately rejects a run when its final reads or
 writes fail. These modeled failures are not unexpected-SUT-response markers.
 
 A coverage failure rejects the run but does not by itself identify an OpenRaft
-failure or its root cause. For example, `:missing-modes` or
-`:missing-target-roles` is written to
-`results.edn`; the mode may be absent from `history.edn`, skipped by an outcome
-such as `:no-supported-leader`, or blocked by a Harness failure recorded in
+failure or its root cause. Missing coverage is recorded in `results.edn` under
+fields such as `:missing-modes` or `:missing-target-roles`. The mode or target
+role may be absent from `history.edn`, skipped by an outcome such as
+`:no-supported-leader`, or blocked by a Harness failure recorded in
 `jepsen.log`. Start with the nested checker result, inspect the corresponding
 operations in `history.edn`, and then use `jepsen.log` for Harness diagnostics.
 

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -88,14 +88,26 @@
 
 (defn- prepare-options [parsed]
   (let [options (:options parsed)
+        nemesis-types (when-not (seq (:errors parsed))
+                        (normalize-nemeses (:nemesis options)))
+        packet-mode-error
+        (cond
+          (and (:packet-mode options)
+               (or (chaos-selection? (:nemesis options))
+                   (not (some #{:packet} nemesis-types))))
+          "--packet-mode requires an explicit Packet Nemesis."
+
+          (and (= [:packet] nemesis-types)
+               (nil? (:packet-mode options)))
+          "--packet-mode is required for Packet Nemesis."
+
+          :else nil)
         seed (or (:seed options)
                  (random/long Long/MAX_VALUE))]
     (random/set-seed! seed)
     (cond-> (assoc-in parsed [:options :seed] seed)
-      (and (chaos-selection? (:nemesis options))
-           (:packet-mode options))
-      (update :errors (fnil conj [])
-              "--packet-mode cannot be used with Chaos."))))
+      packet-mode-error
+      (update :errors (fnil conj []) packet-mode-error))))
 
 (defn- lifecycle-generator
   [failure-state time-limit workload nemesis-package]
@@ -120,7 +132,6 @@
   (let [failure-state (harness/failure-state)
         database (openraft-db/db opts)
         workload (workload/workload opts)
-        chaos? (chaos-selection? (:nemesis opts))
         nemesis-types (normalize-nemeses (:nemesis opts))
         nemesis-package
         (openraft-nemesis/compose-packages
@@ -140,9 +151,9 @@
                    (membership/membership-package database opts)
 
                    :packet
-                   (let [packet-mode (when-not chaos?
-                                       (:packet-mode opts))]
-                     (when-not (or chaos? packet-mode)
+                   (let [packet-mode (:packet-mode opts)]
+                     (when (and (= [:packet] nemesis-types)
+                                (nil? packet-mode))
                        (throw (ex-info
                                "--packet-mode is required for Packet Nemesis"
                                {:nemesis nemesis-types})))

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -81,9 +81,11 @@
 (deftest validates-focused-packet-mode
   (testing "slow and flaky are accepted"
     (doseq [mode ["slow" "flaky"]]
-      (is (empty? (:errors
-                   (tools-cli/parse-opts ["--packet-mode" mode]
-                                         cli/cli-opts))))))
+      (let [parsed (#'cli/prepare-options
+                    (tools-cli/parse-opts ["--nemesis" "packet"
+                                           "--packet-mode" mode]
+                                          cli/cli-opts))]
+        (is (empty? (:errors parsed))))))
 
   (testing "unknown packet modes are rejected"
     (let [parsed (tools-cli/parse-opts ["--packet-mode" "drop"]
@@ -91,7 +93,14 @@
       (is (some #(re-find #"Must be slow or flaky" %)
                 (:errors parsed)))))
 
-  (testing "focused packet runs require an explicit mode"
+  (testing "option parsing requires an explicit mode"
+    (let [parsed (#'cli/prepare-options
+                  (tools-cli/parse-opts ["--nemesis" "packet"]
+                                        cli/cli-opts))]
+      (is (some #(re-find #"--packet-mode is required" %)
+                (:errors parsed)))))
+
+  (testing "direct test construction retains its guard"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo
          #"--packet-mode is required"
@@ -106,19 +115,36 @@
                                       :nodes ["n1" "n2" "n3"]
                                       :time-limit 10}))))))
 
-(deftest chaos-selects-packet-modes-internally
+(deftest validates-packet-mode-selection
   (testing "the default chaos profile does not require --packet-mode"
     (is (= "openraft linearizable registers partition,process,pause,membership,packet"
            (:name (cli/openraft-test {:nodes ["n1" "n2" "n3" "n4" "n5"]
                                       :time-limit 10})))))
 
-  (testing "an explicit packet mode is rejected during option parsing"
-    (let [parsed (#'cli/prepare-options
-                  (tools-cli/parse-opts ["--nemesis" "chaos"
-                                         "--packet-mode" "slow"]
-                                        cli/cli-opts))]
-      (is (some #(re-find #"--packet-mode cannot be used with Chaos" %)
-                (:errors parsed))))))
+  (testing "explicit Packet compositions accept an optional mode"
+    (doseq [args [["--nemesis" "packet,partition"]
+                  ["--nemesis" "packet,partition"
+                   "--packet-mode" "slow"]]]
+      (let [parsed (#'cli/prepare-options
+                    (tools-cli/parse-opts args cli/cli-opts))]
+        (is (empty? (:errors parsed)))))
+    (doseq [opts [{:nemesis [:packet :partition]}
+                  {:nemesis [:packet :partition]
+                   :packet-mode :slow}]]
+      (is (= "openraft linearizable registers partition,packet"
+             (:name (cli/openraft-test
+                     (merge {:nodes ["n1" "n2" "n3" "n4" "n5"]
+                             :time-limit 10}
+                            opts)))))))
+
+  (testing "packet mode is rejected without an explicit Packet selection"
+    (doseq [nemesis ["chaos" "partition"]]
+      (let [parsed (#'cli/prepare-options
+                    (tools-cli/parse-opts ["--nemesis" nemesis
+                                           "--packet-mode" "slow"]
+                                          cli/cli-opts))]
+        (is (some #(re-find #"--packet-mode requires an explicit Packet" %)
+                  (:errors parsed)))))))
 
 (deftest shares-one-harness-state-across-workers-and-generators
   (let [failure-state (harness/failure-state)


### PR DESCRIPTION
## Summary

- reject `--packet-mode` unless Packet is the only selected Nemesis
- report a missing Packet mode as a normal CLI argument error
- reflow and clarify the Packet README sections

## Verification

- `make -C jepsen unit-test`
- `make -C jepsen clojure-lint`
- verified both invalid CLI combinations exit with status 254 without a stack trace

Closes #2033

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2034)
<!-- Reviewable:end -->
