### PR TITLE
test: jepsen: refine process evidence

### DIFF
--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -195,11 +195,12 @@ history records the selected nodes, initial leader, and effective voter
 configuration, together with the voters reachable before the kill, so the
 checker can determine whether a usable quorum remained.
 
-When a quorum remains, a focused Process run requires a definitive client
-response within three maximum election timeouts. Losing quorum permits a
-temporary lack of progress, but never relaxes safety. The target set is fixed
-for one fault episode. Each episode restarts the selected processes, and final
-recovery waits for every node to rejoin a healthy cluster.
+When a quorum remains, a focused Process run requires an `:ok` client operation
+or a CAS `:version-mismatch` within three maximum election timeouts; either
+result proves the service responded. Losing quorum permits a temporary lack of
+progress, but never relaxes safety. The target set is fixed for one fault
+episode. Each episode restarts the selected processes, and final recovery waits
+for every node to rejoin a healthy cluster.
 
 #### Process Pause Nemesis
 
@@ -211,10 +212,11 @@ apply the matching availability expectation.
 Paused processes retain their memory and open TCP connections, so peers observe
 unresponsive processes rather than closed connections. Resume operations target
 every test node as an idempotent cleanup and record the complete resumed node
-set in history. When a quorum remains, the focused checker requires a client
-response that starts after the pause is installed and completes before resume
-begins. This uses the complete fault episode because a request to a paused
-leader can remain blocked until the client timeout.
+set in history. When a quorum remains, the focused checker requires an `:ok`
+client operation or a CAS `:version-mismatch` that starts after the pause is
+installed and completes before resume begins. This uses the complete fault
+episode because a request to a paused leader can remain blocked until the
+client timeout.
 
 #### Membership Nemesis
 

--- a/jepsen/openraft-test-app/src/lib.rs
+++ b/jepsen/openraft-test-app/src/lib.rs
@@ -4,7 +4,6 @@
 use std::num::NonZeroU64;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 
 use clap::Parser;
 use openraft::Config;
@@ -33,10 +32,6 @@ openraft::declare_raft_types!(
 pub type LogStore = log_rocks::RocksLogStore<TypeConfig>;
 pub type StateMachineStore = store::StateMachineStore;
 pub type Raft = openraft::Raft<TypeConfig, StateMachineStore>;
-
-// Jepsen bounds final cluster recovery externally. A local deadline would
-// terminate both servers while a restart is still able to catch up.
-const RESTART_RECOVERY_TIMEOUT: Option<Duration> = None;
 
 #[derive(Parser, Clone, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -106,10 +101,10 @@ pub async fn start_raft_node(options: Opt) -> std::io::Result<()> {
     let raft_server = network_v2_http::Server::new(app.raft.clone()).run(raft_addr);
     let app_server = async move {
         if is_restart {
-            app.raft
-                .wait_for_recovery(RESTART_RECOVERY_TIMEOUT)
-                .await
-                .map_err(|e| std::io::Error::other(e.to_string()))?;
+            // Jepsen bounds final cluster recovery externally. A local
+            // deadline would terminate both servers while a restart is still
+            // able to catch up.
+            app.raft.wait_for_recovery(None).await.map_err(|e| std::io::Error::other(e.to_string()))?;
         }
 
         app_http::Server::new(app)
@@ -131,12 +126,6 @@ mod tests {
     use clap::Parser;
 
     use super::Opt;
-    use super::RESTART_RECOVERY_TIMEOUT;
-
-    #[test]
-    fn restart_recovery_has_no_local_deadline() {
-        assert!(RESTART_RECOVERY_TIMEOUT.is_none());
-    }
 
     #[test]
     fn snapshot_threshold_must_be_positive() {

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -26,6 +26,13 @@
 (def ^:private process-availability-window-nanos
   (* 3 max-election-timeout-ms 1000000))
 
+(defn- target-category [node-count target-count]
+  (cond
+    (= 1 target-count) :one
+    (= node-count target-count) :all
+    (<= target-count (quot (dec node-count) 2)) :minority
+    :else :majority))
+
 (defn- process-disruption [test status mode eligible-nodes]
   (let [leader (:leader status)
         configs (cluster/voter-configs test status)
@@ -35,10 +42,7 @@
         targets (some-> (random/nonempty-subset eligible-nodes) vec)]
     (when (seq targets)
       (let [target-set (set targets)
-            survivors (->> (:nodes test)
-                           (filter reachable-voters)
-                           (remove target-set)
-                           vec)]
+            target-count (count targets)]
         {:mode mode
          :leader leader
          :nodes targets
@@ -46,8 +50,9 @@
          :reachable-voters (->> (:nodes test)
                                 (filter reachable-voters)
                                 vec)
-         :survivors survivors
-         :target-count (count targets)
+         :target-count target-count
+         :target-category (target-category (count (:nodes test))
+                                           target-count)
          :leader-included? (contains? target-set leader)}))))
 
 (def ^:private disruption-start-specs
@@ -374,11 +379,16 @@
 
 (defn- coverage-result
   [required-modes operation-f installed? invalid-states history cluster-state]
-  (let [observed-modes (->> history
-                            (filter #(= operation-f (:f %)))
-                            (filter #(installed? (:value %)))
-                            (keep #(get-in % [:value :mode]))
+  (let [installed-values (->> history
+                              (filter #(= operation-f (:f %)))
+                              (map :value)
+                              (filter installed?))
+        observed-modes (->> installed-values
+                            (keep :mode)
                             set)
+        observed-target-categories (->> installed-values
+                                        (keep :target-category)
+                                        set)
         missing-modes (remove observed-modes required-modes)
         valid? (cond
                  (seq missing-modes) false
@@ -387,6 +397,7 @@
                  :else :unknown)]
     {:valid? valid?
      :observed-modes (vec (sort observed-modes))
+     :observed-target-categories (vec (sort observed-target-categories))
      :missing-modes (vec (sort missing-modes))
      :cluster-state cluster-state}))
 
@@ -561,12 +572,12 @@
                                            episode
                                            Long/MAX_VALUE)
                                   attempts)
-        attempts (filterv #(<= (:invoke-time %) deadline)
-                          episode-attempts)
+        attempts-in-window (filterv #(<= (:invoke-time %) deadline)
+                                    episode-attempts)
         successes (filterv (partial successful-attempt?
                                     episode
                                     deadline)
-                           attempts)
+                           attempts-in-window)
         unexpected-successes (when-not configured-quorum-retained?
                                (filterv (partial unexpected-write-success?
                                                  episode)
@@ -592,7 +603,7 @@
                  (not full-window?)
                  :insufficient-observation-window
 
-                 (empty? attempts)
+                 (empty? attempts-in-window)
                  :no-client-attempts
 
                  :else
@@ -612,7 +623,7 @@
                                       (seq successes)
                                       full-window?))
              :truncated? truncated?
-             :attempt-count (count attempts)
+             :attempt-count (count attempts-in-window)
              :success-count (count successes)
              :unexpected-success-count (count unexpected-successes)}
       reason (assoc :reason reason))))

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -110,10 +110,11 @@
         (is (= :installed (:status value)))
         (is (= selected (:nodes value)))
         (is (= 3 (:target-count value)))
+        (is (= :majority (:target-category value)))
         (is (false? (:leader-included? value)))
         (is (= configs (:voter-configs value)))
         (is (= ["n1" "n2" "n3"] (:reachable-voters value)))
-        (is (= ["n1" "n3"] (:survivors value)))
+        (is (not (contains? value :survivors)))
         (is (= [[:pause selected]]
                (mapv (juxt :f :value) @invocations)))))))
 
@@ -141,12 +142,18 @@
         (is (= :installed (:status value)))
         (is (= selected (:nodes value)))
         (is (= 3 (:target-count value)))
+        (is (= :majority (:target-category value)))
         (is (false? (:leader-included? value)))
         (is (= configs (:voter-configs value)))
         (is (= ["n1" "n2" "n3"] (:reachable-voters value)))
-        (is (= ["n1" "n3"] (:survivors value)))
+        (is (not (contains? value :survivors)))
         (is (= [[:kill selected]]
                (mapv (juxt :f :value) @invocations)))))))
+
+(deftest categorizes-process-target-scale
+  (is (= [:one :minority :majority :majority :all]
+         (mapv (partial #'process/target-category 5)
+               (range 1 6)))))
 
 (deftest process-generator-repeats-random-kill-episodes
   (let [invocations (atom [])]
@@ -307,7 +314,6 @@
                     :leader "n1"
                     :nodes ["n1"]
                     :voter-configs [(set (:nodes test))]
-                    :survivors ["n2" "n3"]
                     :pause-results {"n1" :paused}}
         invoke-with-results
         (fn [results]
@@ -445,7 +451,6 @@
                     :leader "n1"
                     :nodes ["n2" "n3"]
                     :voter-configs [(set voters)]
-                    :survivors ["n1" "n4" "n5"]
                     :pause-results {"n2" :paused "n3" :paused}}
         prefer-planned (fn [candidates]
                          (cons planned (remove #{planned} candidates)))
@@ -574,8 +579,8 @@
                 :nodes ["n1"]
                 :voter-configs [#{"n1" "n2" "n3"}]
                 :reachable-voters ["n1" "n2" "n3"]
-                :survivors ["n2" "n3"]
                 :target-count 1
+                :target-category :one
                 :leader-included? true}
                (get-in resumed [:value :paused])))))))
 
@@ -881,7 +886,8 @@
 (deftest requires-a-process-kill-and-an-intact-cluster
   (let [subject (#'process/coverage-checker)
         complete-history [{:f :kill-process
-                           :value (installed {:mode :random})}
+                           :value (installed {:mode :random
+                                              :target-category :one})}
                           {:f :await-recovery
                            :value (installed {:leader "n1"})}]
         missing-mode-history [{:f :kill-process
@@ -896,6 +902,7 @@
                                       {})}]]
     (let [result (checker/check subject {} complete-history {})]
       (is (:valid? result))
+      (is (= [:one] (:observed-target-categories result)))
       (is (= :intact (:cluster-state result))))
     (let [result (checker/check subject {} missing-mode-history {})]
       (is (false? (:valid? result)))
@@ -914,7 +921,6 @@
                :nodes nodes
                :voter-configs configs
                :reachable-voters (vec reachable-voters)
-               :survivors (vec (remove (set nodes) reachable-voters))
                :stop-results (zipmap nodes (repeat :killed))})))
 
 (defn- process-availability-history
@@ -1375,7 +1381,9 @@
                         :leader "n1"
                         :nodes nodes
                         :voter-configs [(set voters)]
-                        :survivors (vec (remove (set nodes) voters))
+                        :target-category (#'process/target-category
+                                          (count voters)
+                                          (count nodes))
                         :pause-results (zipmap nodes (repeat :paused))}))
         follower-targets (pause-value :random ["n2" "n3"])
         leader-targets (pause-value :random ["n1" "n2"])
@@ -1451,9 +1459,12 @@
                   (zipmap voters (repeat :target-absent)))]
     (testing "random pause episodes complete and recover"
       (is (= {:valid? true
+              :observed-target-categories [:minority]
               :cluster-state :intact}
              (select-keys (check complete-history)
-                          [:valid? :cluster-state]))))
+                          [:valid?
+                           :observed-target-categories
+                           :cluster-state]))))
 
     (testing "the random pause mode is missing"
       (is (= {:valid? false

--- a/jepsen/test/jepsen/openraft/nemesis_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis_test.clj
@@ -117,7 +117,7 @@
                           :leader "n1"
                           :nodes ["n2"]
                           :voter-configs [all-voters]
-                          :survivors (vec (disj all-voters "n2"))
+                          :target-category :one
                           :pause-results {"n2" :paused}}}
                  {:f :resume-process
                   :value {:status :installed


### PR DESCRIPTION
## Summary

- report observed process target categories without failing randomized runs
- align process availability evidence names and documentation
- keep the no-local-deadline recovery policy explicit at its call site

## Testing

- `cargo test --manifest-path jepsen/openraft-test-app/Cargo.toml`
- `make -C jepsen unit-test` (209 tests, 1858 assertions)

CLOSES #2054

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2060)
<!-- Reviewable:end -->
