### PR TITLE
test: membership: fix flaky t24 follower_answers_forward_to_leader

### DIFF
--- a/tests/tests/membership/t24_append_membership.rs
+++ b/tests/tests/membership/t24_append_membership.rs
@@ -226,6 +226,17 @@ async fn follower_answers_forward_to_leader() -> Result<()> {
     let log_index = router.new_cluster(btreeset! {0,1,2}, btreeset! {3}).await?;
     let follower = router.get_raft_handle(&1)?;
 
+    // `new_cluster()` waits for the learner to receive the last entry, not for the voters, so
+    // follower 1 may still be one entry behind here. Pin its log before the append, so that the
+    // last phase can tell an unchanged log from one the append grew.
+    router
+        .wait(&1, timeout())
+        .metrics(
+            |m| m.last_log_index == Some(log_index),
+            "follower 1 receives every entry the cluster wrote",
+        )
+        .await?;
+
     tracing::info!(log_index, "--- a follower forwards the append to the leader");
     {
         let proposed = Membership::new_with_defaults(vec![btreeset! {0,1,2,3}], []);


### PR DESCRIPTION

## Changelog

##### test: membership: fix flaky t24 follower_answers_forward_to_leader
# Summary

`follower_answers_forward_to_leader` in
`tests/tests/membership/t24_append_membership.rs` now waits for follower
1 to hold the cluster's last log entry before it calls
`append_membership()`.

# Details

`RaftRouter::new_cluster(voters, learners)` adds each learner as its last
step and then waits only for the learner ids to apply that entry. Voter 1
is never waited on, so it can still be one entry behind when
`new_cluster()` returns. The closing assertion read follower 1's
`last_log_index` right after that call, and the CI job
`test-crate-tests (nightly, 30)`, which sets
`OPENRAFT_NETWORK_SEND_DELAY=30`, saw `Some(5)` where the test expected
`Some(6)`.

The wait sits before the `append_membership()` call, so the closing
assertion still fails if the follower appends an entry of its own.

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2059)
<!-- Reviewable:end -->
