### PR TITLE
test: jepsen: add wall-clock nemesis

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -84,6 +84,8 @@ jobs:
           - name: packet-flaky
             nemesis: packet
             packet_mode: flaky
+          - name: clock
+            nemesis: clock
           - name: chaos
             nemesis: chaos
 

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -129,6 +129,9 @@ $ make -C jepsen test NEMESIS=pause
 # Run only the membership change test.
 $ make -C jepsen test NEMESIS=membership
 
+# Run only the wall-clock fault test.
+$ make -C jepsen test NEMESIS=clock
+
 # Run only one Packet mode; MODE must be slow or flaky.
 $ make -C jepsen test NEMESIS=packet PACKET_MODE=slow
 
@@ -156,15 +159,18 @@ narrower combination is needed.
 
 ### Nemesis Design
 
-A standalone Nemesis selects each target so the surviving voters still contain
-a quorum in every effective voter configuration. This applies to both stable
-and joint membership. A focused run can therefore exercise one fault class and
-its recovery while retaining a component that can make progress.
+Partition, process, pause, and packet standalone Nemeses select targets so the
+surviving voters retain a quorum in every effective voter configuration. Clock
+faults deliberately allow any non-empty node subset, including a majority or
+all nodes; their focused run does not require progress while no quorum is
+available, but safety and final recovery remain mandatory.
 
-The `chaos` profile composes individually quorum-safe faults without reserving
-one common survivor quorum across fault classes. Their active intervals may
-overlap and temporarily remove the global quorum. Safety and eventual recovery
-remain mandatory in that case, but continuous availability does not.
+The `chaos` profile composes fault packages without reserving one common
+survivor quorum across fault classes. Most focused fault packages select
+quorum-safe targets, while Clock may target a majority or all nodes. Active
+fault intervals may overlap and temporarily remove the global quorum. Safety
+and eventual recovery remain mandatory in that case, but continuous
+availability does not.
 
 #### Network Partition Nemesis
 
@@ -264,10 +270,25 @@ retransmission, and kernel packet selection. Partial installation or cleanup is
 a Harness failure; final recovery and teardown must attempt idempotent cleanup
 on every node.
 
+#### Clock Nemesis
+
+The Clock Nemesis changes only the wall clock observed by OpenRaft application
+processes. It uses node-local `libfaketime` control files and never changes the
+container or host clock. A focused run mixes multi-scale forward and backward
+jumps, rates sampled between 0.5x and 2x, rapid strobe jumps, and resets. Each
+operation replaces the complete clock state, and final cleanup restores every
+node to `+0 x1`.
+
+Targets are arbitrary non-empty subsets and can include a minority, majority,
+or every node. History records the targets, generated parameters, initial
+leader, and whether that leader was selected. The Clock checker validates fault
+coverage and cleanup; the common workload checker remains responsible for
+linearizability and final data recovery.
+
 #### Chaos Composition
 
 The default `chaos` profile independently schedules partition, process, pause,
-membership, and packet faults. It composes the package, generator, final
+membership, packet, and clock faults. It composes the package, generator, final
 recovery, and checker supplied by each Nemesis rather than defining separate
 Chaos-only checker semantics. Packet chooses one of `slow` or `flaky` for each
 independent Packet episode, and never overlaps those two modes with each other.

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -277,7 +277,9 @@ processes. It uses node-local `libfaketime` control files and never changes the
 container or host clock. A focused run mixes multi-scale forward and backward
 jumps, rates sampled between 0.5x and 2x, rapid strobe jumps, and resets. Each
 operation replaces the complete clock state, and final cleanup restores every
-node to `+0 x1`.
+node to `+0 x1`. Rate changes may also jump the wall clock because libfaketime
+rebases the reported time when the multiplier changes; those jumps are part of
+the injected wall-clock fault.
 
 Targets are arbitrary non-empty subsets and can include a minority, majority,
 or every node. History records the targets, generated parameters, initial

--- a/jepsen/docker/node.Dockerfile
+++ b/jepsen/docker/node.Dockerfile
@@ -86,6 +86,9 @@ RUN mkdir -p /run/sshd /var/lib/openraft /var/log/openraft /root/.ssh \
 COPY jepsen/docker/ssh/openraft-jepsen.pub /root/.ssh/authorized_keys
 RUN chmod 600 /root/.ssh/authorized_keys
 
+COPY jepsen/docker/strobe-faketime /usr/local/bin/strobe-faketime
+RUN chmod 755 /usr/local/bin/strobe-faketime
+
 COPY --from=builder \
   /openraft/jepsen/openraft-test-app/target/release/openraft-jepsen-app \
   /usr/local/bin/openraft-jepsen-app

--- a/jepsen/docker/node.Dockerfile
+++ b/jepsen/docker/node.Dockerfile
@@ -62,6 +62,7 @@ RUN apt-get update \
       ca-certificates \
       iproute2 \
       iptables \
+      libfaketime \
       libgcc-s1 \
       librocksdb-dev \
       libstdc++6 \
@@ -71,6 +72,11 @@ RUN apt-get update \
       psmisc \
       sudo \
  && rm -rf /var/lib/apt/lists/*
+
+# Use one architecture-independent path in the application launch environment.
+RUN faketime_lib="$(find /usr/lib -path '*/faketime/libfaketime.so.1' -print -quit)" \
+ && test -n "$faketime_lib" \
+ && ln -s "$faketime_lib" /usr/local/lib/libfaketime.so.1
 
 RUN mkdir -p /run/sshd /var/lib/openraft /var/log/openraft /root/.ssh \
  && chmod 700 /root/.ssh \

--- a/jepsen/docker/strobe-faketime
+++ b/jepsen/docker/strobe-faketime
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+control_file=$1
+offset_setting=$2
+period_seconds=$3
+transitions=$4
+normal_setting='+0 x1'
+
+write_setting() {
+    printf '%s\n' "$1" > "${control_file}.$$"
+    mv "${control_file}.$$" "$control_file"
+}
+
+trap 'write_setting "$normal_setting"' EXIT
+
+for ((i = 0; i < transitions; i++)); do
+    if ((i % 2 == 0)); then
+        write_setting "$offset_setting"
+    else
+        write_setting "$normal_setting"
+    fi
+
+    if ((i + 1 < transitions)); then
+        sleep "$period_seconds"
+    fi
+done
+
+printf '%s\n' "$transitions"

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -14,12 +14,16 @@
              [worker :as worker]
              [workload :as workload]]
             [jepsen.openraft.nemesis [membership :as membership]
+             [clock :as clock]
              [packet :as packet]
              [partition :as partition]
              [process :as process]]))
 
-(def ^:private concrete-nemesis-types
+(def ^:private chaos-nemesis-types
   [:partition :process :pause :membership :packet])
+
+(def ^:private concrete-nemesis-types
+  (conj chaos-nemesis-types :clock))
 
 (def nemesis-types
   (conj (set concrete-nemesis-types) :chaos))
@@ -39,7 +43,7 @@
                        :unknown (vec unknown)})))
     (let [expanded (cond-> (disj requested :chaos)
                      (contains? requested :chaos)
-                     (into concrete-nemesis-types))]
+                     (into chaos-nemesis-types))]
       (filterv expanded concrete-nemesis-types))))
 
 (defn- valid-nemeses? [selection]
@@ -73,7 +77,7 @@
                "Must be a positive integer."]]
 
    [nil "--nemesis TYPES"
-    "Comma-separated faults: membership, packet, partition, process, pause, or chaos."
+    "Comma-separated faults: clock, membership, packet, partition, process, pause, or chaos."
     :default [:chaos]
     :parse-fn parse-nemeses
     :validate [valid-nemeses? "Unknown fault."]]
@@ -150,6 +154,9 @@
 
                    :membership
                    (membership/membership-package database opts)
+
+                   :clock
+                   (clock/clock-package)
 
                    :packet
                    (let [packet-mode (:packet-mode opts)]

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -20,10 +20,10 @@
              [process :as process]]))
 
 (def ^:private chaos-nemesis-types
-  [:partition :process :pause :membership :packet])
+  [:partition :process :pause :membership :packet :clock])
 
 (def ^:private concrete-nemesis-types
-  (conj chaos-nemesis-types :clock))
+  chaos-nemesis-types)
 
 (def nemesis-types
   (conj (set concrete-nemesis-types) :chaos))

--- a/jepsen/src/jepsen/openraft/clock.clj
+++ b/jepsen/src/jepsen/openraft/clock.clj
@@ -9,14 +9,21 @@
   {:LD_PRELOAD library
    :FAKETIME_TIMESTAMP_FILE control-file
    :FAKETIME_NO_CACHE "1"
-   :FAKETIME_XRESET "1"
-   :FAKETIME_DONT_FAKE_STAT "1"
+   :NO_FAKE_STAT "1"
    :FAKETIME_DONT_FAKE_MONOTONIC "1"})
 
 (def ^:private write-setting-script
   (str "set -eu; "
        "printf '%s\\n' \"$1\" > \"$2.tmp\"; "
        "mv \"$2.tmp\" \"$2\"; "
+       "cat \"$2\""))
+
+(def ^:private initialize-setting-script
+  (str "set -eu; "
+       "if test ! -e \"$2\"; then "
+       "printf '%s\\n' \"$1\" > \"$2.tmp\"; "
+       "mv \"$2.tmp\" \"$2\"; "
+       "fi; "
        "cat \"$2\""))
 
 (def ^:private process-environment-script
@@ -54,4 +61,5 @@
 
 (defn prepare! []
   (c/exec :mkdir :-p "/var/lib/openraft")
-  (reset-clock!))
+  (c/exec :bash :-c initialize-setting-script
+          "openraft-clock-setting" normal-setting control-file))

--- a/jepsen/src/jepsen/openraft/clock.clj
+++ b/jepsen/src/jepsen/openraft/clock.clj
@@ -1,0 +1,57 @@
+(ns jepsen.openraft.clock
+  (:require [jepsen.control :as c]))
+
+(def library "/usr/local/lib/libfaketime.so.1")
+(def control-file "/var/lib/openraft/faketime")
+(def normal-setting "+0 x1")
+
+(def application-env
+  {:LD_PRELOAD library
+   :FAKETIME_TIMESTAMP_FILE control-file
+   :FAKETIME_NO_CACHE "1"
+   :FAKETIME_XRESET "1"
+   :FAKETIME_DONT_FAKE_STAT "1"
+   :FAKETIME_DONT_FAKE_MONOTONIC "1"})
+
+(def ^:private write-setting-script
+  (str "set -eu; "
+       "printf '%s\\n' \"$1\" > \"$2.tmp\"; "
+       "mv \"$2.tmp\" \"$2\"; "
+       "cat \"$2\""))
+
+(def ^:private process-environment-script
+  (str "set -eu; "
+       "pattern=$1; library=$2; control_file=$3; "
+       "library_name=${library##*/}; "
+       "pid=$(pgrep -u root -f --ignore-ancestors -- \"$pattern\"); "
+       "test -n \"$pid\"; set -- $pid; pid=$1; "
+       "grep -Fq \"/$library_name\" \"/proc/$pid/maps\"; "
+       "tr '\\0' '\\n' < \"/proc/$pid/environ\" "
+       "| grep -Fxq \"FAKETIME_TIMESTAMP_FILE=$control_file\"; "
+       "printf 'loaded\\n'"))
+
+(defn write-setting!
+  "Atomically replaces the current node's complete faketime setting."
+  [setting]
+  (c/exec :bash :-c write-setting-script
+          "openraft-clock-setting" setting control-file))
+
+(defn reset-clock! []
+  (write-setting! normal-setting))
+
+(defn read-setting! []
+  (c/exec :cat control-file))
+
+(defn probe-wall-time-ms! []
+  (Long/parseLong
+   (c/exec (c/env application-env) :date "+%s%3N")))
+
+(defn verify-application-clock!
+  "Confirms that the application process loaded the node-local clock config."
+  [process-pattern]
+  (c/exec :bash :-c process-environment-script
+          "openraft-clock-process" process-pattern library control-file))
+
+(defn prepare! []
+  (c/exec :mkdir :-p "/var/lib/openraft")
+  (reset-clock!))

--- a/jepsen/src/jepsen/openraft/db.clj
+++ b/jepsen/src/jepsen/openraft/db.clj
@@ -5,6 +5,7 @@
              [db :as db]]
             [jepsen.control.util :as cu]
             [jepsen.openraft.client :as client]
+            [jepsen.openraft.clock :as clock]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.interruption :as interruption]))
 
@@ -144,8 +145,9 @@
 (defn- start-command!
   [node-id api-addr raft-addr snapshot-threshold]
   (control-exec!
-   (c/env {:RUST_BACKTRACE "1"
-           :RUST_LOG "info"})
+   (c/env (merge clock/application-env
+                 {:RUST_BACKTRACE "1"
+                  :RUST_LOG "info"}))
    :start-stop-daemon
    :--start
    :--oknodo
@@ -221,6 +223,7 @@
     db/Kill
     (start! [_ test node]
       (prepare-dirs!)
+      (clock/prepare!)
       (let [node-id (client/node-host node)
             api-addr (client/api-endpoint test node)
             raft-addr (client/raft-addr test node)]

--- a/jepsen/src/jepsen/openraft/nemesis/clock.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/clock.clj
@@ -314,6 +314,14 @@
       (let [bump? (some #(and (= :bump-clock (:f %)) (installed? %)) history)
             strobe? (some #(and (= :strobe-clock (:f %)) (installed? %))
                           history)
+            observed-modes (->> history
+                                (filter installed?)
+                                (keep #(case (:f %)
+                                         :bump-clock :bump
+                                         :rate-clock :rate
+                                         :strobe-clock :strobe
+                                         nil))
+                                set)
             rate-directions (->> history
                                  (filter #(and (= :rate-clock (:f %))
                                                (installed? %)))
@@ -327,8 +335,10 @@
                                recovered?))
          :bump-installed (boolean bump?)
          :strobe-installed (boolean strobe?)
+         :observed-modes observed-modes
          :rate-directions (vec (sort rate-directions))
-         :final-reset-installed (boolean recovered?)}))))
+         :final-reset-installed (boolean recovered?)
+         :cluster-state (if recovered? :intact :unknown)}))))
 
 (defn clock-package []
   {:name :clock

--- a/jepsen/src/jepsen/openraft/nemesis/clock.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/clock.clj
@@ -15,6 +15,7 @@
 (def ^:private application-pattern
   "^/usr/local/bin/openraft-jepsen-app([[:space:]].*)?$")
 (def ^:private offset-tolerance-ms 1000)
+(def ^:private strobe-command "/usr/local/bin/strobe-faketime")
 
 (defn- offset-setting [offset-ms]
   (String/format Locale/ROOT
@@ -35,6 +36,15 @@
               :slow (random/double -1.0 0.0)
               (throw (ex-info "Unknown clock-rate direction"
                               {:direction direction})))))
+
+(defn- random-strobe-delta-ms []
+  (long (Math/pow 2.0 (random/double 2.0 18.0))))
+
+(defn- random-strobe-period-ms []
+  (long (Math/pow 2.0 (random/double 6.0 10.0))))
+
+(defn- random-strobe-duration-ms []
+  (long (random/double 0.0 32000.0)))
 
 (defn- random-targets [test]
   (vec (random/nonempty-subset (:nodes test))))
@@ -101,6 +111,43 @@
                           :observed written})))
        {:setting (clock/read-setting!)
         :rate rate}))))
+
+(defn- strobe-node! [{:keys [delta-ms period-ms duration-ms]}]
+  (let [setting (offset-setting delta-ms)
+        transitions (max 1 (inc (quot duration-ms period-ms)))
+        period-seconds (String/format Locale/ROOT
+                                      "%.3f"
+                                      (to-array [(/ period-ms 1000.0)]))
+        observed (Long/parseLong
+                  (c/exec strobe-command
+                          clock/control-file
+                          setting
+                          period-seconds
+                          transitions))]
+    (when-not (= transitions observed)
+      (throw (ex-info "Clock strobe transition count mismatch"
+                      {:kind :clock-strobe-transition-count-mismatch
+                       :expected transitions
+                       :observed observed})))
+    (when-not (= clock/normal-setting (clock/read-setting!))
+      (throw (ex-info "Clock strobe did not restore normal time"
+                      {:kind :clock-strobe-not-restored
+                       :observed (clock/read-setting!)})))
+    {:delta-ms delta-ms
+     :period-ms period-ms
+     :duration-ms duration-ms
+     :transitions observed
+     :setting setting
+     :final-setting clock/normal-setting}))
+
+(defn- apply-strobes! [test strobes]
+  (try
+    (c/on-nodes test
+                (keys strobes)
+                (fn [_test node]
+                  (strobe-node! (get strobes node))))
+    (finally
+      (reset-targets! test (keys strobes)))))
 
 (defn- leader-evidence [test targets]
   (let [leader (:leader (cluster/membership-status test))]
@@ -172,6 +219,27 @@
                                :evidence evidence}
                               (leader-evidence test targets)))))
 
+      :strobe-clock
+      (let [strobes (:value op)
+            targets (vec (keys strobes))
+            previous (select-keys @settings targets)
+            evidence (apply-strobes! test strobes)]
+        (swap! settings merge
+               (zipmap targets (repeat clock/normal-setting)))
+        (info "Strobed OpenRaft wall clocks" {:strobes strobes})
+        (assoc op
+               :value (outcome/installed
+                       (merge {:mode :strobe
+                               :targets targets
+                               :target-category (target-category
+                                                 (count (:nodes test))
+                                                 (count targets))
+                               :strobes strobes
+                               :previous-settings previous
+                               :setting clock/normal-setting
+                               :evidence evidence}
+                              (leader-evidence test targets)))))
+
       :reset-clock
       (let [targets (or (:value op) (:nodes test))
             previous (select-keys @settings targets)
@@ -190,7 +258,7 @@
 
   nemesis/Reflection
   (fs [_]
-    #{:check-clock :bump-clock :rate-clock :reset-clock}))
+    #{:check-clock :bump-clock :rate-clock :strobe-clock :reset-clock}))
 
 (defn clock-nemesis []
   (ClockNemesis. (atom {})))
@@ -215,6 +283,17 @@
                :rates (zipmap targets
                               (repeatedly #(random-rate direction)))}})))
 
+(defn- strobe-op [test _context]
+  (let [targets (random-targets test)]
+    {:type :info
+     :f :strobe-clock
+     :value (into {}
+                  (map (fn [node]
+                         [node {:delta-ms (random-strobe-delta-ms)
+                                :period-ms (random-strobe-period-ms)
+                                :duration-ms (random-strobe-duration-ms)}]))
+                  targets)}))
+
 (defn- clock-generator []
   (gen/phases
    {:type :info :f :check-clock}
@@ -223,6 +302,7 @@
      (gen/once bump-op)
      (gen/once (rate-op :fast))
      (gen/once (rate-op :slow))
+     (gen/once strobe-op)
      (gen/once reset-op)))))
 
 (defn- installed? [op]
@@ -232,6 +312,8 @@
   (reify checker/Checker
     (check [_ _test history _opts]
       (let [bump? (some #(and (= :bump-clock (:f %)) (installed? %)) history)
+            strobe? (some #(and (= :strobe-clock (:f %)) (installed? %))
+                          history)
             rate-directions (->> history
                                  (filter #(and (= :rate-clock (:f %))
                                                (installed? %)))
@@ -240,9 +322,11 @@
             final-reset (last (filter #(= :reset-clock (:f %)) history))
             recovered? (and final-reset (installed? final-reset))]
         {:valid? (boolean (and bump?
+                               strobe?
                                (= #{:fast :slow} rate-directions)
                                recovered?))
          :bump-installed (boolean bump?)
+         :strobe-installed (boolean strobe?)
          :rate-directions (vec (sort rate-directions))
          :final-reset-installed (boolean recovered?)}))))
 

--- a/jepsen/src/jepsen/openraft/nemesis/clock.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/clock.clj
@@ -25,6 +25,17 @@
   (long (* (random/nth [-1 1])
            (Math/pow 1.5 (+ 6 (random/double 25))))))
 
+(defn- rate-setting [rate]
+  (String/format Locale/ROOT "+0 x%.6f" (to-array [rate])))
+
+(defn- random-rate [direction]
+  (Math/pow 2.0
+            (case direction
+              :fast (random/double 0.0 1.0)
+              :slow (random/double -1.0 0.0)
+              (throw (ex-info "Unknown clock-rate direction"
+                              {:direction direction})))))
+
 (defn- random-targets [test]
   (vec (random/nonempty-subset (:nodes test))))
 
@@ -75,6 +86,22 @@
      (clock/reset-clock!)
      (verify-offset! 0))))
 
+(defn- apply-rates! [test rates]
+  (c/on-nodes
+   test
+   (keys rates)
+   (fn [_test node]
+     (let [rate (get rates node)
+           setting (rate-setting rate)
+           written (clock/write-setting! setting)]
+       (when-not (= setting written)
+         (throw (ex-info "Clock setting readback failed"
+                         {:kind :clock-setting-readback-failed
+                          :expected setting
+                          :observed written})))
+       {:setting (clock/read-setting!)
+        :rate rate}))))
+
 (defn- leader-evidence [test targets]
   (let [leader (:leader (cluster/membership-status test))]
     {:initial-leader leader
@@ -120,6 +147,31 @@
                                :evidence evidence}
                               (leader-evidence test targets)))))
 
+      :rate-clock
+      (let [{:keys [direction rates]} (:value op)
+            targets (vec (keys rates))
+            previous (select-keys @settings targets)
+            evidence (apply-rates! test rates)
+            new-settings (into {} (map (fn [[node rate]]
+                                         [node (rate-setting rate)]))
+                               rates)]
+        (swap! settings merge new-settings)
+        (info "Changed OpenRaft wall-clock rates"
+              {:direction direction :rates rates})
+        (assoc op
+               :value (outcome/installed
+                       (merge {:mode :rate
+                               :direction direction
+                               :targets targets
+                               :target-category (target-category
+                                                 (count (:nodes test))
+                                                 (count targets))
+                               :rates rates
+                               :previous-settings previous
+                               :settings new-settings
+                               :evidence evidence}
+                              (leader-evidence test targets)))))
+
       :reset-clock
       (let [targets (or (:value op) (:nodes test))
             previous (select-keys @settings targets)
@@ -138,7 +190,7 @@
 
   nemesis/Reflection
   (fs [_]
-    #{:check-clock :bump-clock :reset-clock}))
+    #{:check-clock :bump-clock :rate-clock :reset-clock}))
 
 (defn clock-nemesis []
   (ClockNemesis. (atom {})))
@@ -154,12 +206,23 @@
    :f :reset-clock
    :value (random-targets test)})
 
+(defn- rate-op [direction]
+  (fn [test _context]
+    (let [targets (random-targets test)]
+      {:type :info
+       :f :rate-clock
+       :value {:direction direction
+               :rates (zipmap targets
+                              (repeatedly #(random-rate direction)))}})))
+
 (defn- clock-generator []
   (gen/phases
    {:type :info :f :check-clock}
    (gen/cycle
     (gen/phases
      (gen/once bump-op)
+     (gen/once (rate-op :fast))
+     (gen/once (rate-op :slow))
      (gen/once reset-op)))))
 
 (defn- installed? [op]
@@ -169,10 +232,18 @@
   (reify checker/Checker
     (check [_ _test history _opts]
       (let [bump? (some #(and (= :bump-clock (:f %)) (installed? %)) history)
+            rate-directions (->> history
+                                 (filter #(and (= :rate-clock (:f %))
+                                               (installed? %)))
+                                 (keep #(get-in % [:value :direction]))
+                                 set)
             final-reset (last (filter #(= :reset-clock (:f %)) history))
             recovered? (and final-reset (installed? final-reset))]
-        {:valid? (boolean (and bump? recovered?))
+        {:valid? (boolean (and bump?
+                               (= #{:fast :slow} rate-directions)
+                               recovered?))
          :bump-installed (boolean bump?)
+         :rate-directions (vec (sort rate-directions))
          :final-reset-installed (boolean recovered?)}))))
 
 (defn clock-package []

--- a/jepsen/src/jepsen/openraft/nemesis/clock.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/clock.clj
@@ -1,0 +1,186 @@
+(ns jepsen.openraft.nemesis.clock
+  (:require [clojure.tools.logging :refer [info]]
+            [jepsen [checker :as checker]
+             [control :as c]
+             [generator :as gen]
+             [nemesis :as nemesis]
+             [random :as random]]
+            [jepsen.openraft.checker :as openraft-checker]
+            [jepsen.openraft.clock :as clock]
+            [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.nemesis.outcome :as outcome])
+  (:import (java.util Locale)))
+
+(def clock-seconds 10)
+(def ^:private application-pattern
+  "^/usr/local/bin/openraft-jepsen-app([[:space:]].*)?$")
+(def ^:private offset-tolerance-ms 1000)
+
+(defn- offset-setting [offset-ms]
+  (String/format Locale/ROOT
+                 "%+.3fs x1"
+                 (to-array [(/ offset-ms 1000.0)])))
+
+(defn- random-offset-ms []
+  (long (* (random/nth [-1 1])
+           (Math/pow 1.5 (+ 6 (random/double 25))))))
+
+(defn- random-targets [test]
+  (vec (random/nonempty-subset (:nodes test))))
+
+(defn- target-category [node-count target-count]
+  (cond
+    (= 1 target-count) :one
+    (= node-count target-count) :all
+    (<= target-count (quot (dec node-count) 2)) :minority
+    :else :majority))
+
+(defn verify-offset! [offset-ms]
+  (let [before (Long/parseLong (c/exec :date "+%s%3N"))
+        observed (clock/probe-wall-time-ms!)
+        after (Long/parseLong (c/exec :date "+%s%3N"))
+        minimum (- (+ before offset-ms) offset-tolerance-ms)
+        maximum (+ after offset-ms offset-tolerance-ms)]
+    (when-not (<= minimum observed maximum)
+      (throw (ex-info "Clock offset verification failed"
+                      {:kind :clock-offset-verification-failed
+                       :expected-offset-ms offset-ms
+                       :observed-wall-time-ms observed
+                       :host-before-ms before
+                       :host-after-ms after})))
+    {:setting (clock/read-setting!)
+     :observed-offset-ms (- observed before)}))
+
+(defn- apply-offsets! [test offsets]
+  (c/on-nodes
+   test
+   (keys offsets)
+   (fn [_test node]
+     (let [offset-ms (get offsets node)
+           setting (offset-setting offset-ms)
+           written (clock/write-setting! setting)]
+       (when-not (= setting written)
+         (throw (ex-info "Clock setting readback failed"
+                         {:kind :clock-setting-readback-failed
+                          :expected setting
+                          :observed written})))
+       (assoc (verify-offset! offset-ms)
+              :offset-ms offset-ms)))))
+
+(defn- reset-targets! [test targets]
+  (c/on-nodes
+   test
+   targets
+   (fn [_test _node]
+     (clock/reset-clock!)
+     (verify-offset! 0))))
+
+(defn- leader-evidence [test targets]
+  (let [leader (:leader (cluster/membership-status test))]
+    {:initial-leader leader
+     :leader-included (when leader (boolean (some #{leader} targets)))}))
+
+(defrecord ClockNemesis [settings]
+  nemesis/Nemesis
+  (setup! [_ test]
+    (c/on-nodes test
+                (:nodes test)
+                (fn [_test _node]
+                  (clock/verify-application-clock! application-pattern)))
+    (ClockNemesis. (atom (zipmap (:nodes test)
+                                 (repeat clock/normal-setting)))))
+
+  (invoke! [_ test op]
+    (case (:f op)
+      :check-clock
+      (assoc op
+             :value (outcome/installed
+                     {:evidence (reset-targets! test (:nodes test))}))
+
+      :bump-clock
+      (let [offsets (:value op)
+            targets (vec (keys offsets))
+            previous (select-keys @settings targets)
+            evidence (apply-offsets! test offsets)
+            new-settings (into {} (map (fn [[node offset-ms]]
+                                         [node (offset-setting offset-ms)]))
+                               offsets)]
+        (swap! settings merge new-settings)
+        (info "Bumped OpenRaft wall clocks" {:offsets offsets})
+        (assoc op
+               :value (outcome/installed
+                       (merge {:mode :bump
+                               :targets targets
+                               :target-category (target-category
+                                                 (count (:nodes test))
+                                                 (count targets))
+                               :offsets-ms offsets
+                               :previous-settings previous
+                               :settings new-settings
+                               :evidence evidence}
+                              (leader-evidence test targets)))))
+
+      :reset-clock
+      (let [targets (or (:value op) (:nodes test))
+            previous (select-keys @settings targets)
+            evidence (reset-targets! test targets)]
+        (swap! settings merge (zipmap targets (repeat clock/normal-setting)))
+        (assoc op
+               :value (outcome/installed
+                       {:mode :reset
+                        :targets (vec targets)
+                        :previous-settings previous
+                        :setting clock/normal-setting
+                        :evidence evidence})))))
+
+  (teardown! [_ test]
+    (reset-targets! test (:nodes test)))
+
+  nemesis/Reflection
+  (fs [_]
+    #{:check-clock :bump-clock :reset-clock}))
+
+(defn clock-nemesis []
+  (ClockNemesis. (atom {})))
+
+(defn- bump-op [test _context]
+  (let [targets (random-targets test)]
+    {:type :info
+     :f :bump-clock
+     :value (zipmap targets (repeatedly random-offset-ms))}))
+
+(defn- reset-op [test _context]
+  {:type :info
+   :f :reset-clock
+   :value (random-targets test)})
+
+(defn- clock-generator []
+  (gen/phases
+   {:type :info :f :check-clock}
+   (gen/cycle
+    (gen/phases
+     (gen/once bump-op)
+     (gen/once reset-op)))))
+
+(defn- installed? [op]
+  (= :installed (get-in op [:value :status])))
+
+(defn- coverage-checker []
+  (reify checker/Checker
+    (check [_ _test history _opts]
+      (let [bump? (some #(and (= :bump-clock (:f %)) (installed? %)) history)
+            final-reset (last (filter #(= :reset-clock (:f %)) history))
+            recovered? (and final-reset (installed? final-reset))]
+        {:valid? (boolean (and bump? recovered?))
+         :bump-installed (boolean bump?)
+         :final-reset-installed (boolean recovered?)}))))
+
+(defn clock-package []
+  {:name :clock
+   :interval clock-seconds
+   :nemesis (clock-nemesis)
+   :generator (clock-generator)
+   :final-generator {:type :info
+                     :f :reset-clock}
+   :checker (openraft-checker/reject-checker-exceptions
+             (coverage-checker))})

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -78,6 +78,11 @@
     (is (= [:packet]
            (#'cli/normalize-nemeses :packet)))))
 
+(deftest selects-focused-clock-without-changing-chaos
+  (is (= [:clock] (#'cli/normalize-nemeses :clock)))
+  (is (= [:partition :process :pause :membership :packet]
+         (#'cli/normalize-nemeses :chaos))))
+
 (deftest validates-focused-packet-mode
   (testing "slow and flaky are accepted"
     (doseq [mode ["slow" "flaky"]]

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -59,7 +59,7 @@
 
 (deftest selects-composable-nemeses
   (testing "chaos is the default"
-    (is (= [:partition :process :pause :membership :packet]
+    (is (= [:partition :process :pause :membership :packet :clock]
            (#'cli/normalize-nemeses nil))))
 
   (testing "comma-separated faults are parsed and canonically ordered"
@@ -68,7 +68,7 @@
             (#'cli/parse-nemeses "process, partition")))))
 
   (testing "chaos expands to every composable fault without duplicates"
-    (is (= [:partition :process :pause :membership :packet]
+    (is (= [:partition :process :pause :membership :packet :clock]
            (#'cli/normalize-nemeses [:chaos :partition]))))
 
   (testing "membership can be combined with another fault"
@@ -78,9 +78,9 @@
     (is (= [:packet]
            (#'cli/normalize-nemeses :packet)))))
 
-(deftest selects-focused-clock-without-changing-chaos
+(deftest selects-clock-in-focused-and-chaos-runs
   (is (= [:clock] (#'cli/normalize-nemeses :clock)))
-  (is (= [:partition :process :pause :membership :packet]
+  (is (= [:partition :process :pause :membership :packet :clock]
          (#'cli/normalize-nemeses :chaos))))
 
 (deftest validates-focused-packet-mode
@@ -131,7 +131,7 @@
 
 (deftest validates-packet-mode-selection
   (testing "the default chaos profile does not require --packet-mode"
-    (is (= "openraft linearizable registers partition,process,pause,membership,packet"
+    (is (= "openraft linearizable registers partition,process,pause,membership,packet,clock"
            (:name (cli/openraft-test {:nodes ["n1" "n2" "n3" "n4" "n5"]
                                       :time-limit 10})))))
 

--- a/jepsen/test/jepsen/openraft/clock_test.clj
+++ b/jepsen/test/jepsen/openraft/clock_test.clj
@@ -3,7 +3,7 @@
             [jepsen.control :as c]
             [jepsen.openraft.clock :as clock]))
 
-(deftest prepares-a-normal-node-local-clock
+(deftest initializes-a-missing-node-local-clock
   (let [calls (atom [])]
     (with-redefs [c/exec (fn [& command]
                            (swap! calls conj command)
@@ -13,6 +13,7 @@
       (is (= clock/normal-setting (clock/prepare!))))
     (is (= :mkdir (ffirst @calls)))
     (is (= :bash (first (second @calls))))
+    (is (re-find #"test ! -e" (nth (second @calls) 2)))
     (is (= clock/normal-setting (nth (second @calls) 4)))
     (is (= clock/control-file (nth (second @calls) 5)))))
 
@@ -20,6 +21,9 @@
   (is (= clock/library (:LD_PRELOAD clock/application-env)))
   (is (= clock/control-file
          (:FAKETIME_TIMESTAMP_FILE clock/application-env)))
+  (is (= "1" (:NO_FAKE_STAT clock/application-env)))
+  (is (not (contains? clock/application-env :FAKETIME_XRESET)))
+  (is (not (contains? clock/application-env :FAKETIME_DONT_FAKE_STAT)))
   (is (= "1" (:FAKETIME_DONT_FAKE_MONOTONIC clock/application-env))))
 
 (deftest reads-and-probes-clock-state-externally

--- a/jepsen/test/jepsen/openraft/clock_test.clj
+++ b/jepsen/test/jepsen/openraft/clock_test.clj
@@ -1,0 +1,47 @@
+(ns jepsen.openraft.clock-test
+  (:require [clojure.test :refer [deftest is]]
+            [jepsen.control :as c]
+            [jepsen.openraft.clock :as clock]))
+
+(deftest prepares-a-normal-node-local-clock
+  (let [calls (atom [])]
+    (with-redefs [c/exec (fn [& command]
+                           (swap! calls conj command)
+                           (if (= :bash (first command))
+                             (nth command 4)
+                             ""))]
+      (is (= clock/normal-setting (clock/prepare!))))
+    (is (= :mkdir (ffirst @calls)))
+    (is (= :bash (first (second @calls))))
+    (is (= clock/normal-setting (nth (second @calls) 4)))
+    (is (= clock/control-file (nth (second @calls) 5)))))
+
+(deftest application-clock-excludes-monotonic-time
+  (is (= clock/library (:LD_PRELOAD clock/application-env)))
+  (is (= clock/control-file
+         (:FAKETIME_TIMESTAMP_FILE clock/application-env)))
+  (is (= "1" (:FAKETIME_DONT_FAKE_MONOTONIC clock/application-env))))
+
+(deftest reads-and-probes-clock-state-externally
+  (let [calls (atom [])]
+    (with-redefs [c/exec (fn [& command]
+                           (swap! calls conj command)
+                           (if (= :cat (first command))
+                             clock/normal-setting
+                             "1700000000123"))]
+      (is (= clock/normal-setting (clock/read-setting!)))
+      (is (= 1700000000123 (clock/probe-wall-time-ms!))))
+    (is (= [:cat clock/control-file] (first @calls)))
+    (is (some #{:date} (second @calls)))))
+
+(deftest verifies-the-application-preload-from-proc
+  (let [call (atom nil)]
+    (with-redefs [c/exec (fn [& command]
+                           (reset! call command)
+                           "loaded")]
+      (is (= "loaded"
+             (clock/verify-application-clock! "^/usr/local/bin/app"))))
+    (is (= :bash (first @call)))
+    (is (= "^/usr/local/bin/app" (nth @call 4)))
+    (is (= clock/library (nth @call 5)))
+    (is (= clock/control-file (nth @call 6)))))

--- a/jepsen/test/jepsen/openraft/nemesis/clock_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/clock_test.clj
@@ -34,13 +34,21 @@
         (is (= true (get-in result [:value :leader-included])))
         (is (= #{"n1" "n2"} (set (get-in result [:value :targets]))))))))
 
-(deftest clock-checker-requires-bump-and-final-reset
+(deftest clock-checker-requires-bump-rates-and-final-reset
   (let [subject (:checker (clock-nemesis/clock-package))
         installed (fn [f] {:type :info :f f :value {:status :installed}})]
     (testing "complete coverage"
       (is (true? (:valid? (checker/check subject
                                          test-config
                                          [(installed :bump-clock)
+                                          {:type :info
+                                           :f :rate-clock
+                                           :value {:status :installed
+                                                   :direction :fast}}
+                                          {:type :info
+                                           :f :rate-clock
+                                           :value {:status :installed
+                                                   :direction :slow}}
                                           (installed :reset-clock)]
                                          {})))))
     (testing "missing bump"
@@ -48,3 +56,10 @@
                                           test-config
                                           [(installed :reset-clock)]
                                           {})))))))
+
+(deftest rate-settings-cover-both-directions
+  (dotimes [_ 100]
+    (let [fast (#'clock-nemesis/random-rate :fast)
+          slow (#'clock-nemesis/random-rate :slow)]
+      (is (<= 1.0 fast 2.0))
+      (is (<= 0.5 slow 1.0)))))

--- a/jepsen/test/jepsen/openraft/nemesis/clock_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/clock_test.clj
@@ -1,0 +1,50 @@
+(ns jepsen.openraft.nemesis.clock-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen [checker :as checker]
+             [control :as c]
+             [nemesis :as nemesis]]
+            [jepsen.openraft.clock :as clock]
+            [jepsen.openraft.cluster :as cluster]
+            [jepsen.openraft.nemesis.clock :as clock-nemesis]))
+
+(def test-config {:nodes ["n1" "n2" "n3" "n4" "n5"]})
+
+(deftest bump-installs-node-local-offsets
+  (let [settings (atom {})
+        subject (clock-nemesis/clock-nemesis)]
+    (with-redefs [c/on-nodes (fn [_test nodes f]
+                               (into {} (map (fn [node] [node (f test-config node)])) nodes))
+                  clock/verify-application-clock! (constantly "loaded")
+                  clock/write-setting! (fn [setting]
+                                         (swap! settings assoc :current setting)
+                                         setting)
+                  clock-nemesis/verify-offset!
+                  (fn [offset-ms]
+                    {:setting (get @settings :current)
+                     :observed-offset-ms offset-ms})
+                  cluster/membership-status (constantly {:leader "n1"})]
+      (let [subject (nemesis/setup! subject test-config)
+            result (nemesis/invoke! subject
+                                    test-config
+                                    {:type :info
+                                     :f :bump-clock
+                                     :value {"n1" 1000 "n2" -2000}})]
+        (is (= :installed (get-in result [:value :status])))
+        (is (= :bump (get-in result [:value :mode])))
+        (is (= true (get-in result [:value :leader-included])))
+        (is (= #{"n1" "n2"} (set (get-in result [:value :targets]))))))))
+
+(deftest clock-checker-requires-bump-and-final-reset
+  (let [subject (:checker (clock-nemesis/clock-package))
+        installed (fn [f] {:type :info :f f :value {:status :installed}})]
+    (testing "complete coverage"
+      (is (true? (:valid? (checker/check subject
+                                         test-config
+                                         [(installed :bump-clock)
+                                          (installed :reset-clock)]
+                                         {})))))
+    (testing "missing bump"
+      (is (false? (:valid? (checker/check subject
+                                          test-config
+                                          [(installed :reset-clock)]
+                                          {})))))))

--- a/jepsen/test/jepsen/openraft/nemesis/clock_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/clock_test.clj
@@ -34,13 +34,14 @@
         (is (= true (get-in result [:value :leader-included])))
         (is (= #{"n1" "n2"} (set (get-in result [:value :targets]))))))))
 
-(deftest clock-checker-requires-bump-rates-and-final-reset
+(deftest clock-checker-requires-all-faults-and-final-reset
   (let [subject (:checker (clock-nemesis/clock-package))
         installed (fn [f] {:type :info :f f :value {:status :installed}})]
     (testing "complete coverage"
       (is (true? (:valid? (checker/check subject
                                          test-config
                                          [(installed :bump-clock)
+                                          (installed :strobe-clock)
                                           {:type :info
                                            :f :rate-clock
                                            :value {:status :installed
@@ -63,3 +64,12 @@
           slow (#'clock-nemesis/random-rate :slow)]
       (is (<= 1.0 fast 2.0))
       (is (<= 0.5 slow 1.0)))))
+
+(deftest strobe-parameters-stay-in-approved-ranges
+  (dotimes [_ 100]
+    (let [delta-ms (#'clock-nemesis/random-strobe-delta-ms)
+          period-ms (#'clock-nemesis/random-strobe-period-ms)
+          duration-ms (#'clock-nemesis/random-strobe-duration-ms)]
+      (is (<= 4 delta-ms 262144))
+      (is (<= 64 period-ms 1024))
+      (is (<= 0 duration-ms 32000)))))

--- a/jepsen/test/jepsen/openraft/nemesis_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis_test.clj
@@ -10,6 +10,7 @@
              [harness :as harness]
              [nemesis :as openraft-nemesis]
              [worker :as worker]]
+            [jepsen.openraft.nemesis.clock :as clock]
             [jepsen.openraft.nemesis.membership :as membership]
             [jepsen.openraft.nemesis.packet :as packet]
             [jepsen.openraft.nemesis.partition :as partition]
@@ -77,11 +78,13 @@
                   (partition/partition-package)
                   (process/process-package database)
                   (process/pause-package database)
-                  (packet/packet-package database nil)])]
+                  (packet/packet-package database nil)
+                  (clock/clock-package)])]
     (is (= [:stop-partition
             :restart-process
             :resume-process
             :stop-packet
+            :reset-clock
             :restore-membership
             :await-recovery]
            (mapv :f (:final-generator package))))))
@@ -96,6 +99,7 @@
                  [(partition/partition-package)
                   (process/pause-package database)
                   (packet/packet-package database nil)
+                  (clock/clock-package)
                   (membership/membership-package database test-config)])
         check (fn [history]
                 (checker/check (:checker package)
@@ -128,6 +132,11 @@
                  {:f :stop-packet
                   :value {:status :installed
                           :mode :slow}}
+                 {:f :bump-clock
+                  :value {:status :installed
+                          :mode :bump}}
+                 {:f :reset-clock
+                  :value {:status :installed}}
                  {:f :shrink
                   :value {:status :installed
                           :change :shrink
@@ -148,6 +157,7 @@
         (is (true? (get-in result [:partition :fault-class-executed?])))
         (is (true? (get-in result [:pause :fault-class-executed?])))
         (is (true? (get-in result [:packet :fault-class-executed?])))
+        (is (true? (get-in result [:clock :fault-class-executed?])))
         (is (true? (get-in result
                            [:membership :fault-class-executed?])))))
 


### PR DESCRIPTION
## Summary

- inject node-local wall-clock faults into the OpenRaft Jepsen application
  with `libfaketime`, without changing the host or container clock
- add multi-scale forward/backward bumps, randomized fast/slow rates,
  synchronous strobes, external verification, and idempotent reset
- allow focused Clock runs to target minority, majority, or all nodes while
  recording leader and target evidence
- compose Clock faults into Chaos and add standalone CI coverage

## Validation

- `make -C jepsen unit-test`
- `make -C jepsen lint`
- `make -C jepsen test NEMESIS=clock`
- `make -C jepsen test NEMESIS=chaos`
- full Rust workspace test suite

Focused Clock and Chaos runs both completed with `valid? true`.

CLOSES #2041

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2042)
<!-- Reviewable:end -->
