### PR TITLE
test: jepsen: address clock follow-ups

### DIFF
--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -272,14 +272,18 @@ on every node.
 
 #### Clock Nemesis
 
-The Clock Nemesis changes only the wall clock observed by OpenRaft application
+The Clock Nemesis changes the wall clock observed by OpenRaft application
 processes. It uses node-local `libfaketime` control files and never changes the
-container or host clock. A focused run mixes multi-scale forward and backward
-jumps, rates sampled between 0.5x and 2x, rapid strobe jumps, and resets. Each
-operation replaces the complete clock state, and final cleanup restores every
-node to `+0 x1`. Rate changes may also jump the wall clock because libfaketime
+container or host clock. A focused run cycles through multi-scale forward or
+backward jumps, fast and slow rates sampled between 0.5x and 2x, rapid strobe
+jumps, and resets in a fixed order. Targets and fault parameters remain random.
+Each operation replaces the complete clock state, and final cleanup restores
+every node to `+0 x1`. Rate changes may also jump the wall clock because libfaketime
 rebases the reported time when the multiplier changes; those jumps are part of
-the injected wall-clock fault.
+the injected wall-clock fault. Monotonic-clock readings remain unscaled, but
+libfaketime rate settings still scale syscall waits such as `epoll_wait`. Slow
+rates may therefore delay Tokio runtime timers, so a rate-fault failure is not
+evidence of a wall-clock dependency alone.
 
 Targets are arbitrary non-empty subsets and can include a minority, majority,
 or every node. History records the targets, generated parameters, initial

--- a/jepsen/docker/strobe-faketime
+++ b/jepsen/docker/strobe-faketime
@@ -7,6 +7,7 @@ offset_setting=$2
 period_seconds=$3
 transitions=$4
 normal_setting='+0 x1'
+completed=0
 
 write_setting() {
     printf '%s\n' "$1" > "${control_file}.$$"
@@ -21,10 +22,11 @@ for ((i = 0; i < transitions; i++)); do
     else
         write_setting "$normal_setting"
     fi
+    completed=$((completed + 1))
 
     if ((i + 1 < transitions)); then
         sleep "$period_seconds"
     fi
 done
 
-printf '%s\n' "$transitions"
+printf '%s\n' "$completed"

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -19,11 +19,8 @@
              [partition :as partition]
              [process :as process]]))
 
-(def ^:private chaos-nemesis-types
-  [:partition :process :pause :membership :packet :clock])
-
 (def ^:private concrete-nemesis-types
-  chaos-nemesis-types)
+  [:partition :process :pause :membership :packet :clock])
 
 (def nemesis-types
   (conj (set concrete-nemesis-types) :chaos))
@@ -43,7 +40,7 @@
                        :unknown (vec unknown)})))
     (let [expanded (cond-> (disj requested :chaos)
                      (contains? requested :chaos)
-                     (into chaos-nemesis-types))]
+                     (into concrete-nemesis-types))]
       (filterv expanded concrete-nemesis-types))))
 
 (defn- valid-nemeses? [selection]


### PR DESCRIPTION
## Summary

- report the number of completed strobe control-file updates
- document the fixed Clock fault cycle and syscall-wait limitation
- use one canonical list of concrete Nemesis types

## Rationale

These changes address the actionable follow-ups from #2045 without adding
target-category aggregation or a long-running rate probe to every Jepsen run.
The reasoning and the remaining rate-evidence question are documented in the
issue discussion.

## Verification

- `make -C jepsen unit-test`
- `bash -n jepsen/docker/strobe-faketime`
- `git diff --check`

Refs #2045

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2053)
<!-- Reviewable:end -->
