### PR TITLE
change: raft: add single-step Raft::append_membership()

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ What sets OpenRaft apart from a standard Raft implementation:
 - ✅ **Dynamic Membership**: using joint membership config change. Refer to [dynamic membership](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/cluster_control/dynamic_membership/index.html)
 - ✅ **Linearizable read**: [`ensure_linearizable()`][].
 - ✅ **Metrics**: [`Raft::metrics()`][], [`Raft::data_metrics()`][], and [`Raft::server_metrics()`][].
-- ⛔️ **Won't support**: Single-step config change. Single-step membership change is a restricted subset of joint consensus that only allows changing one node at a time. Openraft uses the more general [joint consensus](https://docs.rs/openraft/0.10.0-alpha.34/openraft/docs/cluster_control/dynamic_membership/index.html) approach which supports arbitrary membership changes in a single operation.
+- ✅ **Single-step config change**: [`append_membership()`][] writes a caller-built membership as one log entry, with no intermediate joint config. It is a superset of standard Raft's single-server change, because it also accepts a caller-built joint membership. Use it only when you know exactly which transitions it accepts; [`change_membership()`][] derives the whole membership for you and is the default choice.
 - ✅ Toggle heartbeat / election: [`RuntimeConfigHandle::heartbeat()`][] / [`RuntimeConfigHandle::elect()`][].
 - ✅ Trigger snapshot / election manually: [`Trigger::snapshot()`][] / [`Trigger::elect()`][].
 - ✅ Purge log by policy or manually: [`Trigger::purge_log()`][].
@@ -301,6 +301,7 @@ or the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0), at your
 
 
 [`change_membership()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/struct.Raft.html#method.change_membership
+[`append_membership()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/struct.Raft.html#method.append_membership
 [`add_learner()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/struct.Raft.html#method.add_learner
 [`Trigger::purge_log()`]: https://docs.rs/openraft/0.10.0-alpha.34/openraft/raft/trigger/struct.Trigger.html#method.purge_log
 

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -17,6 +17,7 @@ use crate::ChangeMembers;
 use crate::Instant;
 use crate::Membership;
 use crate::OptionalSend;
+use crate::RaftState;
 use crate::RaftTypeConfig;
 use crate::StorageError;
 use crate::async_runtime::MpscReceiver;
@@ -72,6 +73,7 @@ use crate::errors::LinearizableReadError;
 use crate::errors::PreconditionFailed;
 use crate::errors::StorageIOResult;
 use crate::errors::Timeout;
+use crate::errors::UncommittedLeaderLog;
 use crate::impls::ProgressResponder;
 use crate::log_id::option_raft_log_id_ext::OptionRaftLogIdExt;
 use crate::metrics::HeartbeatMetrics;
@@ -90,6 +92,8 @@ use crate::network::RaftNetworkFactory;
 use crate::progress::VecProgressEntry;
 use crate::progress::inflight_id::InflightId;
 use crate::progress::stream_id::StreamId;
+use crate::proposer::Leader;
+use crate::proposer::LeaderQuorumSet;
 use crate::raft::AppendEntriesRequest;
 use crate::raft::ClientWriteResult;
 use crate::raft::LogSegment;
@@ -488,6 +492,90 @@ where
             #[cfg(feature = "runtime-stats")]
             C::now(),
         );
+    }
+
+    /// Append a caller-built membership as one log entry, with no intermediate joint membership.
+    ///
+    /// `payload` already carries the proposed membership, bound by
+    /// [`RaftPayload::with_membership()`]. That payload is the only source of truth here: the
+    /// membership this method validates is read back out of it, and the entry written to the log
+    /// is that same payload.
+    ///
+    /// [`RaftPayload::with_membership()`]: crate::entry::RaftPayload::with_membership
+    #[tracing::instrument(level = "debug", skip(self, payload, tx, preconditions))]
+    pub(super) fn append_membership(
+        &mut self,
+        payload: C::Payload,
+        preconditions: BatchOf<C, Precondition<C>>,
+        tx: ProgressResponder<C, ClientWriteResult<C>>,
+    ) {
+        let lh = match self.ensure_writable_leader_handler() {
+            Ok(lh) => lh,
+            Err(forward) => {
+                tx.on_complete(Err(ClientWriteError::ForwardToLeader(forward)));
+                return;
+            }
+        };
+
+        if let Err(e) = Self::ensure_leader_log_committed(lh.state, lh.leader) {
+            tx.on_complete(Err(ClientWriteError::ChangeMembershipError(e.into())));
+            return;
+        }
+
+        if let Err(e) = self.ensure_preconditions_satisfied(preconditions) {
+            tx.on_complete(Err(e.into()));
+            return;
+        }
+
+        // Safe unwrap(): the caller bound `membership` into this payload with
+        // `RaftPayload::with_membership()`, whose contract is that `get_membership()` returns it.
+        let membership = payload.get_membership().unwrap();
+
+        let membership_state = &self.engine.state.membership_state;
+        if let Err(e) = membership_state.validate_append_membership(&membership) {
+            tx.on_complete(Err(ClientWriteError::ChangeMembershipError(e)));
+            return;
+        }
+
+        self.write_entries(
+            Batch::of([payload]),
+            Batch::of([Some(CoreResponder::Progress(tx))]),
+            #[cfg(feature = "runtime-stats")]
+            C::now(),
+        );
+    }
+
+    /// Ensure the leader has committed a log entry proposed in its own term.
+    ///
+    /// A direct membership append needs this barrier on top of a valid leader lease. Without it,
+    /// two configurations proposed in different terms from the same committed parent can both
+    /// become committed, even when their quorums do not intersect. See [`UncommittedLeaderLog`]
+    /// for a run that loses a committed membership this way.
+    ///
+    /// A valid lease does not imply the barrier. The lease reads the quorum acknowledgement clock,
+    /// which the heartbeat worker advances even when a follower reports a log conflict, so the
+    /// lease proves a quorum still sees this leader but not that a quorum stored the blank log.
+    ///
+    /// [`Raft::change_membership()`] deliberately does not take this barrier: its two proposals
+    /// share an exact constituent voter set, so every pair of quorums intersects through the two
+    /// strict majorities of that set.
+    ///
+    /// [`Raft::change_membership()`]: crate::raft::Raft::change_membership
+    fn ensure_leader_log_committed(
+        state: &RaftState<C>,
+        leader: &Leader<C, LeaderQuorumSet<C>>,
+    ) -> Result<(), UncommittedLeaderLog<CommittedLeaderIdOf<C>>> {
+        let noop_log_id = leader.noop_log_id();
+        let cluster_committed = state.cluster_committed();
+
+        if cluster_committed >= Some(noop_log_id) {
+            return Ok(());
+        }
+
+        Err(UncommittedLeaderLog {
+            committed: cluster_committed.cloned(),
+            leader_log_id: noop_log_id.clone(),
+        })
     }
 
     /// Ensure this node is the leader and is not transferring leadership.
@@ -1660,6 +1748,20 @@ where
                 );
 
                 self.change_membership(changes, retain, preconditions, payload, tx);
+            }
+            RaftMsg::AppendMembership {
+                payload,
+                preconditions,
+                tx,
+            } => {
+                tracing::info!(
+                    "received RaftMsg::AppendMembership: {}, payload: {}, preconditions: {}",
+                    func_name!(),
+                    payload,
+                    preconditions.as_ref().display()
+                );
+
+                self.append_membership(payload, preconditions, tx);
             }
             RaftMsg::WithRaftState { req } => {
                 req(&self.engine.state);

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -108,6 +108,28 @@ where C: RaftTypeConfig
         tx: ProgressResponder<C, ClientWriteResult<C>>,
     },
 
+    /// Append a caller-built membership as one log entry, with no intermediate joint membership.
+    ///
+    /// Unlike [`RaftMsg::ChangeMembership`], `RaftCore` does not compute the membership here. It
+    /// reads back the membership the caller already bound into `payload`, validates that exact
+    /// value, and appends `payload` unchanged.
+    AppendMembership {
+        /// The caller's payload, after [`RaftPayload::with_membership()`] bound the proposed
+        /// membership into it.
+        ///
+        /// This payload is the single source of truth for the entry: `RaftCore` reads the
+        /// membership to validate out of it, and writes this same value to the log. Carrying the
+        /// membership in a second field would let the validated value and the written value drift
+        /// apart.
+        ///
+        /// [`RaftPayload::with_membership()`]: crate::entry::RaftPayload::with_membership
+        payload: C::Payload,
+
+        preconditions: BatchOf<C, Precondition<C>>,
+
+        tx: ProgressResponder<C, ClientWriteResult<C>>,
+    },
+
     WithRaftState {
         req: BoxOnce<'static, RaftState<C>>,
     },
@@ -151,6 +173,7 @@ where C: RaftTypeConfig
             RaftMsg::GetLinearizer { .. } => RaftMsgName::GetLinearizer,
             RaftMsg::Initialize { .. } => RaftMsgName::Initialize,
             RaftMsg::ChangeMembership { .. } => RaftMsgName::ChangeMembership,
+            RaftMsg::AppendMembership { .. } => RaftMsgName::AppendMembership,
             RaftMsg::HandleTransferLeader { .. } => RaftMsgName::HandleTransferLeader,
             RaftMsg::WithRaftState { .. } => RaftMsgName::WithRaftState,
             RaftMsg::ExternalCommand { cmd } => RaftMsgName::ExternalCommand(cmd.name()),
@@ -195,6 +218,13 @@ where C: RaftTypeConfig
                     preconditions.as_ref().display()
                 )
             }
+            RaftMsg::AppendMembership { preconditions, .. } => {
+                write!(
+                    f,
+                    "AppendMembership: preconditions: {}",
+                    preconditions.as_ref().display()
+                )
+            }
             RaftMsg::WithRaftState { .. } => write!(f, "WithRaftState"),
             RaftMsg::HandleTransferLeader { from, to, last_log_id } => {
                 write!(
@@ -213,5 +243,35 @@ where C: RaftTypeConfig
                 write!(f, "GetRuntimeStats")
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::batch::Batch;
+    use crate::engine::testing::UTConfig;
+    use crate::engine::testing::log_id;
+    use crate::entry::EntryPayload;
+
+    /// `AppendMembership` reports its own name, and prints the preconditions the caller supplied.
+    #[test]
+    fn test_append_membership_name_and_display() {
+        let (tx, _rx) = ProgressResponder::<UTConfig, ClientWriteResult<UTConfig>>::complete_only();
+
+        let precondition = Precondition::LastMembershipLogId {
+            last_membership_log_id: Some(log_id(1, 2, 3)),
+        };
+        let msg = RaftMsg::<UTConfig>::AppendMembership {
+            payload: EntryPayload::Blank,
+            preconditions: BatchOf::<UTConfig, _>::of([precondition]),
+            tx,
+        };
+
+        assert_eq!(RaftMsgName::AppendMembership, msg.name());
+        assert_eq!(
+            "AppendMembership: preconditions: [LastMembershipLogId(T1-N2.3)]",
+            msg.to_string()
+        );
     }
 }

--- a/openraft/src/core/raft_msg/raft_msg_name.rs
+++ b/openraft/src/core/raft_msg/raft_msg_name.rs
@@ -1,4 +1,5 @@
 use openraft_macros::VariantName;
+use openraft_macros::since;
 
 /// Enum representing the name of each `ExternalCommand` variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -22,6 +23,7 @@ pub enum ExternalCommandName {
 /// than as a `RaftMsg` variant, but is still recorded here for runtime stats.
 ///
 /// This provides an efficient way to identify message types without string comparisons.
+#[since]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[derive(VariantName)]
 pub enum RaftMsgName {
@@ -33,6 +35,8 @@ pub enum RaftMsgName {
     GetLinearizer,
     Initialize,
     ChangeMembership,
+    #[since(version = "0.10.0")]
+    AppendMembership,
     HandleTransferLeader,
     WithRaftState,
     ExternalCommand(ExternalCommandName),

--- a/openraft/src/docs/cluster_control/dynamic-membership.md
+++ b/openraft/src/docs/cluster_control/dynamic-membership.md
@@ -85,6 +85,62 @@ need to roll back. For permanent removal in a single call, prefer
 from the cluster without an intermediate learner state.
 
 
+### [`Raft::append_membership()`]
+
+Writes a caller-built membership as **one** log entry, with no intermediate
+joint config. Use it when a one-voter change must cost a single entry, or when
+the cluster must land on a joint membership the caller picked itself.
+
+**Parameters:**
+- `membership`: The exact membership to store, uniform or joint
+- `payload`: The base entry payload. [`RaftPayload::with_membership()`] binds
+  `membership` into it, so the application data and the membership are stored
+  and applied at the same log ID. A caller with no application data passes
+  `C::Payload::blank()`.
+- `preconditions`: Compare-and-set guards, all checked before anything is
+  validated or written
+
+**Accepted transitions:**
+- Both the effective and the proposed membership are uniform, and their voter
+  sets differ by at most one node ID
+- Otherwise, the two memberships share an exactly equal voter set
+
+Any other transition returns [`UnsupportedMembershipTransition`] and writes no
+log. [`extended membership`] proves why these two rules keep quorums
+intersecting.
+
+**Rejections that write no log:**
+- [`InProgress`], while the preceding membership is not yet committed
+- [`UncommittedLeaderLog`], until this leader commits a log entry of its own
+  term. A valid leader lease does not imply that condition.
+- [`NodeMetadataChanged`], when the proposed membership gives a different
+  `Node` to a node ID the cluster already knows. Adding a node and removing a
+  node stay allowed. An intentional metadata update remains
+  [`ChangeMembers::SetNodes`], whose split-brain risk the *Updating Node
+  Metadata* section below explains.
+- [`ClientWriteError::PreconditionFailed`], when a supplied `Precondition` does
+  not hold
+
+**Pass [`Precondition::LastMembershipLogId`]** whenever the proposed membership
+was derived from an observed one. Without it, a membership change that landed
+in between is silently overwritten.
+
+**Example:**
+```ignore
+let observed = raft.metrics().borrow().membership_config.clone();
+
+// Promote learner 4 to voter, keeping every node's metadata as observed.
+let voters = BTreeSet::from([1, 2, 3, 4]);
+let nodes = observed.membership().nodes().map(|(id, n)| (id.clone(), n.clone()));
+let proposed = Membership::new(vec![voters], nodes.collect::<BTreeMap<_, _>>())?;
+
+raft.append_membership(proposed, Request::blank(), [Precondition::LastMembershipLogId {
+    last_membership_log_id: observed.log_id().clone(),
+}])
+.await?;
+```
+
+
 ## Node IDs Must Not Be Reused
 
 A node ID identifies one node, holding one log, for the entire lifetime of the
@@ -205,6 +261,15 @@ Exercise additional care when:
 
 [`Raft::add_learner()`]: `crate::Raft::add_learner`
 [`Raft::change_membership()`]: `crate::Raft::change_membership`
+[`Raft::append_membership()`]: `crate::Raft::append_membership`
+[`RaftPayload::with_membership()`]: `crate::entry::RaftPayload::with_membership`
+[`Precondition::LastMembershipLogId`]: `crate::raft::Precondition::LastMembershipLogId`
+[`ClientWriteError::PreconditionFailed`]: `crate::errors::ClientWriteError::PreconditionFailed`
+[`InProgress`]: `crate::errors::InProgress`
+[`NodeMetadataChanged`]: `crate::errors::NodeMetadataChanged`
+[`UncommittedLeaderLog`]: `crate::errors::UncommittedLeaderLog`
+[`UnsupportedMembershipTransition`]: `crate::errors::UnsupportedMembershipTransition`
+[`extended membership`]: `crate::docs::data::extended_membership`
 [`ChangeMembers::SetNodes`]: `crate::change_members::ChangeMembers::SetNodes`
 [`ChangeMembers::RemoveNodes`]: `crate::change_members::ChangeMembers::RemoveNodes`
 [`Config::allow_log_reversion`]: `crate::config::Config::allow_log_reversion`

--- a/openraft/src/docs/data/extended-membership.md
+++ b/openraft/src/docs/data/extended-membership.md
@@ -141,6 +141,82 @@ If the last committed membership is `[{a, b, c}, {x, y, z}]`, a valid new member
 might be: `[{a, b, c}]`, or `[{x, y, z}]`.
 
 
+## Direct membership append
+
+[`Raft::change_membership()`][] always reaches its target through a joint
+config, so changing one voter costs two log entries.
+[`Raft::append_membership()`][] writes the caller's exact membership as one log
+entry instead. It must still satisfy (2) **old-new-intersect**, and it accepts a
+transition only when one of the two rules below proves that constraint.
+
+### Rule 1: two uniform memberships one voter apart
+
+The old membership `m` and the new membership `m'` each have exactly one voter
+set, `V` and `V'`, and the **total symmetric difference** of those sets holds at
+most one node id:
+
+`|(V \ V') ∪ (V' \ V)| ≤ 1`
+
+This proves **old-new-intersect**. Take `V' = V ∪ {x}` with `|V| = n`. Any
+`qᵢ ∈ m` holds at least `⌊n/2⌋ + 1` nodes of `V`. Any `qⱼ ∈ m'` holds at least
+`⌊(n+1)/2⌋ + 1` nodes of `V'`, so setting `x` aside it holds at least
+`⌊(n+1)/2⌋` nodes of `V`. The two counts add up to at least `n + 1`, which is
+more than `|V| = n`, so `qᵢ ∩ qⱼ ≠ ø`. Removing one voter is the same statement
+with `m` and `m'` swapped.
+
+A difference of two node ids breaks the argument. From `[{a,b,c}]` to
+`[{b,c,d}]`, the quorum `{a,b}` of the old membership and the quorum `{c,d}` of
+the new one share no node.
+
+| Transition | Symmetric difference | Result |
+| --- | --- | --- |
+| `[{a,b,c}]` → `[{a,b,c}]` | `{}` | accept |
+| `[{a,b,c}]` → `[{a,b,c,x}]` | `{x}` | accept |
+| `[{a,b,c,x}]` → `[{a,b,c}]` | `{x}` | accept |
+| `[{a,b,c}]` → `[{b,c,d}]` | `{a, d}` | reject |
+| `[{a,b,c}]` → `[{a,b,c,x,y}]` | `{x, y}` | reject |
+
+### Rule 2: an exactly equal voter set
+
+When either membership has more than one voter set, the two memberships must
+hold one voter set that is exactly equal. This is the condition the extended
+algorithm already uses, and it puts no maximum on the number of voter sets:
+`c1` → `c1c2c3c4` is accepted because `c1` appears in both.
+
+The rule compares whole voter sets, never their members. From
+`[{a,b,c}, {a,b,d}]` to `[{a,b,e}]`, every voter set holds `a` and `b`, yet no
+voter set is equal across the two memberships. The transition is rejected, and
+rightly so: the quorum `{a,c,d}` of the old membership and the quorum `{b,e}` of
+the new one share no node.
+
+The rule is conservative, so it also rejects transitions that are safe but that
+it cannot prove. [`UnsupportedMembershipTransition`][] carries such an example,
+and names every rejected transition unsupported rather than unsafe.
+
+### The current-term guard
+
+The two rules prove that a new membership intersects its parent. They say
+nothing about two children of the same parent. A direct append therefore also
+enforces the corrected Raft single-server rule: the leader must commit a log
+entry of its own term before it appends a configuration entry. Openraft records
+that entry as `Leader::noop_log_id` and the quorum-granted commit as
+[`RaftState::cluster_committed()`][], and rejects the append until:
+
+```text
+cluster_committed >= leader.noop_log_id
+```
+
+Without the guard, two children proposed in different terms can both commit
+while not intersecting each other. From the committed `[{a,b,c,d}]`, one leader
+proposes `[{a,b,c,d,u}]` and a later leader proposes `[{a,b,c,d,v}]`. Both pass
+rule 1, yet the quorum `{a,b,u}` and the quorum `{c,d,v}` share no node.
+[`UncommittedLeaderLog`][] walks through the full run.
+
+[`Raft::change_membership()`][] does not need this guard. Its joint proposal
+shares an exact voter set with the parent, so two joint proposals from the same
+parent intersect through the two strict majorities of that shared set.
+
+
 ## Proof of correctness
 
 (In this proof, ∵ means "because" and ∴ means "therefore")
@@ -189,3 +265,10 @@ encountering a node with the higher `term_2`.
 ∴ It's impossible for two leaders to both commit a log entry.
 
 QED.
+
+
+[`Raft::append_membership()`]: `crate::Raft::append_membership`
+[`Raft::change_membership()`]: `crate::Raft::change_membership`
+[`RaftState::cluster_committed()`]: `crate::RaftState::cluster_committed`
+[`UncommittedLeaderLog`]: `crate::errors::UncommittedLeaderLog`
+[`UnsupportedMembershipTransition`]: `crate::errors::UnsupportedMembershipTransition`

--- a/openraft/src/docs/faq/02-core-concepts/01-differences-from-raft.md
+++ b/openraft/src/docs/faq/02-core-concepts/01-differences-from-raft.md
@@ -52,9 +52,14 @@ This generalization rolls out in phases:
   `c1c2c3 → c1`), as long as the **old-new-intersect** constraint holds between
   adjacent memberships. See [`extended membership`][].
 
-- **No single-step change.** Single-step membership change is a restricted
-  subset of joint consensus; Openraft only exposes the joint variant, which can
-  express any single-step transition and more.
+- **Single-step change is a separate API.** [`Raft::change_membership()`][]
+  always goes through joint consensus. [`Raft::append_membership()`][] writes
+  the caller's exact membership as one log entry, for the two transition shapes
+  whose quorum intersection Openraft can prove cheaply: two uniform memberships
+  whose voter sets differ by at most one node id, or two memberships sharing an
+  exactly equal voter set. It also enforces the corrected single-server rule,
+  which requires the leader to commit a log entry of its own term before it
+  appends a configuration entry. See [`extended membership`][].
 
 - **`change_membership` is concurrency-safe.** Parallel calls may interleave
   and leave the cluster in a valid joint state. This is by design — it
@@ -103,6 +108,8 @@ This generalization rolls out in phases:
 [`LogId`]: `crate::LogId`
 [`leader_id`]: `crate::docs::data::leader_id`
 [`extended membership`]: `crate::docs::data::extended_membership`
+[`Raft::change_membership()`]: `crate::Raft::change_membership`
+[`Raft::append_membership()`]: `crate::Raft::append_membership`
 [`leader lease`]: `crate::docs::protocol::replication::leader_lease`
 [`Linearizable Read`]: `crate::docs::protocol::read`
 [`RaftLogStorage::save_committed()`]: `crate::storage::RaftLogStorage::save_committed`

--- a/openraft/src/docs/faq/faq.md
+++ b/openraft/src/docs/faq/faq.md
@@ -99,9 +99,14 @@ This generalization rolls out in phases:
   `c1c2c3 → c1`), as long as the **old-new-intersect** constraint holds between
   adjacent memberships. See [`extended membership`][].
 
-- **No single-step change.** Single-step membership change is a restricted
-  subset of joint consensus; Openraft only exposes the joint variant, which can
-  express any single-step transition and more.
+- **Single-step change is a separate API.** [`Raft::change_membership()`][]
+  always goes through joint consensus. [`Raft::append_membership()`][] writes
+  the caller's exact membership as one log entry, for the two transition shapes
+  whose quorum intersection Openraft can prove cheaply: two uniform memberships
+  whose voter sets differ by at most one node id, or two memberships sharing an
+  exactly equal voter set. It also enforces the corrected single-server rule,
+  which requires the leader to commit a log entry of its own term before it
+  appends a configuration entry. See [`extended membership`][].
 
 - **`change_membership` is concurrency-safe.** Parallel calls may interleave
   and leave the cluster in a valid joint state. This is by design — it
@@ -150,6 +155,8 @@ This generalization rolls out in phases:
 [`LogId`]: `crate::LogId`
 [`leader_id`]: `crate::docs::data::leader_id`
 [`extended membership`]: `crate::docs::data::extended_membership`
+[`Raft::change_membership()`]: `crate::Raft::change_membership`
+[`Raft::append_membership()`]: `crate::Raft::append_membership`
 [`leader lease`]: `crate::docs::protocol::replication::leader_lease`
 [`Linearizable Read`]: `crate::docs::protocol::read`
 [`RaftLogStorage::save_committed()`]: `crate::storage::RaftLogStorage::save_committed`

--- a/openraft/src/docs/features.md
+++ b/openraft/src/docs/features.md
@@ -7,7 +7,7 @@ detailed guide.
 | Area | Provides | Main APIs and guides |
 | --- | --- | --- |
 | Core integration | Processes Raft events without periodic ticks and batches messages for throughput. Applications implement `RaftLogStorage`, `RaftStateMachine`, and `RaftNetworkV2`; [`Raft`][] is the primary application API. | [`Raft`][] |
-| Cluster formation and membership | Initializes a cluster, adds non-voting learners, and changes membership through joint configuration. Joint consensus supports arbitrary membership changes in one operation; single-step configuration changes are intentionally unsupported. | [`Raft::initialize()`][], [`Raft::add_learner()`][], [`Raft::change_membership()`][], [cluster formation][], [dynamic membership][] |
+| Cluster formation and membership | Initializes a cluster, adds non-voting learners, and changes membership through joint configuration. Joint consensus supports arbitrary membership changes in one operation; `Raft::append_membership()` writes a caller-built membership as a single log entry for the transitions whose quorum intersection Openraft can prove. | [`Raft::initialize()`][], [`Raft::add_learner()`][], [`Raft::change_membership()`][], [`Raft::append_membership()`][], [cluster formation][], [dynamic membership][] |
 | Leadership and elections | Elects leaders by policy or manually, transfers leadership, and offers Pre-Vote to avoid unnecessary term increments. | [`Trigger::elect()`][], [`Trigger::transfer_leader()`][], [`Config::enable_pre_vote`][], [Pre-Vote protocol][] |
 | Logs and snapshots | Compacts logs by snapshotting the state machine, replicates snapshots, and purges logs by policy or on demand. | [`Trigger::snapshot()`][], [`Trigger::purge_log()`][], [snapshot replication][] |
 | Reads | Performs linearizable reads with `ReadPolicy::ReadIndex` or `ReadPolicy::LeaseRead`. | [`Raft::ensure_linearizable()`][], [read protocol][] |
@@ -18,6 +18,7 @@ detailed guide.
 [`Raft::initialize()`]: crate::Raft::initialize
 [`Raft::add_learner()`]: crate::Raft::add_learner
 [`Raft::change_membership()`]: crate::Raft::change_membership
+[`Raft::append_membership()`]: crate::Raft::append_membership
 [`Raft::ensure_linearizable()`]: crate::Raft::ensure_linearizable
 [`Raft::metrics()`]: crate::Raft::metrics
 [`Raft::data_metrics()`]: crate::Raft::data_metrics

--- a/openraft/src/errors/mod.rs
+++ b/openraft/src/errors/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod into_raft_result;
 mod leader_changed;
 mod linearizable_read_error;
 mod membership_error;
+mod node_metadata_changed;
 mod node_not_found;
 mod operation;
 mod precondition_failed;
@@ -22,6 +23,8 @@ pub(crate) mod replication_error;
 pub(crate) mod storage_error;
 mod storage_io_result;
 mod streaming_error;
+mod uncommitted_leader_log;
+mod unsupported_membership_transition;
 
 use std::collections::BTreeSet;
 use std::error::Error;
@@ -38,6 +41,7 @@ pub(crate) use self::higher_vote::HigherVote;
 pub use self::leader_changed::LeaderChanged;
 pub use self::linearizable_read_error::LinearizableReadError;
 pub use self::membership_error::MembershipError;
+pub use self::node_metadata_changed::NodeMetadataChanged;
 pub use self::node_not_found::NodeNotFound;
 pub use self::operation::Operation;
 pub use self::precondition_failed::PreconditionFailed;
@@ -48,6 +52,8 @@ pub use self::replication_closed::ReplicationClosed;
 pub(crate) use self::replication_error::ReplicationError;
 pub(crate) use self::storage_io_result::StorageIOResult;
 pub use self::streaming_error::StreamingError;
+pub use self::uncommitted_leader_log::UncommittedLeaderLog;
+pub use self::unsupported_membership_transition::UnsupportedMembershipTransition;
 use crate::LogId;
 use crate::Membership;
 use crate::RaftTypeConfig;
@@ -125,6 +131,10 @@ where C: RaftTypeConfig
 /// The set of errors which may take place when requesting to propose a config change.
 #[since(
     version = "0.10.0",
+    change = "added `UnsupportedMembershipTransition`, `UncommittedLeaderLog` and `NodeMetadataChanged` variants"
+)]
+#[since(
+    version = "0.10.0",
     change = "from `ChangeMembershipError<C>` to `ChangeMembershipError<CLID, NID>`"
 )]
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -145,6 +155,21 @@ where
     /// A learner that should be in the cluster was not found.
     #[error(transparent)]
     LearnerNotFound(#[from] LearnerNotFound<NID>),
+
+    /// The proposed membership is not a transition a direct membership append supports.
+    #[since(version = "0.10.0")]
+    #[error(transparent)]
+    UnsupportedMembershipTransition(#[from] UnsupportedMembershipTransition<NID>),
+
+    /// The leader has not yet committed a log entry proposed in its own term.
+    #[since(version = "0.10.0")]
+    #[error(transparent)]
+    UncommittedLeaderLog(#[from] UncommittedLeaderLog<CLID>),
+
+    /// The proposed membership changes the metadata of a node id the cluster already knows.
+    #[since(version = "0.10.0")]
+    #[error(transparent)]
+    NodeMetadataChanged(#[from] NodeMetadataChanged<NID>),
 }
 
 /// The set of errors which may take place when initializing a pristine Raft node.

--- a/openraft/src/errors/node_metadata_changed.rs
+++ b/openraft/src/errors/node_metadata_changed.rs
@@ -1,0 +1,23 @@
+use openraft_macros::since;
+
+use crate::node::NodeId;
+
+/// The proposed membership changes the `Node` of a node id that the cluster already knows.
+///
+/// A direct membership append refuses to update node metadata, because replacing the address of a
+/// node that is already a voter can split the cluster into two groups that talk to different
+/// machines under one node id. Adding a new node id and removing an existing one stay allowed.
+///
+/// An intentional metadata update remains a separate [`ChangeMembers::SetNodes`] operation.
+///
+/// [`ChangeMembers::SetNodes`]: crate::ChangeMembers::SetNodes
+#[since(version = "0.10.0")]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+#[error("proposed membership changes the metadata of existing node {node_id}")]
+pub struct NodeMetadataChanged<NID>
+where NID: NodeId
+{
+    /// The node id whose proposed `Node` differs from the one in the current membership.
+    pub node_id: NID,
+}

--- a/openraft/src/errors/uncommitted_leader_log.rs
+++ b/openraft/src/errors/uncommitted_leader_log.rs
@@ -1,0 +1,65 @@
+use display_more::DisplayOptionExt;
+use openraft_macros::since;
+
+use crate::LogId;
+use crate::vote::RaftCommittedLeaderId;
+
+/// The leader has not yet committed a log entry proposed in its own term.
+///
+/// A single-step membership change requires the leader to commit a new log entry of its current
+/// term before it appends a configuration entry. Openraft proposes that entry when the leader is
+/// established and records it as the leader's blank (noop) log id. Until a quorum stores it, a
+/// configuration entry from an earlier term can still be committed, and two configurations whose
+/// quorums do not intersect could both become committed.
+///
+/// A valid leader lease does not imply this condition. The lease only proves that a quorum still
+/// sees this leader; it does not prove that a quorum stored the leader's blank log.
+///
+/// [`RaftState::cluster_committed()`] is the quorum-granted commit this error compares against.
+///
+/// # Example
+///
+/// The cluster starts with the committed membership `[{a,b,c,d}]`, whose quorum is three voters.
+/// `u` and `v` are two nodes that are not voters yet. Both configurations below add one node to
+/// `[{a,b,c,d}]`, so [`UnsupportedMembershipTransition`] accepts both.
+///
+/// 1. Term 1: `a` is elected, and without committing any term-1 log it appends `[{a,b,c,d,u}]` at
+///    index 6. The entry reaches only `a` and `u`. Then `a` crashes.
+/// 2. Term 2: `b`, `c` and `d` elect `d`, because none of them holds index 6.
+/// 3. `d` appends `[{a,b,c,d,v}]` at index 6. The entry reaches `c`, `d` and `v`, a quorum of
+///    `[{a,b,c,d,v}]`, so this configuration **is committed**. Then `d` crashes.
+/// 4. Term 3: `a` restarts and wins with `a`, `b` and `u`, a quorum of the `[{a,b,c,d,u}]` from
+///    step 1. `b` grants the vote because `d` never replicated to `b`, leaving `b` at index 5.
+/// 5. `a` replicates its own index 6 over `c` and `d`, destroying the committed `[{a,b,c,d,v}]`.
+///
+/// Quorum `{a,b,u}` and quorum `{c,d,v}` share no node, so neither election blocked the other.
+/// Committing a term-1 log before step 1 is what rules this run out.
+///
+/// # References
+///
+/// - [Bug in single-server membership changes][ongaro-bug]: Diego Ongaro's report of this bug,
+///   which introduced the rule this error enforces.
+/// - [The Pitfalls of Raft Membership Change][pitfalls]: a walk-through of a run that loses a
+///   committed configuration when the rule is not enforced.
+///
+/// [`RaftState::cluster_committed()`]: crate::RaftState::cluster_committed
+/// [`UnsupportedMembershipTransition`]: crate::errors::UnsupportedMembershipTransition
+/// [ongaro-bug]: https://gist.github.com/ongardie/a11f32b70581e20d6bcd
+/// [pitfalls]: https://blog.openacid.com/distributed/raft-bug/
+#[since(version = "0.10.0")]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+#[error(
+    "single-step membership change is blocked: the leader must first commit a new log of its current term, \
+     but its blank log {leader_log_id} is not committed; cluster committed: {}",
+    committed.display()
+)]
+pub struct UncommittedLeaderLog<CLID>
+where CLID: RaftCommittedLeaderId
+{
+    /// The greatest log id a quorum granted, i.e. the cluster-wide committed log id.
+    pub committed: Option<LogId<CLID>>,
+
+    /// The blank log id the current leader proposed when it was established.
+    pub leader_log_id: LogId<CLID>,
+}

--- a/openraft/src/errors/unsupported_membership_transition.rs
+++ b/openraft/src/errors/unsupported_membership_transition.rs
@@ -1,0 +1,69 @@
+use std::collections::BTreeSet;
+
+use openraft_macros::since;
+
+use crate::node::NodeId;
+
+/// The proposed membership is not one of the transitions a direct membership append supports.
+///
+/// A direct append writes the caller's exact membership as one log entry, without an intermediate
+/// joint membership. It is accepted only when quorum intersection can be proved by a simple rule:
+/// two uniform memberships whose voter sets differ by at most one node id, or two memberships that
+/// share an exactly equal voter set.
+///
+/// The rule is conservative, so a rejected transition is **unsupported**, not necessarily unsafe.
+/// Some rejected transitions do have intersecting quorums; Openraft does not run a general
+/// quorum-intersection solver to find them.
+///
+/// # Rejected transitions
+///
+/// Replacing one voter with another in one step:
+///
+/// ```text
+/// [{a,b,c}] -> [{b,c,d}]
+/// ```
+///
+/// The two uniform voter sets differ by two node ids, `a` and `d`. Quorum `{a,b}` of the previous
+/// membership and quorum `{c,d}` of the proposed one do not intersect, so the transition is
+/// unsafe. Append `[{a,b,c,d}]` first, then `[{b,c,d}]`.
+///
+/// Adding two voters in one step:
+///
+/// ```text
+/// [{a,b,c}] -> [{a,b,c,x,y}]
+/// ```
+///
+/// Quorum `{a,b}` of the previous membership and quorum `{c,x,y}` of the proposed one do not
+/// intersect. Append `x` and `y` one at a time.
+///
+/// Overlapping, but not exactly equal, voter sets:
+///
+/// ```text
+/// [{a,b,c}, {a,b,d}] -> [{a,b,e}]
+/// ```
+///
+/// No previous voter set equals `{a,b,e}`. Sharing `a` and `b` does not help: quorum `{a,c,d}` of
+/// the previous membership and quorum `{b,e}` of the proposed one do not intersect.
+///
+/// A safe transition this rule still rejects:
+///
+/// ```text
+/// [{a,b,c,d}, {a,b,c,e}] -> [{a,b,d,e}, {a,c,d,e}]
+/// ```
+///
+/// Every voter set holds four of the five node ids `{a,b,c,d,e}`, so every quorum holds at least
+/// three of them, and any two such quorums intersect. No voter set is equal across the two
+/// memberships, so this rule cannot see that and rejects the transition.
+#[since(version = "0.10.0")]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+#[error("unsupported membership transition: from voters {previous:?} to voters {proposed:?}")]
+pub struct UnsupportedMembershipTransition<NID>
+where NID: NodeId
+{
+    /// The voter sets of the last effective membership.
+    pub previous: Vec<BTreeSet<NID>>,
+
+    /// The voter sets of the membership the caller proposed.
+    pub proposed: Vec<BTreeSet<NID>>,
+}

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -12,6 +12,7 @@ use crate::errors::Operation;
 use crate::membership::IntoNodes;
 use crate::node::Node;
 use crate::node::NodeId;
+use crate::quorum::Coherent;
 use crate::quorum::FindCoherent;
 
 /// The membership configuration of the cluster.
@@ -157,8 +158,8 @@ where
     /// Membership is defined by a joint of multiple configs.
     /// Each config is a vec of node-id.
     ///
-    /// The returned `Vec` contains one or more configs (currently it is two). If there is only one
-    /// config, it is in a uniform config, otherwise, it is in a joint consensus.
+    /// The returned `Vec` contains one or more configs. If there is only one config, it is in a
+    /// uniform config, otherwise, it is in a joint consensus.
     pub fn get_joint_config(&self) -> &Vec<BTreeSet<NID>> {
         &self.configs
     }
@@ -249,7 +250,7 @@ where
         Ok(())
     }
 
-    /// Ensures that none of the sub-configs in this joint config are empty.
+    /// Ensures that no sub-config in this joint config is empty.
     pub(crate) fn ensure_non_empty_config(&self) -> Result<(), EmptyMembership> {
         for c in self.get_joint_config().iter() {
             if c.is_empty() {
@@ -258,6 +259,26 @@ where
         }
 
         Ok(())
+    }
+
+    /// Ensures that this membership defines a quorum: it holds at least one sub-config, and none
+    /// of them is empty.
+    ///
+    /// Zero sub-configs is as unusable as an empty sub-config: [`QuorumSet::is_quorum()`] iterates
+    /// the sub-configs, so with none of them it returns true for every node set.
+    ///
+    /// [`Membership::default()`] carries exactly that value as the empty sentinel, and storage
+    /// implementations round-trip it through [`Membership::new()`], so this check is not part of
+    /// [`Membership::ensure_valid()`]. Only a path that reads quorums out of a caller-supplied
+    /// membership calls it.
+    ///
+    /// [`QuorumSet::is_quorum()`]: crate::quorum::QuorumSet::is_quorum
+    pub(crate) fn ensure_quorum_defined(&self) -> Result<(), EmptyMembership> {
+        if self.get_joint_config().is_empty() {
+            return Err(EmptyMembership {});
+        }
+
+        self.ensure_non_empty_config()
     }
 
     /// Ensures that every vote has a corresponding Node.
@@ -273,9 +294,61 @@ where
         Ok(())
     }
 
+    /// Returns the first node id that both memberships know but describe with a different [`Node`].
+    ///
+    /// A node id that only one of the two memberships knows is skipped: adding a node and removing
+    /// a node are not metadata changes.
+    pub(crate) fn find_changed_node_metadata(&self, other: &Self) -> Option<NID> {
+        for (node_id, node) in self.nodes.iter() {
+            let Some(other_node) = other.nodes.get(node_id) else {
+                continue;
+            };
+
+            if other_node != node {
+                return Some(node_id.clone());
+            }
+        }
+
+        None
+    }
+
     // ---
     // Quorum related internal API
     // ---
+    /// Returns true if one membership can be appended directly on top of the other, as a single
+    /// log entry without an intermediate joint membership.
+    ///
+    /// The predicate is symmetric, and it accepts a transition only when quorum intersection
+    /// follows from one of two cases:
+    ///
+    /// - Both memberships are uniform, i.e. each has exactly one voter set, and the two voter sets
+    ///   differ by at most one node id. The majority sizes then leave no room for two disjoint
+    ///   quorums.
+    /// - Otherwise, the two memberships share an exactly equal voter set, which is the same
+    ///   argument [`Coherent::is_coherent_with()`] makes for joint consensus.
+    ///
+    /// The rule is conservative: it rejects some transitions whose quorums do intersect. See
+    /// [`UnsupportedMembershipTransition`] for examples.
+    ///
+    /// [`UnsupportedMembershipTransition`]: crate::errors::UnsupportedMembershipTransition
+    pub(crate) fn is_direct_append_compatible_with(&self, other: &Self) -> bool {
+        if self.ensure_quorum_defined().is_err() {
+            return false;
+        }
+        if other.ensure_quorum_defined().is_err() {
+            return false;
+        }
+
+        let both_uniform = self.configs.len() == 1 && other.configs.len() == 1;
+
+        if both_uniform {
+            let differing = self.configs[0].symmetric_difference(&other.configs[0]).count();
+            return differing <= 1;
+        }
+
+        self.configs.is_coherent_with(&other.configs)
+    }
+
     /// Returns the next coherent membership to change to, while the expected final membership is
     /// `goal`.
     ///

--- a/openraft/src/membership/membership_test.rs
+++ b/openraft/src/membership/membership_test.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::fmt::Display;
 use std::fmt::Formatter;
 
@@ -7,6 +8,7 @@ use maplit::btreeset;
 
 use crate::ChangeMembers;
 use crate::Membership;
+use crate::errors::EmptyMembership;
 use crate::errors::MembershipError;
 use crate::errors::NodeNotFound;
 use crate::errors::Operation;
@@ -349,6 +351,171 @@ fn test_membership_next_coherent_retain_false_keeps_existing_learners() -> anyho
         btreemap! {2=>node(2), 3=>node(3)},
         res.nodes().map(|(nid, n)| (*nid, n.clone())).collect::<BTreeMap<_, _>>()
     );
+
+    Ok(())
+}
+
+#[test]
+fn test_membership_ensure_valid() -> anyhow::Result<()> {
+    // An empty voter set.
+    let res = Membership::<u64, ()>::new(vec![btreeset! {1}, btreeset! {}], btreemap! {1=>()});
+    assert_eq!(Err(MembershipError::EmptyMembership(EmptyMembership {})), res);
+
+    // A voter without node data.
+    let res = Membership::<u64, ()>::new(vec![btreeset! {1,2}], btreemap! {1=>()});
+    let want = MembershipError::NodeNotFound(NodeNotFound::new(2, Operation::None));
+    assert_eq!(Err(want), res);
+
+    // Zero voter sets is the value `Membership::default()` carries, so the checking constructor
+    // keeps accepting it; only `ensure_quorum_defined()` rejects it.
+    let m = Membership::<u64, ()>::new(vec![], btreemap! {1=>()})?;
+    assert_eq!(&Vec::<BTreeSet<u64>>::new(), m.get_joint_config());
+    assert_eq!(
+        btreemap! {1=>()},
+        m.nodes().map(|(nid, n)| (*nid, *n)).collect::<BTreeMap<_, _>>()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_membership_ensure_quorum_defined() -> anyhow::Result<()> {
+    let m = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2}], []);
+    assert_eq!(Ok(()), m.ensure_quorum_defined());
+
+    let no_set = Membership::<u64, ()>::new_with_defaults(vec![], []);
+    assert_eq!(Err(EmptyMembership {}), no_set.ensure_quorum_defined());
+
+    let empty_set = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2}, btreeset! {}], []);
+    assert_eq!(Err(EmptyMembership {}), empty_set.ensure_quorum_defined());
+
+    Ok(())
+}
+
+#[test]
+fn test_membership_is_direct_append_compatible_with_uniform() -> anyhow::Result<()> {
+    let abc = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2,3}], []);
+    let abcx = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2,3,4}], []);
+    let bcd = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {2,3,4}], []);
+    let abcxy = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2,3,4,5}], []);
+
+    // Equal voter sets.
+    assert!(abc.is_direct_append_compatible_with(&abc));
+
+    // One voter added, and the same transition in reverse: one voter removed.
+    assert!(abc.is_direct_append_compatible_with(&abcx));
+    assert!(abcx.is_direct_append_compatible_with(&abc));
+
+    // One voter added and one removed: the symmetric difference is 2.
+    assert!(!abc.is_direct_append_compatible_with(&bcd));
+
+    // Two voters added.
+    assert!(!abc.is_direct_append_compatible_with(&abcxy));
+
+    Ok(())
+}
+
+#[test]
+fn test_membership_is_direct_append_compatible_with_joint() -> anyhow::Result<()> {
+    let uniform = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2,3}], []);
+    let joint = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2,3}, btreeset! {3,4,5}], []);
+
+    // `{1,2,3}` is shared exactly, in both directions.
+    assert!(uniform.is_direct_append_compatible_with(&joint));
+    assert!(joint.is_direct_append_compatible_with(&uniform));
+
+    // Sharing voters is not sharing a voter set: `{1,2}` is in every set below, and no set is
+    // shared.
+    let overlapping = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2,3}, btreeset! {1,2,4}], []);
+    let target = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2,5}], []);
+    assert!(!overlapping.is_direct_append_compatible_with(&target));
+
+    // The one-voter-difference rule applies to uniform memberships only: every set below differs
+    // by one voter from its counterpart, and the transition is still rejected.
+    let two_sets = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2,3}, btreeset! {4,5,6}], []);
+    let two_sets_grown = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2,3,7}, btreeset! {4,5,6,8}], []);
+    assert!(!two_sets.is_direct_append_compatible_with(&two_sets_grown));
+
+    Ok(())
+}
+
+#[test]
+fn test_membership_is_direct_append_compatible_with_many_sets() -> anyhow::Result<()> {
+    let shared = || btreeset! {1,2,3};
+    let previous = Membership::<u64, ()>::new_with_defaults(vec![shared()], []);
+
+    // The shared-set rule imposes no maximum on the number of voter sets.
+    for extra_sets in [
+        vec![btreeset! {4,5,6}],
+        vec![btreeset! {4,5,6}, btreeset! {7,8,9}],
+        vec![btreeset! {4,5,6}, btreeset! {7,8,9}, btreeset! {10,11,12}],
+    ] {
+        let mut configs = vec![shared()];
+        configs.extend(extra_sets.clone());
+        let proposed = Membership::<u64, ()>::new_with_defaults(configs, []);
+        assert!(
+            previous.is_direct_append_compatible_with(&proposed),
+            "sharing {:?} must be accepted with extra sets {:?}",
+            shared(),
+            extra_sets
+        );
+
+        let mut configs = vec![btreeset! {1,2,4}];
+        configs.extend(extra_sets.clone());
+        let unshared = Membership::<u64, ()>::new_with_defaults(configs, []);
+        assert!(
+            !previous.is_direct_append_compatible_with(&unshared),
+            "sharing no set must be rejected with extra sets {:?}",
+            extra_sets
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_membership_is_direct_append_compatible_with_invalid_config() -> anyhow::Result<()> {
+    let previous = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2,3}], []);
+
+    // A membership without any voter set is never appendable, in either direction.
+    let no_set = Membership::<u64, ()>::new_with_defaults(vec![], []);
+    assert!(!previous.is_direct_append_compatible_with(&no_set));
+    assert!(!no_set.is_direct_append_compatible_with(&previous));
+
+    // A membership with an empty voter set is never appendable either, even though it shares
+    // `{1,2,3}` with `previous`.
+    let empty_set = Membership::<u64, ()>::new_with_defaults(vec![btreeset! {1,2,3}, btreeset! {}], []);
+    assert!(!previous.is_direct_append_compatible_with(&empty_set));
+    assert!(!empty_set.is_direct_append_compatible_with(&previous));
+
+    Ok(())
+}
+
+#[test]
+fn test_membership_find_changed_node_metadata() -> anyhow::Result<()> {
+    let node = |addr: &str| TestNode {
+        addr: addr.to_string(),
+        data: Default::default(),
+    };
+    let m = |nodes| Membership::<u64, TestNode>::new_unchecked(vec![btreeset! {1,2}], nodes);
+
+    let previous = m(btreemap! {1=>node("a"), 2=>node("b"), 3=>node("c")});
+
+    // Every shared node id keeps its `Node`.
+    let unchanged = m(btreemap! {1=>node("a"), 2=>node("b"), 3=>node("c")});
+    assert_eq!(None, previous.find_changed_node_metadata(&unchanged));
+
+    // Node 3 is removed and node 4 is added: neither is a metadata change.
+    let removed_and_added = m(btreemap! {1=>node("a"), 2=>node("b"), 4=>node("d")});
+    assert_eq!(None, previous.find_changed_node_metadata(&removed_and_added));
+
+    // Voter 2 gets a different address.
+    let voter_changed = m(btreemap! {1=>node("a"), 2=>node("b2"), 3=>node("c")});
+    assert_eq!(Some(2), previous.find_changed_node_metadata(&voter_changed));
+
+    // Learner 3 gets a different address.
+    let learner_changed = m(btreemap! {1=>node("a"), 2=>node("b"), 3=>node("c3")});
+    assert_eq!(Some(3), previous.find_changed_node_metadata(&learner_changed));
 
     Ok(())
 }

--- a/openraft/src/raft/api/management.rs
+++ b/openraft/src/raft/api/management.rs
@@ -6,6 +6,7 @@ use openraft_macros::since;
 
 use crate::ChangeMembers;
 use crate::LogIdOptionExt;
+use crate::Membership;
 use crate::RaftMetrics;
 use crate::RaftTypeConfig;
 use crate::batch::Batch;
@@ -182,6 +183,31 @@ where C: RaftTypeConfig
             uniform: Some(uniform),
         });
         Ok(outcome)
+    }
+
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "info", skip_all)]
+    pub(crate) async fn append_membership(
+        &self,
+        membership: Membership<C::NodeId, C::Node>,
+        payload: C::Payload,
+        preconditions: BatchOf<C, Precondition<C>>,
+    ) -> Result<ClientWriteResult<C>, Fatal<C>> {
+        tracing::info!("append_membership: proposed membership: {}", membership);
+
+        // Bind the membership into the payload here, so the core has exactly one value to
+        // validate and to write: the payload it receives.
+        let payload = payload.with_membership(membership);
+
+        let (tx, rx) = ProgressResponder::<C, _>::complete_only();
+
+        let msg = RaftMsg::AppendMembership {
+            payload,
+            preconditions,
+            tx,
+        };
+
+        self.inner.call_core(msg, rx).await
     }
 
     #[since(version = "0.10.0")]

--- a/openraft/src/raft/impl_raft_blocking_write.rs
+++ b/openraft/src/raft/impl_raft_blocking_write.rs
@@ -5,6 +5,7 @@
 use openraft_macros::since;
 
 use crate::ChangeMembers;
+use crate::Membership;
 use crate::Raft;
 use crate::RaftTypeConfig;
 use crate::batch::Batch;
@@ -153,6 +154,109 @@ where
     ) -> Result<ClientWriteResponse<C>, RaftError<C, ClientWriteError<C>>> {
         self.management_api()
             .change_membership(members, retain, BatchOf::<C, _>::of(preconditions))
+            .await
+            .into_raft_result()
+    }
+
+    /// Append a caller-built membership as one log entry, with no intermediate joint membership.
+    ///
+    /// This is Raft's single-step (single-server) membership change, generalized: besides the
+    /// one-voter step it also accepts a caller-built joint membership. It is not the default way
+    /// to change membership. The caller supplies the whole stored membership here — every voter
+    /// set, every learner and every node's metadata — and openraft checks only the transition
+    /// rule below. Prefer [`Self::change_membership()`], which derives all of that from the
+    /// current membership, unless you know exactly what this method will write.
+    ///
+    /// Unlike [`Self::change_membership()`], which computes a joint config and then flattens it in
+    /// a second entry, this method writes exactly the `membership` given, in one physical log
+    /// entry. It never adds a joint membership and never flattens one, so a caller-built joint
+    /// membership of any number of voter sets is stored as it is. It returns after that entry is
+    /// committed and applied.
+    ///
+    /// `payload` is the base entry payload. This method calls
+    /// [`RaftPayload::with_membership()`] on it, so the application data and the membership share
+    /// one log id. A membership already present in `payload` is replaced; every other application
+    /// field survives according to the application's `with_membership()` implementation. A caller
+    /// with no application data passes `C::Payload::blank()`.
+    ///
+    /// # Accepted transitions
+    ///
+    /// The proposed membership must be reachable from the last committed one by a transition whose
+    /// quorum intersection openraft can prove cheaply:
+    ///
+    /// - Both memberships are uniform, and their voter sets differ by at most one node id.
+    /// - Otherwise, the two memberships share an exactly equal voter set.
+    ///
+    /// Anything else fails with [`UnsupportedMembershipTransition`], which is a limit of this
+    /// rule, not proof that the transition is unsafe.
+    ///
+    /// # Rejections that write no log
+    ///
+    /// - [`InProgress`], while the preceding membership is not committed yet.
+    /// - [`UncommittedLeaderLog`], until this leader commits a log entry of its own term. This
+    ///   holds even after the preceding membership commits and the leader holds a valid lease.
+    /// - [`NodeMetadataChanged`], when the proposed membership gives a different `Node` to a node
+    ///   id the cluster already knows. Adding and removing a node stay allowed; an intentional
+    ///   metadata update is still [`ChangeMembers::SetNodes`].
+    /// - [`ClientWriteError::PreconditionFailed`], when any supplied [`Precondition`] does not
+    ///   hold. All preconditions are checked before anything is validated or written.
+    ///
+    /// A caller that derives the proposed membership from an observed one must pass
+    /// [`Precondition::LastMembershipLogId`] with that membership's log id. Without it, a
+    /// membership change proposed in between is silently overwritten.
+    ///
+    /// # Examples
+    ///
+    /// Add voter `4` to the voter set `{1,2,3}`:
+    ///
+    /// ```ignore
+    /// let observed = raft.metrics().borrow().membership_config.clone();
+    ///
+    /// let voters = BTreeSet::from([1, 2, 3, 4]);
+    /// let nodes = observed.membership().nodes().map(|(id, n)| (id.clone(), n.clone()));
+    /// let proposed = Membership::new(vec![voters], nodes.collect::<BTreeMap<_, _>>())?;
+    ///
+    /// raft.append_membership(proposed, MyPayload::blank(), [Precondition::LastMembershipLogId {
+    ///     last_membership_log_id: observed.log_id().clone(),
+    /// }])
+    /// .await?;
+    /// ```
+    ///
+    /// Move from the uniform `{1,2,3}` to a joint membership of three voter sets. It is accepted
+    /// because `{1,2,3}` appears in both, exactly equal:
+    ///
+    /// ```ignore
+    /// let observed = raft.metrics().borrow().membership_config.clone();
+    ///
+    /// let configs = vec![
+    ///     BTreeSet::from([1, 2, 3]),
+    ///     BTreeSet::from([3, 4, 5]),
+    ///     BTreeSet::from([5, 6, 7]),
+    /// ];
+    /// let nodes = observed.membership().nodes().map(|(id, n)| (id.clone(), n.clone()));
+    /// let proposed = Membership::new(configs, nodes.collect::<BTreeMap<_, _>>())?;
+    ///
+    /// raft.append_membership(proposed, MyPayload::blank(), [Precondition::LastMembershipLogId {
+    ///     last_membership_log_id: observed.log_id().clone(),
+    /// }])
+    /// .await?;
+    /// ```
+    ///
+    /// [`RaftPayload::with_membership()`]: crate::entry::RaftPayload::with_membership
+    /// [`UnsupportedMembershipTransition`]: crate::errors::UnsupportedMembershipTransition
+    /// [`InProgress`]: crate::errors::InProgress
+    /// [`UncommittedLeaderLog`]: crate::errors::UncommittedLeaderLog
+    /// [`NodeMetadataChanged`]: crate::errors::NodeMetadataChanged
+    #[since(version = "0.10.0")]
+    #[tracing::instrument(level = "info", skip_all)]
+    pub async fn append_membership(
+        &self,
+        membership: Membership<C::NodeId, C::Node>,
+        payload: C::Payload,
+        preconditions: impl IntoIterator<Item = Precondition<C>>,
+    ) -> Result<ClientWriteResponse<C>, RaftError<C, ClientWriteError<C>>> {
+        self.management_api()
+            .append_membership(membership, payload, BatchOf::<C, _>::of(preconditions))
             .await
             .into_raft_result()
     }

--- a/openraft/src/raft_state/membership_state/membership_state_test.rs
+++ b/openraft/src/raft_state/membership_state/membership_state_test.rs
@@ -1,10 +1,19 @@
 use std::sync::Arc;
 
+use maplit::btreemap;
 use maplit::btreeset;
 
+use crate::BasicNode;
 use crate::Membership;
+use crate::StoredMembership;
 use crate::engine::testing::UTConfig;
+use crate::engine::testing::UtClid;
 use crate::engine::testing::log_id;
+use crate::errors::ChangeMembershipError;
+use crate::errors::InProgress;
+use crate::errors::NodeMetadataChanged;
+use crate::errors::UnsupportedMembershipTransition;
+use crate::raft_state::MembershipState;
 use crate::type_config::alias::MembershipStateOf;
 use crate::type_config::alias::StoredMembershipOf;
 
@@ -20,6 +29,10 @@ fn m1() -> Membership<u64, ()> {
 
 fn m12() -> Membership<u64, ()> {
     Membership::new_with_defaults(vec![btreeset! {1,2}], [])
+}
+
+fn m123() -> Membership<u64, ()> {
+    Membership::new_with_defaults(vec![btreeset! {1,2,3}], [])
 }
 
 fn m123_345() -> Membership<u64, ()> {
@@ -240,6 +253,100 @@ fn test_membership_state_truncate() -> anyhow::Result<()> {
         assert_eq!(&Some(log_id(2, 1, 2)), ms.committed().log_id());
         assert_eq!(&Some(log_id(2, 1, 2)), ms.effective().log_id());
     }
+
+    Ok(())
+}
+
+/// A `MembershipState` whose effective membership is committed, so that
+/// `validate_append_membership()` gets past its `ensure_committed()` check.
+fn committed_state(m: Membership<u64, ()>) -> MembershipStateOf<UTConfig> {
+    let stored = effmem(3, 4, m);
+    MembershipStateOf::<UTConfig>::new(stored.clone(), stored)
+}
+
+/// The same as [`committed_state`], for a `Node` type that carries metadata.
+fn committed_node_state(m: Membership<u64, BasicNode>) -> MembershipState<UtClid, u64, BasicNode> {
+    let stored = Arc::new(StoredMembership::new(Some(log_id(3, 1, 4)), m));
+    MembershipState::new(stored.clone(), stored)
+}
+
+#[test]
+fn test_validate_append_membership_in_progress() -> anyhow::Result<()> {
+    let ms = MembershipStateOf::<UTConfig>::new(effmem(2, 2, m1()), effmem(3, 4, m123()));
+
+    let got = ms.validate_append_membership(&m123()).unwrap_err();
+
+    let want = ChangeMembershipError::InProgress(InProgress {
+        committed: Some(log_id(2, 1, 2)),
+        membership_log_id: Some(log_id(3, 1, 4)),
+    });
+    assert_eq!(want, got);
+
+    Ok(())
+}
+
+#[test]
+fn test_validate_append_membership_accepts_one_voter_change() -> anyhow::Result<()> {
+    let ms = committed_state(m123());
+
+    let proposed = Membership::new_with_defaults(vec![btreeset! {1,2,3,4}], []);
+    assert_eq!(Ok(()), ms.validate_append_membership(&proposed));
+
+    Ok(())
+}
+
+#[test]
+fn test_validate_append_membership_unsupported_transition() -> anyhow::Result<()> {
+    let ms = committed_state(m123());
+    let before = ms.clone();
+
+    let proposed = Membership::new_with_defaults(vec![btreeset! {2,3,4}], []);
+    let got = ms.validate_append_membership(&proposed).unwrap_err();
+
+    let want = ChangeMembershipError::UnsupportedMembershipTransition(UnsupportedMembershipTransition {
+        previous: vec![btreeset! {1,2,3}],
+        proposed: vec![btreeset! {2,3,4}],
+    });
+    assert_eq!(want, got);
+    assert_eq!(before, ms);
+
+    Ok(())
+}
+
+#[test]
+fn test_validate_append_membership_node_metadata() -> anyhow::Result<()> {
+    let node = |addr: &str| BasicNode::new(addr);
+    let voters = || vec![btreeset! {1,2}];
+    let previous = Membership::new(voters(), btreemap! {1=>node("a"), 2=>node("b"), 3=>node("c")})?;
+
+    let ms = committed_node_state(previous);
+    let before = ms.clone();
+
+    let unchanged = Membership::new(voters(), btreemap! {1=>node("a"), 2=>node("b"), 3=>node("c")})?;
+    assert_eq!(Ok(()), ms.validate_append_membership(&unchanged));
+
+    // Node 4 is new to this cluster, so its metadata is not a change.
+    let added = Membership::new(
+        voters(),
+        btreemap! {1=>node("a"), 2=>node("b"), 3=>node("c"), 4=>node("d")},
+    )?;
+    assert_eq!(Ok(()), ms.validate_append_membership(&added));
+
+    let voter_changed = Membership::new(voters(), btreemap! {1=>node("a"), 2=>node("b2"), 3=>node("c")})?;
+    let got = ms.validate_append_membership(&voter_changed).unwrap_err();
+    assert_eq!(
+        ChangeMembershipError::NodeMetadataChanged(NodeMetadataChanged { node_id: 2 }),
+        got
+    );
+
+    let learner_changed = Membership::new(voters(), btreemap! {1=>node("a"), 2=>node("b"), 3=>node("c3")})?;
+    let got = ms.validate_append_membership(&learner_changed).unwrap_err();
+    assert_eq!(
+        ChangeMembershipError::NodeMetadataChanged(NodeMetadataChanged { node_id: 3 }),
+        got
+    );
+
+    assert_eq!(before, ms);
 
     Ok(())
 }

--- a/openraft/src/raft_state/membership_state/mod.rs
+++ b/openraft/src/raft_state/membership_state/mod.rs
@@ -10,6 +10,8 @@ use crate::LogIdOptionExt;
 use crate::Membership;
 use crate::errors::ChangeMembershipError;
 use crate::errors::InProgress;
+use crate::errors::NodeMetadataChanged;
+use crate::errors::UnsupportedMembershipTransition;
 
 #[cfg(test)]
 mod change_membership_test;
@@ -141,6 +143,47 @@ where
         let membership = effective.membership().clone();
         let new_membership = membership.change(change, retain)?;
         Ok(new_membership)
+    }
+
+    /// Validates a membership a caller wants appended as one log entry, without an intermediate
+    /// joint membership.
+    ///
+    /// It rejects the request unless every one of these holds:
+    ///
+    /// - The last membership log is committed, so the effective membership is also the last
+    ///   committed one, the parent this transition starts from.
+    /// - `proposed` is a valid membership on its own, and it defines a quorum. A public constructor
+    ///   is not enough of a guarantee: deserialization, [`Membership::default()`] and
+    ///   [`Membership::new_with_defaults()`] can all produce a value with no voter set at all, or
+    ///   with an empty one.
+    /// - `proposed` keeps the [`Node`] of every node id the effective membership already knows.
+    /// - The transition from the effective membership to `proposed` is one that a direct append
+    ///   supports.
+    pub(crate) fn validate_append_membership(
+        &self,
+        proposed: &Membership<NID, N>,
+    ) -> Result<(), ChangeMembershipError<CLID, NID>> {
+        self.ensure_committed()?;
+        proposed.ensure_valid()?;
+        proposed.ensure_quorum_defined()?;
+
+        let effective = self.effective().membership();
+
+        let changed_node_id = effective.find_changed_node_metadata(proposed);
+        if let Some(node_id) = changed_node_id {
+            return Err(NodeMetadataChanged { node_id }.into());
+        }
+
+        let compatible = effective.is_direct_append_compatible_with(proposed);
+        if !compatible {
+            let err = UnsupportedMembershipTransition {
+                previous: effective.get_joint_config().clone(),
+                proposed: proposed.get_joint_config().clone(),
+            };
+            return Err(err.into());
+        }
+
+        Ok(())
     }
 
     /// Ensures that the latest membership has been committed.

--- a/tests/tests/membership/main.rs
+++ b/tests/tests/membership/main.rs
@@ -16,6 +16,7 @@ mod t20_change_membership;
 mod t21_change_membership_cases;
 mod t22_change_membership_if;
 mod t23_custom_payload;
+mod t24_append_membership;
 mod t30_commit_joint_config;
 mod t30_elect_with_new_config;
 mod t31_add_remove_follower;

--- a/tests/tests/membership/t23_custom_payload.rs
+++ b/tests/tests/membership/t23_custom_payload.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use futures::Stream;
 use futures::TryStreamExt;
+use maplit::btreemap;
 use maplit::btreeset;
 use openraft::Config;
 use openraft::Entry;
@@ -511,7 +512,7 @@ async fn custom_payload_survives_membership_change_and_recovery() -> anyhow::Res
     let final_membership = Membership::new_with_defaults(vec![btreeset! {0}], []);
 
     tracing::info!("--- a request without payload creates a separate blank for each membership entry");
-    let final_log_id = {
+    {
         let blank_calls = BLANK_CALLS.load(Ordering::SeqCst);
         let request = ChangeMembershipRequest::new([0], false);
         let outcome = node0.change_membership_with_payload(request).await?;
@@ -527,7 +528,7 @@ async fn custom_payload_survives_membership_change_and_recovery() -> anyhow::Res
         let expected_payloads = vec![
             (outcome.first.log_id, CustomPayload {
                 normal: None,
-                membership: Some(final_joint_membership),
+                membership: Some(final_joint_membership.clone()),
             }),
             (uniform.log_id, CustomPayload {
                 normal: None,
@@ -535,18 +536,48 @@ async fn custom_payload_survives_membership_change_and_recovery() -> anyhow::Res
             }),
         ];
         assert_eq!(expected_payloads, read_payloads(&log0, 5..=6).await?);
+    }
 
-        uniform.log_id
+    // Voters `{0}` unchanged, node 1 re-added as a learner: one voter set on both sides, so this
+    // is a direct append.
+    let appended_membership = Membership::new(vec![btreeset! {0}], btreemap! {0=>(), 1=>()})?;
+
+    tracing::info!("--- append_membership binds the membership into the caller's payload");
+    let appended_log_id = {
+        let blank_calls = BLANK_CALLS.load(Ordering::SeqCst);
+
+        // The base payload already carries a membership; `with_membership()` replaces exactly that
+        // field and keeps `normal`.
+        let base = CustomPayload {
+            normal: Some("appended application data".to_string()),
+            membership: Some(final_joint_membership.clone()),
+        };
+        let resp = node0.append_membership(appended_membership.clone(), base, []).await?;
+
+        assert_eq!(blank_calls, BLANK_CALLS.load(Ordering::SeqCst));
+        assert_eq!(7, resp.log_id.index);
+        assert_eq!(Some(appended_membership.clone()), resp.membership);
+
+        // One entry holds both the application data and the proposed membership.
+        let expected_payloads = vec![(resp.log_id, CustomPayload {
+            normal: Some("appended application data".to_string()),
+            membership: Some(appended_membership.clone()),
+        })];
+        assert_eq!(expected_payloads, read_payloads(&log0, 7..=7).await?);
+
+        resp.log_id
     };
 
     let expected_final_state = AppliedState {
-        last_applied: Some(final_log_id),
-        membership: StoredMembership::new(Some(final_log_id), final_membership),
+        last_applied: Some(appended_log_id),
+        membership: StoredMembership::new(Some(appended_log_id), appended_membership),
         commands: vec![
             (joint_log_id, "joint application data".to_string()),
             (uniform_log_id, "uniform application data".to_string()),
+            (appended_log_id, "appended application data".to_string()),
         ],
     };
+    assert_eq!(expected_final_state, sm0.state());
 
     tracing::info!("--- restart node 0 from its log with an empty state machine");
     let recovered_node = {
@@ -557,7 +588,7 @@ async fn custom_payload_survives_membership_change_and_recovery() -> anyhow::Res
         let recovered_sm = TestStateMachine::default();
         let recovered = new_node(0, config.clone(), router.clone(), log0, recovered_sm.clone()).await?;
         router.insert(0, recovered.clone());
-        recovered.wait(timeout()).applied_index(Some(6), "reapply committed log").await?;
+        recovered.wait(timeout()).applied_index(Some(7), "reapply committed log").await?;
 
         assert_eq!(expected_final_state, recovered_sm.state());
         let metrics = recovered.metrics().borrow_watched().clone();
@@ -568,7 +599,7 @@ async fn custom_payload_survives_membership_change_and_recovery() -> anyhow::Res
     tracing::info!("--- install node 0 snapshot into a fresh node");
     let node2 = {
         recovered_node.trigger().snapshot().await?;
-        recovered_node.wait(timeout()).snapshot(final_log_id, "custom payload snapshot").await?;
+        recovered_node.wait(timeout()).snapshot(appended_log_id, "custom payload snapshot").await?;
         let snapshot = recovered_node.get_snapshot().await?.expect("snapshot should exist");
         let vote = recovered_node.metrics().borrow_watched().vote;
 

--- a/tests/tests/membership/t24_append_membership.rs
+++ b/tests/tests/membership/t24_append_membership.rs
@@ -1,0 +1,349 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use maplit::btreeset;
+use openraft::Config;
+use openraft::EntryPayload;
+use openraft::Membership;
+use openraft::Precondition;
+use openraft::RPCTypes;
+use openraft::ServerState;
+use openraft::async_runtime::WatchReceiver;
+use openraft::errors::ChangeMembershipError;
+use openraft::errors::ClientWriteError;
+use openraft::errors::ForwardToLeader;
+use openraft::errors::NetworkError;
+use openraft::errors::PreconditionFailed;
+use openraft::errors::RPCError;
+use openraft::errors::RaftError;
+use openraft::errors::UncommittedLeaderLog;
+use openraft::errors::UnsupportedMembershipTransition;
+use openraft::type_config::alias::LeaderIdOf;
+use openraft::type_config::alias::LogIdOf;
+use openraft::vote::RaftLeaderIdExt;
+use openraft_memstore::TypeConfig;
+
+use crate::fixtures::RaftRouter;
+use crate::fixtures::rpc_request::RpcRequest;
+use crate::fixtures::ut_harness;
+
+/// Election, heartbeat and ticking stay off: every log this test counts must come from its own
+/// `append_membership()` calls.
+fn config() -> Result<Arc<Config>> {
+    let config = Config {
+        enable_tick: false,
+        enable_heartbeat: false,
+        enable_elect: false,
+        ..Default::default()
+    }
+    .validate()?;
+    Ok(Arc::new(config))
+}
+
+/// Adding one voter and removing one voter each write exactly one membership entry.
+///
+/// `change_membership()` writes two entries for the same transition: a joint config and then a
+/// uniform config.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn add_and_remove_one_voter_write_one_entry_each() -> Result<()> {
+    let mut router = RaftRouter::new(config()?);
+
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3}).await?;
+    let leader = router.get_raft_handle(&0)?;
+
+    tracing::info!(log_index, "--- promote learner 3 to voter in one entry");
+    {
+        let proposed = Membership::new_with_defaults(vec![btreeset! {0,1,2,3}], []);
+        let resp = leader.append_membership(proposed.clone(), EntryPayload::Blank, []).await?;
+        log_index += 1;
+
+        assert_eq!(log_index, resp.log_id.index);
+        assert_eq!(Some(proposed), resp.membership);
+
+        for node_id in [0, 1, 2, 3] {
+            router.wait(&node_id, timeout()).applied_index(Some(log_index), "voter 3 added").await?;
+        }
+    }
+
+    tracing::info!(log_index, "--- remove voter 3 in one entry");
+    {
+        let proposed = Membership::new_with_defaults(vec![btreeset! {0,1,2}], []);
+        let resp = leader.append_membership(proposed.clone(), EntryPayload::Blank, []).await?;
+        log_index += 1;
+
+        assert_eq!(log_index, resp.log_id.index);
+        assert_eq!(Some(proposed), resp.membership);
+
+        for node_id in [0, 1, 2] {
+            router.wait(&node_id, timeout()).applied_index(Some(log_index), "voter 3 removed").await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Replacing one voter with another is outside the direct-append rule, and writes no log.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn unsupported_transition_writes_no_log() -> Result<()> {
+    let mut router = RaftRouter::new(config()?);
+
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3}).await?;
+    let leader = router.get_raft_handle(&0)?;
+
+    let membership_before = leader.metrics().borrow_watched().membership_config.clone();
+
+    tracing::info!(log_index, "--- swapping voter 0 for voter 3 is rejected");
+    {
+        let proposed = Membership::new_with_defaults(vec![btreeset! {1,2,3}], []);
+        let err = leader.append_membership(proposed, EntryPayload::Blank, []).await.unwrap_err();
+
+        let transition = UnsupportedMembershipTransition {
+            previous: vec![btreeset! {0,1,2}],
+            proposed: vec![btreeset! {1,2,3}],
+        };
+        let want =
+            ClientWriteError::ChangeMembershipError(ChangeMembershipError::UnsupportedMembershipTransition(transition));
+        assert_eq!(RaftError::APIError(want), err);
+    }
+
+    tracing::info!(log_index, "--- the rejected append wrote nothing");
+    {
+        let metrics = leader.metrics().borrow_watched().clone();
+        assert_eq!(Some(log_index), metrics.last_log_index);
+        assert_eq!(membership_before, metrics.membership_config);
+    }
+
+    Ok(())
+}
+
+/// A caller-built joint membership is stored exactly as given, and left again in one entry.
+///
+/// The joint membership below has three voter sets, which shows that the shared-set rule imposes
+/// no maximum. Both transitions share the voter set `{0,1,2}` exactly.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn joint_membership_is_entered_and_left_in_one_entry_each() -> Result<()> {
+    let mut router = RaftRouter::new(config()?);
+
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3,4}).await?;
+    let leader = router.get_raft_handle(&0)?;
+
+    tracing::info!(log_index, "--- enter a three-set joint membership in one entry");
+    {
+        let configs = vec![btreeset! {0,1,2}, btreeset! {2,3,4}, btreeset! {0,3,4}];
+        let proposed = Membership::new_with_defaults(configs, []);
+        let resp = leader.append_membership(proposed.clone(), EntryPayload::Blank, []).await?;
+        log_index += 1;
+
+        assert_eq!(log_index, resp.log_id.index);
+        assert_eq!(Some(proposed), resp.membership);
+
+        for node_id in [0, 1, 2, 3, 4] {
+            router.wait(&node_id, timeout()).applied_index(Some(log_index), "joint config applied").await?;
+        }
+    }
+
+    tracing::info!(
+        log_index,
+        "--- leave the joint membership for its shared voter set in one entry"
+    );
+    {
+        let proposed = Membership::new_with_defaults(vec![btreeset! {0,1,2}], []);
+        let resp = leader.append_membership(proposed.clone(), EntryPayload::Blank, []).await?;
+        log_index += 1;
+
+        assert_eq!(log_index, resp.log_id.index);
+        assert_eq!(Some(proposed), resp.membership);
+
+        for node_id in [0, 1, 2] {
+            router.wait(&node_id, timeout()).applied_index(Some(log_index), "uniform config applied").await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// `Precondition::LastMembershipLogId` permits the append at the log id it was read at, and
+/// rejects it once another membership entry has moved that log id.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn membership_log_id_precondition_guards_the_append() -> Result<()> {
+    let mut router = RaftRouter::new(config()?);
+
+    let mut log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3}).await?;
+    let leader = router.get_raft_handle(&0)?;
+
+    let observed_log_id = *leader.metrics().borrow_watched().membership_config.log_id();
+
+    tracing::info!(log_index, "--- the append guarded by the observed log id is accepted");
+    {
+        let precondition = Precondition::LastMembershipLogId {
+            last_membership_log_id: observed_log_id,
+        };
+        let proposed = Membership::new_with_defaults(vec![btreeset! {0,1,2,3}], []);
+        let resp = leader.append_membership(proposed, EntryPayload::Blank, [precondition]).await?;
+        log_index += 1;
+
+        assert_eq!(log_index, resp.log_id.index);
+    }
+
+    let current_log_id = *leader.metrics().borrow_watched().membership_config.log_id();
+
+    tracing::info!(log_index, "--- a second append guarded by the same log id is rejected");
+    {
+        let precondition = Precondition::LastMembershipLogId {
+            last_membership_log_id: observed_log_id,
+        };
+        let proposed = Membership::new_with_defaults(vec![btreeset! {0,1,2}], []);
+        let err = leader.append_membership(proposed, EntryPayload::Blank, [precondition]).await.unwrap_err();
+
+        let want = PreconditionFailed::LastMembershipLogIdMismatch {
+            expected: observed_log_id,
+            actual: current_log_id,
+        };
+        assert_eq!(RaftError::APIError(ClientWriteError::PreconditionFailed(want)), err);
+    }
+
+    tracing::info!(log_index, "--- the rejected append wrote nothing");
+    {
+        let metrics = leader.metrics().borrow_watched().clone();
+        assert_eq!(Some(log_index), metrics.last_log_index);
+        assert_eq!(current_log_id, *metrics.membership_config.log_id());
+    }
+
+    Ok(())
+}
+
+/// A follower answers `ForwardToLeader`; it never appends a membership entry of its own.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn follower_answers_forward_to_leader() -> Result<()> {
+    let mut router = RaftRouter::new(config()?);
+
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3}).await?;
+    let follower = router.get_raft_handle(&1)?;
+
+    tracing::info!(log_index, "--- a follower forwards the append to the leader");
+    {
+        let proposed = Membership::new_with_defaults(vec![btreeset! {0,1,2,3}], []);
+        let err = follower.append_membership(proposed, EntryPayload::Blank, []).await.unwrap_err();
+
+        let want = ClientWriteError::ForwardToLeader(ForwardToLeader::new(0, ()));
+        assert_eq!(RaftError::APIError(want), err);
+    }
+
+    tracing::info!(log_index, "--- the forwarded append wrote nothing");
+    {
+        let metrics = follower.metrics().borrow_watched().clone();
+        assert_eq!(Some(log_index), metrics.last_log_index);
+    }
+
+    Ok(())
+}
+
+/// The leader must commit a log of its own term before it appends a membership entry.
+///
+/// A valid leader lease does not imply that condition, so this test keeps the two apart: the
+/// pre-hook drops only the AppendEntries that carry entries, so the new leader's blank log never
+/// reaches a quorum, while the entry-less heartbeats still get acked and keep its lease valid.
+/// Heartbeats and ticking therefore stay on here, unlike in the other tests of this file.
+#[tracing::instrument]
+#[test_harness::test(harness = ut_harness)]
+async fn uncommitted_leader_log_blocks_the_append() -> Result<()> {
+    let config = Arc::new(
+        Config {
+            enable_elect: false,
+            heartbeat_interval: 50,
+            election_timeout_min: 500,
+            election_timeout_max: 501,
+            ..Default::default()
+        }
+        .validate()?,
+    );
+    let mut router = RaftRouter::new(config.clone());
+
+    let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3}).await?;
+    let old_leader = router.get_raft_handle(&0)?;
+    let new_leader = router.get_raft_handle(&1)?;
+
+    tracing::info!(log_index, "--- drop every AppendEntries that carries entries");
+    {
+        router
+            .set_rpc_pre_hook(RPCTypes::AppendEntries, |_router, req, from, to| {
+                let mut carries_entries = false;
+                if let RpcRequest::AppendEntries(append) = &req {
+                    carries_entries = !append.entries.is_empty();
+                }
+
+                let res = if carries_entries {
+                    let msg = format!("blocked: {}->{} append-entries with entries", from, to);
+                    Err(RPCError::Network(NetworkError::<TypeConfig>::from_string(msg)))
+                } else {
+                    Ok(())
+                };
+                Box::pin(futures::future::ready(res))
+            })
+            .await;
+    }
+
+    tracing::info!(
+        log_index,
+        "--- transfer leadership to node 1, whose blank log cannot commit"
+    );
+    {
+        old_leader.trigger().transfer_leader(1).await?;
+        new_leader
+            .wait(timeout())
+            .metrics(
+                |m| m.state == ServerState::Leader && m.last_quorum_acked.is_some(),
+                "node 1 leads and a quorum keeps acking it",
+            )
+            .await?;
+    }
+
+    let blocked_metrics = new_leader.metrics().borrow_watched().clone();
+    let noop_log_id = {
+        let leader_id = LeaderIdOf::<TypeConfig>::new_committed(blocked_metrics.current_term, 1);
+        LogIdOf::<TypeConfig>::new(leader_id, blocked_metrics.last_log_index.unwrap())
+    };
+    let proposed = Membership::new_with_defaults(vec![btreeset! {0,1,2,3}], []);
+
+    tracing::info!(log_index, "--- the append is blocked by the uncommitted blank log");
+    {
+        let err = new_leader.append_membership(proposed.clone(), EntryPayload::Blank, []).await.unwrap_err();
+
+        let uncommitted = UncommittedLeaderLog {
+            committed: None,
+            leader_log_id: noop_log_id,
+        };
+        let want = ClientWriteError::ChangeMembershipError(ChangeMembershipError::UncommittedLeaderLog(uncommitted));
+        assert_eq!(RaftError::APIError(want), err);
+    }
+
+    tracing::info!(log_index, "--- the blocked append wrote nothing");
+    {
+        let metrics = new_leader.metrics().borrow_watched().clone();
+        assert_eq!(blocked_metrics.last_log_index, metrics.last_log_index);
+        assert_eq!(blocked_metrics.membership_config, metrics.membership_config);
+    }
+
+    tracing::info!(log_index, "--- the same append succeeds once the blank log commits");
+    {
+        router.rpc_pre_hook(RPCTypes::AppendEntries, None).await;
+        new_leader.wait(timeout()).applied_index(Some(noop_log_id.index), "blank log committed").await?;
+
+        let resp = new_leader.append_membership(proposed.clone(), EntryPayload::Blank, []).await?;
+
+        assert_eq!(noop_log_id.index + 1, resp.log_id.index);
+        assert_eq!(Some(proposed), resp.membership);
+    }
+
+    Ok(())
+}
+
+fn timeout() -> Option<Duration> {
+    Some(Duration::from_millis(1000))
+}

--- a/tests/tests/public_api_test.rs
+++ b/tests/tests/public_api_test.rs
@@ -140,6 +140,7 @@ use openraft::errors::LinearizableReadError;
 use openraft::errors::MembershipError;
 use openraft::errors::NetworkError;
 use openraft::errors::NoForward;
+use openraft::errors::NodeMetadataChanged;
 use openraft::errors::NodeNotFound;
 use openraft::errors::NotAllowed;
 use openraft::errors::NotInMembers;
@@ -153,7 +154,9 @@ use openraft::errors::ReplicationClosed;
 use openraft::errors::SnapshotMismatch as DeprecatedSnapshotMismatch;
 use openraft::errors::StreamingError;
 use openraft::errors::Timeout;
+use openraft::errors::UncommittedLeaderLog;
 use openraft::errors::Unreachable;
+use openraft::errors::UnsupportedMembershipTransition;
 use openraft::errors::decompose;
 // =============================================================================
 // impls module exports


### PR DESCRIPTION
# Summary

`Raft::append_membership(membership, payload, preconditions)` writes a
caller-built membership as one log entry. `Raft::change_membership()`
appends a joint config and then a second entry to flatten it; this
method stores exactly the membership given, including a caller-built
joint membership of any number of voter sets, and returns once that
entry is applied.

# Details

This is Raft's single-server membership change, generalized.
`Membership::is_direct_append_compatible_with()` holds the accepted
transitions, the ones whose quorum intersection openraft can prove
cheaply: two uniform memberships whose voter sets differ by at most one
node id, or two memberships sharing an exactly equal voter set. The
second case reuses `Coherent::is_coherent_with()`. That trait's own
predicate is left alone, because `Membership::change()` uses it to decide
whether `change_membership()` needs a joint entry; widening it would make
`change_membership()` skip that entry for one-voter changes.

`RaftCore::ensure_leader_log_committed()` adds the barrier that
`ensure_writable_leader_handler()` does not check: the leader must have
committed a log entry of its own term, i.e.
`cluster_committed >= leader.noop_log_id`. Without it, two configurations
proposed in different terms from the same committed parent can both
commit even when their quorums do not intersect. Both `[{a,b,c,d,u}]` and
`[{a,b,c,d,v}]` add one node to the committed parent `[{a,b,c,d}]`, so
the transition rule accepts both, yet the quorums `{a,b,u}` and `{c,d,v}`
share no node. A valid lease does not imply the barrier: the heartbeat
worker advances the quorum acknowledgement clock even when a follower
reports a log conflict, so the lease proves a quorum still sees this
leader, not that a quorum stored the blank log.
`RaftCore::change_membership()` keeps its current behavior, because its
two proposals share an exact constituent voter set.

`ManagementApi::append_membership()` binds the membership into the
payload with `RaftPayload::with_membership()` before sending
`RaftMsg::AppendMembership`. Binding there rather than in `RaftCore`
means the core receives one value that is both what it validates and what
it writes. The application data and the membership therefore land at the
same log id, and a membership already present in the base payload is
replaced.

A caller that derives the proposed membership from an observed one should
pass `Precondition::LastMembershipLogId`. Without it, a membership change
proposed in between is silently overwritten.

`Membership::find_changed_node_metadata()` makes a direct append refuse
to change the `Node` of a node id the cluster already knows: swapping the
address behind an existing voter id can split the cluster into two groups
talking to different machines. A node id that only one side knows is
skipped, so adding and removing a node stay allowed.

`Membership::ensure_non_empty_config()` now also rejects a `configs`
vector holding no sub-config at all, not just an empty sub-config. The
quorum implementation iterates the sub-configs, so with zero of them
`is_quorum()` is vacuously true for every node set.
`Membership::default()` still carries that value as the internal empty
sentinel; the new validation keeps it from reaching the append path.

Three new errors carry the rejection reasons.
`UnsupportedMembershipTransition<NID>` holds the previous and proposed
voter sets; it says "unsupported" rather than "no intersection" because
the rule is conservative and rejects some transitions whose quorums do
intersect. `UncommittedLeaderLog<CLID>` holds the cluster-wide committed
log id and the leader's blank log id. `NodeMetadataChanged<NID>` holds
only the node id, so `ChangeMembershipError` needs no `Node` generic
parameter.

`NodeMetadataChanged` cannot be reached through `RaftRouter`, because
`openraft_memstore::TypeConfig` sets `Node = ()` and every node's
metadata is then equal by construction. Those cases are unit tests in
`membership_state_test.rs` using `BasicNode`, not integration tests.

`README.md`, `openraft/src/docs/features.md` and the FAQ source all
claimed single-step membership change is unsupported, and now describe
this method instead. `openraft/src/docs/faq/faq.md` is generated;
`make -C openraft/src/docs/faq` rebuilt it.

Upgrade tip:

`ChangeMembershipError` gains three variants. A `match` over it that has
no wildcard arm needs arms for `UnsupportedMembershipTransition`,
`UncommittedLeaderLog` and `NodeMetadataChanged`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2051)
<!-- Reviewable:end -->
