### PR TITLE
test: jepsen: broaden process fault targets

### DIFF
--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -159,12 +159,12 @@ narrower combination is needed.
 
 ### Nemesis Design
 
-Target policies are specific to each fault class. Network Partition, Process
-Pause, and Packet faults preserve a voter quorum so focused runs can require
-continuous progress. Process Kill and Clock faults may target any non-empty
-node subset, including a voter majority or every node. Their focused runs do
-not require progress while no usable quorum remains, but safety and final
-recovery remain mandatory. Membership changes retain their own legality and
+Target policies are specific to each fault class. Network Partition and Packet
+faults preserve a voter quorum so focused runs can require continuous progress.
+Process Kill, Process Pause, and Clock faults may target any non-empty node
+subset, including a voter majority or every node. Their focused runs do not
+require progress while no usable quorum remains, but safety and final recovery
+remain mandatory. Membership changes retain their own legality and
 quorum-preserving rules.
 
 The `chaos` profile composes these faults without reserving one common survivor
@@ -203,11 +203,10 @@ recovery waits for every node to rejoin a healthy cluster.
 
 #### Process Pause Nemesis
 
-The pause Nemesis suspends a quorum-safe target set without terminating its
-processes. It covers:
-
-- `leader-paused`: the selected set includes the supported leader;
-- `leader-unpaused`: only non-leader voters are suspended.
+The pause Nemesis suspends a uniformly random non-empty subset of reachable
+nodes without terminating their processes. Like Process Kill, it may retain or
+remove the voter quorum and records enough evidence for the focused checker to
+apply the matching availability expectation.
 
 Paused processes retain their memory and open TCP connections, so peers observe
 unresponsive processes rather than closed connections. Resume operations target

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -211,7 +211,10 @@ apply the matching availability expectation.
 Paused processes retain their memory and open TCP connections, so peers observe
 unresponsive processes rather than closed connections. Resume operations target
 every test node as an idempotent cleanup and record the complete resumed node
-set in history.
+set in history. When a quorum remains, the focused checker requires a client
+response that starts after the pause is installed and completes before resume
+begins. This uses the complete fault episode because a request to a paused
+leader can remain blocked until the client timeout.
 
 #### Membership Nemesis
 
@@ -310,6 +313,12 @@ processes, resumes paused processes, restores membership, and then performs one
 shared readiness check. Client operations continue while faults are active and
 during recovery. Final recovery performs one write and one read per register;
 every operation must succeed.
+
+A restarted test application keeps its Raft RPC service running while it waits
+for local recovery, but does not open the client API until recovery completes.
+This wait has no node-local deadline: Jepsen's shared readiness check provides
+the external 60-second recovery bound, reports a recovery timeout, and leaves
+the process alive for diagnosis and teardown.
 
 ### Results and Stored Evidence
 

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -87,7 +87,7 @@ The `jepsen.openraft` namespace contains the OpenRaft-specific Jepsen code:
 - `nemesis.clj`: fault scheduling, composition, and final recovery.
 - `nemesis/membership.clj`: membership growth, shrink, and final restoration.
 - `nemesis/partition.clj`: leader-aware network partition faults and recovery.
-- `nemesis/process.clj`: quorum-safe process kill/restart and pause/resume faults.
+- `nemesis/process.clj`: process kill/restart and pause/resume faults.
 - `quorum.clj`: stable and joint-consensus quorum calculations.
 - `workload.clj`: generators and checkers for client operations.
 
@@ -159,18 +159,18 @@ narrower combination is needed.
 
 ### Nemesis Design
 
-Partition, process, pause, and packet standalone Nemeses select targets so the
-surviving voters retain a quorum in every effective voter configuration. Clock
-faults deliberately allow any non-empty node subset, including a majority or
-all nodes; their focused run does not require progress while no quorum is
-available, but safety and final recovery remain mandatory.
+Target policies are specific to each fault class. Network Partition, Process
+Pause, and Packet faults preserve a voter quorum so focused runs can require
+continuous progress. Process Kill and Clock faults may target any non-empty
+node subset, including a voter majority or every node. Their focused runs do
+not require progress while no usable quorum remains, but safety and final
+recovery remain mandatory. Membership changes retain their own legality and
+quorum-preserving rules.
 
-The `chaos` profile composes fault packages without reserving one common
-survivor quorum across fault classes. Most focused fault packages select
-quorum-safe targets, while Clock may target a majority or all nodes. Active
-fault intervals may overlap and temporarily remove the global quorum. Safety
-and eventual recovery remain mandatory in that case, but continuous
-availability does not.
+The `chaos` profile composes these faults without reserving one common survivor
+quorum across fault classes. Their active intervals may overlap and temporarily
+remove the global quorum. Safety and eventual recovery remain mandatory in that
+case, but continuous availability does not.
 
 #### Network Partition Nemesis
 
@@ -188,22 +188,23 @@ is skipped and retried later without counting as coverage.
 
 #### Process Kill Nemesis
 
-The process Nemesis reads the effective voter configurations from OpenRaft
-metrics and randomly stops a non-empty voter subset whose survivors still form
-a quorum. It exercises two target cases:
+The process Nemesis randomly stops any non-empty subset of the test nodes. It
+does not filter targets by quorum or leader placement, so an episode may stop a
+single node, a voter minority, a voter majority, learners, or every node. The
+history records the selected nodes, initial leader, and effective voter
+configuration, together with the voters reachable before the kill, so the
+checker can determine whether a usable quorum remained.
 
-- `leader-killed`: the selected processes include the current
-  quorum-supported leader, so the survivors must elect a replacement;
-- `leader-survives`: only non-leader voters are selected, so the existing leader
-  remains with a quorum.
-
-The target set is fixed for one fault episode. Recovery restarts the selected
-processes and waits for them to rejoin the healthy cluster.
+When a quorum remains, a focused Process run requires a definitive client
+response within three maximum election timeouts. Losing quorum permits a
+temporary lack of progress, but never relaxes safety. The target set is fixed
+for one fault episode. Each episode restarts the selected processes, and final
+recovery waits for every node to rejoin a healthy cluster.
 
 #### Process Pause Nemesis
 
-The pause Nemesis uses the same quorum-safe target selection as process kill,
-but suspends the selected processes without terminating them. It covers:
+The pause Nemesis suspends a quorum-safe target set without terminating its
+processes. It covers:
 
 - `leader-paused`: the selected set includes the supported leader;
 - `leader-unpaused`: only non-leader voters are suspended.

--- a/jepsen/openraft-test-app/src/lib.rs
+++ b/jepsen/openraft-test-app/src/lib.rs
@@ -4,11 +4,13 @@
 use std::num::NonZeroU64;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use clap::Parser;
 use openraft::Config;
 use openraft::NodeInfo as Node;
 use openraft::SnapshotPolicy;
+use openraft::storage::RaftLogStorage;
 
 use crate::app::App;
 use crate::store::new_storage;
@@ -77,7 +79,8 @@ pub async fn start_raft_node(options: Opt) -> std::io::Result<()> {
 
     let config = Arc::new(config.validate().unwrap());
 
-    let (log_store, state_machine_store) = new_storage(&dir).await;
+    let (mut log_store, state_machine_store) = new_storage(&dir).await;
+    let is_restart = log_store.get_log_state().await?.last_log_id.is_some();
 
     let kvs = state_machine_store.data.kvs.clone();
 
@@ -97,11 +100,21 @@ pub async fn start_raft_node(options: Opt) -> std::io::Result<()> {
     });
 
     let raft_server = network_v2_http::Server::new(app.raft.clone()).run(raft_addr);
-    let app_server = app_http::Server::new(app)
-        .add_openraft_routes()
-        .post("/read", http_api::read)
-        .post("/linearizable_read", http_api::linearizable_read)
-        .run(api_addr);
+    let app_server = async move {
+        if is_restart {
+            app.raft
+                .wait_for_recovery(Some(Duration::from_secs(5)))
+                .await
+                .map_err(|e| std::io::Error::other(e.to_string()))?;
+        }
+
+        app_http::Server::new(app)
+            .add_openraft_routes()
+            .post("/read", http_api::read)
+            .post("/linearizable_read", http_api::linearizable_read)
+            .run(api_addr)
+            .await
+    };
 
     tokio::try_join!(raft_server, app_server)?;
     Ok(())

--- a/jepsen/openraft-test-app/src/lib.rs
+++ b/jepsen/openraft-test-app/src/lib.rs
@@ -34,6 +34,10 @@ pub type LogStore = log_rocks::RocksLogStore<TypeConfig>;
 pub type StateMachineStore = store::StateMachineStore;
 pub type Raft = openraft::Raft<TypeConfig, StateMachineStore>;
 
+// Jepsen bounds final cluster recovery externally. A local deadline would
+// terminate both servers while a restart is still able to catch up.
+const RESTART_RECOVERY_TIMEOUT: Option<Duration> = None;
+
 #[derive(Parser, Clone, Debug)]
 #[clap(author, version, about, long_about = None)]
 pub struct Opt {
@@ -103,7 +107,7 @@ pub async fn start_raft_node(options: Opt) -> std::io::Result<()> {
     let app_server = async move {
         if is_restart {
             app.raft
-                .wait_for_recovery(Some(Duration::from_secs(5)))
+                .wait_for_recovery(RESTART_RECOVERY_TIMEOUT)
                 .await
                 .map_err(|e| std::io::Error::other(e.to_string()))?;
         }
@@ -127,6 +131,12 @@ mod tests {
     use clap::Parser;
 
     use super::Opt;
+    use super::RESTART_RECOVERY_TIMEOUT;
+
+    #[test]
+    fn restart_recovery_has_no_local_deadline() {
+        assert!(RESTART_RECOVERY_TIMEOUT.is_none());
+    }
 
     #[test]
     fn snapshot_threshold_must_be_positive() {

--- a/jepsen/src/jepsen/openraft/nemesis.clj
+++ b/jepsen/src/jepsen/openraft/nemesis.clj
@@ -15,7 +15,7 @@
 (def ^:private initial-healthy-seconds 5)
 (def ^:private retry-interval-seconds 1)
 (def ^:private retryable-skip-reasons
-  #{:no-quorum-safe-process-target
+  #{:no-process-target
     :no-reachable-pause-target
     :no-safe-packet-target
     :no-safe-partition-target

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -1,5 +1,6 @@
 (ns jepsen.openraft.nemesis.process
-  (:require [clojure.tools.logging :refer [info]]
+  (:require [clojure.set :as set]
+            [clojure.tools.logging :refer [info]]
             [jepsen [checker :as checker]
              [generator :as gen]
              [nemesis :as nemesis]
@@ -14,11 +15,18 @@
 
 (def downtime-seconds 10)
 (def required-process-modes
-  #{:leader-killed :leader-survives})
+  #{:random})
 (def required-pause-modes
   #{:leader-paused :leader-unpaused})
 
-(defn- process-targets [eligible-nodes configs leader mode]
+;; openraft-test-app uses OpenRaft's 300 ms maximum election timeout. Three
+;; windows allow a split vote to settle without turning a retained-quorum
+;; outage into a silent success.
+(def ^:private max-election-timeout-ms 300)
+(def ^:private process-availability-window-nanos
+  (* 3 max-election-timeout-ms 1000000))
+
+(defn- pause-targets [eligible-nodes configs leader mode]
   (let [voters (quorum/voter-set configs)]
     (when-not (contains? voters leader)
       (throw (ex-info "The current leader is not a voter"
@@ -27,10 +35,10 @@
     (let [eligible-node-set (set eligible-nodes)
           fault-sets (quorum/fault-sets configs)
           candidates (->> (cond
-                            (#{:leader-killed :leader-paused} mode)
+                            (= :leader-paused mode)
                             (filter #(contains? % leader) fault-sets)
 
-                            (#{:leader-survives :leader-unpaused} mode)
+                            (= :leader-unpaused mode)
                             (remove #(contains? % leader) fault-sets)
 
                             :else
@@ -43,22 +51,32 @@
              (filter target-set)
              vec)))))
 
-(defn- process-disruption [test status mode eligible-nodes]
+(defn- process-disruption [kind test status mode eligible-nodes]
   (let [leader (:leader status)
         configs (cluster/voter-configs test status)
-        targets (process-targets eligible-nodes configs leader mode)]
-    (when targets
-      (let [voters (quorum/voter-set configs)
-            target-set (set targets)
+        voters (quorum/voter-set configs)
+        reachable-node-set (set (keys (:metrics status)))
+        reachable-voters (set/intersection voters reachable-node-set)
+        targets (case kind
+                  :process (some-> (random/nonempty-subset eligible-nodes) vec)
+                  :pause (pause-targets eligible-nodes configs leader mode))]
+    (when (seq targets)
+      (let [target-set (set targets)
             survivors (->> (:nodes test)
-                           (filter voters)
+                           (filter reachable-voters)
                            (remove target-set)
                            vec)]
-        {:mode mode
-         :leader leader
-         :nodes targets
-         :voter-configs configs
-         :survivors survivors}))))
+        (cond-> {:mode mode
+                 :leader leader
+                 :nodes targets
+                 :voter-configs configs
+                 :survivors survivors}
+          (= :process kind)
+          (assoc :reachable-voters (->> (:nodes test)
+                                        (filter reachable-voters)
+                                        vec)
+                 :target-count (count targets)
+                 :leader-included? (contains? target-set leader)))))))
 
 (def ^:private disruption-start-specs
   {:process {:delegate-f :kill
@@ -191,7 +209,8 @@
                                     (filter (set (keys (:metrics status))))
                                     vec)
                                (:nodes test))]
-          (if-let [disruption (process-disruption test
+          (if-let [disruption (process-disruption kind
+                                                  test
                                                   status
                                                   mode
                                                   eligible-nodes)]
@@ -218,11 +237,11 @@
                              :mode mode
                              :voter-configs (cluster/voter-configs test
                                                                    status)}]
-                (info "Skipping process kill without a quorum-safe target"
+                (info "Skipping process kill without an eligible target"
                       details)
                 (assoc op
                        :value (outcome/skipped
-                               :no-quorum-safe-process-target
+                               :no-process-target
                                details)))
 
               :pause
@@ -377,12 +396,7 @@
    (gen/phases
     {:type :info
      :f :kill-process
-     :value :leader-survives}
-    {:type :info
-     :f :restart-process}
-    {:type :info
-     :f :kill-process
-     :value :leader-killed}
+     :value :random}
     {:type :info
      :f :restart-process})))
 
@@ -465,15 +479,228 @@
                          history
                          cluster-state)))))
 
+(def ^:private client-completion-types
+  #{:ok :fail :info})
+
+(defn- main-client-operation? [op]
+  (and (not= :nemesis (:process op))
+       (= :main (:phase op))
+       (#{:read :write :cas} (:f op))))
+
+(defn- completed-client-attempts [history]
+  (:attempts
+   (reduce
+    (fn [{:keys [pending] :as state} [index op]]
+      (cond
+        (and (main-client-operation? op)
+             (= :invoke (:type op)))
+        (assoc-in state [:pending (:process op)]
+                  {:index index
+                   :op op})
+
+        (and (main-client-operation? op)
+             (client-completion-types (:type op)))
+        (if-let [{invoke-index :index
+                  invocation :op} (get pending (:process op))]
+          (-> state
+              (update :attempts conj
+                      {:process (:process op)
+                       :f (:f op)
+                       :invoke-index invoke-index
+                       :invoke-time (:time invocation)
+                       :completion-index index
+                       :completion-time (:time op)
+                       :type (:type op)
+                       :error (:error op)})
+              (update :pending dissoc (:process op)))
+          state)
+
+        :else state))
+    {:pending {}
+     :attempts []}
+    (map-indexed vector history))))
+
+(defn- installed-random-kill? [op]
+  (and (= :kill-process (:f op))
+       (disruption-installed? required-process-modes
+                              (:value op))))
+
+(defn- restart-invocation? [op]
+  (and (= :restart-process (:f op))
+       (nil? (:value op))))
+
+(defn- process-episodes [history]
+  (let [{:keys [active episodes]}
+        (reduce
+         (fn [{:keys [active] :as state} [index op]]
+           (cond
+             (installed-random-kill? op)
+             (assoc state
+                    :active {:start-index index
+                             :started-at (:time op)
+                             :details (:value op)})
+
+             (and active (restart-invocation? op))
+             (-> state
+                 (update :episodes conj
+                         (assoc active
+                                :end-index index
+                                :ended-at (:time op)
+                                :final-restart?
+                                (:process-final-restart? op)))
+                 (assoc :active nil))
+
+             :else state))
+         {:active nil
+          :episodes []}
+         (map-indexed vector history))]
+    (cond-> episodes
+      active (conj active))))
+
+(defn- attempt-started-during?
+  [{:keys [start-index end-index started-at]} deadline attempt]
+  (and (< start-index (:invoke-index attempt))
+       (or (nil? end-index)
+           (< (:invoke-index attempt) end-index))
+       (<= started-at (:invoke-time attempt) deadline)))
+
+(defn- successful-attempt?
+  [{:keys [end-index]} deadline attempt]
+  (and (or (= :ok (:type attempt))
+           (and (= :fail (:type attempt))
+                (= :version-mismatch (:error attempt))))
+       (or (nil? end-index)
+           (< (:completion-index attempt) end-index))
+       (<= (:completion-time attempt) deadline)))
+
+(defn- unexpected-write-success?
+  [{:keys [end-index]} attempt]
+  (and (= :ok (:type attempt))
+       (#{:write :cas} (:f attempt))
+       (or (nil? end-index)
+           (< (:completion-index attempt) end-index))))
+
+(defn- episode-availability [window-nanos attempts episode]
+  (let [{:keys [started-at ended-at final-restart? details]} episode
+        configs (:voter-configs details)
+        targets (set (:nodes details))
+        reachable-voters (set (:reachable-voters details))
+        configured-voters (quorum/voter-set configs)
+        survivors (set/difference reachable-voters targets)
+        configured-survivors (set/difference configured-voters targets)
+        quorum-retained? (quorum/quorum? configs survivors)
+        configured-quorum-retained? (quorum/quorum? configs
+                                                    configured-survivors)
+        deadline (+ started-at window-nanos)
+        episode-attempts (filterv (partial attempt-started-during?
+                                           episode
+                                           Long/MAX_VALUE)
+                                  attempts)
+        attempts (filterv #(<= (:invoke-time %) deadline)
+                          episode-attempts)
+        successes (filterv (partial successful-attempt?
+                                    episode
+                                    deadline)
+                           attempts)
+        unexpected-successes (when-not configured-quorum-retained?
+                               (filterv (partial unexpected-write-success?
+                                                 episode)
+                                        episode-attempts))
+        full-window? (and ended-at (<= deadline ended-at))
+        truncated? (and final-restart? (not full-window?))
+        reason (cond
+                 (seq unexpected-successes)
+                 :unexpected-success-without-quorum
+
+                 (not quorum-retained?)
+                 nil
+
+                 (seq successes)
+                 nil
+
+                 truncated?
+                 nil
+
+                 (not full-window?)
+                 :insufficient-observation-window
+
+                 (empty? attempts)
+                 :no-client-attempts
+
+                 :else
+                 :no-success-with-quorum)]
+    (cond-> {:started-at started-at
+             :ended-at ended-at
+             :deadline deadline
+             :targets (vec (:nodes details))
+             :voter-configs configs
+             :reachable-voters (vec (sort reachable-voters))
+             :survivors (vec (sort survivors))
+             :configured-survivors (vec (sort configured-survivors))
+             :quorum-retained? quorum-retained?
+             :configured-quorum-retained? configured-quorum-retained?
+             :evaluable? (boolean (or (not quorum-retained?)
+                                      (seq successes)
+                                      full-window?))
+             :truncated? truncated?
+             :attempt-count (count attempts)
+             :success-count (count successes)
+             :unexpected-success-count (count unexpected-successes)}
+      reason (assoc :reason reason))))
+
+(defn- availability-checker [window-nanos]
+  (reify checker/Checker
+    (check [_ _test history _opts]
+      (let [attempts (completed-client-attempts history)
+            episodes (mapv (partial episode-availability
+                                    window-nanos
+                                    attempts)
+                           (process-episodes history))
+            failures (filterv :reason episodes)
+            retained (filterv :quorum-retained? episodes)
+            evaluated-retained (filterv :evaluable? retained)
+            valid? (not (seq failures))]
+        {:valid? valid?
+         :window-nanos window-nanos
+         :episode-count (count episodes)
+         :quorum-episode-count (count retained)
+         :no-quorum-episode-count
+         (count (remove :configured-quorum-retained? episodes))
+         :indeterminate-quorum-episode-count
+         (count (filter #(and (:configured-quorum-retained? %)
+                              (not (:quorum-retained? %)))
+                        episodes))
+         :evaluated-quorum-episode-count (count evaluated-retained)
+         :truncated-episode-count (count (filter :truncated? episodes))
+         :episodes episodes
+         :failures failures}))))
+
+(defn- process-checker []
+  (let [coverage (coverage-checker)
+        availability (availability-checker process-availability-window-nanos)]
+    (reify checker/Checker
+      (check [_ test history opts]
+        (let [coverage-result (checker/check coverage test history opts)
+              availability-result (checker/check availability
+                                                 test
+                                                 history
+                                                 opts)]
+          (assoc coverage-result
+                 :valid? (checker/merge-valid
+                          [(:valid? coverage-result)
+                           (:valid? availability-result)])
+                 :availability availability-result))))))
+
 (defn process-package [db]
   {:name :process
    :interval downtime-seconds
    :nemesis (process-nemesis db)
    :generator (process-generator)
    :final-generator {:type :info
-                     :f :restart-process}
+                     :f :restart-process
+                     :process-final-restart? true}
    :checker (openraft-checker/reject-checker-exceptions
-             (coverage-checker))})
+             (process-checker))})
 
 (defn- next-pause-state [expected-nodes state op]
   (let [error? (operation-error? op)

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -553,7 +553,10 @@
         quorum-retained? (quorum/quorum? configs survivors)
         configured-quorum-retained? (quorum/quorum? configs
                                                     configured-survivors)
-        deadline (+ started-at window-nanos)
+        episode-window? (nil? window-nanos)
+        deadline (if episode-window?
+                   (or ended-at Long/MAX_VALUE)
+                   (+ started-at window-nanos))
         episode-attempts (filterv (partial attempt-started-during?
                                            episode
                                            Long/MAX_VALUE)
@@ -568,8 +571,11 @@
                                (filterv (partial unexpected-write-success?
                                                  episode)
                                         episode-attempts))
-        full-window? (and ended-at (<= deadline ended-at))
-        truncated? (and final-restart? (not full-window?))
+        full-window? (if episode-window?
+                       (boolean ended-at)
+                       (and ended-at (<= deadline ended-at)))
+        truncated? (and final-restart?
+                        (or episode-window? (not full-window?)))
         reason (cond
                  (seq unexpected-successes)
                  :unexpected-success-without-quorum
@@ -612,6 +618,8 @@
       reason (assoc :reason reason))))
 
 (defn- availability-checker
+  ;; A nil window checks the complete disruption episode, ending at the
+  ;; recovery invocation. A numeric window retains the fixed-deadline policy.
   ([window-nanos]
    (availability-checker window-nanos
                          :kill-process
@@ -729,7 +737,7 @@
 (defn- pause-checker []
   (let [coverage (pause-coverage-checker)
         availability (availability-checker
-                      process-availability-window-nanos
+                      nil
                       :pause-process
                       :resume-process
                       required-pause-modes

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -17,7 +17,7 @@
 (def required-process-modes
   #{:random})
 (def required-pause-modes
-  #{:leader-paused :leader-unpaused})
+  #{:random})
 
 ;; openraft-test-app uses OpenRaft's 300 ms maximum election timeout. Three
 ;; windows allow a split vote to settle without turning a retained-quorum
@@ -26,57 +26,29 @@
 (def ^:private process-availability-window-nanos
   (* 3 max-election-timeout-ms 1000000))
 
-(defn- pause-targets [eligible-nodes configs leader mode]
-  (let [voters (quorum/voter-set configs)]
-    (when-not (contains? voters leader)
-      (throw (ex-info "The current leader is not a voter"
-                      {:leader leader
-                       :configs configs})))
-    (let [eligible-node-set (set eligible-nodes)
-          fault-sets (quorum/fault-sets configs)
-          candidates (->> (cond
-                            (= :leader-paused mode)
-                            (filter #(contains? % leader) fault-sets)
-
-                            (= :leader-unpaused mode)
-                            (remove #(contains? % leader) fault-sets)
-
-                            :else
-                            (throw (ex-info "Unknown process nemesis mode"
-                                            {:mode mode})))
-                          (filter #(every? eligible-node-set %)))
-          target-set (first (random/shuffle candidates))]
-      (when target-set
-        (->> eligible-nodes
-             (filter target-set)
-             vec)))))
-
-(defn- process-disruption [kind test status mode eligible-nodes]
+(defn- process-disruption [test status mode eligible-nodes]
   (let [leader (:leader status)
         configs (cluster/voter-configs test status)
         voters (quorum/voter-set configs)
         reachable-node-set (set (keys (:metrics status)))
         reachable-voters (set/intersection voters reachable-node-set)
-        targets (case kind
-                  :process (some-> (random/nonempty-subset eligible-nodes) vec)
-                  :pause (pause-targets eligible-nodes configs leader mode))]
+        targets (some-> (random/nonempty-subset eligible-nodes) vec)]
     (when (seq targets)
       (let [target-set (set targets)
             survivors (->> (:nodes test)
                            (filter reachable-voters)
                            (remove target-set)
                            vec)]
-        (cond-> {:mode mode
-                 :leader leader
-                 :nodes targets
-                 :voter-configs configs
-                 :survivors survivors}
-          (= :process kind)
-          (assoc :reachable-voters (->> (:nodes test)
-                                        (filter reachable-voters)
-                                        vec)
-                 :target-count (count targets)
-                 :leader-included? (contains? target-set leader)))))))
+        {:mode mode
+         :leader leader
+         :nodes targets
+         :voter-configs configs
+         :reachable-voters (->> (:nodes test)
+                                (filter reachable-voters)
+                                vec)
+         :survivors survivors
+         :target-count (count targets)
+         :leader-included? (contains? target-set leader)}))))
 
 (def ^:private disruption-start-specs
   {:process {:delegate-f :kill
@@ -209,8 +181,7 @@
                                     (filter (set (keys (:metrics status))))
                                     vec)
                                (:nodes test))]
-          (if-let [disruption (process-disruption kind
-                                                  test
+          (if-let [disruption (process-disruption test
                                                   status
                                                   mode
                                                   eligible-nodes)]
@@ -350,25 +321,12 @@
 
 (defn- pause-installed? [value]
   (let [targets (:nodes value)
-        target-set (set targets)
-        results (:pause-results value)
-        mode (:mode value)
-        leader (:leader value)]
+        results (:pause-results value)]
     (and (= :installed (:status value))
-         (required-pause-modes mode)
+         (required-pause-modes (:mode value))
          (seq targets)
-         (map? results)
-         (= (set targets) (set (keys results)))
-         (case mode
-           :leader-paused
-           (and (contains? target-set leader)
-                (= :paused (get results leader)))
-
-           :leader-unpaused
-           (and (not (contains? target-set leader))
-                (some #{:paused} (vals results)))
-
-           false))))
+         (complete-control-results? (set targets) pause-results results)
+         (some #{:paused} (vals results)))))
 
 (defn- any-node-paused? [value]
   (let [targets (:nodes value)
@@ -405,12 +363,7 @@
    (gen/phases
     {:type :info
      :f :pause-process
-     :value :leader-unpaused}
-    {:type :info
-     :f :resume-process}
-    {:type :info
-     :f :pause-process
-     :value :leader-paused}
+     :value :random}
     {:type :info
      :f :resume-process})))
 
@@ -520,34 +473,34 @@
      :attempts []}
     (map-indexed vector history))))
 
-(defn- installed-random-kill? [op]
-  (and (= :kill-process (:f op))
-       (disruption-installed? required-process-modes
-                              (:value op))))
+(defn- installed-random-disruption? [operation-f required-modes op]
+  (and (= operation-f (:f op))
+       (disruption-installed? required-modes (:value op))))
 
-(defn- restart-invocation? [op]
-  (and (= :restart-process (:f op))
+(defn- recovery-invocation? [operation-f op]
+  (and (= operation-f (:f op))
        (nil? (:value op))))
 
-(defn- process-episodes [history]
+(defn- disruption-episodes
+  [disruption-f recovery-f required-modes final-marker history]
   (let [{:keys [active episodes]}
         (reduce
          (fn [{:keys [active] :as state} [index op]]
            (cond
-             (installed-random-kill? op)
+             (installed-random-disruption? disruption-f required-modes op)
              (assoc state
                     :active {:start-index index
                              :started-at (:time op)
                              :details (:value op)})
 
-             (and active (restart-invocation? op))
+             (and active (recovery-invocation? recovery-f op))
              (-> state
                  (update :episodes conj
                          (assoc active
                                 :end-index index
                                 :ended-at (:time op)
                                 :final-restart?
-                                (:process-final-restart? op)))
+                                (boolean (get op final-marker))))
                  (assoc :active nil))
 
              :else state))
@@ -580,10 +533,19 @@
        (or (nil? end-index)
            (< (:completion-index attempt) end-index))))
 
+(defn- effective-targets [details]
+  (let [results (or (:stop-results details)
+                    (:pause-results details))
+        installed-results #{:killed :paused}]
+    (->> results
+         (keep (fn [[node result]]
+                 (when (installed-results result) node)))
+         set)))
+
 (defn- episode-availability [window-nanos attempts episode]
   (let [{:keys [started-at ended-at final-restart? details]} episode
         configs (:voter-configs details)
-        targets (set (:nodes details))
+        targets (effective-targets details)
         reachable-voters (set (:reachable-voters details))
         configured-voters (quorum/voter-set configs)
         survivors (set/difference reachable-voters targets)
@@ -632,7 +594,8 @@
     (cond-> {:started-at started-at
              :ended-at ended-at
              :deadline deadline
-             :targets (vec (:nodes details))
+             :targets (vec (sort targets))
+             :planned-targets (vec (:nodes details))
              :voter-configs configs
              :reachable-voters (vec (sort reachable-voters))
              :survivors (vec (sort survivors))
@@ -648,36 +611,53 @@
              :unexpected-success-count (count unexpected-successes)}
       reason (assoc :reason reason))))
 
-(defn- availability-checker [window-nanos]
-  (reify checker/Checker
-    (check [_ _test history _opts]
-      (let [attempts (completed-client-attempts history)
-            episodes (mapv (partial episode-availability
-                                    window-nanos
-                                    attempts)
-                           (process-episodes history))
-            failures (filterv :reason episodes)
-            retained (filterv :quorum-retained? episodes)
-            evaluated-retained (filterv :evaluable? retained)
-            valid? (not (seq failures))]
-        {:valid? valid?
-         :window-nanos window-nanos
-         :episode-count (count episodes)
-         :quorum-episode-count (count retained)
-         :no-quorum-episode-count
-         (count (remove :configured-quorum-retained? episodes))
-         :indeterminate-quorum-episode-count
-         (count (filter #(and (:configured-quorum-retained? %)
-                              (not (:quorum-retained? %)))
-                        episodes))
-         :evaluated-quorum-episode-count (count evaluated-retained)
-         :truncated-episode-count (count (filter :truncated? episodes))
-         :episodes episodes
-         :failures failures}))))
+(defn- availability-checker
+  ([window-nanos]
+   (availability-checker window-nanos
+                         :kill-process
+                         :restart-process
+                         required-process-modes
+                         :process-final-restart?))
+  ([window-nanos disruption-f recovery-f required-modes final-marker]
+   (reify checker/Checker
+     (check [_ _test history _opts]
+       (let [attempts (completed-client-attempts history)
+             episodes (->> (disruption-episodes disruption-f
+                                                recovery-f
+                                                required-modes
+                                                final-marker
+                                                history)
+                           (filter #(number? (:started-at %)))
+                           (mapv (partial episode-availability
+                                          window-nanos
+                                          attempts)))
+             failures (filterv :reason episodes)
+             retained (filterv :quorum-retained? episodes)
+             evaluated-retained (filterv :evaluable? retained)
+             valid? (not (seq failures))]
+         {:valid? valid?
+          :window-nanos window-nanos
+          :episode-count (count episodes)
+          :quorum-episode-count (count retained)
+          :no-quorum-episode-count
+          (count (remove :configured-quorum-retained? episodes))
+          :indeterminate-quorum-episode-count
+          (count (filter #(and (:configured-quorum-retained? %)
+                               (not (:quorum-retained? %)))
+                         episodes))
+          :evaluated-quorum-episode-count (count evaluated-retained)
+          :truncated-episode-count (count (filter :truncated? episodes))
+          :episodes episodes
+          :failures failures})))))
 
 (defn- process-checker []
   (let [coverage (coverage-checker)
-        availability (availability-checker process-availability-window-nanos)]
+        availability (availability-checker
+                      process-availability-window-nanos
+                      :kill-process
+                      :restart-process
+                      required-process-modes
+                      :process-final-restart?)]
     (reify checker/Checker
       (check [_ test history opts]
         (let [coverage-result (checker/check coverage test history opts)
@@ -746,12 +726,34 @@
                          history
                          cluster-state)))))
 
+(defn- pause-checker []
+  (let [coverage (pause-coverage-checker)
+        availability (availability-checker
+                      process-availability-window-nanos
+                      :pause-process
+                      :resume-process
+                      required-pause-modes
+                      :pause-final-resume?)]
+    (reify checker/Checker
+      (check [_ test history opts]
+        (let [coverage-result (checker/check coverage test history opts)
+              availability-result (checker/check availability
+                                                 test
+                                                 history
+                                                 opts)]
+          (assoc coverage-result
+                 :valid? (checker/merge-valid
+                          [(:valid? coverage-result)
+                           (:valid? availability-result)])
+                 :availability availability-result))))))
+
 (defn pause-package [db]
   {:name :pause
    :interval downtime-seconds
    :nemesis (pause-nemesis db)
    :generator (pause-generator)
    :final-generator {:type :info
-                     :f :resume-process}
+                     :f :resume-process
+                     :pause-final-resume? true}
    :checker (openraft-checker/reject-checker-exceptions
-             (pause-coverage-checker))})
+             (pause-checker))})

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -2,8 +2,10 @@
   (:require [clojure.test :refer [deftest is testing]]
             [jepsen [checker :as checker]
              [db :as db]
+             [generator :as gen]
              [nemesis :as nemesis]
              [random :as random]]
+            [jepsen.generator.test :as gen-test]
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.harness :as harness]
             [jepsen.openraft.nemesis :as openraft-nemesis]
@@ -12,6 +14,10 @@
             [jepsen.openraft.worker :as worker]))
 
 (def voters ["n1" "n2" "n3" "n4" "n5"])
+
+(defn- healthy-status [nodes leader]
+  {:leader leader
+   :metrics (zipmap nodes (repeat {}))})
 
 (defn- installed [details]
   (assoc details :status :installed))
@@ -80,38 +86,86 @@
       (swap! events conj :teardown)
       (throw error))))
 
-(deftest selects-fault-set-for-leader-mode
+(deftest selects-fault-set-for-pause-leader-mode
   (let [configs [(set voters)]
         fault-sets (set (quorum/fault-sets configs))]
-    (doseq [mode [:leader-killed
-                  :leader-survives
-                  :leader-paused
+    (doseq [mode [:leader-paused
                   :leader-unpaused]]
       (testing (name mode)
-        (let [targets (#'process/process-targets
+        (let [targets (#'process/pause-targets
                        voters
                        configs
                        "n1"
                        mode)]
           (is (contains? fault-sets (set targets)))
-          (is (= (boolean (#{:leader-killed :leader-paused} mode))
+          (is (= (= :leader-paused mode)
                  (contains? (set targets) "n1"))))))))
+
+(deftest process-selects-any-nonempty-node-subset
+  (let [invocations (atom [])
+        delegate (recording-nemesis invocations)
+        subject (process/->ProcessNemesis delegate (atom nil))
+        test {:nodes ["n1" "n2" "n3" "n4" "n5"]}
+        configs [#{"n1" "n2" "n3"}]
+        selected ["n2" "n4" "n5"]]
+    (with-redefs [cluster/membership-status
+                  (constantly (healthy-status (:nodes test) "n1"))
+                  cluster/voter-configs
+                  (fn [_test _status] configs)
+                  random/nonempty-subset
+                  (fn [nodes]
+                    (is (= (:nodes test) nodes))
+                    selected)]
+      (let [completion (nemesis/invoke! subject
+                                        test
+                                        {:type :info
+                                         :f :kill-process
+                                         :value :random})
+            value (:value completion)]
+        (is (= :installed (:status value)))
+        (is (= selected (:nodes value)))
+        (is (= 3 (:target-count value)))
+        (is (false? (:leader-included? value)))
+        (is (= configs (:voter-configs value)))
+        (is (= ["n1" "n2" "n3"] (:reachable-voters value)))
+        (is (= ["n1" "n3"] (:survivors value)))
+        (is (= [[:kill selected]]
+               (mapv (juxt :f :value) @invocations)))))))
+
+(deftest process-generator-repeats-random-kill-episodes
+  (let [invocations (atom [])]
+    (gen-test/simulate
+     (gen/limit 4 (#'process/process-generator))
+     (fn [_context operation]
+       (swap! invocations conj operation)
+       (assoc operation :type :info)))
+    (is (= [[:kill-process :random]
+            [:restart-process nil]
+            [:kill-process :random]
+            [:restart-process nil]]
+           (mapv (juxt :f :value) @invocations)))))
+
+(deftest process-final-restart-uses-a-private-marker
+  (let [operation (:final-generator (process/process-package nil))]
+    (is (:process-final-restart? operation))
+    (is (not (contains? operation :final?)))))
 
 (deftest restarts-the-processes-that-were-killed
   (let [invocations (atom [])
         delegate (recording-nemesis invocations)
         subject (process/->ProcessNemesis delegate (atom nil))
         test {:nodes ["n1" "n2" "n3"]}
-        status {:leader "n1"}]
+        status (healthy-status (:nodes test) "n1")]
     (with-redefs [cluster/membership-status (fn [_test] status)
                   cluster/voter-configs
-                  (fn [_test _status] [(set (:nodes test))])]
+                  (fn [_test _status] [(set (:nodes test))])
+                  random/nonempty-subset (constantly ["n1"])]
       (let [killed (nemesis/invoke!
                     subject
                     test
                     {:type :info
                      :f :kill-process
-                     :value :leader-killed})
+                     :value :random})
             restarted (nemesis/invoke!
                        subject
                        test
@@ -131,7 +185,7 @@
 
 (deftest derives-process-outcomes-from-confirmed-node-results
   (let [test {:nodes ["n1" "n2" "n3"]}
-        status {:leader "n1"}
+        status (healthy-status (:nodes test) "n1")
         invoke-with-results
         (fn [results]
           (let [delegate (reify nemesis/Nemesis
@@ -142,12 +196,13 @@
                 subject (process/->ProcessNemesis delegate (atom nil))]
             (with-redefs [cluster/membership-status (constantly status)
                           cluster/voter-configs
-                          (fn [_test _status] [(set (:nodes test))])]
+                          (fn [_test _status] [(set (:nodes test))])
+                          random/nonempty-subset (constantly ["n1"])]
               (nemesis/invoke! subject
                                test
                                {:type :info
                                 :f :kill-process
-                                :value :leader-killed}))))]
+                                :value :random}))))]
     (testing "every pre-probe absence skips the kill"
       (let [value (:value (invoke-with-results {"n1" :target-absent}))]
         (is (= :skipped (:status value)))
@@ -168,21 +223,19 @@
                        (invoke! [_ _test op]
                          (assoc op :value results))
                        (teardown! [this _test] this))
-            subject (process/->ProcessNemesis delegate (atom nil))
-            prefer-targets (fn [candidates]
-                             (cons #{"n2" "n3"}
-                                   (remove #{#{"n2" "n3"}} candidates)))]
+            subject (process/->ProcessNemesis delegate (atom nil))]
         (with-redefs [cluster/membership-status
-                      (constantly {:leader "n1"})
+                      (constantly
+                       (healthy-status (:nodes five-node-test) "n1"))
                       cluster/voter-configs
                       (fn [_test _status] [(set voters)])
-                      random/shuffle prefer-targets]
+                      random/nonempty-subset (constantly ["n2" "n3"])]
           (let [value (:value
                        (nemesis/invoke! subject
                                         five-node-test
                                         {:type :info
                                          :f :kill-process
-                                         :value :leader-survives}))]
+                                         :value :random}))]
             (is (= :installed (:status value)))
             (is (= results (:stop-results value)))))))))
 
@@ -290,15 +343,17 @@
                    (teardown! [this _test] this))
         active (atom nil)
         subject (process/->ProcessNemesis delegate active)]
-    (with-redefs [cluster/membership-status (constantly {:leader "n1"})
+    (with-redefs [cluster/membership-status
+                  (constantly (healthy-status (:nodes test) "n1"))
                   cluster/voter-configs
-                  (fn [_test _status] [(set (:nodes test))])]
+                  (fn [_test _status] [(set (:nodes test))])
+                  random/nonempty-subset (constantly ["n1"])]
       (let [error (try
                     (nemesis/invoke! subject
                                      test
                                      {:type :info
                                       :f :kill-process
-                                      :value :leader-killed})
+                                      :value :random})
                     nil
                     (catch Exception e
                       e))]
@@ -376,7 +431,7 @@
           #(InterruptedException. "interrupted")
           process/process-nemesis
           nil
-          {:type :info :f :kill-process :value :leader-survives}]
+          {:type :info :f :kill-process :value :random}]
          [:start
           #(java.io.InterruptedIOException. "interrupted")
           process/process-nemesis
@@ -419,6 +474,8 @@
                                 :metrics (zipmap voters (repeat {}))})
                               cluster/voter-configs
                               (fn [_test _status] [(set voters)])
+                              random/nonempty-subset
+                              (constantly ["n2" "n3"])
                               random/shuffle prefer-planned]
                   (try
                     (nemesis/invoke! subject test op)
@@ -437,13 +494,12 @@
                                   (ex-info "kill failed" {}))
         subject (process/->ProcessNemesis delegate (atom nil))
         test {:nodes voters}
-        planned #{"n2" "n3"}
-        prefer-planned (fn [candidates]
-                         (cons planned (remove #{planned} candidates)))]
-    (with-redefs [cluster/membership-status (constantly {:leader "n1"})
+        planned ["n2" "n3"]]
+    (with-redefs [cluster/membership-status
+                  (constantly (healthy-status (:nodes test) "n1"))
                   cluster/voter-configs (fn [_test _status]
                                           [(set voters)])
-                  random/shuffle prefer-planned]
+                  random/nonempty-subset (constantly planned)]
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"kill failed"
@@ -451,7 +507,7 @@
                             test
                             {:type :info
                              :f :kill-process
-                             :value :leader-survives})))
+                             :value :random})))
       (let [restarted (nemesis/invoke! subject
                                        test
                                        {:type :info :f :restart-process})]
@@ -584,12 +640,13 @@
                                                :metrics @metrics})
                   cluster/voter-configs (fn [_test _status]
                                           [(set voters)])
+                  random/nonempty-subset (constantly ["n2"])
                   random/shuffle prefer-n2]
       (let [killed (nemesis/invoke! process-nemesis
                                     test
                                     {:type :info
                                      :f :kill-process
-                                     :value :leader-survives})
+                                     :value :random})
             killed-nodes (set (get-in killed [:value :nodes]))]
         (is (= #{"n2"} killed-nodes))
         (swap! metrics #(apply dissoc % killed-nodes))
@@ -749,7 +806,7 @@
         operations [[(process/->ProcessNemesis delegate (atom nil))
                      {:type :info
                       :f :kill-process
-                      :value :leader-killed}]
+                      :value :random}]
                     [(process/->PauseNemesis delegate (atom nil))
                      {:type :info
                       :f :pause-process
@@ -760,25 +817,11 @@
                (:value (nemesis/invoke! subject test op))))))
     (is (empty? @invocations))))
 
-(deftest skips-known-process-precondition-misses
+(deftest skips-known-process-state-conflicts
   (let [invocations (atom [])
         delegate (recording-nemesis invocations)
         test {:nodes ["n1"]}
         subject (process/->ProcessNemesis delegate (atom nil))]
-    (testing "there is no quorum-safe kill target"
-      (with-redefs [cluster/membership-status
-                    (constantly {:leader "n1"})
-                    cluster/voter-configs
-                    (fn [_test _status] [#{"n1"}])]
-        (let [value (:value
-                     (nemesis/invoke! subject
-                                      test
-                                      {:type :info
-                                       :f :kill-process
-                                       :value :leader-survives}))]
-          (is (= :skipped (:status value)))
-          (is (= :no-quorum-safe-process-target (:reason value))))))
-
     (testing "there are no killed processes to restart"
       (is (= (skipped :no-processes-killed {})
              (:value (nemesis/invoke! subject
@@ -787,7 +830,7 @@
                                        :f :restart-process})))))
 
     (testing "a tracked disruption is already active"
-      (let [active {:mode :leader-killed
+      (let [active {:mode :random
                     :nodes ["n1"]}
             active-subject (process/->ProcessNemesis delegate
                                                      (atom active))
@@ -796,35 +839,25 @@
                                     test
                                     {:type :info
                                      :f :kill-process
-                                     :value :leader-killed}))]
+                                     :value :random}))]
         (is (= :skipped (:status value)))
         (is (= :processes-already-killed (:reason value)))
         (is (= active (:killed value)))))
 
     (is (empty? @invocations))))
 
-(deftest requires-both-process-modes-and-an-intact-cluster
+(deftest requires-a-process-kill-and-an-intact-cluster
   (let [subject (#'process/coverage-checker)
         complete-history [{:f :kill-process
-                           :value (installed {:mode :leader-survives})}
+                           :value (installed {:mode :random})}
                           {:f :await-recovery
-                           :value (installed {:leader "n1"})}
-                          {:f :kill-process
-                           :value (installed {:mode :leader-killed})}
-                          {:f :await-recovery
-                           :value (installed {:leader "n2"})}]
+                           :value (installed {:leader "n1"})}]
         missing-mode-history [{:f :kill-process
-                               :value (installed {:mode :leader-survives})}
-                              {:f :kill-process
                                :value (skipped
                                        :no-supported-leader
                                        {})}]
         unrecovered-history [{:f :kill-process
-                              :value (installed {:mode :leader-survives})}
-                             {:f :await-recovery
-                              :value (installed {:leader "n1"})}
-                             {:f :kill-process
-                              :value (installed {:mode :leader-killed})}
+                              :value (installed {:mode :random})}
                              {:f :await-recovery
                               :value (indeterminate
                                       :recovery-timeout
@@ -834,28 +867,369 @@
       (is (= :intact (:cluster-state result))))
     (let [result (checker/check subject {} missing-mode-history {})]
       (is (false? (:valid? result)))
-      (is (= [:leader-killed] (:missing-modes result)))
-      (is (= :degraded (:cluster-state result))))
+      (is (= [:random] (:missing-modes result)))
+      (is (= :intact (:cluster-state result))))
     (let [result (checker/check subject {} unrecovered-history {})]
       (is (false? (:valid? result)))
       (is (empty? (:missing-modes result)))
       (is (= :degraded (:cluster-state result))))))
 
+(defn- process-kill-value
+  ([configs nodes]
+   (process-kill-value configs (quorum/voter-set configs) nodes))
+  ([configs reachable-voters nodes]
+   (installed {:mode :random
+               :nodes nodes
+               :voter-configs configs
+               :reachable-voters (vec reachable-voters)
+               :survivors (vec (remove (set nodes) reachable-voters))
+               :stop-results (zipmap nodes (repeat :killed))})))
+
+(defn- process-availability-history
+  ([configs nodes client-events restart-time]
+   (process-availability-history configs
+                                 nodes
+                                 client-events
+                                 restart-time
+                                 false))
+  ([configs nodes client-events restart-time final-restart?]
+   (into [{:time 0
+           :type :info
+           :process :nemesis
+           :f :kill-process
+           :value (process-kill-value configs nodes)}]
+         (concat client-events
+                 [(cond-> {:time restart-time
+                           :type :info
+                           :process :nemesis
+                           :f :restart-process
+                           :value nil}
+                    final-restart?
+                    (assoc :process-final-restart? true))]))))
+
+(deftest standalone-process-requires-progress-when-voters-retain-quorum
+  (let [subject (#'process/availability-checker 30)
+        configs [#{"n1" "n2" "n3"}]
+        check (fn [nodes client-events restart-time]
+                (checker/check
+                 subject
+                 {}
+                 (process-availability-history configs
+                                               nodes
+                                               client-events
+                                               restart-time)
+                 {}))
+        successful-attempt [{:time 5
+                             :type :invoke
+                             :process 0
+                             :phase :main
+                             :f :read}
+                            {:time 10
+                             :type :ok
+                             :process 0
+                             :phase :main
+                             :f :read}]
+        failed-attempt [{:time 5
+                         :type :invoke
+                         :process 0
+                         :phase :main
+                         :f :read}
+                        {:time 10
+                         :type :fail
+                         :process 0
+                         :phase :main
+                         :f :read}]]
+    (testing "a post-kill success proves retained-quorum availability"
+      (let [result (check ["n1"] successful-attempt 40)]
+        (is (:valid? result))
+        (is (= 1 (:quorum-episode-count result)))
+        (is (empty? (:failures result)))))
+
+    (testing "client attempts without a success reject the run"
+      (let [result (check ["n1"] failed-attempt 40)]
+        (is (false? (:valid? result)))
+        (is (= [:no-success-with-quorum]
+               (mapv :reason (:failures result))))))
+
+    (testing "missing client attempts are missing availability evidence"
+      (let [result (check ["n1"] [] 40)]
+        (is (false? (:valid? result)))
+        (is (= [:no-client-attempts]
+               (mapv :reason (:failures result))))))
+
+    (testing "an early success proves availability before the window ends"
+      (let [result (check ["n1"] successful-attempt 20)]
+        (is (:valid? result))
+        (is (true? (get-in result [:episodes 0 :evaluable?])))
+        (is (empty? (:failures result)))))
+
+    (testing "a short episode without success lacks enough evidence"
+      (let [result (check ["n1"] failed-attempt 20)]
+        (is (false? (:valid? result)))
+        (is (= [:insufficient-observation-window]
+               (mapv :reason (:failures result))))))
+
+    (testing "a CAS version mismatch proves the service responded"
+      (let [result (check ["n1"]
+                          [{:time 5
+                            :type :invoke
+                            :process 0
+                            :phase :main
+                            :f :cas}
+                           {:time 10
+                            :type :fail
+                            :process 0
+                            :phase :main
+                            :f :cas
+                            :error :version-mismatch}]
+                          40)]
+        (is (:valid? result))
+        (is (= 1 (get-in result [:episodes 0 :success-count])))))
+
+    (testing "an operation invoked before the kill is not availability proof"
+      (let [result (check ["n1"]
+                          [{:time -5
+                            :type :invoke
+                            :process 0
+                            :phase :main
+                            :f :read}
+                           {:time 5
+                            :type :ok
+                            :process 0
+                            :phase :main
+                            :f :read}]
+                          40)]
+        (is (false? (:valid? result)))
+        (is (= [:no-client-attempts]
+               (mapv :reason (:failures result))))))
+
+    (testing "a success after the deadline does not satisfy availability"
+      (let [result (check ["n1"]
+                          [{:time 5
+                            :type :invoke
+                            :process 0
+                            :phase :main
+                            :f :read}
+                           {:time 31
+                            :type :ok
+                            :process 0
+                            :phase :main
+                            :f :read}]
+                          40)]
+        (is (false? (:valid? result)))
+        (is (= [:no-success-with-quorum]
+               (mapv :reason (:failures result))))))
+
+    (testing "a dangling invocation is not successful progress"
+      (let [result (check ["n1"]
+                          [{:time 5
+                            :type :invoke
+                            :process 0
+                            :phase :main
+                            :f :read}]
+                          40)]
+        (is (false? (:valid? result)))
+        (is (= [:no-client-attempts]
+               (mapv :reason (:failures result))))))))
+
+(deftest excludes-completions-after-restart-from-process-availability
+  (let [subject (#'process/availability-checker 30)
+        configs [#{"n1" "n2" "n3"}]
+        history [{:time 0
+                  :type :info
+                  :process :nemesis
+                  :f :kill-process
+                  :value (process-kill-value configs ["n1"])}
+                 {:time 5
+                  :type :invoke
+                  :process 0
+                  :phase :main
+                  :f :read}
+                 {:time 30
+                  :type :info
+                  :process :nemesis
+                  :f :restart-process
+                  :value nil}
+                 {:time 30
+                  :type :ok
+                  :process 0
+                  :phase :main
+                  :f :read}]
+        result (checker/check subject {} history {})]
+    (is (false? (:valid? result)))
+    (is (= [:no-success-with-quorum]
+           (mapv :reason (:failures result))))))
+
+(deftest treats-a-short-final-process-episode-as-unevaluated
+  (let [subject (#'process/availability-checker 30)
+        configs [#{"n1" "n2" "n3"}]
+        history (process-availability-history configs
+                                              ["n1"]
+                                              []
+                                              20
+                                              true)
+        result (checker/check subject {} history {})]
+    (is (:valid? result))
+    (is (= 1 (:truncated-episode-count result)))
+    (is (zero? (:evaluated-quorum-episode-count result)))
+    (is (empty? (:failures result)))))
+
+(deftest standalone-process-does-not-require-progress-without-quorum
+  (let [subject (#'process/availability-checker 30)
+        configs [#{"n1" "n2" "n3"}]
+        history (process-availability-history configs
+                                              ["n1" "n2"]
+                                              []
+                                              40)
+        result (checker/check subject {} history {})]
+    (is (:valid? result))
+    (is (zero? (:quorum-episode-count result)))
+    (is (= 1 (:no-quorum-episode-count result)))
+    (is (empty? (:failures result)))))
+
+(deftest standalone-process-rejects-write-success-without-quorum
+  (let [subject (#'process/availability-checker 30)
+        configs [#{"n1" "n2" "n3"}]
+        history (process-availability-history
+                 configs
+                 ["n1" "n2"]
+                 [{:time 5
+                   :type :invoke
+                   :process 0
+                   :phase :main
+                   :f :write}
+                  {:time 10
+                   :type :ok
+                   :process 0
+                   :phase :main
+                   :f :write}]
+                 40)
+        result (checker/check subject {} history {})]
+    (is (false? (:valid? result)))
+    (is (= [:unexpected-success-without-quorum]
+           (mapv :reason (:failures result))))
+    (is (= 1 (get-in result [:episodes 0 :unexpected-success-count])))))
+
+(deftest standalone-process-uses-reachable-voters-for-quorum
+  (let [subject (#'process/availability-checker 30)
+        configs [#{"n1" "n2" "n3" "n4" "n5"}]
+        kill-value (process-kill-value configs
+                                       ["n1" "n2" "n3"]
+                                       ["n1"])
+        history [{:time 0
+                  :type :info
+                  :process :nemesis
+                  :f :kill-process
+                  :value kill-value}
+                 {:time 40
+                  :type :info
+                  :process :nemesis
+                  :f :restart-process
+                  :value nil}]
+        result (checker/check subject {} history {})]
+    (is (:valid? result))
+    (is (false? (get-in result [:episodes 0 :quorum-retained?])))
+    (is (= ["n2" "n3"] (get-in result [:episodes 0 :survivors])))))
+
+(deftest standalone-process-allows-success-when-quorum-is-only-possible
+  (let [subject (#'process/availability-checker 30)
+        configs [#{"n1" "n2" "n3"}]
+        kill-value (process-kill-value configs
+                                       ["n1" "n2"]
+                                       ["n1"])
+        history [{:time 0
+                  :type :info
+                  :process :nemesis
+                  :f :kill-process
+                  :value kill-value}
+                 {:time 5
+                  :type :invoke
+                  :process 0
+                  :phase :main
+                  :f :write}
+                 {:time 10
+                  :type :ok
+                  :process 0
+                  :phase :main
+                  :f :write}
+                 {:time 40
+                  :type :info
+                  :process :nemesis
+                  :f :restart-process
+                  :value nil}]
+        result (checker/check subject {} history {})]
+    (is (:valid? result))
+    (is (false? (get-in result [:episodes 0 :quorum-retained?])))
+    (is (true? (get-in result
+                       [:episodes 0 :configured-quorum-retained?])))
+    (is (= 1 (:indeterminate-quorum-episode-count result)))
+    (is (zero? (get-in result
+                       [:episodes 0 :unexpected-success-count])))
+    (is (empty? (:failures result)))))
+
+(deftest standalone-process-excludes-learners-from-quorum
+  (let [subject (#'process/availability-checker 30)
+        configs [#{"n1" "n2" "n3"}]
+        history (process-availability-history configs ["n4"] [] 40)
+        result (checker/check subject {} history {})]
+    (is (false? (:valid? result)))
+    (is (= 1 (:quorum-episode-count result)))
+    (is (= [:no-client-attempts]
+           (mapv :reason (:failures result))))))
+
+(deftest standalone-process-checks-every-joint-voter-config
+  (let [subject (#'process/availability-checker 30)
+        configs [#{"n1" "n2" "n3"}
+                 #{"n3" "n4" "n5"}]
+        no-quorum-history (process-availability-history configs
+                                                        ["n1" "n2"]
+                                                        []
+                                                        40)
+        retained-history (process-availability-history configs
+                                                       ["n1"]
+                                                       []
+                                                       40)]
+    (is (:valid? (checker/check subject {} no-quorum-history {})))
+    (is (= [:no-client-attempts]
+           (->> (checker/check subject {} retained-history {})
+                :failures
+                (mapv :reason))))))
+
+(deftest chaos-reuses-random-kills-without-standalone-availability-verdicts
+  (let [package (process/process-package nil)
+        raw-checker (:checker package)
+        chaos-checker (#'openraft-nemesis/fault-class-checker raw-checker)
+        configs [#{"n1" "n2" "n3"}]
+        history (into (process-availability-history configs
+                                                    ["n1"]
+                                                    []
+                                                    40)
+                      [{:time 41
+                        :type :info
+                        :process :nemesis
+                        :f :await-recovery
+                        :value (installed {:leader "n2"})}])
+        standalone-result (checker/check raw-checker {} history {})
+        chaos-result (checker/check chaos-checker {} history {})]
+    (is (false? (:valid? standalone-result)))
+    (is (= [:random] (:observed-modes standalone-result)))
+    (is (= :intact (:cluster-state standalone-result)))
+    (is (false? (get-in standalone-result [:availability :valid?])))
+    (is (:valid? chaos-result))
+    (is (:fault-class-executed? chaos-result))
+    (is (false? (get-in chaos-result [:availability :valid?])))))
+
 (deftest reports-an-indeterminate-process-state
   (let [subject (#'process/coverage-checker)
         covered-history [{:f :kill-process
-                          :value (installed {:mode :leader-survives})}
+                          :value (installed {:mode :random})}
                          {:f :await-recovery
-                          :value (installed {:leader "n1"})}
-                         {:f :kill-process
-                          :value (installed {:mode :leader-killed})}
-                         {:f :await-recovery
-                          :value (installed {:leader "n2"})}]
+                          :value (installed {:leader "n1"})}]
         indeterminate-history (conj covered-history
                                     {:f :kill-process
                                      :value (indeterminate
                                              :effect-unknown
-                                             {:mode :leader-killed})})
+                                             {:mode :random})})
         recovered-history (conj indeterminate-history
                                 {:f :await-recovery
                                  :value (installed {:leader "n2"})})]

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -86,20 +86,36 @@
       (swap! events conj :teardown)
       (throw error))))
 
-(deftest selects-fault-set-for-pause-leader-mode
-  (let [configs [(set voters)]
-        fault-sets (set (quorum/fault-sets configs))]
-    (doseq [mode [:leader-paused
-                  :leader-unpaused]]
-      (testing (name mode)
-        (let [targets (#'process/pause-targets
-                       voters
-                       configs
-                       "n1"
-                       mode)]
-          (is (contains? fault-sets (set targets)))
-          (is (= (= :leader-paused mode)
-                 (contains? (set targets) "n1"))))))))
+(deftest pause-selects-any-nonempty-node-subset
+  (let [invocations (atom [])
+        delegate (recording-nemesis invocations)
+        subject (process/->PauseNemesis delegate (atom nil))
+        test {:nodes ["n1" "n2" "n3" "n4" "n5"]}
+        configs [#{"n1" "n2" "n3"}]
+        selected ["n2" "n4" "n5"]]
+    (with-redefs [cluster/membership-status
+                  (constantly (healthy-status (:nodes test) "n1"))
+                  cluster/voter-configs
+                  (fn [_test _status] configs)
+                  random/nonempty-subset
+                  (fn [nodes]
+                    (is (= (:nodes test) nodes))
+                    selected)]
+      (let [completion (nemesis/invoke! subject
+                                        test
+                                        {:type :info
+                                         :f :pause-process
+                                         :value :random})
+            value (:value completion)]
+        (is (= :installed (:status value)))
+        (is (= selected (:nodes value)))
+        (is (= 3 (:target-count value)))
+        (is (false? (:leader-included? value)))
+        (is (= configs (:voter-configs value)))
+        (is (= ["n1" "n2" "n3"] (:reachable-voters value)))
+        (is (= ["n1" "n3"] (:survivors value)))
+        (is (= [[:pause selected]]
+               (mapv (juxt :f :value) @invocations)))))))
 
 (deftest process-selects-any-nonempty-node-subset
   (let [invocations (atom [])
@@ -148,6 +164,11 @@
 (deftest process-final-restart-uses-a-private-marker
   (let [operation (:final-generator (process/process-package nil))]
     (is (:process-final-restart? operation))
+    (is (not (contains? operation :final?)))))
+
+(deftest pause-final-resume-uses-a-private-marker
+  (let [operation (:final-generator (process/pause-package nil))]
+    (is (:pause-final-resume? operation))
     (is (not (contains? operation :final?)))))
 
 (deftest restarts-the-processes-that-were-killed
@@ -255,12 +276,13 @@
                 subject (process/->PauseNemesis delegate (atom nil))]
             (with-redefs [cluster/membership-status (constantly status)
                           cluster/voter-configs
-                          (fn [_test _status] [(set (:nodes test))])]
+                          (fn [_test _status] [(set (:nodes test))])
+                          random/nonempty-subset (constantly ["n1"])]
               (nemesis/invoke! subject
                                test
                                {:type :info
                                 :f :pause-process
-                                :value :leader-paused}))))]
+                                :value :random}))))]
     (testing "every pre-probe absence skips the pause"
       (let [value (:value (invoke-with-result :target-absent))]
         (is (= :skipped (:status value)))
@@ -281,7 +303,7 @@
 
 (deftest derives-resume-outcomes-from-confirmed-node-results
   (let [test {:nodes ["n1" "n2" "n3"]}
-        disruption {:mode :leader-paused
+        disruption {:mode :random
                     :leader "n1"
                     :nodes ["n1"]
                     :voter-configs [(set (:nodes test))]
@@ -387,13 +409,14 @@
         subject (process/->PauseNemesis delegate active)]
     (with-redefs [cluster/membership-status (constantly status)
                   cluster/voter-configs
-                  (fn [_test _status] [(set (:nodes test))])]
+                  (fn [_test _status] [(set (:nodes test))])
+                  random/nonempty-subset (constantly ["n1"])]
       (let [error (try
                     (nemesis/invoke! subject
                                      test
                                      {:type :info
                                       :f :pause-process
-                                      :value :leader-paused})
+                                      :value :random})
                     nil
                     (catch Exception e
                       e))]
@@ -418,7 +441,7 @@
   (let [test {:nodes voters
               :sessions (zipmap voters (repeat :unused-session))}
         planned #{"n2" "n3"}
-        disruption {:mode :leader-unpaused
+        disruption {:mode :random
                     :leader "n1"
                     :nodes ["n2" "n3"]
                     :voter-configs [(set voters)]
@@ -441,7 +464,7 @@
           #(java.nio.channels.ClosedByInterruptException.)
           process/pause-nemesis
           nil
-          {:type :info :f :pause-process :value :leader-unpaused}]
+          {:type :info :f :pause-process :value :random}]
          [:resume
           #(ex-info "interrupted" {:kind :interrupted})
           process/pause-nemesis
@@ -527,17 +550,18 @@
                 :metrics (zipmap (:nodes test) (repeat {}))}]
     (with-redefs [cluster/membership-status (fn [_test] status)
                   cluster/voter-configs (fn [_test _status]
-                                          [(set (:nodes test))])]
+                                          [(set (:nodes test))])
+                  random/nonempty-subset (constantly ["n1"])]
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo
            #"pause failed"
            (nemesis/invoke! subject test {:type :info
                                           :f :pause-process
-                                          :value :leader-paused})))
+                                          :value :random})))
       (let [skipped-value
             (:value (nemesis/invoke! subject test {:type :info
                                                    :f :pause-process
-                                                   :value :leader-unpaused}))]
+                                                   :value :random}))]
         (is (= :skipped (:status skipped-value)))
         (is (= :processes-already-paused (:reason skipped-value))))
       (is (= [[:pause ["n1"]]]
@@ -545,11 +569,14 @@
       (let [resumed (nemesis/invoke! subject
                                      test
                                      {:type :info :f :resume-process})]
-        (is (= {:mode :leader-paused
+        (is (= {:mode :random
                 :leader "n1"
                 :nodes ["n1"]
                 :voter-configs [#{"n1" "n2" "n3"}]
-                :survivors ["n2" "n3"]}
+                :reachable-voters ["n1" "n2" "n3"]
+                :survivors ["n2" "n3"]
+                :target-count 1
+                :leader-included? true}
                (get-in resumed [:value :paused])))))))
 
 (deftest records-pause-recovery-history
@@ -575,12 +602,13 @@
     (with-redefs [cluster/membership-status (fn [_test] status)
                   cluster/await-ready! (fn [_test] status)
                   cluster/voter-configs
-                  (fn [_test _status] [(set (:nodes test))])]
-      (let [leader-pause (invoke! :pause-process :leader-paused)
-            duplicate-pause (invoke! :pause-process :leader-unpaused)
+                  (fn [_test _status] [(set (:nodes test))])
+                  random/nonempty-subset (constantly ["n1"])]
+      (let [leader-pause (invoke! :pause-process :random)
+            duplicate-pause (invoke! :pause-process :random)
             leader-resume (invoke! :resume-process)
             leader-recovery (recover!)
-            follower-pause (invoke! :pause-process :leader-unpaused)
+            follower-pause (invoke! :pause-process :random)
             follower-resume (invoke! :resume-process)
             follower-recovery (recover!)
             cleanup-resume (invoke! :resume-process)
@@ -640,7 +668,11 @@
                                                :metrics @metrics})
                   cluster/voter-configs (fn [_test _status]
                                           [(set voters)])
-                  random/nonempty-subset (constantly ["n2"])
+                  random/nonempty-subset
+                  (fn [nodes]
+                    (if (some #{"n2"} nodes)
+                      ["n2"]
+                      [(first nodes)]))
                   random/shuffle prefer-n2]
       (let [killed (nemesis/invoke! process-nemesis
                                     test
@@ -654,7 +686,7 @@
                                       test
                                       {:type :info
                                        :f :pause-process
-                                       :value :leader-unpaused})
+                                       :value :random})
               paused-nodes (get-in paused [:value :nodes])
               delegated-pause (first (filter #(= :pause (:f %))
                                              @invocations))]
@@ -662,7 +694,7 @@
           (is (every? (set (keys @metrics)) paused-nodes))
           (is (= paused-nodes (:value delegated-pause))))))))
 
-(deftest skips-a-pause-without-a-reachable-target
+(deftest pause-may-target-the-only-reachable-voter
   (let [invocations (atom [])
         subject (process/->PauseNemesis
                  (recording-nemesis invocations)
@@ -677,16 +709,16 @@
                                         test
                                         {:type :info
                                          :f :pause-process
-                                         :value :leader-unpaused})
+                                         :value :random})
             result (checker/check (#'process/pause-coverage-checker)
                                   test
                                   [completion]
                                   {})]
-        (is (= :skipped (get-in completion [:value :status])))
-        (is (= :no-reachable-pause-target
-               (get-in completion [:value :reason])))
-        (is (empty? @invocations))
-        (is (empty? (:observed-modes result)))))))
+        (is (= :installed (get-in completion [:value :status])))
+        (is (= ["n1"] (get-in completion [:value :nodes])))
+        (is (= [[:pause ["n1"]]]
+               (mapv (juxt :f :value) @invocations)))
+        (is (= [:random] (:observed-modes result)))))))
 
 (deftest teardown-cleanup-failure-records-a-harness-failure
   (let [failure-state (harness/failure-state)
@@ -810,7 +842,7 @@
                     [(process/->PauseNemesis delegate (atom nil))
                      {:type :info
                       :f :pause-process
-                      :value :leader-paused}]]]
+                      :value :random}]]]
     (with-redefs [cluster/membership-status (constantly nil)]
       (doseq [[subject op] operations]
         (is (= (skipped :no-supported-leader {})
@@ -1240,6 +1272,71 @@
       (is (= :unknown (:valid? result)))
       (is (= :unknown (:cluster-state result))))))
 
+(defn- pause-availability-history
+  [configs nodes client-events resume-time]
+  (into [{:time 0
+          :type :info
+          :process :nemesis
+          :f :pause-process
+          :value (installed
+                  {:mode :random
+                   :nodes nodes
+                   :voter-configs configs
+                   :reachable-voters (vec (quorum/voter-set configs))
+                   :pause-results (zipmap nodes (repeat :paused))})}]
+        (concat client-events
+                [{:time resume-time
+                  :type :info
+                  :process :nemesis
+                  :f :resume-process
+                  :value nil}])))
+
+(deftest standalone-pause-applies-quorum-aware-availability
+  (let [subject (#'process/availability-checker
+                 30
+                 :pause-process
+                 :resume-process
+                 process/required-pause-modes
+                 :pause-final-resume?)
+        configs [#{"n1" "n2" "n3"}]
+        success [{:time 5
+                  :type :invoke
+                  :process 0
+                  :phase :main
+                  :f :read}
+                 {:time 10
+                  :type :ok
+                  :process 0
+                  :phase :main
+                  :f :read}]
+        retained (checker/check
+                  subject
+                  {}
+                  (pause-availability-history configs ["n1"] success 40)
+                  {})
+        retained-without-progress (checker/check
+                                   subject
+                                   {}
+                                   (pause-availability-history configs
+                                                               ["n1"]
+                                                               []
+                                                               40)
+                                   {})
+        no-quorum (checker/check
+                   subject
+                   {}
+                   (pause-availability-history configs
+                                               ["n1" "n2"]
+                                               []
+                                               40)
+                   {})]
+    (is (:valid? retained))
+    (is (false? (:valid? retained-without-progress)))
+    (is (= :no-client-attempts
+           (get-in retained-without-progress [:failures 0 :reason])))
+    (is (:valid? no-quorum))
+    (is (= 1 (:no-quorum-episode-count no-quorum)))))
+
 (deftest checks-pause-coverage-and-recovery-state
   (let [subject (#'process/pause-coverage-checker)
         test {:nodes voters}
@@ -1252,31 +1349,25 @@
                         :voter-configs [(set voters)]
                         :survivors (vec (remove (set nodes) voters))
                         :pause-results (zipmap nodes (repeat :paused))}))
-        leader-unpaused (pause-value :leader-unpaused ["n2" "n3"])
-        leader-paused (pause-value :leader-paused ["n1" "n2"])
+        follower-targets (pause-value :random ["n2" "n3"])
+        leader-targets (pause-value :random ["n1" "n2"])
         resumed-all (installed
                      {:paused nil
                       :resumed voters
                       :resume-results (zipmap voters (repeat :resumed))})
         complete-history [{:f :pause-process
-                           :value leader-unpaused}
+                           :value follower-targets}
                           {:f :resume-process
                            :value resumed-all}
                           {:f :await-recovery
                            :value (installed {:leader "n1"})}
                           {:f :pause-process
-                           :value leader-paused}
+                           :value leader-targets}
                           {:f :resume-process
                            :value resumed-all}
                           {:f :await-recovery
                            :value (installed {:leader "n2"})}]
         missing-mode-history [{:f :pause-process
-                               :value leader-unpaused}
-                              {:f :resume-process
-                               :value resumed-all}
-                              {:f :await-recovery
-                               :value (installed {:leader "n1"})}
-                              {:f :pause-process
                                :value (skipped
                                        :no-supported-leader
                                        {})}]
@@ -1290,10 +1381,10 @@
                                     {:f :pause-process
                                      :value (indeterminate
                                              :effect-unknown
-                                             {:mode :leader-paused})})
+                                             {:mode :random})})
         paused-history (conj complete-history
                              {:f :pause-process
-                              :value leader-paused})
+                              :value leader-targets})
         resuming-history (conj paused-history
                                {:type :info
                                 :f :resume-process})
@@ -1305,16 +1396,16 @@
         partial-resume-history (assoc-in complete-history
                                          [4 :value :resumed]
                                          ["n1"])
-        mixed-leader-pause (assoc-in leader-paused
-                                     [:pause-results "n1"]
-                                     :target-absent)
+        mixed-pause (assoc-in leader-targets
+                              [:pause-results "n1"]
+                              :target-absent)
         mixed-pause-history (conj (subvec complete-history 0 3)
                                   {:f :pause-process
-                                   :value mixed-leader-pause})
+                                   :value mixed-pause})
         covered-then-mixed-pause-history
         (conj complete-history
               {:f :pause-process
-               :value mixed-leader-pause})
+               :value mixed-pause})
         mixed-resume-history (assoc-in complete-history
                                        [4 :value :resume-results "n5"]
                                        :target-absent)
@@ -1330,15 +1421,15 @@
         (assoc-in complete-history
                   [4 :value :resume-results]
                   (zipmap voters (repeat :target-absent)))]
-    (testing "both pause modes complete and recover"
+    (testing "random pause episodes complete and recover"
       (is (= {:valid? true
               :cluster-state :intact}
              (select-keys (check complete-history)
                           [:valid? :cluster-state]))))
 
-    (testing "a pause mode is missing"
+    (testing "the random pause mode is missing"
       (is (= {:valid? false
-              :missing-modes [:leader-paused]
+              :missing-modes [:random]
               :cluster-state :intact}
              (select-keys (check missing-mode-history)
                           [:valid? :missing-modes :cluster-state]))))
@@ -1368,9 +1459,9 @@
              (select-keys (check partial-resume-history)
                           [:valid? :cluster-state]))))
 
-    (testing "mixed pause evidence does not credit the planned leader mode"
+    (testing "mixed pause evidence still confirms a random disruption"
       (is (= {:valid? false
-              :missing-modes [:leader-paused]
+              :missing-modes []
               :cluster-state :paused}
              (select-keys (check mixed-pause-history)
                           [:valid? :missing-modes :cluster-state]))))

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -1337,6 +1337,34 @@
     (is (:valid? no-quorum))
     (is (= 1 (:no-quorum-episode-count no-quorum)))))
 
+(deftest standalone-pause-accepts-progress-throughout-the-pause-episode
+  (let [second 1000000000
+        subject (#'process/availability-checker
+                 nil
+                 :pause-process
+                 :resume-process
+                 process/required-pause-modes
+                 :pause-final-resume?)
+        configs [#{"n1" "n2" "n3"}]
+        history (pause-availability-history
+                 configs
+                 ["n1"]
+                 [{:time (* 50 1000000)
+                   :type :invoke
+                   :process 0
+                   :phase :main
+                   :f :read}
+                  {:time (+ (* 5 second) (* 20 1000000))
+                   :type :ok
+                   :process 0
+                   :phase :main
+                   :f :read}]
+                 (* 10 second))
+        result (checker/check subject {} history {})]
+    (is (:valid? result))
+    (is (= 1 (get-in result [:episodes 0 :success-count])))
+    (is (empty? (:failures result)))))
+
 (deftest checks-pause-coverage-and-recovery-state
   (let [subject (#'process/pause-coverage-checker)
         test {:nodes voters}

--- a/jepsen/test/jepsen/openraft/nemesis_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis_test.clj
@@ -113,7 +113,7 @@
                   :value {:status :installed}}
                  {:f :pause-process
                   :value {:status :installed
-                          :mode :leader-unpaused
+                          :mode :random
                           :leader "n1"
                           :nodes ["n2"]
                           :voter-configs [all-voters]

--- a/jepsen/test/jepsen/openraft/nemesis_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis_test.clj
@@ -24,7 +24,7 @@
                        (map (fn [reason]
                               {:status :skipped
                                :reason reason})
-                            [:no-quorum-safe-process-target
+                            [:no-process-target
                              :no-reachable-pause-target
                              :no-safe-packet-target
                              :no-safe-partition-target


### PR DESCRIPTION
## Summary

- wait for recovered state machines before serving client requests
- allow standalone Process Kill to target any non-empty node subset
- apply the same target selection and availability checks to Process Pause
- preserve safety requirements when a target set removes the voter quorum

## Verification

- `lein test jepsen.openraft.nemesis.process-test jepsen.openraft.nemesis-test`
- 44 tests, 295 assertions, 0 failures, 0 errors
- standalone Kill and Pause Jepsen runs completed with `valid? true` before rebase

CLOSES #2043

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2052)
<!-- Reviewable:end -->
