### PR TITLE
change: entry: add RaftPayload construction methods

### DIFF
--- a/benchmarks/minimal/src/store.rs
+++ b/benchmarks/minimal/src/store.rs
@@ -68,6 +68,7 @@ impl RaftTypeConfig for TypeConfig {
     type Term = u64;
     type LeaderId = LeaderId;
     type Vote = Vote<Self::LeaderId>;
+    type Payload = EntryPayload<Self::D, Self::NodeId, Self::Node>;
     type Entry = DefaultEntryOf<Self>;
     type Responder<T>
         = openraft::impls::OneshotResponder<Self, T>

--- a/examples/raft-kv-memstore-grpc/src/pb_impl/impl_entry.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/impl_entry.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use openraft::EntryPayload;
 use openraft::alias::LogIdOf;
 use openraft::entry::RaftEntry;
-use openraft::entry::RaftPayload;
 
 use crate::TypeConfig;
 use crate::protobuf as pb;
@@ -15,19 +14,11 @@ impl fmt::Display for pb::Entry {
     }
 }
 
-impl RaftPayload<crate::NodeId, pb::Node> for pb::Entry {
-    fn get_membership(&self) -> Option<typ::Membership> {
-        self.membership.clone().map(Into::into)
-    }
-}
-
 impl RaftEntry for pb::Entry {
     type CommittedLeaderId = u64;
-    type D = pb::SetRequest;
-    type NodeId = u64;
-    type Node = pb::Node;
+    type Payload = EntryPayload<pb::SetRequest, u64, pb::Node>;
 
-    fn new(log_id: LogIdOf<TypeConfig>, payload: EntryPayload<pb::SetRequest, u64, pb::Node>) -> Self {
+    fn new(log_id: LogIdOf<TypeConfig>, payload: Self::Payload) -> Self {
         let mut app_data = None;
         let mut membership = None;
         match payload {
@@ -51,5 +42,9 @@ impl RaftEntry for pb::Entry {
     fn set_log_id(&mut self, new: LogIdOf<TypeConfig>) {
         self.term = new.leader_id;
         self.index = new.index;
+    }
+
+    fn get_membership(&self) -> Option<typ::Membership> {
+        self.membership.clone().map(Into::into)
     }
 }

--- a/examples/sm-mem/src/lib.rs
+++ b/examples/sm-mem/src/lib.rs
@@ -13,6 +13,7 @@ use openraft::OptionalSend;
 use openraft::RaftSnapshotBuilder;
 use openraft::RaftTypeConfig;
 use openraft::alias::DefaultEntryOf;
+use openraft::alias::EntryPayloadOf;
 use openraft::alias::LogIdOf;
 use openraft::alias::SnapshotMetaOf;
 use openraft::alias::SnapshotOf;
@@ -85,7 +86,12 @@ impl<C: RaftTypeConfig> StateMachineStore<C> {
 }
 
 impl<C> RaftSnapshotBuilder<C> for StateMachineStore<C>
-where C: RaftTypeConfig<D = types_kv::Request, R = types_kv::Response, Entry = DefaultEntryOf<C>>
+where C: RaftTypeConfig<
+            D = types_kv::Request,
+            R = types_kv::Response,
+            Payload = EntryPayloadOf<C>,
+            Entry = DefaultEntryOf<C>,
+        >
 {
     type SnapshotData = Cursor<Vec<u8>>;
 
@@ -116,7 +122,12 @@ where C: RaftTypeConfig<D = types_kv::Request, R = types_kv::Response, Entry = D
 }
 
 impl<C> RaftStateMachine<C> for StateMachineStore<C>
-where C: RaftTypeConfig<D = types_kv::Request, R = types_kv::Response, Entry = DefaultEntryOf<C>>
+where C: RaftTypeConfig<
+            D = types_kv::Request,
+            R = types_kv::Response,
+            Payload = EntryPayloadOf<C>,
+            Entry = DefaultEntryOf<C>,
+        >
 {
     type SnapshotData = Cursor<Vec<u8>>;
 
@@ -235,7 +246,12 @@ where C: RaftTypeConfig<D = types_kv::Request, R = types_kv::Response, Entry = D
 
 /// Supports snapshot reception through the legacy v1 network protocol.
 impl<C> SnapshotReceiverFactory<C> for StateMachineStore<C>
-where C: RaftTypeConfig<D = types_kv::Request, R = types_kv::Response, Entry = DefaultEntryOf<C>>
+where C: RaftTypeConfig<
+            D = types_kv::Request,
+            R = types_kv::Response,
+            Payload = EntryPayloadOf<C>,
+            Entry = DefaultEntryOf<C>,
+        >
 {
     type SnapshotReceiver = Cursor<Vec<u8>>;
 

--- a/openraft/benches/bench/leader_append_entries.rs
+++ b/openraft/benches/bench/leader_append_entries.rs
@@ -11,9 +11,9 @@ use criterion::Criterion;
 use criterion::criterion_group;
 use openraft::bench_internals::BenchEngine;
 use openraft::bench_internals::UTConfig;
-use openraft::type_config::alias::EntryPayloadOf;
+use openraft::type_config::alias::PayloadOf;
 
-type Payload = EntryPayloadOf<UTConfig>;
+type Payload = PayloadOf<UTConfig>;
 
 /// How many appends to time before draining the engine's command buffer.
 ///

--- a/openraft/src/bench_internals.rs
+++ b/openraft/src/bench_internals.rs
@@ -21,7 +21,7 @@ use crate::engine::testing::log_id;
 use crate::progress::VecProgress;
 pub use crate::quorum::QuorumSet;
 use crate::type_config::TypeConfigExt;
-use crate::type_config::alias::EntryPayloadOf;
+use crate::type_config::alias::PayloadOf;
 use crate::type_config::alias::StoredMembershipOf;
 use crate::utime::Leased;
 
@@ -63,7 +63,7 @@ impl BenchEngine {
     /// Append `payloads` as the leader.
     #[inline]
     pub fn append<I>(&mut self, payloads: I)
-    where I: IntoIterator<Item = EntryPayloadOf<UTConfig>> + AsRef<[EntryPayloadOf<UTConfig>]> {
+    where I: IntoIterator<Item = PayloadOf<UTConfig>> + AsRef<[PayloadOf<UTConfig>]> {
         self.0.try_leader_handler().unwrap().leader_append_entries(payloads);
     }
 

--- a/openraft/src/core/io_flush_tracking/watch_progress.rs
+++ b/openraft/src/core/io_flush_tracking/watch_progress.rs
@@ -197,8 +197,8 @@ mod tests {
         type Term = u64;
         type LeaderId = crate::impls::leader_id_adv::LeaderId<u64, u64>;
         type Vote = Vote<Self::LeaderId>;
-        type Entry =
-            crate::Entry<<Self::LeaderId as crate::vote::RaftLeaderId>::Committed, Self::D, Self::NodeId, Self::Node>;
+        type Payload = crate::EntryPayload<Self::D, Self::NodeId, Self::Node>;
+        type Entry = crate::Entry<<Self::LeaderId as crate::vote::RaftLeaderId>::Committed, Self::Payload>;
         type AsyncRuntime = TokioRuntime;
         type Responder<T>
             = crate::impls::OneshotResponder<Self, T>

--- a/openraft/src/core/merged_raft_msg_receiver.rs
+++ b/openraft/src/core/merged_raft_msg_receiver.rs
@@ -245,7 +245,7 @@ mod tests {
     use crate::type_config::TypeConfigExt;
     use crate::type_config::alias::BatchOf;
     use crate::type_config::alias::CommittedLeaderIdOf;
-    use crate::type_config::alias::EntryPayloadOf;
+    use crate::type_config::alias::PayloadOf;
 
     type C = UTConfig<()>;
 
@@ -267,7 +267,7 @@ mod tests {
         }
     }
 
-    fn extract_payload_data(payloads: &BatchOf<C, EntryPayloadOf<C>>) -> Vec<u64> {
+    fn extract_payload_data(payloads: &BatchOf<C, PayloadOf<C>>) -> Vec<u64> {
         payloads
             .as_ref()
             .iter()

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -61,7 +61,7 @@ use crate::engine::TargetProgress;
 use crate::engine::handler::leader_handler::LeaderHandler;
 use crate::engine::leader_log_ids::LeaderLogIds;
 use crate::entry::RaftEntry;
-use crate::entry::payload::EntryPayload;
+use crate::entry::RaftPayload;
 use crate::errors::AllowNextRevertError;
 use crate::errors::ClientWriteError;
 use crate::errors::Fatal;
@@ -118,15 +118,17 @@ use crate::storage::RaftLogStorage;
 use crate::storage::RaftStateMachine;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::BatchOf;
+use crate::type_config::alias::ChangeMembershipErrorOf;
 use crate::type_config::alias::CommittedLeaderIdOf;
 use crate::type_config::alias::CommittedVoteOf;
-use crate::type_config::alias::EntryPayloadOf;
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::MembershipStateOf;
 use crate::type_config::alias::MpscReceiverOf;
 use crate::type_config::alias::MpscSenderOf;
 use crate::type_config::alias::MutexOf;
 use crate::type_config::alias::OneshotReceiverOf;
+use crate::type_config::alias::PayloadOf;
 use crate::type_config::alias::VoteOf;
 use crate::type_config::alias::WatchReceiverOf;
 use crate::type_config::alias::WatchSenderOf;
@@ -161,6 +163,19 @@ impl<C: RaftTypeConfig> fmt::Display for ApplyResult<C> {
             self.since, self.end, self.last_applied,
         )
     }
+}
+
+fn apply_membership_to_payload<C>(
+    membership_state: &MembershipStateOf<C>,
+    changes: ChangeMembers<C::NodeId, C::Node>,
+    retain: bool,
+    payload: C::Payload,
+) -> Result<C::Payload, ChangeMembershipErrorOf<C>>
+where
+    C: RaftTypeConfig,
+{
+    let membership = membership_state.change_handler().apply(changes, retain)?;
+    Ok(payload.with_membership(membership))
 }
 
 /// The core type implementing the Raft protocol.
@@ -438,12 +453,13 @@ where
     //       Because allowing this requires the engine to be able to store more than 2
     //       membership logs. And it does not need to wait for the previous membership log to commit
     //       to propose the new membership log.
-    #[tracing::instrument(level = "debug", skip(self, tx, preconditions))]
+    #[tracing::instrument(level = "debug", skip(self, payload, tx, preconditions))]
     pub(super) fn change_membership(
         &mut self,
         changes: ChangeMembers<C::NodeId, C::Node>,
         retain: bool,
         preconditions: BatchOf<C, Precondition<C>>,
+        payload: C::Payload,
         tx: ProgressResponder<C, ClientWriteResult<C>>,
     ) {
         if let Err(e) = self.ensure_leader_handler() {
@@ -456,8 +472,8 @@ where
             return;
         }
 
-        let res = self.engine.state.membership_state.change_handler().apply(changes, retain);
-        let new_membership = match res {
+        let res = apply_membership_to_payload::<C>(&self.engine.state.membership_state, changes, retain, payload);
+        let payload = match res {
             Ok(x) => x,
             Err(e) => {
                 tx.on_complete(Err(ClientWriteError::ChangeMembershipError(e)));
@@ -466,7 +482,7 @@ where
         };
 
         self.write_entries(
-            Batch::of([EntryPayload::Membership(new_membership)]),
+            Batch::of([payload]),
             Batch::of([Some(CoreResponder::Progress(tx))]),
             #[cfg(feature = "runtime-stats")]
             C::now(),
@@ -518,7 +534,7 @@ where
     #[tracing::instrument(level = "debug", skip_all, fields(id = display(&self.id)))]
     pub fn write_entries(
         &mut self,
-        payloads: BatchOf<C, EntryPayloadOf<C>>,
+        payloads: BatchOf<C, PayloadOf<C>>,
         responders: BatchOf<C, Option<CoreResponder<C>>>,
         #[cfg(feature = "runtime-stats")] proposed_at: InstantOf<C>,
     ) -> Option<LeaderLogIds<CommittedLeaderIdOf<C>>> {
@@ -1629,6 +1645,7 @@ where
             }
             RaftMsg::ChangeMembership {
                 changes,
+                payload,
                 retain,
                 preconditions,
                 tx,
@@ -1641,7 +1658,7 @@ where
                     preconditions.as_ref().display()
                 );
 
-                self.change_membership(changes, retain, preconditions, tx);
+                self.change_membership(changes, retain, preconditions, payload, tx);
             }
             RaftMsg::WithRaftState { req } => {
                 req(&self.engine.state);
@@ -2528,5 +2545,94 @@ where
         }
 
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt;
+    use std::sync::Arc;
+
+    use maplit::btreemap;
+    use maplit::btreeset;
+    use openraft_rt_tokio::TokioRuntime;
+
+    use super::apply_membership_to_payload;
+    use crate::ChangeMembers;
+    use crate::Membership;
+    use crate::entry::RaftPayload;
+    use crate::type_config::alias::MembershipStateOf;
+    use crate::type_config::alias::StoredMembershipOf;
+
+    #[derive(Debug, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    struct TestPayload {
+        normal: Option<u64>,
+        membership: Option<Membership<u64, ()>>,
+    }
+
+    impl fmt::Display for TestPayload {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "normal={:?}, membership={:?}", self.normal, self.membership)
+        }
+    }
+
+    impl RaftPayload for TestPayload {
+        type D = u64;
+        type NodeId = u64;
+        type Node = ();
+
+        fn blank() -> Self {
+            Self {
+                normal: None,
+                membership: None,
+            }
+        }
+
+        fn with_normal(mut self, data: u64) -> Self {
+            self.normal = Some(data);
+            self
+        }
+
+        fn with_membership(mut self, membership: Membership<u64, ()>) -> Self {
+            self.membership = Some(membership);
+            self
+        }
+
+        fn get_membership(&self) -> Option<Membership<u64, ()>> {
+            self.membership.clone()
+        }
+    }
+
+    crate::declare_raft_types!(
+        TestConfig:
+            D = u64,
+            R = (),
+            Node = (),
+            Payload = TestPayload,
+            AsyncRuntime = TokioRuntime,
+    );
+
+    #[test]
+    fn membership_change_replaces_payload_membership() {
+        let current = Membership::new_with_defaults(vec![btreeset! {1}], []);
+        let stored = Arc::new(StoredMembershipOf::<TestConfig>::new(None, current));
+        let membership_state = MembershipStateOf::<TestConfig>::new(stored.clone(), stored);
+
+        let input_membership = Membership::new_with_defaults(vec![btreeset! {9}], []);
+        let payload = TestPayload {
+            normal: Some(7),
+            membership: Some(input_membership),
+        };
+
+        let changes = ChangeMembers::AddNodes(btreemap! {2 => ()});
+        let actual = apply_membership_to_payload::<TestConfig>(&membership_state, changes, false, payload).unwrap();
+
+        let expected_membership = Membership::new_with_defaults(vec![btreeset! {1}], btreeset! {2});
+        let expected = TestPayload {
+            normal: Some(7),
+            membership: Some(expected_membership),
+        };
+        assert_eq!(expected, actual);
     }
 }

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -175,7 +175,8 @@ where
     C: RaftTypeConfig,
 {
     let membership = membership_state.change_handler().apply(changes, retain)?;
-    Ok(payload.with_membership(membership))
+    let payload = payload.with_membership(membership);
+    Ok(payload)
 }
 
 /// The core type implementing the Raft protocol.
@@ -2626,11 +2627,30 @@ mod tests {
         };
 
         let changes = ChangeMembers::AddNodes(btreemap! {2 => ()});
-        let actual = apply_membership_to_payload::<TestConfig>(&membership_state, changes, false, payload).unwrap();
+        let result = apply_membership_to_payload::<TestConfig>(&membership_state, changes, false, payload);
+        let actual = result.unwrap();
 
         let expected_membership = Membership::new_with_defaults(vec![btreeset! {1}], btreeset! {2});
         let expected = TestPayload {
             normal: Some(7),
+            membership: Some(expected_membership),
+        };
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn membership_change_from_blank_payload_creates_membership_payload() {
+        let current = Membership::new_with_defaults(vec![btreeset! {1}], []);
+        let stored = Arc::new(StoredMembershipOf::<TestConfig>::new(None, current));
+        let membership_state = MembershipStateOf::<TestConfig>::new(stored.clone(), stored);
+
+        let changes = ChangeMembers::AddNodes(btreemap! {2 => ()});
+        let result = apply_membership_to_payload::<TestConfig>(&membership_state, changes, false, TestPayload::blank());
+        let actual = result.unwrap();
+
+        let expected_membership = Membership::new_with_defaults(vec![btreeset! {1}], btreeset! {2});
+        let expected = TestPayload {
+            normal: None,
             membership: Some(expected_membership),
         };
         assert_eq!(expected, actual);

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -96,6 +96,7 @@ where C: RaftTypeConfig
     ChangeMembership {
         changes: ChangeMembers<C::NodeId, C::Node>,
 
+        /// Payload whose membership OpenRaft replaces with the computed membership.
         payload: C::Payload,
 
         /// If `retain` is `true`, then the voters that are not in the new

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -27,11 +27,11 @@ use crate::raft::responder::core_responder::CoreResponder;
 use crate::raft::stream_append::StreamAppendResult;
 use crate::type_config::alias::BatchOf;
 use crate::type_config::alias::CommittedLeaderIdOf;
-use crate::type_config::alias::EntryPayloadOf;
 #[cfg(feature = "runtime-stats")]
 use crate::type_config::alias::InstantOf;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::OneshotSenderOf;
+use crate::type_config::alias::PayloadOf;
 use crate::type_config::alias::VoteOf;
 
 pub(crate) mod external_command;
@@ -76,7 +76,7 @@ where C: RaftTypeConfig
     },
 
     ClientWrite {
-        payloads: BatchOf<C, EntryPayloadOf<C>>,
+        payloads: BatchOf<C, PayloadOf<C>>,
         responders: BatchOf<C, Option<CoreResponder<C>>>,
         expected_leader: Option<CommittedLeaderIdOf<C>>,
         #[cfg(feature = "runtime-stats")]
@@ -95,6 +95,8 @@ where C: RaftTypeConfig
 
     ChangeMembership {
         changes: ChangeMembers<C::NodeId, C::Node>,
+
+        payload: C::Payload,
 
         /// If `retain` is `true`, then the voters that are not in the new
         /// config will be converted into learners, otherwise they will be removed.

--- a/openraft/src/core/tick.rs
+++ b/openraft/src/core/tick.rs
@@ -209,8 +209,8 @@ mod tests {
         type Term = u64;
         type LeaderId = crate::impls::leader_id_adv::LeaderId<u64, u64>;
         type Vote = crate::impls::Vote<Self::LeaderId>;
-        type Entry =
-            crate::Entry<<Self::LeaderId as crate::vote::RaftLeaderId>::Committed, Self::D, Self::NodeId, Self::Node>;
+        type Payload = crate::EntryPayload<Self::D, Self::NodeId, Self::Node>;
+        type Entry = crate::Entry<<Self::LeaderId as crate::vote::RaftLeaderId>::Committed, Self::Payload>;
         type AsyncRuntime = TokioRuntime;
         type Responder<T>
             = crate::impls::OneshotResponder<Self, T>

--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -23,7 +23,7 @@ use crate::engine::handler::server_state_handler::ServerStateHandler;
 use crate::engine::handler::snapshot_handler::SnapshotHandler;
 use crate::engine::handler::vote_handler::VoteHandler;
 use crate::entry::RaftEntry;
-use crate::entry::payload::EntryPayload;
+use crate::entry::RaftPayload;
 use crate::errors::ForwardToLeader;
 use crate::errors::InitializeError;
 use crate::errors::NotAllowed;
@@ -243,7 +243,8 @@ where
 
         // The very first log id
         let log_id = LogIdOf::<C>::new(leader_id.to_committed(), 0);
-        let entry = C::Entry::new(log_id, EntryPayload::Membership(membership));
+        let payload = C::Payload::membership(membership);
+        let entry = C::Entry::new(log_id, payload);
         self.following_handler().do_append_entries(vec![entry]);
 
         Ok(())
@@ -947,7 +948,7 @@ where
         // No need to submit UpdateIOProgress command,
         // IO progress is updated by the new blank log
 
-        self.try_leader_handler().unwrap().leader_append_entries([EntryPayload::Blank]);
+        self.try_leader_handler().unwrap().leader_append_entries([C::Payload::blank()]);
     }
 
     /// Check if a raft node is in a state that allows to initialize.

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -15,7 +15,6 @@ use crate::engine::handler::log_handler::LogHandler;
 use crate::engine::handler::server_state_handler::ServerStateHandler;
 use crate::engine::handler::snapshot_handler::SnapshotHandler;
 use crate::entry::RaftEntry;
-use crate::entry::RaftPayload;
 use crate::entry::raft_entry_ext::RaftEntryExt;
 use crate::errors::ConflictingLogId;
 use crate::errors::RejectAppendEntries;

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -6,7 +6,6 @@ use crate::engine::EngineOutput;
 use crate::engine::handler::replication_handler::ReplicationHandler;
 use crate::engine::leader_log_ids::LeaderLogIds;
 use crate::entry::RaftEntry;
-use crate::entry::RaftPayload;
 use crate::proposer::Leader;
 use crate::proposer::LeaderQuorumSet;
 use crate::raft::linearizable_read::ReadLogId;
@@ -16,7 +15,7 @@ use crate::replication::ReplicationSessionId;
 use crate::storage::RaftStateMachine;
 use crate::type_config::alias::BatchOf;
 use crate::type_config::alias::CommittedLeaderIdOf;
-use crate::type_config::alias::EntryPayloadOf;
+use crate::type_config::alias::PayloadOf;
 
 #[cfg(test)]
 mod append_entries_test;
@@ -78,7 +77,7 @@ where
     /// TODO(xp): if vote indicates this node is not the leader, refuse append
     #[tracing::instrument(level = "debug", skip(self, payloads))]
     pub(crate) fn leader_append_entries<I>(&mut self, payloads: I) -> Option<LeaderLogIds<CommittedLeaderIdOf<C>>>
-    where I: IntoIterator<Item = EntryPayloadOf<C>> + AsRef<[EntryPayloadOf<C>]> {
+    where I: IntoIterator<Item = PayloadOf<C>> + AsRef<[PayloadOf<C>]> {
         let log_ids = self.leader.assign_log_ids(payloads.as_ref().len())?;
 
         self.state.extend_log_ids_from_same_leader(log_ids.clone());

--- a/openraft/src/engine/handler/vote_handler/mod.rs
+++ b/openraft/src/engine/handler/vote_handler/mod.rs
@@ -16,7 +16,7 @@ use crate::engine::ValueSender;
 use crate::engine::handler::leader_handler::LeaderHandler;
 use crate::engine::handler::replication_handler::ReplicationHandler;
 use crate::engine::handler::server_state_handler::ServerStateHandler;
-use crate::entry::payload::EntryPayload;
+use crate::entry::RaftPayload;
 use crate::errors::RejectVote;
 use crate::proposer::CandidateState;
 use crate::proposer::LeaderState;
@@ -227,7 +227,7 @@ where
         // If the leader has not yet proposed any log, propose a blank log and initiate replication;
         // Otherwise, just initiate replication.
         if last_log_id.as_ref() < Some(&noop_log_id) {
-            self.leader_handler().leader_append_entries([EntryPayload::Blank]);
+            self.leader_handler().leader_append_entries([C::Payload::blank()]);
         } else {
             self.replication_handler().initiate_replication();
         }

--- a/openraft/src/engine/testing.rs
+++ b/openraft/src/engine/testing.rs
@@ -43,6 +43,7 @@ where N: Node + Ord
     type Term = u64;
     type LeaderId = crate::impls::leader_id_adv::LeaderId<u64, u64>;
     type Vote = crate::impls::Vote<Self::LeaderId>;
+    type Payload = crate::EntryPayload<Self::D, Self::NodeId, Self::Node>;
     type Entry = DefaultEntryOf<Self>;
     type AsyncRuntime = TokioRuntime;
     type Responder<T>

--- a/openraft/src/entry/entry.rs
+++ b/openraft/src/entry/entry.rs
@@ -2,39 +2,32 @@ use std::fmt;
 
 use openraft_macros::since;
 
-use crate::AppData;
-use crate::EntryPayload;
 use crate::Membership;
 use crate::entry::RaftEntry;
 use crate::entry::RaftPayload;
 use crate::log_id::LogId;
-use crate::node::Node;
-use crate::node::NodeId;
 use crate::vote::RaftCommittedLeaderId;
 
 /// A Raft log entry.
+#[since(version = "0.10.0", change = "from `Entry<CLID, D, NID, N>` to `Entry<CLID, P>`")]
 #[since(version = "0.10.0", change = "from `Entry<C>` to `Entry<CLID, D, NID, N>`")]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub struct Entry<CLID, D, NID, N>
+pub struct Entry<CLID, P>
 where
     CLID: RaftCommittedLeaderId,
-    D: AppData,
-    NID: NodeId,
-    N: Node,
+    P: RaftPayload,
 {
     /// The log ID uniquely identifying this entry.
     pub log_id: LogId<CLID>,
 
     /// This entry's payload.
-    pub payload: EntryPayload<D, NID, N>,
+    pub payload: P,
 }
 
-impl<CLID, D, NID, N> Clone for Entry<CLID, D, NID, N>
+impl<CLID, P> Clone for Entry<CLID, P>
 where
     CLID: RaftCommittedLeaderId,
-    D: AppData + Clone,
-    NID: NodeId,
-    N: Node,
+    P: RaftPayload + Clone,
 {
     fn clone(&self) -> Self {
         Self {
@@ -44,79 +37,55 @@ where
     }
 }
 
-impl<CLID, D, NID, N> fmt::Debug for Entry<CLID, D, NID, N>
+impl<CLID, P> fmt::Debug for Entry<CLID, P>
 where
     CLID: RaftCommittedLeaderId,
-    D: AppData,
-    NID: NodeId,
-    N: Node,
+    P: RaftPayload,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Entry").field("log_id", &self.log_id).field("payload", &self.payload).finish()
     }
 }
 
-impl<CLID, D, NID, N> PartialEq for Entry<CLID, D, NID, N>
+impl<CLID, P> PartialEq for Entry<CLID, P>
 where
     CLID: RaftCommittedLeaderId,
-    D: AppData + PartialEq,
-    NID: NodeId,
-    N: Node,
+    P: RaftPayload + PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         self.log_id == other.log_id && self.payload == other.payload
     }
 }
 
-impl<CLID, D, NID, N> AsRef<Entry<CLID, D, NID, N>> for Entry<CLID, D, NID, N>
+impl<CLID, P> AsRef<Entry<CLID, P>> for Entry<CLID, P>
 where
     CLID: RaftCommittedLeaderId,
-    D: AppData,
-    NID: NodeId,
-    N: Node,
+    P: RaftPayload,
 {
-    fn as_ref(&self) -> &Entry<CLID, D, NID, N> {
+    fn as_ref(&self) -> &Entry<CLID, P> {
         self
     }
 }
 
-impl<CLID, D, NID, N> fmt::Display for Entry<CLID, D, NID, N>
+impl<CLID, P> fmt::Display for Entry<CLID, P>
 where
     CLID: RaftCommittedLeaderId,
-    D: AppData,
-    NID: NodeId,
-    N: Node,
+    P: RaftPayload,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.log_id, self.payload)
     }
 }
 
-impl<CLID, D, NID, N> RaftPayload<NID, N> for Entry<CLID, D, NID, N>
+impl<CLID, P> RaftEntry for Entry<CLID, P>
 where
     CLID: RaftCommittedLeaderId,
-    D: AppData,
-    NID: NodeId,
-    N: Node,
-{
-    fn get_membership(&self) -> Option<Membership<NID, N>> {
-        self.payload.get_membership()
-    }
-}
-
-impl<CLID, D, NID, N> RaftEntry for Entry<CLID, D, NID, N>
-where
-    CLID: RaftCommittedLeaderId,
-    D: AppData,
-    NID: NodeId,
-    N: Node,
+    P: RaftPayload,
 {
     type CommittedLeaderId = CLID;
-    type D = D;
-    type NodeId = NID;
-    type Node = N;
+    type Payload = P;
 
-    fn new(log_id: LogId<CLID>, payload: EntryPayload<D, NID, N>) -> Self {
+    fn new(log_id: LogId<CLID>, payload: P) -> Self {
         Self { log_id, payload }
     }
 
@@ -126,5 +95,9 @@ where
 
     fn set_log_id(&mut self, new: LogId<CLID>) {
         self.log_id = new;
+    }
+
+    fn get_membership(&self) -> Option<Membership<P::NodeId, P::Node>> {
+        self.payload.get_membership()
     }
 }

--- a/openraft/src/entry/payload.rs
+++ b/openraft/src/entry/payload.rs
@@ -101,12 +101,28 @@ where
     }
 }
 
-impl<D, NID, N> crate::entry::raft_payload::RaftPayload<NID, N> for EntryPayload<D, NID, N>
+impl<AppData, NID, N> crate::entry::raft_payload::RaftPayload for EntryPayload<AppData, NID, N>
 where
-    D: AppData,
+    AppData: crate::AppData,
     NID: NodeId,
     N: Node,
 {
+    type D = AppData;
+    type NodeId = NID;
+    type Node = N;
+
+    fn blank() -> Self {
+        EntryPayload::Blank
+    }
+
+    fn with_normal(self, data: AppData) -> Self {
+        EntryPayload::Normal(data)
+    }
+
+    fn with_membership(self, membership: Membership<NID, N>) -> Self {
+        EntryPayload::Membership(membership)
+    }
+
     fn get_membership(&self) -> Option<Membership<NID, N>> {
         if let EntryPayload::Membership(m) = self {
             Some(m.clone())
@@ -120,7 +136,43 @@ where
 mod tests {
     use std::collections::BTreeSet;
 
+    use crate::entry::RaftPayload;
     use crate::entry::payload::EntryPayload;
+
+    #[test]
+    fn test_constructors() {
+        let actual = EntryPayload::<u64, u64, ()>::blank();
+        assert_eq!(actual, EntryPayload::Blank);
+
+        let actual = EntryPayload::<u64, u64, ()>::normal(3);
+        assert_eq!(actual, EntryPayload::Normal(3));
+
+        let membership = crate::Membership::new_with_defaults(vec![BTreeSet::from([1, 2])], []);
+        let actual = EntryPayload::<u64, u64, ()>::membership(membership.clone());
+        assert_eq!(actual, EntryPayload::Membership(membership));
+    }
+
+    #[test]
+    fn test_with_membership_replaces_normal() {
+        let membership = crate::Membership::new_with_defaults(vec![BTreeSet::from([1, 2])], []);
+        let payload = EntryPayload::<u64, u64, ()>::Normal(3);
+
+        let actual = payload.with_membership(membership.clone());
+
+        let expected = EntryPayload::<u64, u64, ()>::Membership(membership);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_with_normal_replaces_membership() {
+        let membership = crate::Membership::new_with_defaults(vec![BTreeSet::from([1, 2])], []);
+        let payload = EntryPayload::<u64, u64, ()>::Membership(membership);
+
+        let actual = payload.with_normal(3);
+
+        let expected = EntryPayload::<u64, u64, ()>::Normal(3);
+        assert_eq!(actual, expected);
+    }
 
     #[test]
     fn test_debug() {

--- a/openraft/src/entry/raft_entry.rs
+++ b/openraft/src/entry/raft_entry.rs
@@ -3,46 +3,41 @@ use std::fmt::Display;
 
 use openraft_macros::since;
 
-use crate::AppData;
-use crate::EntryPayload;
 use crate::Membership;
 use crate::base::OptionalFeatures;
 use crate::base::finalized::Final;
 use crate::entry::RaftPayload;
 use crate::log_id::LogId;
-use crate::node::Node;
-use crate::node::NodeId;
 use crate::vote::RaftCommittedLeaderId;
 
 /// Defines operations on an entry.
 #[since(
     version = "0.10.0",
+    change = "replaced `D`, `NodeId`, and `Node` associated types with `Payload`"
+)]
+#[since(
+    version = "0.10.0",
+    change = "moved membership inspection from `RaftPayload` to `RaftEntry`"
+)]
+#[since(
+    version = "0.10.0",
     change = "removed `C: RaftTypeConfig` generic parameter, added associated types"
 )]
 pub trait RaftEntry
-where
-    Self: OptionalFeatures + Debug + Display,
-    Self: RaftPayload<Self::NodeId, Self::Node>,
+where Self: OptionalFeatures + Debug + Display
 {
     /// The committed leader ID type used in log IDs.
     #[since(version = "0.10.0")]
     type CommittedLeaderId: RaftCommittedLeaderId;
 
-    /// Application-specific data type stored in log entries.
+    /// The payload stored in log entries.
     #[since(version = "0.10.0")]
-    type D: AppData;
+    type Payload: RaftPayload;
 
-    /// The node ID type.
+    /// Create a new log entry with a log ID and configured payload.
+    #[since(version = "0.10.0", change = "accept configured payload type")]
     #[since(version = "0.10.0")]
-    type NodeId: NodeId;
-
-    /// The node type.
-    #[since(version = "0.10.0")]
-    type Node: Node;
-
-    /// Create a new log entry with log id and payload of application data or membership config.
-    #[since(version = "0.10.0")]
-    fn new(log_id: LogId<Self::CommittedLeaderId>, payload: EntryPayload<Self::D, Self::NodeId, Self::Node>) -> Self;
+    fn new(log_id: LogId<Self::CommittedLeaderId>, payload: Self::Payload) -> Self;
 
     /// Returns references to the components of this entry's log ID: the committed leader ID and
     /// index.
@@ -61,27 +56,42 @@ where
     #[since(version = "0.10.0", change = "use owned argument log id")]
     fn set_log_id(&mut self, new: LogId<Self::CommittedLeaderId>);
 
+    /// Return `Some(Membership)` if this entry contains a membership payload.
+    #[since(version = "0.10.0", change = "derive membership type from `Payload`")]
+    #[since(version = "0.10.0")]
+    fn get_membership(
+        &self,
+    ) -> Option<Membership<<Self::Payload as RaftPayload>::NodeId, <Self::Payload as RaftPayload>::Node>>;
+
     /// Create a new blank log entry.
+    #[since(version = "0.10.0", change = "construct configured payload type")]
     #[since(version = "0.10.0", change = "become a default method")]
     fn new_blank(log_id: LogId<Self::CommittedLeaderId>) -> Self
     where Self: Final + Sized {
-        Self::new(log_id, EntryPayload::Blank)
+        Self::new(log_id, Self::Payload::blank())
     }
 
     /// Create a new normal log entry that contains application data.
+    #[since(version = "0.10.0", change = "construct configured payload type")]
     #[since(version = "0.10.0", change = "become a default method")]
-    fn new_normal(log_id: LogId<Self::CommittedLeaderId>, data: Self::D) -> Self
+    fn new_normal(log_id: LogId<Self::CommittedLeaderId>, data: <Self::Payload as RaftPayload>::D) -> Self
     where Self: Final + Sized {
-        Self::new(log_id, EntryPayload::Normal(data))
+        Self::new(log_id, Self::Payload::normal(data))
     }
 
     /// Create a new membership log entry.
     ///
     /// The returned instance must return `Some()` for `Self::get_membership()`.
+    #[since(version = "0.10.0", change = "construct configured payload type")]
     #[since(version = "0.10.0", change = "become a default method")]
-    fn new_membership(log_id: LogId<Self::CommittedLeaderId>, m: Membership<Self::NodeId, Self::Node>) -> Self
-    where Self: Final + Sized {
-        Self::new(log_id, EntryPayload::Membership(m))
+    fn new_membership(
+        log_id: LogId<Self::CommittedLeaderId>,
+        m: Membership<<Self::Payload as RaftPayload>::NodeId, <Self::Payload as RaftPayload>::Node>,
+    ) -> Self
+    where
+        Self: Final + Sized,
+    {
+        Self::new(log_id, Self::Payload::membership(m))
     }
 
     /// Returns the `LogId` of this entry.

--- a/openraft/src/entry/raft_payload.rs
+++ b/openraft/src/entry/raft_payload.rs
@@ -34,6 +34,9 @@ where Self: OptionalFeatures + Debug + Display + Sized + 'static
     type Node: Node;
 
     /// Create a blank payload.
+    ///
+    /// OpenRaft uses a new blank payload as the base of a membership-change entry when the
+    /// application does not supply a payload.
     #[since(version = "0.10.0")]
     fn blank() -> Self;
 
@@ -42,6 +45,9 @@ where Self: OptionalFeatures + Debug + Display + Sized + 'static
     fn with_normal(self, data: Self::D) -> Self;
 
     /// Replace the membership in this payload.
+    ///
+    /// OpenRaft calls this method for every physical membership-change entry. An implementation
+    /// may preserve other application fields.
     #[since(version = "0.10.0")]
     fn with_membership(self, membership: Membership<Self::NodeId, Self::Node>) -> Self;
 

--- a/openraft/src/entry/raft_payload.rs
+++ b/openraft/src/entry/raft_payload.rs
@@ -1,19 +1,65 @@
+use std::fmt::Debug;
+use std::fmt::Display;
+
 use openraft_macros::since;
 
+use crate::AppData;
 use crate::Membership;
+use crate::base::OptionalFeatures;
 use crate::node::Node;
 use crate::node::NodeId;
 
-/// Defines operations on an entry payload.
+/// Defines operations for constructing and inspecting an entry payload.
+#[since(
+    version = "0.10.0",
+    change = "replaced generic parameters with associated types and added construction methods"
+)]
 #[since(
     version = "0.10.0",
     change = "replaced `C: RaftTypeConfig` with `NID: NodeId, N: Node`"
 )]
-pub trait RaftPayload<NID, N>
-where
-    NID: NodeId,
-    N: Node,
+pub trait RaftPayload
+where Self: OptionalFeatures + Debug + Display + Sized + 'static
 {
+    /// Application-specific data stored in the payload.
+    #[since(version = "0.10.0")]
+    type D: AppData;
+
+    /// The node ID type used in memberships.
+    #[since(version = "0.10.0")]
+    type NodeId: NodeId;
+
+    /// The node type used in memberships.
+    #[since(version = "0.10.0")]
+    type Node: Node;
+
+    /// Create a blank payload.
+    #[since(version = "0.10.0")]
+    fn blank() -> Self;
+
+    /// Replace the normal application data in this payload.
+    #[since(version = "0.10.0")]
+    fn with_normal(self, data: Self::D) -> Self;
+
+    /// Replace the membership in this payload.
+    #[since(version = "0.10.0")]
+    fn with_membership(self, membership: Membership<Self::NodeId, Self::Node>) -> Self;
+
     /// Return `Some(Membership)` if the entry payload contains a membership payload.
-    fn get_membership(&self) -> Option<Membership<NID, N>>;
+    #[since(version = "0.10.0", change = "use associated node types")]
+    fn get_membership(&self) -> Option<Membership<Self::NodeId, Self::Node>>;
+
+    /// Create a payload containing normal application data.
+    #[since(version = "0.10.0")]
+    fn normal(data: Self::D) -> Self {
+        let payload = Self::blank();
+        payload.with_normal(data)
+    }
+
+    /// Create a payload containing a membership.
+    #[since(version = "0.10.0")]
+    fn membership(membership: Membership<Self::NodeId, Self::Node>) -> Self {
+        let payload = Self::blank();
+        payload.with_membership(membership)
+    }
 }

--- a/openraft/src/impls/mod.rs
+++ b/openraft/src/impls/mod.rs
@@ -6,6 +6,7 @@
 //! ## Key Types
 //!
 //! - [`Entry`] - Default log entry implementation
+//! - [`EntryPayload`] - Default log entry payload implementation
 //! - [`LogId`] - Default log identifier
 //! - [`Vote`] - Default vote implementation
 //! - [`BasicNode`] - Simple node information with address
@@ -28,11 +29,14 @@
 mod boxed_error_source;
 
 pub use boxed_error_source::BoxedErrorSource;
+use openraft_macros::since;
 #[cfg(feature = "tokio-rt")]
 #[deprecated(since = "0.10.0", note = "use `openraft_rt_tokio::TokioRuntime` directly")]
 pub use openraft_rt_tokio::TokioRuntime;
 
 pub use crate::entry::Entry;
+#[since(version = "0.10.0", change = "re-exported from `impls`")]
+pub use crate::entry::EntryPayload;
 pub use crate::node::BasicNode;
 pub use crate::node::EmptyNode;
 pub use crate::node::NodeInfo;

--- a/openraft/src/raft/api/app.rs
+++ b/openraft/src/raft/api/app.rs
@@ -21,9 +21,9 @@ use crate::raft::responder::core_responder::CoreResponder;
 #[cfg(feature = "runtime-stats")]
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::BatchOf;
-use crate::type_config::alias::EntryPayloadOf;
 #[cfg(feature = "runtime-stats")]
 use crate::type_config::alias::InstantOf;
+use crate::type_config::alias::PayloadOf;
 use crate::type_config::alias::WriteResponderOf;
 
 /// Provides application-facing APIs for interacting with the Raft system.
@@ -57,7 +57,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip(self, payload))]
     pub(crate) async fn client_write(
         &self,
-        payload: EntryPayloadOf<C>,
+        payload: PayloadOf<C>,
         // TODO: ClientWriteError can only be ForwardToLeader Error
     ) -> Result<Result<ClientWriteResponse<C>, ClientWriteError<C>>, Fatal<C>> {
         let (responder, complete_rx) = ProgressResponder::complete_only();
@@ -77,7 +77,7 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn client_write_ff(
         &self,
-        payload: EntryPayloadOf<C>,
+        payload: PayloadOf<C>,
         responder: Option<WriteResponderOf<C>>,
     ) -> Result<(), Fatal<C>> {
         self.do_client_write_ff(
@@ -91,7 +91,7 @@ where C: RaftTypeConfig
     #[since(version = "0.10.0")]
     async fn do_client_write_ff(
         &self,
-        payloads: BatchOf<C, EntryPayloadOf<C>>,
+        payloads: BatchOf<C, PayloadOf<C>>,
         responders: BatchOf<C, Option<CoreResponder<C>>>,
     ) -> Result<(), Fatal<C>> {
         self.inner
@@ -118,9 +118,9 @@ where C: RaftTypeConfig
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn client_write_many(
         &self,
-        payloads: impl IntoIterator<Item = EntryPayloadOf<C>>,
+        payloads: impl IntoIterator<Item = PayloadOf<C>>,
     ) -> Result<BoxStream<'static, Result<WriteResult<C>, Fatal<C>>>, Fatal<C>> {
-        let payloads: Vec<EntryPayloadOf<C>> = payloads.into_iter().collect();
+        let payloads: Vec<PayloadOf<C>> = payloads.into_iter().collect();
 
         let mut responders = Vec::with_capacity(payloads.len());
         let mut receivers = Vec::with_capacity(payloads.len());

--- a/openraft/src/raft/api/management.rs
+++ b/openraft/src/raft/api/management.rs
@@ -12,10 +12,13 @@ use crate::batch::Batch;
 use crate::core::raft_msg::RaftMsg;
 use crate::core::replication_lag;
 use crate::entry::RaftPayload;
+use crate::errors::ClientWriteError;
 use crate::errors::Fatal;
 use crate::errors::InitializeError;
 use crate::impls::ProgressResponder;
 use crate::membership::IntoNodes;
+use crate::raft::ChangeMembershipOutcome;
+use crate::raft::ChangeMembershipRequest;
 use crate::raft::ClientWriteResult;
 use crate::raft::Precondition;
 use crate::raft::raft_inner::RaftInner;
@@ -60,7 +63,21 @@ where C: RaftTypeConfig
         retain: bool,
         preconditions: BatchOf<C, Precondition<C>>,
     ) -> Result<ClientWriteResult<C>, Fatal<C>> {
-        let changes: ChangeMembers<C::NodeId, C::Node> = members.into();
+        let request = ChangeMembershipRequest::new(members, retain).with_preconditions(preconditions);
+        let result = self.change_membership_with_payload(request).await?;
+        let result = result.map(|outcome| outcome.uniform.unwrap_or(outcome.first));
+        Ok(result)
+    }
+
+    pub(crate) async fn change_membership_with_payload(
+        &self,
+        request: ChangeMembershipRequest<C>,
+    ) -> Result<Result<ChangeMembershipOutcome<C>, ClientWriteError<C>>, Fatal<C>> {
+        let (changes, retain, preconditions, payload) = request.into_parts();
+        let (first_payload, uniform_payload) = match payload {
+            Some((first, uniform)) => (first, uniform),
+            None => (C::Payload::blank(), C::Payload::blank()),
+        };
 
         tracing::info!(
             "change_membership: start to commit joint config: changes: {:?}, retain: {}",
@@ -79,7 +96,7 @@ where C: RaftTypeConfig
             .call_core(
                 RaftMsg::ChangeMembership {
                     changes: changes.clone(),
-                    payload: C::Payload::blank(),
+                    payload: first_payload,
                     retain,
                     preconditions: Batch::of(preconditions.as_ref().iter().cloned()),
                     tx,
@@ -106,7 +123,11 @@ where C: RaftTypeConfig
         let (log_id, joint) = (&resp.log_id, resp.membership.clone().unwrap());
 
         if joint.get_joint_config().len() == 1 {
-            return Ok(Ok(resp));
+            let outcome = ChangeMembershipOutcome {
+                first: resp,
+                uniform: None,
+            };
+            return Ok(Ok(outcome));
         }
 
         tracing::debug!("committed a joint config: {} {:?}", log_id, joint);
@@ -138,7 +159,7 @@ where C: RaftTypeConfig
             .call_core(
                 RaftMsg::ChangeMembership {
                     changes,
-                    payload: C::Payload::blank(),
+                    payload: uniform_payload,
                     retain,
                     preconditions,
                     tx,
@@ -156,7 +177,11 @@ where C: RaftTypeConfig
             tracing::error!("the second step error: {}", e);
         }
 
-        Ok(client_write_result)
+        let outcome = client_write_result.map(|uniform| ChangeMembershipOutcome {
+            first: resp,
+            uniform: Some(uniform),
+        });
+        Ok(outcome)
     }
 
     #[since(version = "0.10.0")]

--- a/openraft/src/raft/api/management.rs
+++ b/openraft/src/raft/api/management.rs
@@ -11,6 +11,7 @@ use crate::RaftTypeConfig;
 use crate::batch::Batch;
 use crate::core::raft_msg::RaftMsg;
 use crate::core::replication_lag;
+use crate::entry::RaftPayload;
 use crate::errors::Fatal;
 use crate::errors::InitializeError;
 use crate::impls::ProgressResponder;
@@ -78,6 +79,7 @@ where C: RaftTypeConfig
             .call_core(
                 RaftMsg::ChangeMembership {
                     changes: changes.clone(),
+                    payload: C::Payload::blank(),
                     retain,
                     preconditions: Batch::of(preconditions.as_ref().iter().cloned()),
                     tx,
@@ -136,6 +138,7 @@ where C: RaftTypeConfig
             .call_core(
                 RaftMsg::ChangeMembership {
                     changes,
+                    payload: C::Payload::blank(),
                     retain,
                     preconditions,
                     tx,
@@ -168,6 +171,7 @@ where C: RaftTypeConfig
 
         let msg = RaftMsg::ChangeMembership {
             changes: ChangeMembers::AddNodes(btreemap! {id.clone()=>node}),
+            payload: C::Payload::blank(),
             retain: true,
             preconditions: Batch::of([]),
             tx,

--- a/openraft/src/raft/declare_raft_types_test.rs
+++ b/openraft/src/raft/declare_raft_types_test.rs
@@ -11,6 +11,7 @@ use crate::Membership;
 use crate::RaftTypeConfig;
 use crate::declare_raft_types;
 use crate::entry::RaftPayload;
+use crate::raft::ChangeMembershipRequest;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -105,4 +106,18 @@ fn test_payload_type() {
 
     assert_payload::<WithCustomPayload, CustomPayload>();
     assert_payload::<Empty, EntryPayload<String, u64, crate::impls::BasicNode>>();
+}
+
+#[test]
+fn test_change_membership_request_accepts_distinct_non_clone_payloads() {
+    let first_payload = CustomPayload(EntryPayload::Normal(1));
+    let uniform_payload = CustomPayload(EntryPayload::Normal(2));
+    let request =
+        ChangeMembershipRequest::<WithCustomPayload>::new([1], false).with_payload(first_payload, uniform_payload);
+
+    let (_, _, _, payloads) = request.into_parts();
+    let (first_payload, uniform_payload) = payloads.unwrap();
+    let actual = (first_payload.0, uniform_payload.0);
+    let expected = (EntryPayload::Normal(1), EntryPayload::Normal(2));
+    assert_eq!(expected, actual);
 }

--- a/openraft/src/raft/declare_raft_types_test.rs
+++ b/openraft/src/raft/declare_raft_types_test.rs
@@ -2,9 +2,47 @@
 
 #![allow(dead_code)]
 
+use std::fmt;
+
 use openraft_rt_tokio::TokioRuntime;
 
+use crate::EntryPayload;
+use crate::Membership;
+use crate::RaftTypeConfig;
 use crate::declare_raft_types;
+use crate::entry::RaftPayload;
+
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+struct CustomPayload(EntryPayload<u64, u64, ()>);
+
+impl fmt::Display for CustomPayload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl RaftPayload for CustomPayload {
+    type D = u64;
+    type NodeId = u64;
+    type Node = ();
+
+    fn blank() -> Self {
+        Self(EntryPayload::blank())
+    }
+
+    fn with_normal(self, data: u64) -> Self {
+        Self(self.0.with_normal(data))
+    }
+
+    fn with_membership(self, membership: Membership<u64, ()>) -> Self {
+        Self(self.0.with_membership(membership))
+    }
+
+    fn get_membership(&self) -> Option<Membership<u64, ()>> {
+        self.0.get_membership()
+    }
+}
 
 declare_raft_types!(
     All:
@@ -18,7 +56,7 @@ declare_raft_types!(
         R = (),
         Term = u64,
         LeaderId = crate::impls::leader_id_std::LeaderId<u64, u64>,
-        Entry = crate::Entry<<Self::LeaderId as crate::vote::RaftLeaderId>::Committed, Self::D, Self::NodeId, Self::Node>,
+        Entry = crate::Entry<<Self::LeaderId as crate::vote::RaftLeaderId>::Committed, Self::Payload>,
         Vote = crate::impls::Vote<Self::LeaderId>,
         AsyncRuntime = TokioRuntime,
         // Responder<T> is not supported by  declare_raft_types
@@ -30,7 +68,7 @@ declare_raft_types!(
         R = (),
         NodeId = u64,
         Node = (),
-        Entry = crate::Entry<<Self::LeaderId as crate::vote::RaftLeaderId>::Committed, Self::D, Self::NodeId, Self::Node>,
+        Entry = crate::Entry<<Self::LeaderId as crate::vote::RaftLeaderId>::Committed, Self::Payload>,
         AsyncRuntime = TokioRuntime,
 );
 
@@ -39,10 +77,32 @@ declare_raft_types!(
         D = u64,
         NodeId = u64,
         Node = (),
-        Entry = crate::Entry<<Self::LeaderId as crate::vote::RaftLeaderId>::Committed, Self::D, Self::NodeId, Self::Node>,
+        Entry = crate::Entry<<Self::LeaderId as crate::vote::RaftLeaderId>::Committed, Self::Payload>,
         AsyncRuntime = TokioRuntime,
 );
 
 declare_raft_types!(EmptyWithColon:);
 
 declare_raft_types!(Empty);
+
+declare_raft_types!(
+    WithCustomPayload:
+        D = u64,
+        R = (),
+        Node = (),
+        Payload = CustomPayload,
+        AsyncRuntime = TokioRuntime,
+);
+
+#[test]
+fn test_payload_type() {
+    fn assert_payload<C, P>()
+    where
+        C: RaftTypeConfig<Payload = P>,
+        P: RaftPayload,
+    {
+    }
+
+    assert_payload::<WithCustomPayload, CustomPayload>();
+    assert_payload::<Empty, EntryPayload<String, u64, crate::impls::BasicNode>>();
+}

--- a/openraft/src/raft/impl_raft_blocking_write.rs
+++ b/openraft/src/raft/impl_raft_blocking_write.rs
@@ -13,6 +13,8 @@ use crate::errors::RaftError;
 use crate::errors::into_raft_result::IntoRaftResult;
 #[cfg(doc)]
 use crate::impls::OneshotResponder;
+use crate::raft::ChangeMembershipOutcome;
+use crate::raft::ChangeMembershipRequest;
 use crate::raft::ClientWriteResponse;
 #[cfg(doc)]
 use crate::raft::ManagementApi;
@@ -80,6 +82,43 @@ where
             .change_membership(members, retain, BatchOf::<C, _>::of([]))
             .await
             .into_raft_result()
+    }
+
+    /// Propose a cluster configuration change from a [`ChangeMembershipRequest`].
+    ///
+    /// A request without an application-defined payload starts each physical log entry from a
+    /// separate `C::Payload::blank()`. [`ChangeMembershipRequest::with_payload()`] supplies
+    /// separate application-defined bases instead. OpenRaft calls `with_membership()` on each
+    /// base payload with the membership computed for that physical log entry.
+    ///
+    /// Request preconditions follow the same two-step rules as [`Self::change_membership_if()`].
+    /// They guard the first proposal. OpenRaft updates the membership-log precondition for a
+    /// possible uniform proposal and carries over only the committed-leader precondition.
+    ///
+    /// A voter change may append a joint entry followed by a uniform entry. `with_payload()`
+    /// accepts one payload for the requested change and another for the possible uniform entry.
+    /// If `with_membership()` preserves application data, the state machine applies each
+    /// payload at its corresponding log ID.
+    ///
+    /// Both supplied payloads are serialized, stored, and replicated when the change requires two
+    /// physical entries.
+    ///
+    /// If the uniform proposal fails, the joint entry is already committed. A retry must build a
+    /// new request with the original payloads and preconditions based on the current joint state.
+    ///
+    /// The returned [`ChangeMembershipOutcome`] contains the first response and the uniform
+    /// response when the change entered joint consensus.
+    #[since(
+        version = "0.10.0",
+        change = "accept a request with an optional payload and preconditions"
+    )]
+    #[since(version = "0.10.0", change = "added payload-aware membership change API")]
+    #[tracing::instrument(level = "info", skip_all)]
+    pub async fn change_membership_with_payload(
+        &self,
+        request: ChangeMembershipRequest<C>,
+    ) -> Result<ChangeMembershipOutcome<C>, RaftError<C, ClientWriteError<C>>> {
+        self.management_api().change_membership_with_payload(request).await.into_raft_result()
     }
 
     /// Propose a cluster configuration change only if every [`Precondition`] is satisfied.

--- a/openraft/src/raft/message/change_membership.rs
+++ b/openraft/src/raft/message/change_membership.rs
@@ -1,0 +1,36 @@
+use std::fmt;
+
+use openraft_macros::since;
+
+use crate::RaftTypeConfig;
+use crate::raft::ClientWriteResponse;
+
+/// Responses from the physical log entries of a membership change.
+#[since(version = "0.10.0", change = "added payload-aware membership outcome")]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(bound = "C::R: crate::AppDataResponse")
+)]
+pub struct ChangeMembershipOutcome<C>
+where C: RaftTypeConfig
+{
+    /// The response from the requested membership change.
+    pub first: ClientWriteResponse<C>,
+
+    /// The response from flattening a joint membership to a uniform membership.
+    pub uniform: Option<ClientWriteResponse<C>>,
+}
+
+impl<C> fmt::Debug for ChangeMembershipOutcome<C>
+where
+    C: RaftTypeConfig,
+    C::R: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ChangeMembershipOutcome")
+            .field("first", &self.first)
+            .field("uniform", &self.uniform)
+            .finish()
+    }
+}

--- a/openraft/src/raft/message/change_membership_request.rs
+++ b/openraft/src/raft/message/change_membership_request.rs
@@ -1,0 +1,70 @@
+use openraft_macros::since;
+
+use crate::ChangeMembers;
+use crate::RaftTypeConfig;
+use crate::batch::Batch;
+use crate::raft::Precondition;
+use crate::type_config::alias::BatchOf;
+
+/// Parameters for a membership change that may carry an application-defined payload.
+#[since(version = "0.10.0", change = "added configurable membership change request")]
+pub struct ChangeMembershipRequest<C>
+where C: RaftTypeConfig
+{
+    members: ChangeMembers<C::NodeId, C::Node>,
+    retain_removed_as_learners: bool,
+    preconditions: BatchOf<C, Precondition<C>>,
+    payload: Option<(C::Payload, C::Payload)>,
+}
+
+impl<C> ChangeMembershipRequest<C>
+where C: RaftTypeConfig
+{
+    /// Create a request that uses a new blank payload for each membership entry and has no
+    /// preconditions.
+    #[since(version = "0.10.0", change = "added configurable membership change request")]
+    pub fn new(members: impl Into<ChangeMembers<C::NodeId, C::Node>>, retain: bool) -> Self {
+        let members = members.into();
+        Self {
+            members,
+            retain_removed_as_learners: retain,
+            preconditions: BatchOf::<C, _>::of([]),
+            payload: None,
+        }
+    }
+
+    /// Use separate application-defined payloads for the membership-change steps.
+    ///
+    /// `first_payload` is used for the requested change. `uniform_payload` is used only when a
+    /// second entry is needed to flatten a joint membership.
+    #[since(version = "0.10.0", change = "accept separate payloads for membership change steps")]
+    #[since(version = "0.10.0", change = "added optional membership change payload")]
+    pub fn with_payload(mut self, first_payload: C::Payload, uniform_payload: C::Payload) -> Self {
+        self.payload = Some((first_payload, uniform_payload));
+        self
+    }
+
+    /// Guard the first membership proposal with the given preconditions.
+    #[since(version = "0.10.0", change = "added membership change preconditions")]
+    pub fn with_preconditions(mut self, preconditions: impl IntoIterator<Item = Precondition<C>>) -> Self {
+        let preconditions = BatchOf::<C, _>::of(preconditions);
+        self.preconditions = preconditions;
+        self
+    }
+
+    pub(crate) fn into_parts(
+        self,
+    ) -> (
+        ChangeMembers<C::NodeId, C::Node>,
+        bool,
+        BatchOf<C, Precondition<C>>,
+        Option<(C::Payload, C::Payload)>,
+    ) {
+        (
+            self.members,
+            self.retain_removed_as_learners,
+            self.preconditions,
+            self.payload,
+        )
+    }
+}

--- a/openraft/src/raft/message/mod.rs
+++ b/openraft/src/raft/message/mod.rs
@@ -5,6 +5,8 @@
 
 mod append_entries_request;
 mod append_entries_response;
+mod change_membership;
+mod change_membership_request;
 mod install_snapshot;
 mod log_segment;
 mod precondition;
@@ -18,6 +20,8 @@ mod write_request;
 
 pub use append_entries_request::AppendEntriesRequest;
 pub use append_entries_response::AppendEntriesResponse;
+pub use change_membership::ChangeMembershipOutcome;
+pub use change_membership_request::ChangeMembershipRequest;
 pub use client_write::ClientWriteResponse;
 pub use client_write::ClientWriteResult;
 #[allow(deprecated)]

--- a/openraft/src/raft/message/write_request.rs
+++ b/openraft/src/raft/message/write_request.rs
@@ -6,7 +6,7 @@ use crate::RaftTypeConfig;
 use crate::base::BoxFuture;
 use crate::batch::Batch;
 use crate::core::raft_msg::RaftMsg;
-use crate::entry::EntryPayload;
+use crate::entry::RaftPayload;
 use crate::errors::Fatal;
 #[cfg(feature = "runtime-stats")]
 use crate::raft::api::app::propose_at_now;
@@ -140,7 +140,7 @@ where C: RaftTypeConfig
         Box::pin(async move {
             self.inner
                 .send_msg(RaftMsg::ClientWrite {
-                    payloads: Batch::of([EntryPayload::Normal(self.app_data)]),
+                    payloads: Batch::of([C::Payload::normal(self.app_data)]),
                     responders: Batch::of([self.responder]),
                     expected_leader: self.expected_leader,
                     #[cfg(feature = "runtime-stats")]

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -42,6 +42,8 @@ use linearizable_read::LinearizerOption;
 use linearizable_read::ReadLogId;
 pub use message::AppendEntriesRequest;
 pub use message::AppendEntriesResponse;
+pub use message::ChangeMembershipOutcome;
+pub use message::ChangeMembershipRequest;
 pub use message::ClientWriteResponse;
 pub use message::ClientWriteResult;
 #[allow(deprecated)]

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -111,7 +111,7 @@ use crate::core::sm;
 use crate::core::sm::worker;
 use crate::engine::Engine;
 use crate::engine::EngineConfig;
-use crate::entry::EntryPayload;
+use crate::entry::RaftPayload;
 use crate::errors::ClientWriteError;
 use crate::errors::Fatal;
 use crate::errors::ForwardToLeader;
@@ -169,7 +169,11 @@ use crate::vote::raft_vote::RaftVoteExt;
 ///        Term         = u64,
 ///        LeaderId     = openraft::impls::leader_id_adv::LeaderId<Self::Term, Self::NodeId>,
 ///        Vote           = openraft::impls::Vote<Self::LeaderId>,
-///        Entry          = openraft::Entry<Self>,
+///        Payload        = openraft::EntryPayload<Self::D, Self::NodeId, Self::Node>,
+///        Entry          = openraft::Entry<
+///            <Self::LeaderId as openraft::vote::RaftLeaderId>::Committed,
+///            Self::Payload,
+///        >,
 ///        Responder<T>   = openraft::impls::OneshotResponder<Self, T>,
 ///        AsyncRuntime   = openraft::TokioRuntime,
 /// );
@@ -183,7 +187,8 @@ use crate::vote::raft_vote::RaftVoteExt;
 /// - `Term`:         `u64`
 /// - `LeaderId`:     `::openraft::impls::leader_id_adv::LeaderId<Self::Term, Self::NodeId>`
 /// - `Vote`:           `::openraft::impls::Vote<Self::LeaderId>`
-/// - `Entry`:          `::openraft::impls::Entry<Self>`
+/// - `Payload`:        `::openraft::EntryPayload<Self::D, Self::NodeId, Self::Node>`
+/// - `Entry`:          `::openraft::impls::Entry<CommittedLeaderId, Self::Payload>`
 /// - `Responder<T>`:   `::openraft::impls::OneshotResponder<Self, T>`
 /// - `AsyncRuntime`:   `::openraft::impls::TokioRuntime`
 /// - `ErrorSource`:    `::anyerror::AnyError`
@@ -232,7 +237,8 @@ macro_rules! declare_raft_types {
                 (Term         , , u64                                          ),
                 (LeaderId     , , $crate::impls::leader_id_adv::LeaderId<Self::Term, Self::NodeId> ),
                 (Vote           , , $crate::impls::Vote<Self::LeaderId>            ),
-                (Entry          , , $crate::Entry<<Self::LeaderId as $crate::vote::RaftLeaderId>::Committed, Self::D, Self::NodeId, Self::Node> ),
+                (Payload        , , $crate::EntryPayload<Self::D, Self::NodeId, Self::Node> ),
+                (Entry          , , $crate::Entry<<Self::LeaderId as $crate::vote::RaftLeaderId>::Committed, Self::Payload> ),
                 (Responder<T>   , , $crate::impls::ProgressResponder<Self, T> where T: $crate::OptionalSend + 'static     ),
                 (Batch<T>       , , $crate::impls::InlineBatch<T> where T: $crate::OptionalSend + 'static     ),
                 (AsyncRuntime   , , $crate::impls::TokioRuntime                  ),
@@ -1230,7 +1236,7 @@ where
         &self,
         app_data: C::D,
     ) -> Result<ClientWriteResponse<C>, RaftError<C, ClientWriteError<C>>> {
-        self.app_api().client_write(EntryPayload::Normal(app_data)).await.into_raft_result()
+        self.app_api().client_write(C::Payload::normal(app_data)).await.into_raft_result()
     }
 
     /// Write a blank log entry to the Raft log.
@@ -1244,7 +1250,7 @@ where
     #[since(version = "0.10.0")]
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn write_blank(&self) -> Result<ClientWriteResponse<C>, RaftError<C, ClientWriteError<C>>> {
-        self.app_api().client_write(EntryPayload::Blank).await.into_raft_result()
+        self.app_api().client_write(C::Payload::blank()).await.into_raft_result()
     }
 
     /// Submit a mutating client request to Raft to update the state machine, returns an application
@@ -1260,7 +1266,7 @@ where
         app_data: C::D,
         responder: Option<WriteResponderOf<C>>,
     ) -> Result<(), Fatal<C>> {
-        self.app_api().client_write_ff(EntryPayload::Normal(app_data), responder).await
+        self.app_api().client_write_ff(C::Payload::normal(app_data), responder).await
     }
 
     /// Write multiple application data payloads in a single batch.
@@ -1290,7 +1296,7 @@ where
         &self,
         app_data: impl IntoIterator<Item = C::D>,
     ) -> Result<BoxStream<'static, Result<WriteResult<C>, Fatal<C>>>, Fatal<C>> {
-        self.app_api().client_write_many(app_data.into_iter().map(EntryPayload::Normal)).await
+        self.app_api().client_write_many(app_data.into_iter().map(C::Payload::normal)).await
     }
 
     /// Submit a write request to Raft.

--- a/openraft/src/storage/helper.rs
+++ b/openraft/src/storage/helper.rs
@@ -15,7 +15,6 @@ use crate::StorageError;
 use crate::base::shared_id_generator::SharedIdGenerator;
 use crate::engine::LogIdList;
 use crate::entry::RaftEntry;
-use crate::entry::RaftPayload;
 use crate::errors::StorageIOResult;
 use crate::raft_state::IOState;
 use crate::storage::RaftLogStorage;

--- a/openraft/src/storage/v2/entry_responder.rs
+++ b/openraft/src/storage/v2/entry_responder.rs
@@ -1,6 +1,5 @@
 use crate::RaftTypeConfig;
 use crate::entry::RaftEntry;
-use crate::entry::RaftPayload;
 use crate::raft::responder::core_responder::CoreResponder;
 use crate::storage::v2::apply_responder::ApplyResponder;
 use crate::storage::v2::apply_responder_inner::ApplyResponderInner;

--- a/openraft/src/type_config.rs
+++ b/openraft/src/type_config.rs
@@ -21,6 +21,7 @@ use crate::OptionalSend;
 use crate::OptionalSync;
 use crate::batch::Batch;
 use crate::entry::RaftEntry;
+use crate::entry::RaftPayload;
 use crate::errors::ErrorSource;
 use crate::raft::responder::Responder;
 use crate::vote::RaftLeaderId;
@@ -61,7 +62,11 @@ use crate::vote::raft_vote::RaftVote;
 ///         Term             = u64,
 ///         LeaderId         = openraft::impls::leader_id_adv::LeaderId<Self::Term, Self::NodeId>,
 ///         Vote             = openraft::impls::Vote<Self::LeaderId>,
-///         Entry            = openraft::impls::Entry<Self>,
+///         Payload          = openraft::EntryPayload<Self::D, Self::NodeId, Self::Node>,
+///         Entry            = openraft::impls::Entry<
+///             <Self::LeaderId as openraft::vote::RaftLeaderId>::Committed,
+///             Self::Payload,
+///         >,
 ///         Responder<T>     = openraft::impls::OneshotResponder<Self, T>,
 ///         AsyncRuntime     = openraft::impls::TokioRuntime,
 /// );
@@ -81,6 +86,7 @@ use crate::vote::raft_vote::RaftVote;
 ///
 /// [`Raft`]: crate::Raft
 /// [`declare_raft_types!`]: crate::declare_raft_types
+#[since(version = "0.10.0", change = "added `Payload` associated type")]
 pub trait RaftTypeConfig:
     Sized + OptionalSend + OptionalSync + Debug + Clone + Copy + Default + Eq + PartialEq + Ord + PartialOrd + 'static
 {
@@ -118,17 +124,17 @@ pub trait RaftTypeConfig:
     )]
     type Vote: RaftVote<LeaderId = Self::LeaderId>;
 
-    /// Raft log entry, which can be built from an AppData.
+    /// Raft log entry payload.
+    #[since(version = "0.10.0", change = "added configurable log payload type")]
+    type Payload: RaftPayload<D = Self::D, NodeId = Self::NodeId, Node = Self::Node>;
+
+    /// Raft log entry with the configured payload.
+    #[since(version = "0.10.0", change = "link entry payload to configured `Payload`")]
     #[since(
         version = "0.10.0",
         change = "from `RaftEntry<Self>` to `RaftEntry` with associated type constraints"
     )]
-    type Entry: RaftEntry<
-            CommittedLeaderId = <Self::LeaderId as RaftLeaderId>::Committed,
-            D = Self::D,
-            NodeId = Self::NodeId,
-            Node = Self::Node,
-        >;
+    type Entry: RaftEntry<CommittedLeaderId = <Self::LeaderId as RaftLeaderId>::Committed, Payload = Self::Payload>;
 
     /// Asynchronous runtime type.
     type AsyncRuntime: AsyncRuntime;
@@ -172,6 +178,8 @@ pub trait RaftTypeConfig:
 ///
 /// [`type-alias`]: crate::docs::feature_flags#feature-flag-type-alias
 pub mod alias {
+    use openraft_macros::since;
+
     use crate::EntryPayload;
     use crate::LogId;
     use crate::RaftTypeConfig;
@@ -192,6 +200,8 @@ pub mod alias {
     pub type TermOf<C> = <C as RaftTypeConfig>::Term;
     pub type LeaderIdOf<C> = <C as RaftTypeConfig>::LeaderId;
     pub type VoteOf<C> = <C as RaftTypeConfig>::Vote;
+    #[since(version = "0.10.0")]
+    pub type PayloadOf<C> = <C as RaftTypeConfig>::Payload;
     pub type EntryOf<C> = <C as RaftTypeConfig>::Entry;
     pub type SnapshotDataOf<C, SM> = <SM as RaftStateMachine<C>>::SnapshotData;
     pub type AsyncRuntimeOf<C> = <C as RaftTypeConfig>::AsyncRuntime;
@@ -234,7 +244,8 @@ pub mod alias {
     pub type CommittedLeaderIdOf<C> = <LeaderIdOf<C> as RaftLeaderId>::Committed;
     pub(crate) type RefLogIdOf<'a, C> = crate::log_id::ref_log_id::RefLogId<'a, CommittedLeaderIdOf<C>>;
     pub type EntryPayloadOf<C> = EntryPayload<DOf<C>, NodeIdOf<C>, NodeOf<C>>;
-    pub type DefaultEntryOf<C> = crate::Entry<CommittedLeaderIdOf<C>, DOf<C>, NodeIdOf<C>, NodeOf<C>>;
+    #[since(version = "0.10.0", change = "use configured payload type")]
+    pub type DefaultEntryOf<C> = crate::Entry<CommittedLeaderIdOf<C>, PayloadOf<C>>;
     pub type StoredMembershipOf<C> = crate::StoredMembership<CommittedLeaderIdOf<C>, NodeIdOf<C>, NodeOf<C>>;
     pub type SnapshotSignatureOf<C> = crate::storage::SnapshotSignature<CommittedLeaderIdOf<C>>;
     pub type SnapshotMetaOf<C> = crate::storage::SnapshotMeta<CommittedLeaderIdOf<C>, NodeIdOf<C>, NodeOf<C>>;

--- a/openraft/src/type_config/util.rs
+++ b/openraft/src/type_config/util.rs
@@ -219,8 +219,8 @@ mod tests {
         type Term = u64;
         type LeaderId = crate::impls::leader_id_adv::LeaderId<u64, u64>;
         type Vote = crate::impls::Vote<Self::LeaderId>;
-        type Entry =
-            crate::Entry<<Self::LeaderId as crate::vote::RaftLeaderId>::Committed, Self::D, Self::NodeId, Self::Node>;
+        type Payload = crate::EntryPayload<Self::D, Self::NodeId, Self::Node>;
+        type Entry = crate::Entry<<Self::LeaderId as crate::vote::RaftLeaderId>::Committed, Self::Payload>;
         type AsyncRuntime = TokioRuntime;
         type Responder<T>
             = crate::impls::OneshotResponder<Self, T>

--- a/openraft/tests/measure_error_size.rs
+++ b/openraft/tests/measure_error_size.rs
@@ -11,7 +11,7 @@ openraft::declare_raft_types!(
     pub TestConfig:
         NodeId = u64,
         Node = BasicNode,
-        Entry = openraft::Entry<<Self::LeaderId as openraft::vote::RaftLeaderId>::Committed, Self::D, Self::NodeId, Self::Node>,
+        Entry = openraft::Entry<<Self::LeaderId as openraft::vote::RaftLeaderId>::Committed, Self::Payload>,
         AsyncRuntime = openraft::impls::TokioRuntime
 );
 

--- a/tests/tests/custom_type_config_test.rs
+++ b/tests/tests/custom_type_config_test.rs
@@ -67,7 +67,8 @@ impl RaftTypeConfig for CustomConfig {
     type Term = u64;
     type LeaderId = openraft::impls::leader_id_adv::LeaderId<u64, u64>;
     type Vote = openraft::impls::Vote<Self::LeaderId>;
-    type Entry = Entry<<Self::LeaderId as openraft::vote::RaftLeaderId>::Committed, Self::D, Self::NodeId, Self::Node>;
+    type Payload = openraft::EntryPayload<Self::D, Self::NodeId, Self::Node>;
+    type Entry = Entry<<Self::LeaderId as openraft::vote::RaftLeaderId>::Committed, Self::Payload>;
     type AsyncRuntime = TokioRuntime;
     type Responder<T>
         = OneshotResponder<Self, T>

--- a/tests/tests/membership/main.rs
+++ b/tests/tests/membership/main.rs
@@ -15,6 +15,7 @@ mod t12_concurrent_write_and_add_learner;
 mod t20_change_membership;
 mod t21_change_membership_cases;
 mod t22_change_membership_if;
+mod t23_custom_payload;
 mod t30_commit_joint_config;
 mod t30_elect_with_new_config;
 mod t31_add_remove_follower;

--- a/tests/tests/membership/t20_change_membership.rs
+++ b/tests/tests/membership/t20_change_membership.rs
@@ -4,11 +4,13 @@ use std::time::Duration;
 
 use maplit::btreeset;
 use openraft::Config;
+use openraft::EntryPayload;
 use openraft::LogIdOptionExt;
 use openraft::RaftLogReader;
 use openraft::ServerState;
 use openraft::errors::ChangeMembershipError;
 use openraft::errors::ClientWriteError;
+use openraft::raft::ChangeMembershipRequest;
 use openraft_memstore::MemNodeId;
 
 use crate::fixtures::RaftRouter;
@@ -32,10 +34,44 @@ async fn update_membership_state() -> anyhow::Result<()> {
     tracing::info!(log_index, "--- change membership from 012 to 01234");
     {
         let leader = router.get_raft_handle(&0)?;
-        let res = leader.change_membership([0, 1, 2, 3, 4], false).await?;
-        log_index += 2;
+        let request = ChangeMembershipRequest::new([0, 1, 2, 3, 4], false);
+        let change = leader.change_membership_with_payload(request);
+        let outcome = change.await?;
 
-        tracing::info!(log_index, "--- change_membership blocks until success: {:?}", res);
+        let first_log_index = log_index + 1;
+        assert_eq!(first_log_index, outcome.first.log_id.index);
+
+        let uniform = outcome.uniform.as_ref().expect("voter change should enter joint consensus");
+        let uniform_log_index = log_index + 2;
+        assert_eq!(uniform_log_index, uniform.log_id.index);
+
+        tracing::info!(
+            first_log_index,
+            uniform_log_index,
+            "--- inspect membership log payloads"
+        );
+        {
+            let first_membership = outcome.first.membership.clone().unwrap();
+            let uniform_membership = uniform.membership.clone().unwrap();
+            let expected_memberships = vec![first_membership, uniform_membership];
+
+            let (mut log_store, _) = router.get_storage_handle(&0)?;
+            let entries = log_store.try_get_log_entries(first_log_index..=uniform_log_index).await?;
+            let mut actual_memberships = Vec::new();
+            for entry in entries {
+                let membership = match entry.payload {
+                    EntryPayload::Membership(membership) => membership,
+                    payload => panic!("expected membership payload, got: {payload:?}"),
+                };
+                actual_memberships.push(membership);
+            }
+
+            assert_eq!(expected_memberships, actual_memberships);
+        }
+
+        log_index = uniform_log_index;
+
+        tracing::info!(log_index, "--- change_membership blocks until success: {:?}", outcome);
 
         for node_id in [0, 1, 2, 3, 4] {
             router

--- a/tests/tests/membership/t22_change_membership_if.rs
+++ b/tests/tests/membership/t22_change_membership_if.rs
@@ -4,12 +4,14 @@ use std::time::Duration;
 use anyhow::Result;
 use maplit::btreeset;
 use openraft::Config;
+use openraft::EntryPayload;
 use openraft::Precondition;
 use openraft::async_runtime::WatchReceiver;
 use openraft::errors::ClientWriteError;
 use openraft::errors::ForwardToLeader;
 use openraft::errors::PreconditionFailed;
 use openraft::errors::RaftError;
+use openraft::raft::ChangeMembershipRequest;
 use openraft::type_config::alias::LeaderIdOf;
 use openraft::type_config::alias::LogIdOf;
 use openraft::vote::RaftLeaderIdExt;
@@ -51,7 +53,12 @@ async fn matching_membership_log_id_completes_joint_change() -> Result<()> {
         let precondition = Precondition::LastMembershipLogId {
             last_membership_log_id: membership_log_id,
         };
-        let resp = leader.change_membership_if([0, 1, 2, 3], false, [precondition]).await?;
+        let request = ChangeMembershipRequest::<TypeConfig>::new([0, 1, 2, 3], false)
+            .with_payload(EntryPayload::Blank, EntryPayload::Blank)
+            .with_preconditions([precondition]);
+        let change = leader.change_membership_with_payload(request);
+        let outcome = change.await?;
+        let resp = outcome.uniform.as_ref().expect("voter change should enter joint consensus");
 
         // A joint config log and a uniform config log.
         log_index += 2;

--- a/tests/tests/membership/t23_custom_payload.rs
+++ b/tests/tests/membership/t23_custom_payload.rs
@@ -1,0 +1,594 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::future::Future;
+use std::io;
+use std::io::Cursor;
+use std::ops::RangeBounds;
+use std::ops::RangeInclusive;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use futures::Stream;
+use futures::TryStreamExt;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::Entry;
+use openraft::LogState;
+use openraft::Membership;
+use openraft::OptionalSend;
+use openraft::Raft;
+use openraft::RaftLogReader;
+use openraft::RaftNetworkFactory;
+use openraft::RaftSnapshotBuilder;
+use openraft::RaftTypeConfig;
+use openraft::Snapshot;
+use openraft::StoredMembership;
+use openraft::alias::EntryOf;
+use openraft::alias::LogIdOf;
+use openraft::alias::SnapshotMetaOf;
+use openraft::alias::SnapshotOf;
+use openraft::alias::StoredMembershipOf;
+use openraft::alias::VoteOf;
+use openraft::async_runtime::WatchReceiver;
+use openraft::entry::RaftPayload;
+use openraft::errors::RPCError;
+use openraft::errors::ReplicationClosed;
+use openraft::errors::StreamingError;
+use openraft::errors::Unreachable;
+use openraft::network::RPCOption;
+use openraft::network::v2::RaftNetworkV2;
+use openraft::raft::AppendEntriesRequest;
+use openraft::raft::AppendEntriesResponse;
+use openraft::raft::ChangeMembershipRequest;
+use openraft::raft::SnapshotResponse;
+use openraft::raft::VoteRequest;
+use openraft::raft::VoteResponse;
+use openraft::storage::EntryResponder;
+use openraft::storage::IOFlushed;
+use openraft::storage::RaftLogStorage;
+use openraft::storage::RaftStateMachine;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::fixtures::ut_harness;
+
+static BLANK_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+struct CustomPayload {
+    normal: Option<String>,
+    membership: Option<Membership<u64, ()>>,
+}
+
+impl fmt::Display for CustomPayload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "normal={:?}, membership={:?}", self.normal, self.membership)
+    }
+}
+
+impl RaftPayload for CustomPayload {
+    type D = String;
+    type NodeId = u64;
+    type Node = ();
+
+    fn blank() -> Self {
+        BLANK_CALLS.fetch_add(1, Ordering::SeqCst);
+        Self::default()
+    }
+
+    fn with_normal(mut self, data: String) -> Self {
+        self.normal = Some(data);
+        self
+    }
+
+    fn with_membership(mut self, membership: Membership<u64, ()>) -> Self {
+        self.membership = Some(membership);
+        self
+    }
+
+    fn get_membership(&self) -> Option<Membership<u64, ()>> {
+        self.membership.clone()
+    }
+}
+
+openraft::declare_raft_types!(
+    TestConfig:
+        D = String,
+        R = (),
+        Node = (),
+        Payload = CustomPayload,
+);
+
+#[derive(Clone, Debug, Default)]
+struct TestLogStore(Arc<Mutex<TestLogStoreInner>>);
+
+#[derive(Debug, Default)]
+struct TestLogStoreInner {
+    last_purged_log_id: Option<LogIdOf<TestConfig>>,
+    log: BTreeMap<u64, EntryOf<TestConfig>>,
+    committed: Option<LogIdOf<TestConfig>>,
+    vote: Option<VoteOf<TestConfig>>,
+}
+
+impl RaftLogReader<TestConfig> for TestLogStore {
+    async fn try_get_log_entries<RB>(&mut self, range: RB) -> Result<Vec<EntryOf<TestConfig>>, io::Error>
+    where RB: RangeBounds<u64> + Clone + fmt::Debug + OptionalSend {
+        let inner = self.0.lock().unwrap();
+        let entries = inner.log.range(range).map(|(_, entry)| entry.clone()).collect();
+        Ok(entries)
+    }
+
+    async fn read_vote(&mut self) -> Result<Option<VoteOf<TestConfig>>, io::Error> {
+        let inner = self.0.lock().unwrap();
+        Ok(inner.vote)
+    }
+}
+
+impl RaftLogStorage<TestConfig> for TestLogStore {
+    type LogReader = Self;
+
+    async fn get_log_state(&mut self) -> Result<LogState<TestConfig>, io::Error> {
+        let inner = self.0.lock().unwrap();
+        let last_log_id = inner.log.last_key_value().map(|(_, entry)| entry.log_id);
+        let last_log_id = last_log_id.or(inner.last_purged_log_id);
+
+        Ok(LogState {
+            last_purged_log_id: inner.last_purged_log_id,
+            last_log_id,
+        })
+    }
+
+    async fn get_log_reader(&mut self) -> Self::LogReader {
+        self.clone()
+    }
+
+    async fn save_vote(&mut self, vote: &VoteOf<TestConfig>) -> Result<(), io::Error> {
+        self.0.lock().unwrap().vote = Some(*vote);
+        Ok(())
+    }
+
+    async fn save_committed(&mut self, committed: Option<LogIdOf<TestConfig>>) -> Result<(), io::Error> {
+        self.0.lock().unwrap().committed = committed;
+        Ok(())
+    }
+
+    async fn read_committed(&mut self) -> Result<Option<LogIdOf<TestConfig>>, io::Error> {
+        let inner = self.0.lock().unwrap();
+        Ok(inner.committed)
+    }
+
+    async fn append<I>(&mut self, entries: I, callback: IOFlushed<TestConfig>) -> Result<(), io::Error>
+    where
+        I: IntoIterator<Item = EntryOf<TestConfig>> + OptionalSend,
+        I::IntoIter: OptionalSend,
+    {
+        let mut inner = self.0.lock().unwrap();
+        for entry in entries {
+            inner.log.insert(entry.log_id.index, entry);
+        }
+        drop(inner);
+
+        callback.io_completed(Ok(()));
+        Ok(())
+    }
+
+    async fn truncate_after(&mut self, last_log_id: Option<LogIdOf<TestConfig>>) -> Result<(), io::Error> {
+        let start_index = last_log_id.map(|log_id| log_id.index + 1).unwrap_or(0);
+        self.0.lock().unwrap().log.retain(|index, _| *index < start_index);
+        Ok(())
+    }
+
+    async fn purge(&mut self, log_id: LogIdOf<TestConfig>) -> Result<(), io::Error> {
+        let mut inner = self.0.lock().unwrap();
+        assert!(inner.last_purged_log_id.as_ref() <= Some(&log_id));
+        inner.last_purged_log_id = Some(log_id);
+        inner.log.retain(|index, _| *index > log_id.index);
+        Ok(())
+    }
+}
+
+type TestRaft = Raft<TestConfig, TestStateMachine>;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+struct AppliedState {
+    last_applied: Option<LogIdOf<TestConfig>>,
+    membership: StoredMembershipOf<TestConfig>,
+    commands: Vec<(LogIdOf<TestConfig>, String)>,
+}
+
+#[derive(Clone, Debug)]
+struct StoredSnapshot {
+    meta: SnapshotMetaOf<TestConfig>,
+    data: Vec<u8>,
+}
+
+#[derive(Debug, Default)]
+struct StateMachineInner {
+    state: AppliedState,
+    snapshot: Option<StoredSnapshot>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct TestStateMachine(Arc<Mutex<StateMachineInner>>);
+
+impl TestStateMachine {
+    fn state(&self) -> AppliedState {
+        self.0.lock().unwrap().state.clone()
+    }
+
+    fn apply_entry(&self, entry: EntryOf<TestConfig>) {
+        let log_id = entry.log_id;
+        let payload = entry.payload;
+        let mut inner = self.0.lock().unwrap();
+
+        inner.state.last_applied = Some(log_id);
+        if let Some(membership) = payload.membership {
+            inner.state.membership = StoredMembership::new(Some(log_id), membership);
+        }
+        if let Some(normal) = payload.normal {
+            inner.state.commands.push((log_id, normal));
+        }
+    }
+}
+
+impl RaftSnapshotBuilder<TestConfig> for TestStateMachine {
+    type SnapshotData = Cursor<Vec<u8>>;
+
+    async fn build_snapshot(&mut self) -> Result<SnapshotOf<TestConfig, Self::SnapshotData>, io::Error> {
+        let mut inner = self.0.lock().unwrap();
+        let data = bincode::serialize(&inner.state).map_err(invalid_data)?;
+        let meta = SnapshotMetaOf::<TestConfig> {
+            last_log_id: inner.state.last_applied,
+            last_membership: inner.state.membership.clone(),
+        };
+
+        inner.snapshot = Some(StoredSnapshot {
+            meta: meta.clone(),
+            data: data.clone(),
+        });
+
+        Ok(Snapshot {
+            meta,
+            snapshot: Cursor::new(data),
+        })
+    }
+}
+
+impl RaftStateMachine<TestConfig> for TestStateMachine {
+    type SnapshotData = Cursor<Vec<u8>>;
+    type SnapshotBuilder = Self;
+
+    async fn applied_state(
+        &mut self,
+    ) -> Result<(Option<LogIdOf<TestConfig>>, StoredMembershipOf<TestConfig>), io::Error> {
+        let state = self.state();
+        Ok((state.last_applied, state.membership))
+    }
+
+    async fn apply<Strm>(&mut self, mut entries: Strm) -> Result<(), io::Error>
+    where Strm: Stream<Item = Result<EntryResponder<TestConfig>, io::Error>> + Unpin + OptionalSend {
+        while let Some((entry, responder)) = entries.try_next().await? {
+            self.apply_entry(entry);
+            if let Some(responder) = responder {
+                responder.send(());
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        meta: &SnapshotMetaOf<TestConfig>,
+        snapshot: Self::SnapshotData,
+    ) -> Result<(), io::Error> {
+        let data = snapshot.into_inner();
+        let mut state: AppliedState = bincode::deserialize(&data).map_err(invalid_data)?;
+        state.last_applied = meta.last_log_id;
+        state.membership = meta.last_membership.clone();
+
+        let mut inner = self.0.lock().unwrap();
+        inner.state = state;
+        inner.snapshot = Some(StoredSnapshot {
+            meta: meta.clone(),
+            data,
+        });
+        Ok(())
+    }
+
+    async fn get_current_snapshot(&mut self) -> Result<Option<SnapshotOf<TestConfig, Self::SnapshotData>>, io::Error> {
+        let inner = self.0.lock().unwrap();
+        let snapshot = inner.snapshot.as_ref().map(|stored| Snapshot {
+            meta: stored.meta.clone(),
+            snapshot: Cursor::new(stored.data.clone()),
+        });
+        Ok(snapshot)
+    }
+
+    async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
+        self.clone()
+    }
+}
+
+fn invalid_data(error: bincode::Error) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, error)
+}
+
+#[derive(Clone, Default)]
+struct Router {
+    nodes: Arc<Mutex<BTreeMap<u64, TestRaft>>>,
+}
+
+impl Router {
+    fn insert(&self, node_id: u64, raft: TestRaft) {
+        self.nodes.lock().unwrap().insert(node_id, raft);
+    }
+
+    fn remove(&self, node_id: u64) -> Option<TestRaft> {
+        self.nodes.lock().unwrap().remove(&node_id)
+    }
+
+    fn get(&self, node_id: u64) -> Option<TestRaft> {
+        self.nodes.lock().unwrap().get(&node_id).cloned()
+    }
+}
+
+impl RaftNetworkFactory<TestConfig> for Router {
+    type Network = Connection;
+
+    async fn new_client(&mut self, target: u64, _node: &()) -> Self::Network {
+        Connection {
+            router: self.clone(),
+            target,
+        }
+    }
+}
+
+struct Connection {
+    router: Router,
+    target: u64,
+}
+
+impl Connection {
+    fn target(&self) -> Result<TestRaft, RPCError<TestConfig>> {
+        self.router.get(self.target).ok_or_else(|| {
+            let error = Unreachable::from_string(format!("node {} is not running", self.target));
+            RPCError::Unreachable(error)
+        })
+    }
+}
+
+impl RaftNetworkV2<TestConfig> for Connection {
+    type SnapshotData = Cursor<Vec<u8>>;
+
+    async fn append_entries(
+        &mut self,
+        request: AppendEntriesRequest<TestConfig>,
+        _option: RPCOption,
+    ) -> Result<AppendEntriesResponse<TestConfig>, RPCError<TestConfig>> {
+        let target = self.target()?;
+        let response = target.append_entries(request).await;
+        response.map_err(|error| RPCError::Unreachable(Unreachable::new(&error)))
+    }
+
+    async fn full_snapshot(
+        &mut self,
+        vote: <TestConfig as RaftTypeConfig>::Vote,
+        snapshot: SnapshotOf<TestConfig, Self::SnapshotData>,
+        _cancel: impl Future<Output = ReplicationClosed> + OptionalSend + 'static,
+        _option: RPCOption,
+    ) -> Result<SnapshotResponse<TestConfig>, StreamingError<TestConfig>> {
+        let target = self.target()?;
+        let response = target.install_full_snapshot(vote, snapshot).await;
+        let response = response.map_err(|error| Unreachable::new(&error))?;
+        Ok(response)
+    }
+
+    async fn vote(
+        &mut self,
+        request: VoteRequest<TestConfig>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<TestConfig>, RPCError<TestConfig>> {
+        let target = self.target()?;
+        let response = target.vote(request).await;
+        response.map_err(|error| RPCError::Unreachable(Unreachable::new(&error)))
+    }
+}
+
+async fn new_node(
+    node_id: u64,
+    config: Arc<Config>,
+    router: Router,
+    log_store: TestLogStore,
+    state_machine: TestStateMachine,
+) -> anyhow::Result<TestRaft> {
+    let raft = Raft::new(node_id, config, router, log_store, state_machine).await?;
+    Ok(raft)
+}
+
+async fn read_payloads(
+    log_store: &TestLogStore,
+    range: RangeInclusive<u64>,
+) -> anyhow::Result<Vec<(LogIdOf<TestConfig>, CustomPayload)>> {
+    let mut reader = log_store.clone();
+    let entries: Vec<Entry<_, CustomPayload>> = reader.try_get_log_entries(range).await?;
+    let payloads = entries.into_iter().map(|entry| (entry.log_id, entry.payload)).collect();
+    Ok(payloads)
+}
+
+/// A custom payload carries distinct application data through both membership entries and recovery.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn custom_payload_survives_membership_change_and_recovery() -> anyhow::Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_tick: false,
+            enable_heartbeat: false,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let router = Router::default();
+    let log0 = TestLogStore::default();
+    let log1 = TestLogStore::default();
+    let sm0 = TestStateMachine::default();
+    let sm1 = TestStateMachine::default();
+
+    let node0 = new_node(0, config.clone(), router.clone(), log0.clone(), sm0.clone()).await?;
+    let node1 = new_node(1, config.clone(), router.clone(), log1.clone(), sm1.clone()).await?;
+    router.insert(0, node0.clone());
+    router.insert(1, node1.clone());
+
+    tracing::info!("--- initialize node 0 and add node 1 as a learner");
+    {
+        node0.initialize(btreeset! {0}).await?;
+        node0.wait(timeout()).applied_index(Some(1), "initial leader blank").await?;
+
+        let response = node0.add_learner(1, (), true).await?;
+        assert_eq!(2, response.log_id.index);
+        node1.wait(timeout()).applied_index(Some(2), "learner applied membership").await?;
+    }
+
+    let joint_membership = Membership::new_with_defaults(vec![btreeset! {0}, btreeset! {0,1}], []);
+    let uniform_membership = Membership::new_with_defaults(vec![btreeset! {0,1}], []);
+
+    tracing::info!("--- promote node 1 with distinct payloads for the joint and uniform entries");
+    let (joint_log_id, uniform_log_id) = {
+        let first_payload = CustomPayload::normal("joint application data".to_string());
+        let uniform_payload = CustomPayload::normal("uniform application data".to_string());
+        let request = ChangeMembershipRequest::new([0, 1], false).with_payload(first_payload, uniform_payload);
+        let outcome = node0.change_membership_with_payload(request).await?;
+        let uniform = outcome.uniform.expect("voter change should enter joint consensus");
+
+        assert_eq!(Some(joint_membership.clone()), outcome.first.membership);
+        assert_eq!(Some(uniform_membership.clone()), uniform.membership);
+        assert_eq!(3, outcome.first.log_id.index);
+        assert_eq!(4, uniform.log_id.index);
+        assert!(outcome.first.log_id < uniform.log_id);
+
+        (outcome.first.log_id, uniform.log_id)
+    };
+
+    tracing::info!("--- both nodes store and apply both custom membership payloads");
+    {
+        node0.wait(timeout()).applied_index(Some(4), "leader applied uniform membership").await?;
+        node1.wait(timeout()).applied_index(Some(4), "follower applied uniform membership").await?;
+
+        let expected_payloads = vec![
+            (joint_log_id, CustomPayload {
+                normal: Some("joint application data".to_string()),
+                membership: Some(joint_membership.clone()),
+            }),
+            (uniform_log_id, CustomPayload {
+                normal: Some("uniform application data".to_string()),
+                membership: Some(uniform_membership.clone()),
+            }),
+        ];
+        assert_eq!(expected_payloads, read_payloads(&log0, 3..=4).await?);
+        assert_eq!(expected_payloads, read_payloads(&log1, 3..=4).await?);
+
+        let expected_state = AppliedState {
+            last_applied: Some(uniform_log_id),
+            membership: StoredMembership::new(Some(uniform_log_id), uniform_membership.clone()),
+            commands: vec![
+                (joint_log_id, "joint application data".to_string()),
+                (uniform_log_id, "uniform application data".to_string()),
+            ],
+        };
+        assert_eq!(expected_state, sm0.state());
+        assert_eq!(expected_state, sm1.state());
+
+        let leader_metrics = node0.metrics().borrow_watched().clone();
+        assert_eq!(&expected_state.membership, leader_metrics.membership_config.as_ref());
+        let follower_metrics = node1.metrics().borrow_watched().clone();
+        assert_eq!(&expected_state.membership, follower_metrics.membership_config.as_ref());
+    }
+
+    let final_joint_membership = Membership::new_with_defaults(vec![btreeset! {0,1}, btreeset! {0}], []);
+    let final_membership = Membership::new_with_defaults(vec![btreeset! {0}], []);
+
+    tracing::info!("--- a request without payload creates a separate blank for each membership entry");
+    let final_log_id = {
+        let blank_calls = BLANK_CALLS.load(Ordering::SeqCst);
+        let request = ChangeMembershipRequest::new([0], false);
+        let outcome = node0.change_membership_with_payload(request).await?;
+        let uniform = outcome.uniform.expect("voter change should enter joint consensus");
+        let new_blank_calls = BLANK_CALLS.load(Ordering::SeqCst);
+
+        assert_eq!(blank_calls + 2, new_blank_calls);
+        assert_eq!(5, outcome.first.log_id.index);
+        assert_eq!(6, uniform.log_id.index);
+        assert_eq!(Some(final_joint_membership.clone()), outcome.first.membership);
+        assert_eq!(Some(final_membership.clone()), uniform.membership);
+
+        let expected_payloads = vec![
+            (outcome.first.log_id, CustomPayload {
+                normal: None,
+                membership: Some(final_joint_membership),
+            }),
+            (uniform.log_id, CustomPayload {
+                normal: None,
+                membership: Some(final_membership.clone()),
+            }),
+        ];
+        assert_eq!(expected_payloads, read_payloads(&log0, 5..=6).await?);
+
+        uniform.log_id
+    };
+
+    let expected_final_state = AppliedState {
+        last_applied: Some(final_log_id),
+        membership: StoredMembership::new(Some(final_log_id), final_membership),
+        commands: vec![
+            (joint_log_id, "joint application data".to_string()),
+            (uniform_log_id, "uniform application data".to_string()),
+        ],
+    };
+
+    tracing::info!("--- restart node 0 from its log with an empty state machine");
+    let recovered_node = {
+        let removed = router.remove(0);
+        assert!(removed.is_some());
+        node0.shutdown().await?;
+
+        let recovered_sm = TestStateMachine::default();
+        let recovered = new_node(0, config.clone(), router.clone(), log0, recovered_sm.clone()).await?;
+        router.insert(0, recovered.clone());
+        recovered.wait(timeout()).applied_index(Some(6), "reapply committed log").await?;
+
+        assert_eq!(expected_final_state, recovered_sm.state());
+        let metrics = recovered.metrics().borrow_watched().clone();
+        assert_eq!(&expected_final_state.membership, metrics.membership_config.as_ref());
+        recovered
+    };
+
+    tracing::info!("--- install node 0 snapshot into a fresh node");
+    let node2 = {
+        recovered_node.trigger().snapshot().await?;
+        recovered_node.wait(timeout()).snapshot(final_log_id, "custom payload snapshot").await?;
+        let snapshot = recovered_node.get_snapshot().await?.expect("snapshot should exist");
+        let vote = recovered_node.metrics().borrow_watched().vote;
+
+        let snapshot_sm = TestStateMachine::default();
+        let node = new_node(2, config, router.clone(), TestLogStore::default(), snapshot_sm.clone()).await?;
+        router.insert(2, node.clone());
+        node.install_full_snapshot(vote, snapshot).await?;
+
+        assert_eq!(expected_final_state, snapshot_sm.state());
+        let metrics = node.metrics().borrow_watched().clone();
+        assert_eq!(&expected_final_state.membership, metrics.membership_config.as_ref());
+        node
+    };
+
+    recovered_node.shutdown().await?;
+    node1.shutdown().await?;
+    node2.shutdown().await?;
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_secs(2))
+}


### PR DESCRIPTION

## Changelog

##### change: entry: add RaftPayload construction methods
# Summary

RaftPayload now owns its application and node types and can create or
replace blank, normal, and membership payload content.

# Details

RaftEntry now owns membership inspection because an entry cannot implement
payload construction without a LogId.

EntryPayload keeps its three variants and replaces the active variant, so
its serialized form does not change.

Upgrade tip:

Implement the RaftPayload associated types and construction methods for
custom payloads. Move entry-level get_membership() implementations to
RaftEntry.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2036)
<!-- Reviewable:end -->
