### PR TITLE
feat: legacy: expose transfer_leader method on RaftNetwork legacy interface

### DIFF
--- a/legacy/Cargo.toml
+++ b/legacy/Cargo.toml
@@ -17,6 +17,7 @@ repository.workspace = true
 openraft = { path = "../openraft", version = "0.10.0-alpha.34", default-features = false }
 openraft-macros = { path = "../macros", version = "0.10.0-alpha.34" }
 
+anyerror = { workspace = true }
 derive_more = { workspace = true }
 display-more = { workspace = true }
 futures = { workspace = true }

--- a/legacy/src/network_v1/adapter.rs
+++ b/legacy/src/network_v1/adapter.rs
@@ -20,6 +20,8 @@ use openraft::network::v2::RaftNetworkV2;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::AppendEntriesResponse;
 use openraft::raft::SnapshotResponse;
+use openraft::raft::TransferLeaderRequest;
+use openraft::raft::TransferLeaderResponse;
 use openraft::raft::VoteRequest;
 use openraft::raft::VoteResponse;
 use openraft::type_config::alias::SnapshotOf;
@@ -111,6 +113,14 @@ where
         option: RPCOption,
     ) -> Result<SnapshotResponse<C>, StreamingError<C>> {
         Sender::<C, SD>::send_snapshot(&mut self.network, vote, snapshot, cancel, option).await
+    }
+
+    async fn transfer_leader(
+        &mut self,
+        rpc: TransferLeaderRequest<C>,
+        option: RPCOption,
+    ) -> Result<TransferLeaderResponse<C>, RPCError<C>> {
+        RaftNetwork::<C>::transfer_leader(&mut self.network, rpc, option).await
     }
 
     fn backoff(&self) -> Option<Backoff> {

--- a/legacy/src/network_v1/raft_network.rs
+++ b/legacy/src/network_v1/raft_network.rs
@@ -5,15 +5,19 @@
 
 use std::time::Duration;
 
+use anyerror::AnyError;
 use openraft::OptionalSend;
 use openraft::OptionalSync;
 use openraft::RaftTypeConfig;
 use openraft::errors::RPCError;
 use openraft::errors::RaftError;
+use openraft::errors::Unreachable;
 use openraft::network::Backoff;
 use openraft::network::RPCOption;
 use openraft::raft::AppendEntriesRequest;
 use openraft::raft::AppendEntriesResponse;
+use openraft::raft::TransferLeaderRequest;
+use openraft::raft::TransferLeaderResponse;
 use openraft::raft::VoteRequest;
 use openraft::raft::VoteResponse;
 use openraft_macros::add_async_trait;
@@ -68,6 +72,25 @@ where C: RaftTypeConfig
         rpc: VoteRequest<C>,
         option: RPCOption,
     ) -> Result<VoteResponse<C>, RPCError<C, RaftError<C>>>;
+
+    /// Send TransferLeader RPC to the target.
+    ///
+    /// The node received this message should pass it to [`Raft::handle_transfer_leader()`].
+    ///
+    /// This method provides a default implementation that just returns [`Unreachable`] error to
+    /// ignore it. In case the application did not implement it, other nodes just wait for the
+    /// Leader lease to timeout and then restart election.
+    ///
+    /// [`Raft::handle_transfer_leader()`]: openraft::raft::Raft::handle_transfer_leader
+    async fn transfer_leader(
+        &mut self,
+        _req: TransferLeaderRequest<C>,
+        _option: RPCOption,
+    ) -> Result<TransferLeaderResponse<C>, RPCError<C>> {
+        Err(RPCError::Unreachable(Unreachable::new(&AnyError::error(
+            "transfer_leader not implemented",
+        ))))
+    }
 
     /// Build a backoff instance if the target node is temporarily(or permanently) unreachable.
     ///


### PR DESCRIPTION
This is a little one for 0.10.x: it allows the openraft-legacy `RaftNetwork` trait to expose the `transfer_leader` method, because I'd like to have an implementation which reuses the 0.9.x-compatible chunked transfer encoding for snapshots, but also supports the `transfer_leader` method.

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2067)
<!-- Reviewable:end -->
