### PR TITLE
test: jepsen: avoid false packet errors

### DIFF
--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -91,17 +91,18 @@
         nemesis-types (when-not (seq (:errors parsed))
                         (normalize-nemeses (:nemesis options)))
         packet-mode-error
-        (cond
-          (and (:packet-mode options)
-               (or (chaos-selection? (:nemesis options))
-                   (not (some #{:packet} nemesis-types))))
-          "--packet-mode requires an explicit Packet Nemesis."
+        (when nemesis-types
+          (cond
+            (and (:packet-mode options)
+                 (or (chaos-selection? (:nemesis options))
+                     (not (some #{:packet} nemesis-types))))
+            "--packet-mode requires an explicit Packet Nemesis."
 
-          (and (= [:packet] nemesis-types)
-               (nil? (:packet-mode options)))
-          "--packet-mode is required for Packet Nemesis."
+            (and (= [:packet] nemesis-types)
+                 (nil? (:packet-mode options)))
+            "--packet-mode is required for Packet Nemesis."
 
-          :else nil)
+            :else nil))
         seed (or (:seed options)
                  (random/long Long/MAX_VALUE))]
     (random/set-seed! seed)

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -93,6 +93,15 @@
       (is (some #(re-find #"Must be slow or flaky" %)
                 (:errors parsed)))))
 
+  (testing "unrelated parse errors do not add Packet selection errors"
+    (let [parsed (#'cli/prepare-options
+                  (tools-cli/parse-opts ["--nemesis" "packet"
+                                         "--packet-mode" "slow"
+                                         "--seed" "bad"]
+                                        cli/cli-opts))]
+      (is (= ["Failed to validate \"--seed bad\": Must be an integer."]
+             (:errors parsed)))))
+
   (testing "option parsing requires an explicit mode"
     (let [parsed (#'cli/prepare-options
                   (tools-cli/parse-opts ["--nemesis" "packet"]


### PR DESCRIPTION
When an unrelated CLI option fails to parse, the normalized Nemesis selection is unavailable. Packet validation previously treated that unknown state as a non-Packet selection and added a misleading error.

This skips derived Packet validation until Nemesis normalization is available and adds a regression test that checks the complete error list.

Tests:
- `make -C jepsen unit-test`
- `make -C jepsen clojure-lint`

Closes #2035

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2037)
<!-- Reviewable:end -->
