### PR TITLE
test: jepsen: report clock target coverage

### DIFF
--- a/jepsen/src/jepsen/openraft/nemesis/clock.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/clock.clj
@@ -49,13 +49,6 @@
 (defn- random-targets [test]
   (vec (random/nonempty-subset (:nodes test))))
 
-(defn- target-category [node-count target-count]
-  (cond
-    (= 1 target-count) :one
-    (= node-count target-count) :all
-    (<= target-count (quot (dec node-count) 2)) :minority
-    :else :majority))
-
 (defn verify-offset! [offset-ms]
   (let [before (Long/parseLong (c/exec :date "+%s%3N"))
         observed (clock/probe-wall-time-ms!)
@@ -185,7 +178,7 @@
                :value (outcome/installed
                        (merge {:mode :bump
                                :targets targets
-                               :target-category (target-category
+                               :target-category (outcome/target-category
                                                  (count (:nodes test))
                                                  (count targets))
                                :offsets-ms offsets
@@ -210,7 +203,7 @@
                        (merge {:mode :rate
                                :direction direction
                                :targets targets
-                               :target-category (target-category
+                               :target-category (outcome/target-category
                                                  (count (:nodes test))
                                                  (count targets))
                                :rates rates
@@ -231,7 +224,7 @@
                :value (outcome/installed
                        (merge {:mode :strobe
                                :targets targets
-                               :target-category (target-category
+                               :target-category (outcome/target-category
                                                  (count (:nodes test))
                                                  (count targets))
                                :strobes strobes

--- a/jepsen/src/jepsen/openraft/nemesis/clock.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/clock.clj
@@ -304,7 +304,14 @@
 (defn- coverage-checker []
   (reify checker/Checker
     (check [_ _test history _opts]
-      (let [bump? (some #(and (= :bump-clock (:f %)) (installed? %)) history)
+      (let [installed-values (->> history
+                                  (filter #(and (contains? #{:bump-clock
+                                                             :rate-clock
+                                                             :strobe-clock}
+                                                           (:f %))
+                                                (installed? %)))
+                                  (map :value))
+            bump? (some #(and (= :bump-clock (:f %)) (installed? %)) history)
             strobe? (some #(and (= :strobe-clock (:f %)) (installed? %))
                           history)
             observed-modes (->> history
@@ -320,6 +327,9 @@
                                                (installed? %)))
                                  (keep #(get-in % [:value :direction]))
                                  set)
+            observed-target-categories (->> installed-values
+                                            (keep :target-category)
+                                            set)
             final-reset (last (filter #(= :reset-clock (:f %)) history))
             recovered? (and final-reset (installed? final-reset))]
         {:valid? (boolean (and bump?
@@ -329,6 +339,8 @@
          :bump-installed (boolean bump?)
          :strobe-installed (boolean strobe?)
          :observed-modes observed-modes
+         :observed-target-categories
+         (vec (sort observed-target-categories))
          :rate-directions (vec (sort rate-directions))
          :final-reset-installed (boolean recovered?)
          :cluster-state (if recovered? :intact :unknown)}))))

--- a/jepsen/src/jepsen/openraft/nemesis/outcome.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/outcome.clj
@@ -1,5 +1,12 @@
 (ns jepsen.openraft.nemesis.outcome)
 
+(defn target-category [node-count target-count]
+  (cond
+    (= 1 target-count) :one
+    (= node-count target-count) :all
+    (<= target-count (quot (dec node-count) 2)) :minority
+    :else :majority))
+
 (defn installed
   "Returns a confirmed Nemesis outcome with structured details."
   [details]

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -26,13 +26,6 @@
 (def ^:private process-availability-window-nanos
   (* 3 max-election-timeout-ms 1000000))
 
-(defn- target-category [node-count target-count]
-  (cond
-    (= 1 target-count) :one
-    (= node-count target-count) :all
-    (<= target-count (quot (dec node-count) 2)) :minority
-    :else :majority))
-
 (defn- process-disruption [test status mode eligible-nodes]
   (let [leader (:leader status)
         configs (cluster/voter-configs test status)
@@ -51,8 +44,8 @@
                                 (filter reachable-voters)
                                 vec)
          :target-count target-count
-         :target-category (target-category (count (:nodes test))
-                                           target-count)
+         :target-category (outcome/target-category (count (:nodes test))
+                                                   target-count)
          :leader-included? (contains? target-set leader)}))))
 
 (def ^:private disruption-start-specs

--- a/jepsen/test/jepsen/openraft/nemesis/clock_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/clock_test.clj
@@ -58,6 +58,28 @@
                                           [(installed :reset-clock)]
                                           {})))))))
 
+(deftest clock-checker-reports-target-categories
+  (let [subject (:checker (clock-nemesis/clock-package))
+        installed (fn [f details]
+                    {:type :info
+                     :f f
+                     :value (assoc details :status :installed)})
+        result (checker/check
+                subject
+                test-config
+                [(installed :bump-clock {:target-category :one})
+                 (installed :strobe-clock {:target-category :minority})
+                 (installed :rate-clock {:direction :fast
+                                         :target-category :all})
+                 (installed :rate-clock {:direction :slow
+                                         :target-category :one})
+                 (installed :kill-process {:target-category :majority})
+                 (installed :reset-clock {})]
+                {})]
+    (is (:valid? result))
+    (is (= [:all :minority :one]
+           (:observed-target-categories result)))))
+
 (deftest rate-settings-cover-both-directions
   (dotimes [_ 100]
     (let [fast (#'clock-nemesis/random-rate :fast)

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -9,6 +9,7 @@
             [jepsen.openraft.cluster :as cluster]
             [jepsen.openraft.harness :as harness]
             [jepsen.openraft.nemesis :as openraft-nemesis]
+            [jepsen.openraft.nemesis.outcome :as outcome]
             [jepsen.openraft.nemesis.process :as process]
             [jepsen.openraft.quorum :as quorum]
             [jepsen.openraft.worker :as worker]))
@@ -150,9 +151,9 @@
         (is (= [[:kill selected]]
                (mapv (juxt :f :value) @invocations)))))))
 
-(deftest categorizes-process-target-scale
+(deftest categorizes-target-scale
   (is (= [:one :minority :majority :majority :all]
-         (mapv (partial #'process/target-category 5)
+         (mapv (partial outcome/target-category 5)
                (range 1 6)))))
 
 (deftest process-generator-repeats-random-kill-episodes
@@ -1381,7 +1382,7 @@
                         :leader "n1"
                         :nodes nodes
                         :voter-configs [(set voters)]
-                        :target-category (#'process/target-category
+                        :target-category (outcome/target-category
                                           (count voters)
                                           (count nodes))
                         :pause-results (zipmap nodes (repeat :paused))}))


### PR DESCRIPTION
## Summary

- share one target-category classifier between Clock and Process faults
- report observed Clock target categories without changing validity
- exclude other Nemesis events when Clock analyzes a Chaos history

## Testing

- `lein test jepsen.openraft.nemesis.clock-test jepsen.openraft.nemesis.process-test`
- `make -C jepsen unit-test` (210 tests, 1860 assertions)

CLOSES #2061

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2065)
<!-- Reviewable:end -->
