### PR TITLE
test: membership: fix flaky t23 snapshot membership assertion

### DIFF
--- a/tests/tests/membership/t23_custom_payload.rs
+++ b/tests/tests/membership/t23_custom_payload.rs
@@ -630,6 +630,10 @@ async fn custom_payload_survives_membership_change_and_recovery() -> anyhow::Res
         let node = new_node(2, config, router.clone(), TestLogStore::default(), snapshot_sm.clone()).await?;
         router.insert(2, node.clone());
         node.install_full_snapshot(vote, snapshot).await?;
+        // `install_full_snapshot()` answers as soon as the snapshot is installed, before the
+        // RaftCore loop publishes the next metrics. Wait for the installed index, so that the
+        // membership assertion below reads the metrics the snapshot produced.
+        node.wait(timeout()).applied_index(Some(appended_log_id.index), "install snapshot").await?;
 
         assert_eq!(expected_final_state, snapshot_sm.state());
         let metrics = node.metrics().borrow_watched().clone();


### PR DESCRIPTION

## Changelog

##### test: membership: fix flaky t23 snapshot membership assertion
# Summary

`custom_payload_survives_membership_change_and_recovery` in
`tests/tests/membership/t23_custom_payload.rs` now waits for node 2 to
report applied index 7 before it reads `metrics.membership_config`.

# Details

`Raft::install_full_snapshot()` returns as soon as RaftCore answers it.
`RaftCore::runtime_loop` publishes metrics at the top of each iteration
and sends that answer later in the same iteration, from
`run_engine_commands()`. The caller can therefore read the metrics
published before the install.

Job 98860885572 of run 33174905543 hit that window: node 2's
`membership_config` still held its startup value `StoredMembership {
log_id: None, membership: {} }`. The state-machine assertion two lines
above had already passed, so the snapshot was installed and only the
metrics lagged.

Every other metrics assertion in the file already sits behind a `wait()`
on the same node. Node 2 was the only node read without one.

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2066)
<!-- Reviewable:end -->
