### PR TITLE
change: raft: with_payload() selects payload by membership shape

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -50,6 +50,7 @@ use crate::core::raft_msg::ResultSender;
 use crate::core::raft_msg::VoteTx;
 use crate::core::raft_msg::external_command::ExternalCommand;
 use crate::core::raft_msg::install_full_snapshot_request::InstallFullSnapshotRequest;
+use crate::core::raft_msg::membership_payloads::MembershipPayloads;
 use crate::core::runtime_stats::RuntimeStats;
 use crate::core::sm;
 use crate::core::stage::Stage;
@@ -173,13 +174,13 @@ fn apply_membership_to_payload<C>(
     membership_state: &MembershipStateOf<C>,
     changes: ChangeMembers<C::NodeId, C::Node>,
     retain: bool,
-    payload: C::Payload,
+    payloads: MembershipPayloads<C>,
 ) -> Result<C::Payload, ChangeMembershipErrorOf<C>>
 where
     C: RaftTypeConfig,
 {
     let membership = membership_state.next_membership(changes, retain)?;
-    let payload = payload.with_membership(membership);
+    let payload = payloads.select(membership);
     Ok(payload)
 }
 
@@ -458,13 +459,13 @@ where
     //       Because allowing this requires the engine to be able to store more than 2
     //       membership logs. And it does not need to wait for the previous membership log to commit
     //       to propose the new membership log.
-    #[tracing::instrument(level = "debug", skip(self, payload, tx, preconditions))]
+    #[tracing::instrument(level = "debug", skip(self, payloads, tx, preconditions))]
     pub(super) fn change_membership(
         &mut self,
         changes: ChangeMembers<C::NodeId, C::Node>,
         retain: bool,
         preconditions: BatchOf<C, Precondition<C>>,
-        payload: C::Payload,
+        payloads: MembershipPayloads<C>,
         tx: ProgressResponder<C, ClientWriteResult<C>>,
     ) {
         if let Err(e) = self.ensure_leader_handler() {
@@ -477,7 +478,7 @@ where
             return;
         }
 
-        let res = apply_membership_to_payload::<C>(&self.engine.state.membership_state, changes, retain, payload);
+        let res = apply_membership_to_payload::<C>(&self.engine.state.membership_state, changes, retain, payloads);
         let payload = match res {
             Ok(x) => x,
             Err(e) => {
@@ -1740,7 +1741,7 @@ where
             }
             RaftMsg::ChangeMembership {
                 changes,
-                payload,
+                payloads,
                 retain,
                 preconditions,
                 tx,
@@ -1753,7 +1754,7 @@ where
                     preconditions.as_ref().display()
                 );
 
-                self.change_membership(changes, retain, preconditions, payload, tx);
+                self.change_membership(changes, retain, preconditions, payloads, tx);
             }
             RaftMsg::AppendMembership {
                 payload,
@@ -2669,7 +2670,9 @@ mod tests {
     use super::apply_membership_to_payload;
     use crate::ChangeMembers;
     use crate::Membership;
+    use crate::core::raft_msg::membership_payloads::MembershipPayloads;
     use crate::entry::RaftPayload;
+    use crate::type_config::TypeConfigExt;
     use crate::type_config::alias::MembershipStateOf;
     use crate::type_config::alias::StoredMembershipOf;
 
@@ -2734,8 +2737,9 @@ mod tests {
             membership: Some(input_membership),
         };
 
+        let payloads = MembershipPayloads::<TestConfig>::Uniform(payload);
         let changes = ChangeMembers::AddNodes(btreemap! {2 => ()});
-        let result = apply_membership_to_payload::<TestConfig>(&membership_state, changes, false, payload);
+        let result = apply_membership_to_payload::<TestConfig>(&membership_state, changes, false, payloads);
         let actual = result.unwrap();
 
         let expected_membership = Membership::new_with_defaults(vec![btreeset! {1}], btreeset! {2});
@@ -2752,8 +2756,9 @@ mod tests {
         let stored = Arc::new(StoredMembershipOf::<TestConfig>::new(None, current));
         let membership_state = MembershipStateOf::<TestConfig>::new(stored.clone(), stored);
 
+        let payloads = MembershipPayloads::<TestConfig>::Uniform(TestPayload::blank());
         let changes = ChangeMembers::AddNodes(btreemap! {2 => ()});
-        let result = apply_membership_to_payload::<TestConfig>(&membership_state, changes, false, TestPayload::blank());
+        let result = apply_membership_to_payload::<TestConfig>(&membership_state, changes, false, payloads);
         let actual = result.unwrap();
 
         let expected_membership = Membership::new_with_defaults(vec![btreeset! {1}], btreeset! {2});
@@ -2762,5 +2767,65 @@ mod tests {
             membership: Some(expected_membership),
         };
         assert_eq!(expected, actual);
+    }
+
+    /// Replacing the voters computes a joint membership, so the joint payload carries it and the
+    /// uniform payload goes back to the caller.
+    #[test]
+    fn joint_membership_selects_joint_payload() {
+        let current = Membership::new_with_defaults(vec![btreeset! {1, 2, 3}], btreeset! {4, 5});
+        let stored = Arc::new(StoredMembershipOf::<TestConfig>::new(None, current));
+        let membership_state = MembershipStateOf::<TestConfig>::new(stored.clone(), stored);
+
+        let (unused_tx, mut unused_rx) = TestConfig::oneshot();
+        let payloads = MembershipPayloads::<TestConfig>::JointOrUniform {
+            joint: TestPayload::normal(1),
+            uniform: TestPayload::normal(2),
+            unused_tx,
+        };
+
+        let changes = ChangeMembers::ReplaceAllVoters(btreeset! {3, 4, 5});
+        let result = apply_membership_to_payload::<TestConfig>(&membership_state, changes, false, payloads);
+        let actual = result.unwrap();
+
+        let joint_membership = Membership::new_with_defaults(vec![btreeset! {1, 2, 3}, btreeset! {3, 4, 5}], []);
+        let expected = TestPayload {
+            normal: Some(1),
+            membership: Some(joint_membership),
+        };
+        assert_eq!(expected, actual);
+
+        let returned = unused_rx.try_recv().unwrap();
+        assert_eq!(TestPayload::normal(2), returned);
+    }
+
+    /// Adding a node moves no voter, so the computed membership is uniform and the uniform
+    /// payload carries it, sending the joint payload back to the caller.
+    #[test]
+    fn uniform_membership_selects_uniform_payload() {
+        let current = Membership::new_with_defaults(vec![btreeset! {1}], []);
+        let stored = Arc::new(StoredMembershipOf::<TestConfig>::new(None, current));
+        let membership_state = MembershipStateOf::<TestConfig>::new(stored.clone(), stored);
+
+        let (unused_tx, mut unused_rx) = TestConfig::oneshot();
+        let payloads = MembershipPayloads::<TestConfig>::JointOrUniform {
+            joint: TestPayload::normal(1),
+            uniform: TestPayload::normal(2),
+            unused_tx,
+        };
+
+        let changes = ChangeMembers::AddNodes(btreemap! {2 => ()});
+        let result = apply_membership_to_payload::<TestConfig>(&membership_state, changes, false, payloads);
+        let actual = result.unwrap();
+
+        let expected_membership = Membership::new_with_defaults(vec![btreeset! {1}], btreeset! {2});
+        let expected = TestPayload {
+            normal: Some(2),
+            membership: Some(expected_membership),
+        };
+        assert_eq!(expected, actual);
+
+        let returned = unused_rx.try_recv().unwrap();
+        assert_eq!(TestPayload::normal(1), returned);
     }
 }

--- a/openraft/src/core/raft_msg/membership_payloads.rs
+++ b/openraft/src/core/raft_msg/membership_payloads.rs
@@ -1,0 +1,59 @@
+use crate::Membership;
+use crate::RaftTypeConfig;
+use crate::async_runtime::OneshotSender;
+use crate::entry::RaftPayload;
+use crate::type_config::alias::OneshotSenderOf;
+
+/// The base payloads a membership change offers for the entry `RaftCore` computes.
+///
+/// A change proposes one entry, and `RaftCore` decides the shape of its membership. The caller
+/// therefore cannot know in advance which entry its payload lands on, so it hands over one
+/// payload per shape and lets `RaftCore` select.
+pub(crate) enum MembershipPayloads<C>
+where C: RaftTypeConfig
+{
+    /// The change cannot compute a joint membership, so one payload covers its only entry.
+    ///
+    /// Adding a learner and flattening a joint membership both leave the voter sets alone.
+    Uniform(C::Payload),
+
+    /// The change may compute a joint or a uniform membership.
+    ///
+    /// `RaftCore` selects the payload of the computed shape and sends the other one back through
+    /// `unused_tx`. A joint membership therefore returns `uniform`, which the caller spends on
+    /// the entry that flattens that joint membership.
+    JointOrUniform {
+        joint: C::Payload,
+        uniform: C::Payload,
+        unused_tx: OneshotSenderOf<C, C::Payload>,
+    },
+}
+
+impl<C> MembershipPayloads<C>
+where C: RaftTypeConfig
+{
+    /// Bind `membership` into the payload that matches its shape, and return that payload.
+    pub(crate) fn select(self, membership: Membership<C::NodeId, C::Node>) -> C::Payload {
+        let payload = match self {
+            Self::Uniform(uniform) => uniform,
+            Self::JointOrUniform {
+                joint,
+                uniform,
+                unused_tx,
+            } => {
+                let (selected, unused) = if membership.is_joint() {
+                    (joint, uniform)
+                } else {
+                    (uniform, joint)
+                };
+
+                // The caller owns the payload this entry does not spend. It needs the uniform
+                // one back to write the entry that flattens a joint membership.
+                let _ = unused_tx.send(unused);
+                selected
+            }
+        };
+
+        payload.with_membership(membership)
+    }
+}

--- a/openraft/src/core/raft_msg/mod.rs
+++ b/openraft/src/core/raft_msg/mod.rs
@@ -9,6 +9,7 @@ use crate::RaftState;
 use crate::RaftTypeConfig;
 use crate::base::BoxOnce;
 use crate::core::raft_msg::external_command::ExternalCommand;
+use crate::core::raft_msg::membership_payloads::MembershipPayloads;
 #[cfg(feature = "runtime-stats")]
 use crate::core::runtime_stats::RuntimeStats;
 use crate::display_ext::DisplayBTreeMapDebugValueExt;
@@ -36,6 +37,7 @@ use crate::type_config::alias::VoteOf;
 
 pub(crate) mod external_command;
 pub(crate) mod install_full_snapshot_request;
+pub(crate) mod membership_payloads;
 mod raft_msg_name;
 
 pub use raft_msg_name::ExternalCommandName;
@@ -96,8 +98,11 @@ where C: RaftTypeConfig
     ChangeMembership {
         changes: ChangeMembers<C::NodeId, C::Node>,
 
-        /// Payload whose membership OpenRaft replaces with the computed membership.
-        payload: C::Payload,
+        /// Payloads whose membership OpenRaft replaces with the computed membership.
+        ///
+        /// `RaftCore` computes the membership, so it also picks the payload that matches the
+        /// shape of that membership.
+        payloads: MembershipPayloads<C>,
 
         /// If `retain` is `true`, then the voters that are not in the new
         /// config will be converted into learners, otherwise they will be removed.

--- a/openraft/src/membership/membership.rs
+++ b/openraft/src/membership/membership.rs
@@ -164,6 +164,11 @@ where
         &self.configs
     }
 
+    /// Returns true if this membership is in joint consensus, i.e. it has more than one config.
+    pub(crate) fn is_joint(&self) -> bool {
+        self.configs.len() > 1
+    }
+
     /// Returns an Iterator of all nodes(voters and learners).
     pub fn nodes(&self) -> impl Iterator<Item = (&NID, &N)> {
         self.nodes.iter()

--- a/openraft/src/raft/api/management.rs
+++ b/openraft/src/raft/api/management.rs
@@ -11,6 +11,7 @@ use crate::RaftMetrics;
 use crate::RaftTypeConfig;
 use crate::batch::Batch;
 use crate::core::raft_msg::RaftMsg;
+use crate::core::raft_msg::membership_payloads::MembershipPayloads;
 use crate::core::replication_lag;
 use crate::entry::RaftPayload;
 use crate::errors::ClientWriteError;
@@ -23,6 +24,7 @@ use crate::raft::ChangeMembershipRequest;
 use crate::raft::ClientWriteResult;
 use crate::raft::Precondition;
 use crate::raft::raft_inner::RaftInner;
+use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::BatchOf;
 use crate::type_config::alias::LogIdOf;
 
@@ -66,7 +68,7 @@ where C: RaftTypeConfig
     ) -> Result<ClientWriteResult<C>, Fatal<C>> {
         let request = ChangeMembershipRequest::new(members, retain).with_preconditions(preconditions);
         let result = self.change_membership_with_payload(request).await?;
-        let result = result.map(|outcome| outcome.uniform.unwrap_or(outcome.first));
+        let result = result.map(|outcome| outcome.uniform);
         Ok(result)
     }
 
@@ -75,8 +77,8 @@ where C: RaftTypeConfig
         request: ChangeMembershipRequest<C>,
     ) -> Result<Result<ChangeMembershipOutcome<C>, ClientWriteError<C>>, Fatal<C>> {
         let (changes, retain, preconditions, payload) = request.into_parts();
-        let (first_payload, uniform_payload) = match payload {
-            Some((first, uniform)) => (first, uniform),
+        let (joint_payload, uniform_payload) = match payload {
+            Some((joint, uniform)) => (joint, uniform),
             None => (C::Payload::blank(), C::Payload::blank()),
         };
 
@@ -90,6 +92,16 @@ where C: RaftTypeConfig
 
         tracing::debug!("change_membership: start",);
 
+        // `RaftCore` computes the membership, so only `RaftCore` can tell whether this change
+        // needs a joint membership. It spends `joint_payload` on a joint membership and
+        // `uniform_payload` on a uniform one, and returns the payload it did not spend.
+        let (unused_tx, unused_rx) = C::oneshot();
+        let payloads = MembershipPayloads::JointOrUniform {
+            joint: joint_payload,
+            uniform: uniform_payload,
+            unused_tx,
+        };
+
         // res is error if membership cannot be changed.
         // If no error, it will enter a joint state
         let client_write_result = self
@@ -97,7 +109,7 @@ where C: RaftTypeConfig
             .call_core(
                 RaftMsg::ChangeMembership {
                     changes: changes.clone(),
-                    payload: first_payload,
+                    payloads,
                     retain,
                     preconditions: Batch::of(preconditions.as_ref().iter().cloned()),
                     tx,
@@ -121,17 +133,21 @@ where C: RaftTypeConfig
 
         tracing::debug!("res of first step: {}", resp);
 
-        let (log_id, joint) = (&resp.log_id, resp.membership.clone().unwrap());
+        let (log_id, membership) = (&resp.log_id, resp.membership.clone().unwrap());
 
-        if joint.get_joint_config().len() == 1 {
+        if !membership.is_joint() {
             let outcome = ChangeMembershipOutcome {
-                first: resp,
-                uniform: None,
+                joint: None,
+                uniform: resp,
             };
             return Ok(Ok(outcome));
         }
 
-        tracing::debug!("committed a joint config: {} {:?}", log_id, joint);
+        // The first step spent `joint_payload` on the joint entry, so the payload it returned is
+        // `uniform_payload`, for the entry this second step writes.
+        let uniform_payload = self.inner.recv_msg(unused_rx).await?;
+
+        tracing::debug!("committed a joint config: {} {:?}", log_id, membership);
         tracing::debug!("the second step is to change to uniform config: {:?}", changes);
 
         // The last membership config log ID is changed because we have proposed a new membership config
@@ -160,7 +176,7 @@ where C: RaftTypeConfig
             .call_core(
                 RaftMsg::ChangeMembership {
                     changes,
-                    payload: uniform_payload,
+                    payloads: MembershipPayloads::Uniform(uniform_payload),
                     retain,
                     preconditions,
                     tx,
@@ -179,8 +195,8 @@ where C: RaftTypeConfig
         }
 
         let outcome = client_write_result.map(|uniform| ChangeMembershipOutcome {
-            first: resp,
-            uniform: Some(uniform),
+            joint: Some(resp),
+            uniform,
         });
         Ok(outcome)
     }
@@ -222,7 +238,7 @@ where C: RaftTypeConfig
 
         let msg = RaftMsg::ChangeMembership {
             changes: ChangeMembers::AddNodes(btreemap! {id.clone()=>node}),
-            payload: C::Payload::blank(),
+            payloads: MembershipPayloads::Uniform(C::Payload::blank()),
             retain: true,
             preconditions: Batch::of([]),
             tx,

--- a/openraft/src/raft/declare_raft_types_test.rs
+++ b/openraft/src/raft/declare_raft_types_test.rs
@@ -110,14 +110,14 @@ fn test_payload_type() {
 
 #[test]
 fn test_change_membership_request_accepts_distinct_non_clone_payloads() {
-    let first_payload = CustomPayload(EntryPayload::Normal(1));
+    let joint_payload = CustomPayload(EntryPayload::Normal(1));
     let uniform_payload = CustomPayload(EntryPayload::Normal(2));
     let request =
-        ChangeMembershipRequest::<WithCustomPayload>::new([1], false).with_payload(first_payload, uniform_payload);
+        ChangeMembershipRequest::<WithCustomPayload>::new([1], false).with_payload(joint_payload, uniform_payload);
 
     let (_, _, _, payloads) = request.into_parts();
-    let (first_payload, uniform_payload) = payloads.unwrap();
-    let actual = (first_payload.0, uniform_payload.0);
+    let (joint_payload, uniform_payload) = payloads.unwrap();
+    let actual = (joint_payload.0, uniform_payload.0);
     let expected = (EntryPayload::Normal(1), EntryPayload::Normal(2));
     assert_eq!(expected, actual);
 }

--- a/openraft/src/raft/impl_raft_blocking_write.rs
+++ b/openraft/src/raft/impl_raft_blocking_write.rs
@@ -97,8 +97,10 @@ where
     /// possible uniform proposal and carries over only the committed-leader precondition.
     ///
     /// A voter change may append a joint entry followed by a uniform entry. `with_payload()`
-    /// accepts one payload for the requested change and another for the possible uniform entry.
-    /// If `with_membership()` preserves application data, the state machine applies each
+    /// binds each payload to the shape of the membership it carries: the joint payload to the
+    /// joint entry, the uniform payload to the uniform entry. A change that moves no voter needs
+    /// no joint entry, so it drops the joint payload and writes its single entry with the uniform
+    /// payload. If `with_membership()` preserves application data, the state machine applies each
     /// payload at its corresponding log ID.
     ///
     /// Both supplied payloads are serialized, stored, and replicated when the change requires two
@@ -107,8 +109,8 @@ where
     /// If the uniform proposal fails, the joint entry is already committed. A retry must build a
     /// new request with the original payloads and preconditions based on the current joint state.
     ///
-    /// The returned [`ChangeMembershipOutcome`] contains the first response and the uniform
-    /// response when the change entered joint consensus.
+    /// The returned [`ChangeMembershipOutcome`] always contains the uniform response, and the
+    /// joint response when the change entered joint consensus.
     #[since(
         version = "0.10.0",
         change = "accept a request with an optional payload and preconditions"

--- a/openraft/src/raft/message/change_membership.rs
+++ b/openraft/src/raft/message/change_membership.rs
@@ -6,6 +6,10 @@ use crate::RaftTypeConfig;
 use crate::raft::ClientWriteResponse;
 
 /// Responses from the physical log entries of a membership change.
+#[since(
+    version = "0.10.0",
+    change = "report the joint entry as optional and the uniform entry as always present"
+)]
 #[since(version = "0.10.0", change = "added payload-aware membership outcome")]
 #[cfg_attr(
     feature = "serde",
@@ -15,11 +19,11 @@ use crate::raft::ClientWriteResponse;
 pub struct ChangeMembershipOutcome<C>
 where C: RaftTypeConfig
 {
-    /// The response from the requested membership change.
-    pub first: ClientWriteResponse<C>,
+    /// The response from the joint membership entry, if the change needed one.
+    pub joint: Option<ClientWriteResponse<C>>,
 
-    /// The response from flattening a joint membership to a uniform membership.
-    pub uniform: Option<ClientWriteResponse<C>>,
+    /// The response from the uniform membership entry, which every completed change writes.
+    pub uniform: ClientWriteResponse<C>,
 }
 
 impl<C> fmt::Debug for ChangeMembershipOutcome<C>
@@ -29,7 +33,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ChangeMembershipOutcome")
-            .field("first", &self.first)
+            .field("joint", &self.joint)
             .field("uniform", &self.uniform)
             .finish()
     }

--- a/openraft/src/raft/message/change_membership_request.rs
+++ b/openraft/src/raft/message/change_membership_request.rs
@@ -35,12 +35,16 @@ where C: RaftTypeConfig
 
     /// Use separate application-defined payloads for the membership-change steps.
     ///
-    /// `first_payload` is used for the requested change. `uniform_payload` is used only when a
-    /// second entry is needed to flatten a joint membership.
+    /// Each payload is tied to the shape of the membership it carries, not to the order of the
+    /// steps. `joint_payload` is used only for a joint membership entry, which the change writes
+    /// only when it moves voters. `uniform_payload` is used for the uniform membership entry,
+    /// which every completed change writes. A change that needs no joint entry therefore drops
+    /// `joint_payload` and writes its single entry with `uniform_payload`.
+    #[since(version = "0.10.0", change = "select each payload by the shape of its membership")]
     #[since(version = "0.10.0", change = "accept separate payloads for membership change steps")]
     #[since(version = "0.10.0", change = "added optional membership change payload")]
-    pub fn with_payload(mut self, first_payload: C::Payload, uniform_payload: C::Payload) -> Self {
-        self.payload = Some((first_payload, uniform_payload));
+    pub fn with_payload(mut self, joint_payload: C::Payload, uniform_payload: C::Payload) -> Self {
+        self.payload = Some((joint_payload, uniform_payload));
         self
     }
 

--- a/tests/tests/membership/t20_change_membership.rs
+++ b/tests/tests/membership/t20_change_membership.rs
@@ -38,25 +38,25 @@ async fn update_membership_state() -> anyhow::Result<()> {
         let change = leader.change_membership_with_payload(request);
         let outcome = change.await?;
 
-        let first_log_index = log_index + 1;
-        assert_eq!(first_log_index, outcome.first.log_id.index);
+        let joint = outcome.joint.as_ref().expect("voter change should enter joint consensus");
+        let joint_log_index = log_index + 1;
+        assert_eq!(joint_log_index, joint.log_id.index);
 
-        let uniform = outcome.uniform.as_ref().expect("voter change should enter joint consensus");
         let uniform_log_index = log_index + 2;
-        assert_eq!(uniform_log_index, uniform.log_id.index);
+        assert_eq!(uniform_log_index, outcome.uniform.log_id.index);
 
         tracing::info!(
-            first_log_index,
+            joint_log_index,
             uniform_log_index,
             "--- inspect membership log payloads"
         );
         {
-            let first_membership = outcome.first.membership.clone().unwrap();
-            let uniform_membership = uniform.membership.clone().unwrap();
-            let expected_memberships = vec![first_membership, uniform_membership];
+            let joint_membership = joint.membership.clone().unwrap();
+            let uniform_membership = outcome.uniform.membership.clone().unwrap();
+            let expected_memberships = vec![joint_membership, uniform_membership];
 
             let (mut log_store, _) = router.get_storage_handle(&0)?;
-            let entries = log_store.try_get_log_entries(first_log_index..=uniform_log_index).await?;
+            let entries = log_store.try_get_log_entries(joint_log_index..=uniform_log_index).await?;
             let mut actual_memberships = Vec::new();
             for entry in entries {
                 let membership = match entry.payload {

--- a/tests/tests/membership/t22_change_membership_if.rs
+++ b/tests/tests/membership/t22_change_membership_if.rs
@@ -58,7 +58,8 @@ async fn matching_membership_log_id_completes_joint_change() -> Result<()> {
             .with_preconditions([precondition]);
         let change = leader.change_membership_with_payload(request);
         let outcome = change.await?;
-        let resp = outcome.uniform.as_ref().expect("voter change should enter joint consensus");
+        assert!(outcome.joint.is_some(), "voter change should enter joint consensus");
+        let resp = &outcome.uniform;
 
         // A joint config log and a uniform config log.
         log_index += 2;

--- a/tests/tests/membership/t23_custom_payload.rs
+++ b/tests/tests/membership/t23_custom_payload.rs
@@ -15,6 +15,7 @@ use futures::Stream;
 use futures::TryStreamExt;
 use maplit::btreemap;
 use maplit::btreeset;
+use openraft::ChangeMembers;
 use openraft::Config;
 use openraft::Entry;
 use openraft::LogState;
@@ -458,19 +459,19 @@ async fn custom_payload_survives_membership_change_and_recovery() -> anyhow::Res
 
     tracing::info!("--- promote node 1 with distinct payloads for the joint and uniform entries");
     let (joint_log_id, uniform_log_id) = {
-        let first_payload = CustomPayload::normal("joint application data".to_string());
+        let joint_payload = CustomPayload::normal("joint application data".to_string());
         let uniform_payload = CustomPayload::normal("uniform application data".to_string());
-        let request = ChangeMembershipRequest::new([0, 1], false).with_payload(first_payload, uniform_payload);
+        let request = ChangeMembershipRequest::new([0, 1], false).with_payload(joint_payload, uniform_payload);
         let outcome = node0.change_membership_with_payload(request).await?;
-        let uniform = outcome.uniform.expect("voter change should enter joint consensus");
+        let joint = outcome.joint.expect("voter change should enter joint consensus");
 
-        assert_eq!(Some(joint_membership.clone()), outcome.first.membership);
-        assert_eq!(Some(uniform_membership.clone()), uniform.membership);
-        assert_eq!(3, outcome.first.log_id.index);
-        assert_eq!(4, uniform.log_id.index);
-        assert!(outcome.first.log_id < uniform.log_id);
+        assert_eq!(Some(joint_membership.clone()), joint.membership);
+        assert_eq!(Some(uniform_membership.clone()), outcome.uniform.membership);
+        assert_eq!(3, joint.log_id.index);
+        assert_eq!(4, outcome.uniform.log_id.index);
+        assert!(joint.log_id < outcome.uniform.log_id);
 
-        (outcome.first.log_id, uniform.log_id)
+        (joint.log_id, outcome.uniform.log_id)
     };
 
     tracing::info!("--- both nodes store and apply both custom membership payloads");
@@ -516,21 +517,21 @@ async fn custom_payload_survives_membership_change_and_recovery() -> anyhow::Res
         let blank_calls = BLANK_CALLS.load(Ordering::SeqCst);
         let request = ChangeMembershipRequest::new([0], false);
         let outcome = node0.change_membership_with_payload(request).await?;
-        let uniform = outcome.uniform.expect("voter change should enter joint consensus");
+        let joint = outcome.joint.expect("voter change should enter joint consensus");
         let new_blank_calls = BLANK_CALLS.load(Ordering::SeqCst);
 
         assert_eq!(blank_calls + 2, new_blank_calls);
-        assert_eq!(5, outcome.first.log_id.index);
-        assert_eq!(6, uniform.log_id.index);
-        assert_eq!(Some(final_joint_membership.clone()), outcome.first.membership);
-        assert_eq!(Some(final_membership.clone()), uniform.membership);
+        assert_eq!(5, joint.log_id.index);
+        assert_eq!(6, outcome.uniform.log_id.index);
+        assert_eq!(Some(final_joint_membership.clone()), joint.membership);
+        assert_eq!(Some(final_membership.clone()), outcome.uniform.membership);
 
         let expected_payloads = vec![
-            (outcome.first.log_id, CustomPayload {
+            (joint.log_id, CustomPayload {
                 normal: None,
                 membership: Some(final_joint_membership.clone()),
             }),
-            (uniform.log_id, CustomPayload {
+            (outcome.uniform.log_id, CustomPayload {
                 normal: None,
                 membership: Some(final_membership.clone()),
             }),
@@ -538,9 +539,30 @@ async fn custom_payload_survives_membership_change_and_recovery() -> anyhow::Res
         assert_eq!(expected_payloads, read_payloads(&log0, 5..=6).await?);
     }
 
-    // Voters `{0}` unchanged, node 1 re-added as a learner: one voter set on both sides, so this
-    // is a direct append.
-    let appended_membership = Membership::new(vec![btreeset! {0}], btreemap! {0=>(), 1=>()})?;
+    // Voters `{0}` unchanged, node 1 back as a learner: one voter set on both sides, so this is a
+    // direct append.
+    let learner_membership = Membership::new(vec![btreeset! {0}], btreemap! {0=>(), 1=>()})?;
+
+    tracing::info!("--- a change that moves no voter writes one uniform entry, with the uniform payload");
+    let learner_log_id = {
+        let joint_payload = CustomPayload::normal("joint application data".to_string());
+        let uniform_payload = CustomPayload::normal("learner application data".to_string());
+        let changes = ChangeMembers::AddNodes(btreemap! {1 => ()});
+        let request = ChangeMembershipRequest::new(changes, false).with_payload(joint_payload, uniform_payload);
+        let outcome = node0.change_membership_with_payload(request).await?;
+
+        assert!(outcome.joint.is_none(), "adding a learner needs no joint membership");
+        assert_eq!(7, outcome.uniform.log_id.index);
+        assert_eq!(Some(learner_membership.clone()), outcome.uniform.membership);
+
+        let expected_payloads = vec![(outcome.uniform.log_id, CustomPayload {
+            normal: Some("learner application data".to_string()),
+            membership: Some(learner_membership.clone()),
+        })];
+        assert_eq!(expected_payloads, read_payloads(&log0, 7..=7).await?);
+
+        outcome.uniform.log_id
+    };
 
     tracing::info!("--- append_membership binds the membership into the caller's payload");
     let appended_log_id = {
@@ -552,28 +574,29 @@ async fn custom_payload_survives_membership_change_and_recovery() -> anyhow::Res
             normal: Some("appended application data".to_string()),
             membership: Some(final_joint_membership.clone()),
         };
-        let resp = node0.append_membership(appended_membership.clone(), base, []).await?;
+        let resp = node0.append_membership(learner_membership.clone(), base, []).await?;
 
         assert_eq!(blank_calls, BLANK_CALLS.load(Ordering::SeqCst));
-        assert_eq!(7, resp.log_id.index);
-        assert_eq!(Some(appended_membership.clone()), resp.membership);
+        assert_eq!(8, resp.log_id.index);
+        assert_eq!(Some(learner_membership.clone()), resp.membership);
 
         // One entry holds both the application data and the proposed membership.
         let expected_payloads = vec![(resp.log_id, CustomPayload {
             normal: Some("appended application data".to_string()),
-            membership: Some(appended_membership.clone()),
+            membership: Some(learner_membership.clone()),
         })];
-        assert_eq!(expected_payloads, read_payloads(&log0, 7..=7).await?);
+        assert_eq!(expected_payloads, read_payloads(&log0, 8..=8).await?);
 
         resp.log_id
     };
 
     let expected_final_state = AppliedState {
         last_applied: Some(appended_log_id),
-        membership: StoredMembership::new(Some(appended_log_id), appended_membership),
+        membership: StoredMembership::new(Some(appended_log_id), learner_membership),
         commands: vec![
             (joint_log_id, "joint application data".to_string()),
             (uniform_log_id, "uniform application data".to_string()),
+            (learner_log_id, "learner application data".to_string()),
             (appended_log_id, "appended application data".to_string()),
         ],
     };
@@ -588,7 +611,7 @@ async fn custom_payload_survives_membership_change_and_recovery() -> anyhow::Res
         let recovered_sm = TestStateMachine::default();
         let recovered = new_node(0, config.clone(), router.clone(), log0, recovered_sm.clone()).await?;
         router.insert(0, recovered.clone());
-        recovered.wait(timeout()).applied_index(Some(7), "reapply committed log").await?;
+        recovered.wait(timeout()).applied_index(Some(8), "reapply committed log").await?;
 
         assert_eq!(expected_final_state, recovered_sm.state());
         let metrics = recovered.metrics().borrow_watched().clone();


### PR DESCRIPTION

## Changelog

##### change: raft: with_payload() selects payload by membership shape
# Summary

`ChangeMembershipRequest::with_payload()` now attaches `joint_payload` to
a joint membership entry and `uniform_payload` to a uniform one. Before
this commit the first entry always carried `joint_payload`, so a change
that needed no joint membership wrote it there and left `uniform_payload`
unused.

# Details

A caller cannot predict whether openraft needs a joint phase: adding a
learner, or flattening a joint config after a failed recovery, produces a
single uniform entry. Tying each payload to a membership shape lets an
application put the end state in `uniform_payload` and find it on
whichever entry ends the change.

Only `RaftCore` computes the membership, so the selection lives there.
`RaftMsg::ChangeMembership` carries both payloads as `MembershipPayloads`
and `RaftCore` returns the one it does not spend through a oneshot. That
return path is what lets `ManagementApi` spend `uniform_payload` on the
entry that flattens a joint membership without requiring
`C::Payload: Clone`.

`ChangeMembershipOutcome` follows the same rule: every completed change
writes a uniform entry, and only a voter change writes a joint one.

Upgrade tip:

`ChangeMembershipOutcome` swapped which field is optional:

    - pub first: ClientWriteResponse<C>,
    - pub uniform: Option<ClientWriteResponse<C>>,
    + pub joint: Option<ClientWriteResponse<C>>,
    + pub uniform: ClientWriteResponse<C>,

Read the entry that ends the change from `outcome.uniform`, and the joint
entry, when there is one, from `outcome.joint`. A `with_payload()` caller
that put the end state in the first payload must move it to
`uniform_payload`.

- Fix: #2063

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2064)
<!-- Reviewable:end -->
