### PR TITLE
refactor: raft: correct append_membership() error order and its docs

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -517,13 +517,19 @@ where
             }
         };
 
-        if let Err(e) = Self::ensure_leader_log_committed(lh.state, lh.leader) {
-            tx.on_complete(Err(ClientWriteError::ChangeMembershipError(e.into())));
-            return;
-        }
+        // Read the barrier while the leader handler is still borrowed, but report it only after
+        // the preconditions: every `Precondition` is checked before anything else is validated,
+        // so a caller holding a stale membership log id learns that instead of being told to
+        // retry.
+        let leader_log_committed = Self::ensure_leader_log_committed(lh.state, lh.leader);
 
         if let Err(e) = self.ensure_preconditions_satisfied(preconditions) {
             tx.on_complete(Err(e.into()));
+            return;
+        }
+
+        if let Err(e) = leader_log_committed {
+            tx.on_complete(Err(ClientWriteError::ChangeMembershipError(e.into())));
             return;
         }
 

--- a/openraft/src/docs/cluster_control/dynamic-membership.md
+++ b/openraft/src/docs/cluster_control/dynamic-membership.md
@@ -94,8 +94,12 @@ the cluster must land on a joint membership the caller picked itself.
 **Parameters:**
 - `membership`: The exact membership to store, uniform or joint
 - `payload`: The base entry payload. [`RaftPayload::with_membership()`] binds
-  `membership` into it, so the application data and the membership are stored
-  and applied at the same log ID. A caller with no application data passes
+  `membership` into it, and that implementation decides how much of the base
+  survives. When it preserves application data, the data and the membership are
+  stored and applied at the same log ID. The default
+  `EntryPayload::with_membership()` returns `EntryPayload::Membership`, so it
+  replaces an `EntryPayload::Normal(data)` base and the state machine never
+  receives `data`. A caller with no application data passes
   `C::Payload::blank()`.
 - `preconditions`: Compare-and-set guards, all checked before anything is
   validated or written

--- a/openraft/src/raft/impl_raft_blocking_write.rs
+++ b/openraft/src/raft/impl_raft_blocking_write.rs
@@ -174,10 +174,12 @@ where
     /// committed and applied.
     ///
     /// `payload` is the base entry payload. This method calls
-    /// [`RaftPayload::with_membership()`] on it, so the application data and the membership share
-    /// one log id. A membership already present in `payload` is replaced; every other application
-    /// field survives according to the application's `with_membership()` implementation. A caller
-    /// with no application data passes `C::Payload::blank()`.
+    /// [`RaftPayload::with_membership()`] on it, and that implementation decides how much of the
+    /// base survives: if it preserves application data, the data and the membership are stored
+    /// and applied at one log id. The default `EntryPayload::with_membership()` returns
+    /// `EntryPayload::Membership`, so it replaces an `EntryPayload::Normal(data)` base and the
+    /// state machine never receives `data`. A caller with no application data passes
+    /// `C::Payload::blank()`.
     ///
     /// # Accepted transitions
     ///
@@ -207,7 +209,9 @@ where
     ///
     /// # Examples
     ///
-    /// Add voter `4` to the voter set `{1,2,3}`:
+    /// Promote learner `4` to a voter of `{1,2,3}`. Node `4` must already be a learner, so
+    /// that `observed` carries its `Node`: `Membership::new()` returns `NodeNotFound` for a
+    /// voter whose metadata is absent.
     ///
     /// ```ignore
     /// let observed = raft.metrics().borrow().membership_config.clone();
@@ -222,8 +226,9 @@ where
     /// .await?;
     /// ```
     ///
-    /// Move from the uniform `{1,2,3}` to a joint membership of three voter sets. It is accepted
-    /// because `{1,2,3}` appears in both, exactly equal:
+    /// Move from the uniform `{1,2,3}` to a joint membership of three voter sets, where nodes `4`
+    /// through `7` are already learners. It is accepted because `{1,2,3}` appears in both, exactly
+    /// equal:
     ///
     /// ```ignore
     /// let observed = raft.metrics().borrow().membership_config.clone();

--- a/tests/tests/membership/t24_append_membership.rs
+++ b/tests/tests/membership/t24_append_membership.rs
@@ -334,6 +334,24 @@ async fn uncommitted_leader_log_blocks_the_append() -> Result<()> {
         assert_eq!(RaftError::APIError(want), err);
     }
 
+    tracing::info!(
+        log_index,
+        "--- a stale precondition is reported instead of the blank-log barrier"
+    );
+    {
+        // An initialized node always has an effective membership log id, so `None` never holds.
+        let stale = Precondition::LastMembershipLogId {
+            last_membership_log_id: None,
+        };
+        let err = new_leader.append_membership(proposed.clone(), EntryPayload::Blank, [stale]).await.unwrap_err();
+
+        let want = PreconditionFailed::LastMembershipLogIdMismatch {
+            expected: None,
+            actual: *blocked_metrics.membership_config.log_id(),
+        };
+        assert_eq!(RaftError::APIError(ClientWriteError::PreconditionFailed(want)), err);
+    }
+
     tracing::info!(log_index, "--- the blocked append wrote nothing");
     {
         let metrics = new_leader.metrics().borrow_watched().clone();


### PR DESCRIPTION

## Changelog

##### refactor: raft: correct append_membership() error order and its docs
# Summary

`RaftCore::append_membership()` now reports a failed `Precondition`
before it reports `UncommittedLeaderLog`, matching what
`Raft::append_membership()` documents. Two doc claims about that method
are corrected alongside it.

# Details

`RaftCore::append_membership()` ran `ensure_leader_log_committed()` ahead
of `ensure_preconditions_satisfied()`. A caller whose
`Precondition::LastMembershipLogId` was already stale therefore received
`UncommittedLeaderLog` while a new leader's blank log was still
uncommitted. That error tells the caller to retry a request the stale
membership log id already rules out. `RaftCore::change_membership()`
checks preconditions right after the leader check, so the two paths now
agree. The barrier is still read while the leader handler is borrowed,
and only its reporting moves after the precondition check.

`uncommitted_leader_log_blocks_the_append` gains a phase that sends a
stale `LastMembershipLogId` while the blank log is blocked, and asserts
`PreconditionFailed`. It reports `UncommittedLeaderLog` without this fix.

Payload retention is no longer promised unconditionally. The rustdoc on
`Raft::append_membership()` and the matching section of
`openraft/src/docs/cluster_control/dynamic-membership.md` stated flatly
that the application data and the membership are stored and applied at
one log id. The default `EntryPayload::with_membership()` returns
`EntryPayload::Membership`, which drops an `EntryPayload::Normal(data)`
base, so a caller using the default payload type got a successful
membership response while the state machine never received `data`. Both
texts now carry the condition that
`Raft::change_membership_with_payload()` already uses, and name what the
default implementation does.

Both `Raft::append_membership()` examples now state that every new voter
is already a learner. Each example builds its node map by copying
`observed.membership().nodes()`, and `Membership::new()` returns
`NodeNotFound` for a voter with no `Node` value, so the examples only
work under that unstated condition.

---

- Improvement

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2062)
<!-- Reviewable:end -->
