### PR TITLE
perf: jepsen: probe every node at once in collect-reachable-metrics-from

### DIFF
--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -267,9 +267,9 @@ at node-IP granularity and across DB-to-DB ports. It does not provide one-way,
 per-RPC, or per-port shaping. Because both modes own the same root qdisc, they
 are never active at the same time.
 
-The same Packet package and checker are used in focused and chaos runs. Packet
-coverage requires the selected mode and both leader-target cases to be installed
-and later cleared successfully. It does not require an election, timeout, or
+The same Packet package and checker are used in focused and chaos runs. A
+focused Packet run requires the selected mode and both leader-target cases to be
+installed and later cleared successfully. It does not require an election, timeout, or
 indeterminate mutation, because those observations depend on timing, TCP
 retransmission, and kernel packet selection. Partial installation or cleanup is
 a Harness failure; final recovery and teardown must attempt idempotent cleanup
@@ -303,10 +303,33 @@ linearizability and final data recovery.
 
 The default `chaos` profile independently schedules partition, process, pause,
 membership, packet, and clock faults. It composes the package, generator, final
-recovery, and checker supplied by each Nemesis rather than defining separate
-Chaos-only checker semantics. Packet chooses one of `slow` or `flaky` for each
-independent Packet episode, and never overlaps those two modes with each other.
-Different fault classes may remain active at the same time.
+recovery, and checker supplied by each Nemesis, and changes only how the
+composed verdict treats per-class coverage. Packet chooses one of `slow` or
+`flaky` for each independent Packet episode, and never overlaps those two modes
+with each other. Different fault classes may remain active at the same time.
+
+A chaos run does not require every fault class to install. All six classes draw
+from one 60-second random schedule, so whether a class ever meets a healthy
+cluster depends on wall-clock timing. `results.edn` therefore records
+`:fault-class-executed?` next to the observed and missing entries of each class,
+and a class that never installed does not reject the run. Coverage stays a hard
+requirement in the focused CI jobs, which run one Nemesis at a time. A chaos run
+still rejects fault errors, incomplete cleanup, and failed recovery.
+
+Only an absent or explicitly skipped fault is relaxed. Three shapes are Nemesis
+defects rather than a schedule that never reached the class: an installed fault
+without the evidence its checker reads, such as a `:start-partition` outcome
+carrying no mode; an outcome carrying no `:status`; and an outcome whose
+`:status` is none of `:installed`, `:skipped` and `:indeterminate`. `results.edn`
+counts those under `:malformed-outcomes`, and a positive count rejects the run,
+in a chaos run and in a focused run alike.
+
+A chaos run must still install one fault. Relaxing every class on its own would
+otherwise let a run in which all six classes were absent or skipped pass on the
+workload, the cleanup and the final recovery alone, so an entirely inert Nemesis
+would look successful. `results.edn` reports how many classes installed a
+recognized fault under `:fault-classes-executed`, and zero rejects the run.
+Cleanup, clock reset and recovery operations do not count toward it.
 
 Every Jepsen node builds a snapshot after 100 newly committed logs by default.
 The regular write workload therefore exercises snapshot construction during
@@ -346,8 +369,8 @@ must return to the required state within the recovery deadline.
 The `final-workload` checker separately rejects a run when its final reads or
 writes fail. These modeled failures are not unexpected-SUT-response markers.
 
-A coverage failure rejects the run but does not by itself identify an OpenRaft
-failure or its root cause. Missing coverage is recorded in `results.edn` under
+A coverage failure rejects a focused run but does not by itself identify an
+OpenRaft failure or its root cause. Missing coverage is recorded in `results.edn` under
 fields such as `:missing-modes` or `:missing-target-roles`. The mode or target
 role may be absent from `history.edn`, skipped by an outcome such as
 `:no-supported-leader`, or blocked by a Harness failure recorded in

--- a/jepsen/src/jepsen/openraft/cluster.clj
+++ b/jepsen/src/jepsen/openraft/cluster.clj
@@ -5,7 +5,12 @@
             [jepsen.openraft.await :as await]
             [jepsen.openraft.client :as client]
             [jepsen.openraft.interruption :as interruption]
-            [jepsen.openraft.quorum :as quorum]))
+            [jepsen.openraft.quorum :as quorum])
+  (:import (java.util.concurrent ExecutionException
+                                 Executors
+                                 ExecutorService
+                                 Future
+                                 TimeUnit)))
 
 (defn node-info [test node]
   {:node-id (client/node-host node)
@@ -84,19 +89,117 @@
 (defn- modeled-metrics-failure? [e]
   (contains? modeled-metrics-failure-kinds (:kind (ex-data e))))
 
-(defn- collect-reachable-metrics-from [test nodes]
-  (into {}
-        (keep
-         (fn [node]
-           (try
-             [node (node-metrics! test node)]
-             (catch InterruptedException e
-               (throw e))
-             (catch Exception e
-               (if (modeled-metrics-failure? e)
-                 nil
-                 (throw e)))))
-         nodes)))
+(def ^:private probe-drain-seconds 10)
+
+(defn- probe-result
+  "Reads one finished probe, surfacing the exception the probe itself threw."
+  [^Future probe]
+  (try
+    (.get probe)
+    (catch ExecutionException e
+      (throw (.getCause e)))))
+
+(defn- drain-probes!
+  "Stops the pool, waits for every probe thread to leave, and reports whether
+  the wait absorbed an interrupt.
+
+  `invokeAll` cancellation and `shutdownNow` only ask a probe to stop, and the
+  pool's threads are not daemons, so a scan that returns without waiting leaves
+  live threads behind. Each probe is one `client/metrics!` call bounded by its
+  five-second request timeout, so a probe that never observes its interrupt
+  still ends well inside `probe-drain-seconds`.
+
+  A second interrupt must not shorten the wait, or the scan would again return
+  over live threads. The loop therefore waits against an absolute deadline and
+  remembers the interrupt instead of obeying it, leaving the caller to restore
+  the flag once the pool is empty. A pool still running at the deadline is
+  reported rather than ignored, and that report carries the remembered
+  interrupt so the caller can restore the flag on that path too."
+  [^ExecutorService pool]
+  (.shutdownNow pool)
+  (let [deadline (+ (System/nanoTime)
+                    (* probe-drain-seconds 1000000000))]
+    (loop [interrupted? false]
+      (let [remaining (- deadline (System/nanoTime))]
+        (cond
+          (.isTerminated pool)
+          interrupted?
+
+          (not (pos? remaining))
+          (throw (ex-info "OpenRaft metrics probes did not terminate"
+                          {:timeout-seconds probe-drain-seconds
+                           :interrupted? interrupted?}))
+
+          :else
+          (recur (try
+                   (.awaitTermination pool remaining TimeUnit/NANOSECONDS)
+                   interrupted?
+                   (catch InterruptedException _
+                     true))))))))
+
+(defn- collect-reachable-metrics-from
+  "Fetches metrics from nodes at once, dropping the unreachable ones.
+
+  A node whose process is paused answers no request, so its probe ends at
+  `client/metrics!`'s five-second request timeout. One Nemesis thread runs
+  every fault class, and a sequential scan would hold that thread for one
+  timeout per paused node, delaying the cleanup that resumes them.
+
+  `ExecutorService.invokeAll` never drops an interrupt that arrives while this
+  thread waits for the probes: it cancels the unfinished ones and rethrows the
+  InterruptedException, or it returns while this thread still carries the flag.
+  A helper that joins each probe in turn can lose the interrupt instead, when
+  the probe it is joining finishes between the throw and the liveness check.
+
+  The scan drains the pool before it restores the flag, so it never returns
+  while a probe thread is still running, and the drain is not cut short by the
+  interrupt it is about to restore. It captures `Throwable` rather than
+  `Exception`, because `probe-result` rethrows whatever a probe threw, and an
+  `AssertionError` escaping past the drain would leave the pool's non-daemon
+  threads alive."
+  [test nodes]
+  (let [^ExecutorService pool (Executors/newCachedThreadPool)
+        probes (mapv (fn [node]
+                       (fn []
+                         (try
+                           [node (node-metrics! test node)]
+                           (catch InterruptedException e
+                             (throw e))
+                           (catch Exception e
+                             (if (modeled-metrics-failure? e)
+                               nil
+                               (throw e))))))
+                     nodes)
+        scan (try
+               {:metrics (->> (.invokeAll pool probes)
+                              (map probe-result)
+                              (into {} (remove nil?)))}
+               (catch Throwable t
+                 {:error t}))
+        ;; invokeAll clears the flag on this thread when it throws, so this
+        ;; drain runs before the flag is put back.
+        drain (try
+                {:interrupted? (drain-probes! pool)}
+                (catch Throwable t
+                  {:error t}))
+        scan-error (:error scan)
+        drain-error (:error drain)
+        absorbed? (or (:interrupted? drain)
+                      (:interrupted? (ex-data drain-error)))
+        interrupted? (boolean
+                      (or absorbed?
+                          (interruption/interruption? scan-error)
+                          (interruption/interruption? drain-error)))]
+    ;; A drain failure means probe threads leaked, which outranks whatever
+    ;; ended the scan, so it becomes the thrown error and carries the scan
+    ;; failure with it.
+    (when (and scan-error drain-error)
+      (.addSuppressed ^Throwable drain-error ^Throwable scan-error))
+    (when interrupted?
+      (.interrupt (Thread/currentThread)))
+    (when-let [error (or drain-error scan-error)]
+      (throw error))
+    (:metrics scan)))
 
 (defn- collect-reachable-metrics [test]
   (collect-reachable-metrics-from test (:nodes test)))

--- a/jepsen/src/jepsen/openraft/nemesis.clj
+++ b/jepsen/src/jepsen/openraft/nemesis.clj
@@ -154,7 +154,21 @@
                      :f :await-recovery}
    :perf #{}})
 
-(defn- fault-class-checker [fault-checker]
+(defn- fault-class-checker
+  "Reports what one fault class covered in a composed run, without requiring it.
+
+  A composed run draws every fault class from one random schedule, so whether a
+  class ever meets a healthy cluster depends on wall-clock timing. The
+  single-class jepsen.yml jobs own per-class coverage and keep failing on their
+  own missing modes, target roles and changes. A composed run therefore keeps
+  the cleanup, error and recovery verdicts and reports the observed and missing
+  entries instead of failing on them.
+
+  Only an absent or skipped fault is relaxed. An outcome that claims an
+  installed fault the class cannot read, or that carries a missing or unknown
+  status, is a Nemesis defect rather than a schedule that never reached the
+  class, so `:malformed-outcomes` still rejects the run."
+  [fault-checker]
   (openraft-checker/reject-checker-exceptions
    (reify checker/Checker
      (check [_ test history opts]
@@ -165,7 +179,7 @@
              executed? (boolean (seq observed))
              cluster-state (:cluster-state result)
              valid? (cond
-                      (not executed?) false
+                      (pos? (or (:malformed-outcomes result) 0)) false
                       (pos? (or (:error-count result) 0)) false
                       (contains? result :restored?)
                       (and (:restored? result)
@@ -173,12 +187,36 @@
                       (= :intact cluster-state) true
                       (= :unknown cluster-state) :unknown
                       :else false)]
-         (-> result
-             (dissoc :missing-modes
-                     :missing-target-roles
-                     :missing-changes)
-             (assoc :valid? valid?
-                    :fault-class-executed? executed?)))))))
+         (assoc result
+                :valid? valid?
+                :fault-class-executed? executed?))))))
+
+(defn- chaos-checker
+  "Requires that a composed run installed at least one recognized fault.
+
+  Every class relaxes its own coverage in a composed run, so without this gate
+  a run in which each of the six classes was absent or skipped would pass on
+  the workload, the cleanup and the final recovery alone, and an entirely
+  inert Nemesis would look successful. Only a class reporting
+  `:fault-class-executed? true` counts, and that flag reads the class's own
+  fault operation, so cleanup, clock reset and recovery operations do not
+  satisfy the gate.
+
+  The gate depends on wall-clock timing, like the per-class coverage it
+  replaces, but far more weakly: it needs one installation out of six classes
+  over the whole run rather than every mode of every class."
+  [composed]
+  (reify checker/Checker
+    (check [_ test history opts]
+      (let [result (checker/check composed test history opts)
+            executed (->> (vals result)
+                          (filter map?)
+                          (filter :fault-class-executed?)
+                          count)
+            any-fault? (pos? executed)]
+        (assoc result
+               :valid? (if any-fault? (:valid? result) false)
+               :fault-classes-executed executed)))))
 
 (defn- cleanup-order [packages]
   (let [membership? #(= :membership (:name %))]
@@ -223,4 +261,4 @@
            :checker (if (= 1 (count packages))
                       (:checker (first packages))
                       (openraft-checker/reject-checker-exceptions
-                       (checker/compose checkers))))))
+                       (chaos-checker (checker/compose checkers)))))))

--- a/jepsen/src/jepsen/openraft/nemesis/clock.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/clock.clj
@@ -301,40 +301,67 @@
 (defn- installed? [op]
   (= :installed (get-in op [:value :status])))
 
+(def ^:private required-rate-directions #{:fast :slow})
+(def ^:private fault-operations [:bump-clock :rate-clock :strobe-clock])
+(def ^:private operation-modes
+  {:bump-clock :bump
+   :rate-clock :rate
+   :strobe-clock :strobe})
+
+(defn- clock-fault-installed?
+  "Says whether one clock fault outcome carries the evidence coverage reads.
+
+  A `:rate-clock` outcome counts only when it names the direction it applied,
+  because Clock coverage requires both `:fast` and `:slow`. Without that
+  check, a rate change with an unusable direction would still contribute the
+  `:rate` mode and hide a Nemesis defect."
+  [operation-f value]
+  (and (= :installed (:status value))
+       (= (get operation-modes operation-f) (:mode value))
+       (or (not= :rate-clock operation-f)
+           (contains? required-rate-directions (:direction value)))))
+
 (defn- coverage-checker []
   (reify checker/Checker
     (check [_ _test history _opts]
-      (let [installed-values (->> history
-                                  (filter #(and (contains? #{:bump-clock
-                                                             :rate-clock
-                                                             :strobe-clock}
-                                                           (:f %))
-                                                (installed? %)))
-                                  (map :value))
-            bump? (some #(and (= :bump-clock (:f %)) (installed? %)) history)
-            strobe? (some #(and (= :strobe-clock (:f %)) (installed? %))
-                          history)
-            observed-modes (->> history
-                                (filter installed?)
-                                (keep #(case (:f %)
-                                         :bump-clock :bump
-                                         :rate-clock :rate
-                                         :strobe-clock :strobe
-                                         nil))
+      (let [values-by-operation
+            (into {}
+                  (map (fn [operation-f]
+                         [operation-f (->> history
+                                           (filter #(= operation-f (:f %)))
+                                           (map :value))]))
+                  fault-operations)
+            recognized-by-operation
+            (into {}
+                  (map (fn [[operation-f values]]
+                         [operation-f
+                          (filter #(clock-fault-installed? operation-f %)
+                                  values)]))
+                  values-by-operation)
+            malformed (->> values-by-operation
+                           (map (fn [[operation-f values]]
+                                  (outcome/malformed-outcomes
+                                   #(clock-fault-installed? operation-f %)
+                                   values)))
+                           (reduce + 0))
+            recognized-values (apply concat (vals recognized-by-operation))
+            bump? (seq (get recognized-by-operation :bump-clock))
+            strobe? (seq (get recognized-by-operation :strobe-clock))
+            observed-modes (->> recognized-values
+                                (keep :mode)
                                 set)
-            rate-directions (->> history
-                                 (filter #(and (= :rate-clock (:f %))
-                                               (installed? %)))
-                                 (keep #(get-in % [:value :direction]))
+            rate-directions (->> (get recognized-by-operation :rate-clock)
+                                 (keep :direction)
                                  set)
-            observed-target-categories (->> installed-values
+            observed-target-categories (->> recognized-values
                                             (keep :target-category)
                                             set)
             final-reset (last (filter #(= :reset-clock (:f %)) history))
             recovered? (and final-reset (installed? final-reset))]
-        {:valid? (boolean (and bump?
+        {:valid? (boolean (and (zero? malformed)
+                               bump?
                                strobe?
-                               (= #{:fast :slow} rate-directions)
+                               (= required-rate-directions rate-directions)
                                recovered?))
          :bump-installed (boolean bump?)
          :strobe-installed (boolean strobe?)
@@ -342,6 +369,7 @@
          :observed-target-categories
          (vec (sort observed-target-categories))
          :rate-directions (vec (sort rate-directions))
+         :malformed-outcomes malformed
          :final-reset-installed (boolean recovered?)
          :cluster-state (if recovered? :intact :unknown)}))))
 

--- a/jepsen/src/jepsen/openraft/nemesis/membership.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/membership.clj
@@ -917,6 +917,9 @@
   (reify checker/Checker
     (check [_ test history _opts]
       (let [required-changes #{:grow :shrink}
+            change-installed? #(membership-change-installed?
+                                required-changes
+                                %)
             expected-voters (set (:nodes test))
             membership-history (->> history
                                     (filter
@@ -924,23 +927,33 @@
                                          :shrink
                                          :restore-membership} (:f %)))
                                     vec)
+            ;; A restore reports the change it completed under
+            ;; :resolved-change, and its own value describes the restored
+            ;; membership rather than a change, so only :grow and :shrink
+            ;; contribute their outer value. A :resolved-change becomes a
+            ;; candidate only when the key is present, so an outcome that
+            ;; carries no nested change is not mistaken for a malformed one.
+            change-values (->> membership-history
+                               (filter #(#{:grow :shrink} (:f %)))
+                               (map :value))
+            resolved-changes (->> membership-history
+                                  (map :value)
+                                  (filter map?)
+                                  (filter #(contains? % :resolved-change))
+                                  (map :resolved-change))
+            change-candidates (concat change-values resolved-changes)
             errors (->> membership-history
                         (filter #(or (:error %)
                                      (:exception %)))
                         vec)
-            observed-changes (->> membership-history
-                                  (mapcat
-                                   (fn [op]
-                                     (let [value (:value op)]
-                                       [value
-                                        (:resolved-change value)])))
+            observed-changes (->> change-candidates
                                   (keep
                                    (fn [change]
-                                     (when (membership-change-installed?
-                                            required-changes
-                                            change)
+                                     (when (change-installed? change)
                                        (:change change))))
                                   set)
+            malformed (outcome/malformed-outcomes change-installed?
+                                                  change-candidates)
             missing-changes (remove observed-changes
                                     required-changes)
             final-operation (peek membership-history)
@@ -953,12 +966,14 @@
                                 last)
             recovered? (boolean
                         (recovery-installed? (:value final-recovery)))]
-        {:valid? (and (empty? errors)
+        {:valid? (and (zero? malformed)
+                      (empty? errors)
                       (empty? missing-changes)
                       restored?
                       recovered?)
          :observed-changes (vec (sort observed-changes))
          :missing-changes (vec (sort missing-changes))
+         :malformed-outcomes malformed
          :restored? restored?
          :recovered? recovered?
          :error-count (count errors)

--- a/jepsen/src/jepsen/openraft/nemesis/outcome.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/outcome.clj
@@ -19,6 +19,36 @@
          :status :skipped
          :reason reason))
 
+(defn malformed-outcomes
+  "Counts fault outcomes a coverage checker cannot read.
+
+  A checker recognizes an installed outcome by the evidence it carries, such
+  as the mode or the target role. Two shapes are defects of the Nemesis rather
+  than a fault the random schedule never reached, so a run must reject them
+  instead of reporting missing coverage: an `:installed` value that fails
+  `recognized?`, and a value whose `:status` is none of `:installed`,
+  `:skipped` and `:indeterminate`.
+
+  A `:skipped` outcome stays legal, because relaxing skipped faults is what a
+  composed run is built on, and an `:indeterminate` one keeps the lifecycle
+  meaning its own checker gives it.
+
+  A value carrying no `:status` at all is passed over. The history holds the
+  invocation and the completion of every Nemesis operation under one `:f`, the
+  Jepsen interpreter gives the two entries separate `:index` values, and an
+  invocation's value never carries a `:status`. A checker reading the history
+  therefore cannot tell an invocation apart from a completion whose status went
+  missing, and rejecting a missing `:status` would reject every real run."
+  [recognized? values]
+  (->> values
+       (filter #(and (map? %) (contains? % :status)))
+       (remove (fn [value]
+                 (case (:status value)
+                   :installed (boolean (recognized? value))
+                   (:skipped :indeterminate) true
+                   false)))
+       count))
+
 (defn indeterminate
   "Returns an attempted action whose side effect cannot be confirmed."
   [reason details]

--- a/jepsen/src/jepsen/openraft/nemesis/packet.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/packet.clj
@@ -206,17 +206,25 @@
 (defn- coverage-checker [packet-mode]
   (reify checker/Checker
     (check [_ _test history _opts]
-      (let [observed-roles (->> history
-                                (filter #(= :start-packet (:f %)))
-                                (filter #(packet-start-installed? (:value %)))
-                                (filter #(or (nil? packet-mode)
-                                             (= packet-mode
-                                                (get-in % [:value :mode]))))
-                                (keep #(get-in % [:value :target-role]))
+      ;; One predicate drives both coverage and malformed-outcome validation.
+      ;; A fixed-mode package that reports the other mode is a Nemesis defect,
+      ;; so it must not merely drop out of the observed roles.
+      (let [recognized? (fn [value]
+                          (and (packet-start-installed? value)
+                               (or (nil? packet-mode)
+                                   (= packet-mode (:mode value)))))
+            start-values (->> history
+                              (filter #(= :start-packet (:f %)))
+                              (map :value))
+            observed-roles (->> start-values
+                                (filter recognized?)
+                                (keep :target-role)
                                 set)
             missing-roles (remove observed-roles required-target-roles)
+            malformed (outcome/malformed-outcomes recognized? start-values)
             cluster-state (reduce next-cluster-state :intact history)
             valid? (cond
+                     (pos? malformed) false
                      (seq missing-roles) false
                      (= :intact cluster-state) true
                      (= :recovery-pending cluster-state) false
@@ -225,6 +233,7 @@
          :mode (or packet-mode :mixed)
          :observed-target-roles (vec (sort observed-roles))
          :missing-target-roles (vec (sort missing-roles))
+         :malformed-outcomes malformed
          :cluster-state cluster-state}))))
 
 (defn packet-package [database packet-mode]

--- a/jepsen/src/jepsen/openraft/nemesis/partition.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/partition.clj
@@ -187,15 +187,19 @@
 (defn- coverage-checker []
   (reify checker/Checker
     (check [_ _test history _opts]
-      (let [observed-modes (->> history
-                                (filter #(= :start-partition (:f %)))
-                                (filter #(partition-start-installed?
-                                          (:value %)))
-                                (keep #(get-in % [:value :mode]))
+      (let [start-values (->> history
+                              (filter #(= :start-partition (:f %)))
+                              (map :value))
+            observed-modes (->> start-values
+                                (filter partition-start-installed?)
+                                (keep :mode)
                                 set)
             missing-modes (remove observed-modes required-partition-modes)
+            malformed (outcome/malformed-outcomes partition-start-installed?
+                                                  start-values)
             cluster-state (reduce next-cluster-state :intact history)
             valid? (cond
+                     (pos? malformed) false
                      (seq missing-modes) false
                      (= :intact cluster-state) true
                      (= :recovery-pending cluster-state) false
@@ -203,6 +207,7 @@
         {:valid? valid?
          :observed-modes (vec (sort observed-modes))
          :missing-modes (vec (sort missing-modes))
+         :malformed-outcomes malformed
          :cluster-state cluster-state}))))
 
 (defn partition-package []

--- a/jepsen/src/jepsen/openraft/nemesis/process.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/process.clj
@@ -372,10 +372,10 @@
 
 (defn- coverage-result
   [required-modes operation-f installed? invalid-states history cluster-state]
-  (let [installed-values (->> history
-                              (filter #(= operation-f (:f %)))
-                              (map :value)
-                              (filter installed?))
+  (let [values (->> history
+                    (filter #(= operation-f (:f %)))
+                    (map :value))
+        installed-values (filter installed? values)
         observed-modes (->> installed-values
                             (keep :mode)
                             set)
@@ -383,7 +383,9 @@
                                         (keep :target-category)
                                         set)
         missing-modes (remove observed-modes required-modes)
+        malformed (outcome/malformed-outcomes installed? values)
         valid? (cond
+                 (pos? malformed) false
                  (seq missing-modes) false
                  (= :intact cluster-state) true
                  (contains? invalid-states cluster-state) false
@@ -392,6 +394,7 @@
      :observed-modes (vec (sort observed-modes))
      :observed-target-categories (vec (sort observed-target-categories))
      :missing-modes (vec (sort missing-modes))
+     :malformed-outcomes malformed
      :cluster-state cluster-state}))
 
 (defn- coverage-checker []

--- a/jepsen/test/jepsen/openraft/cli_test.clj
+++ b/jepsen/test/jepsen/openraft/cli_test.clj
@@ -215,7 +215,7 @@
         result (checker/check (:checker test) test (history/history []) {})]
     (is (= #{:valid? :seed :stats :exceptions :crash :nemesis :workload}
            (set (keys result))))
-    (is (= #{:valid? :partition :membership}
+    (is (= #{:valid? :fault-classes-executed :partition :membership}
            (set (keys (:nemesis result)))))))
 
 (defn- lifecycle-test-generator [failure-state]

--- a/jepsen/test/jepsen/openraft/cluster_test.clj
+++ b/jepsen/test/jepsen/openraft/cluster_test.clj
@@ -8,6 +8,13 @@
   {:nodes ["n1" "n2" "n3"]
    :api-port 21001})
 
+(defn- spin-millis
+  "Burns the calling thread for `ms`, which an interrupt cannot cut short."
+  [ms]
+  (let [deadline (+ (System/nanoTime) (* ms 1000000))]
+    (while (< (System/nanoTime) deadline)
+      nil)))
+
 (defn- vote [term leader]
   {:leader_id {:term term
                :node_id leader}
@@ -67,6 +74,163 @@
                         (throw (ex-info "unreachable"
                                         {:kind :unreachable}))))]
       (is (nil? (#'cluster/cluster-status test-config))))))
+
+(deftest probes-every-node-concurrently
+  (let [nodes (:nodes test-config)
+        follower {:state "Follower"
+                  :current_leader "n2"
+                  :vote (vote 3 "n2")}
+        arrived (java.util.concurrent.CountDownLatch. (count nodes))]
+    (with-redefs [client/metrics!
+                  (fn [endpoint]
+                    (.countDown arrived)
+                    ;; A sequential scan never lets the last node arrive, so
+                    ;; the first probe waits out the timeout and fails here.
+                    (when-not (.await arrived
+                                      10
+                                      java.util.concurrent.TimeUnit/SECONDS)
+                      (throw (ex-info "a node probe waited for an earlier one"
+                                      {:endpoint endpoint})))
+                    follower)]
+      (is (= (zipmap nodes (repeat follower))
+             (#'cluster/collect-reachable-metrics test-config))))))
+
+(deftest restores-an-interrupt-after-draining-every-probe
+  (let [node-count (count (:nodes test-config))
+        probing (java.util.concurrent.CountDownLatch. node-count)
+        cleaned (java.util.concurrent.CountDownLatch. node-count)
+        coordinator (promise)
+        scan (future
+               (deliver coordinator (Thread/currentThread))
+               (try
+                 (with-redefs [client/metrics!
+                               (fn [_endpoint]
+                                 (.countDown probing)
+                                 (try
+                                   (Thread/sleep 60000)
+                                   nil
+                                   (catch InterruptedException e
+                                     ;; A cancelled probe still runs cleanup,
+                                     ;; and the scan owes it that time.
+                                     (spin-millis 150)
+                                     (.countDown cleaned)
+                                     (throw e))))]
+                   (#'cluster/collect-reachable-metrics test-config)
+                   [nil
+                    (.isInterrupted (Thread/currentThread))
+                    (.getCount cleaned)])
+                 (catch Exception e
+                   [e
+                    (.isInterrupted (Thread/currentThread))
+                    (.getCount cleaned)])
+                 (finally
+                   (Thread/interrupted))))]
+    (is (.await probing 10 java.util.concurrent.TimeUnit/SECONDS))
+    (.interrupt ^Thread @coordinator)
+    (let [outcome (deref scan 30000 ::timeout)]
+      (is (vector? outcome) "the scan never returned")
+      (when (vector? outcome)
+        (let [[thrown interrupted? unfinished] outcome]
+          (is (instance? InterruptedException thrown))
+          (is interrupted?)
+          (is (zero? unfinished)))))))
+
+(deftest keeps-draining-when-a-second-interrupt-arrives
+  (let [node-count (count (:nodes test-config))
+        probing (java.util.concurrent.CountDownLatch. node-count)
+        cleaned (java.util.concurrent.CountDownLatch. node-count)
+        coordinator (promise)
+        scan (future
+               (deliver coordinator (Thread/currentThread))
+               (try
+                 (with-redefs [client/metrics!
+                               (fn [_endpoint]
+                                 (.countDown probing)
+                                 (try
+                                   (Thread/sleep 60000)
+                                   nil
+                                   (catch InterruptedException e
+                                     (spin-millis 300)
+                                     (.countDown cleaned)
+                                     (throw e))))]
+                   (#'cluster/collect-reachable-metrics test-config)
+                   [nil
+                    (.isInterrupted (Thread/currentThread))
+                    (.getCount cleaned)])
+                 (catch Throwable t
+                   [t
+                    (.isInterrupted (Thread/currentThread))
+                    (.getCount cleaned)])
+                 (finally
+                   (Thread/interrupted))))]
+    (is (.await probing 10 java.util.concurrent.TimeUnit/SECONDS))
+    (let [^Thread thread @coordinator]
+      (.interrupt thread)
+      ;; Keep interrupting while the drain waits. The drain must remember each
+      ;; interrupt rather than obey it, or it would return over live probes.
+      (dotimes [_ 20]
+        (spin-millis 10)
+        (.interrupt thread)))
+    (let [outcome (deref scan 30000 ::timeout)]
+      (is (vector? outcome) "the scan never returned")
+      (when (vector? outcome)
+        (let [[thrown interrupted? unfinished] outcome]
+          (is (instance? InterruptedException thrown))
+          (is interrupted?)
+          (is (zero? unfinished)))))))
+
+(deftest reports-probes-that-outlast-the-drain-deadline
+  (let [probing (java.util.concurrent.CountDownLatch.
+                 (count (:nodes test-config)))
+        coordinator (promise)
+        scan (future
+               (deliver coordinator (Thread/currentThread))
+               (try
+                 (with-redefs [client/metrics!
+                               (fn [_endpoint]
+                                 (.countDown probing)
+                                 (try
+                                   (Thread/sleep 60000)
+                                   nil
+                                   (catch InterruptedException e
+                                     ;; Outlive the shortened drain deadline.
+                                     (spin-millis 200)
+                                     (throw e))))
+                               cluster/probe-drain-seconds 0]
+                   (#'cluster/collect-reachable-metrics test-config)
+                   [nil (.isInterrupted (Thread/currentThread))])
+                 (catch Throwable t
+                   [t (.isInterrupted (Thread/currentThread))])
+                 (finally
+                   (Thread/interrupted))))]
+    (is (.await probing 10 java.util.concurrent.TimeUnit/SECONDS))
+    (.interrupt ^Thread @coordinator)
+    (let [outcome (deref scan 30000 ::timeout)]
+      (is (vector? outcome) "the scan never returned")
+      (when (vector? outcome)
+        (let [[thrown interrupted?] outcome
+              suppressed (seq (.getSuppressed ^Throwable thrown))]
+          (is (= "OpenRaft metrics probes did not terminate"
+                 (ex-message thrown)))
+          (is (= 1 (count suppressed)))
+          (is (instance? InterruptedException (first suppressed)))
+          (is interrupted?))))))
+
+(deftest rethrows-a-probe-assertion-error-after-draining
+  (let [failure (AssertionError. "probe assertion")
+        threads (atom [])
+        thrown (try
+                 (with-redefs [client/metrics!
+                               (fn [_endpoint]
+                                 (swap! threads conj (Thread/currentThread))
+                                 (throw failure))]
+                   (#'cluster/collect-reachable-metrics test-config))
+                 nil
+                 (catch Throwable t
+                   t))]
+    (is (identical? failure thrown))
+    (is (= (count (:nodes test-config)) (count @threads)))
+    (is (every? #(not (.isAlive ^Thread %)) @threads))))
 
 (deftest distinguishes-modeled-metrics-failures-from-harness-errors
   (testing "recognized SUT observations make a node unavailable"

--- a/jepsen/test/jepsen/openraft/nemesis/clock_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/clock_test.clj
@@ -36,27 +36,56 @@
 
 (deftest clock-checker-requires-all-faults-and-final-reset
   (let [subject (:checker (clock-nemesis/clock-package))
-        installed (fn [f] {:type :info :f f :value {:status :installed}})]
+        installed (fn [f mode]
+                    {:type :info
+                     :f f
+                     :value {:status :installed :mode mode}})
+        rate (fn [direction]
+               {:type :info
+                :f :rate-clock
+                :value {:status :installed
+                        :mode :rate
+                        :direction direction}})
+        complete [(installed :bump-clock :bump)
+                  (installed :strobe-clock :strobe)
+                  (rate :fast)
+                  (rate :slow)
+                  (installed :reset-clock :reset)]]
     (testing "complete coverage"
       (is (true? (:valid? (checker/check subject
                                          test-config
-                                         [(installed :bump-clock)
-                                          (installed :strobe-clock)
-                                          {:type :info
-                                           :f :rate-clock
-                                           :value {:status :installed
-                                                   :direction :fast}}
-                                          {:type :info
-                                           :f :rate-clock
-                                           :value {:status :installed
-                                                   :direction :slow}}
-                                          (installed :reset-clock)]
+                                         complete
                                          {})))))
     (testing "missing bump"
       (is (false? (:valid? (checker/check subject
                                           test-config
-                                          [(installed :reset-clock)]
-                                          {})))))))
+                                          [(installed :reset-clock :reset)]
+                                          {})))))
+
+    (testing "an installed rate change without a direction is malformed"
+      (let [result (checker/check
+                    subject
+                    test-config
+                    (into [{:type :info
+                            :f :rate-clock
+                            :value {:status :installed :mode :rate}}]
+                          complete)
+                    {})]
+        (is (false? (:valid? result)))
+        (is (= 1 (:malformed-outcomes result)))
+        (is (= [:fast :slow] (:rate-directions result)))))
+
+    (testing "an unknown status is malformed"
+      (let [result (checker/check
+                    subject
+                    test-config
+                    (into [{:type :info
+                            :f :bump-clock
+                            :value {:status :bogus :mode :bump}}]
+                          complete)
+                    {})]
+        (is (false? (:valid? result)))
+        (is (= 1 (:malformed-outcomes result)))))))
 
 (deftest clock-checker-reports-target-categories
   (let [subject (:checker (clock-nemesis/clock-package))
@@ -67,11 +96,15 @@
         result (checker/check
                 subject
                 test-config
-                [(installed :bump-clock {:target-category :one})
-                 (installed :strobe-clock {:target-category :minority})
-                 (installed :rate-clock {:direction :fast
+                [(installed :bump-clock {:mode :bump
+                                         :target-category :one})
+                 (installed :strobe-clock {:mode :strobe
+                                           :target-category :minority})
+                 (installed :rate-clock {:mode :rate
+                                         :direction :fast
                                          :target-category :all})
-                 (installed :rate-clock {:direction :slow
+                 (installed :rate-clock {:mode :rate
+                                         :direction :slow
                                          :target-category :one})
                  (installed :kill-process {:target-category :majority})
                  (installed :reset-clock {})]

--- a/jepsen/test/jepsen/openraft/nemesis/membership_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/membership_test.clj
@@ -1207,6 +1207,34 @@
                                   [shrink grow restore recovery]
                                   {}))))
 
+    (testing "an installed change without its evidence is a defect"
+      (let [result (checker/check subject
+                                  test-config
+                                  [(assoc shrink :value (installed {}))
+                                   grow
+                                   restore
+                                   recovery]
+                                  {})]
+        (is (false? (:valid? result)))
+        (is (= 1 (:malformed-outcomes result)))
+        (is (= [:shrink] (:missing-changes result)))))
+
+    (testing "a nested installed change without its evidence is a defect"
+      (let [result (checker/check
+                    subject
+                    test-config
+                    [(assoc shrink
+                            :value (skipped :no-supported-leader
+                                            {:resolved-change
+                                             (installed {})}))
+                     grow
+                     restore
+                     recovery]
+                    {})]
+        (is (false? (:valid? result)))
+        (is (= 1 (:malformed-outcomes result)))
+        (is (= [:shrink] (:missing-changes result)))))
+
     (testing "an indeterminate request does not count as coverage"
       (let [result (checker/check
                     subject

--- a/jepsen/test/jepsen/openraft/nemesis/packet_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/packet_test.clj
@@ -205,7 +205,60 @@
                                    stop]
                                   {})]
         (is (false? (:valid? result)))
-        (is (= :recovery-pending (:cluster-state result)))))))
+        (is (= :recovery-pending (:cluster-state result)))))
+
+    (testing "an installed degradation without a target role is a defect"
+      (let [result (checker/check subject
+                                  {}
+                                  [{:type :info
+                                    :process :nemesis
+                                    :f :start-packet
+                                    :value (installed {:mode :slow})}
+                                   stop
+                                   recovered]
+                                  {})]
+        (is (= 1 (:malformed-outcomes result)))
+        (is (empty? (:observed-target-roles result)))))
+
+    (testing "the other mode in a fixed-mode package fails the focused run"
+      (let [result (checker/check subject
+                                  {}
+                                  [(start :leader-included)
+                                   stop
+                                   (start :leader-excluded)
+                                   stop
+                                   {:type :info
+                                    :process :nemesis
+                                    :f :start-packet
+                                    :value (installed
+                                            {:mode :flaky
+                                             :target-role :leader-included})}
+                                   stop
+                                   recovered]
+                                  {})]
+        (is (false? (:valid? result)))
+        (is (= 1 (:malformed-outcomes result)))
+        (is (empty? (:missing-target-roles result)))))
+
+    (testing "an unknown status fails the focused run"
+      (let [result (checker/check subject
+                                  {}
+                                  [(start :leader-included)
+                                   stop
+                                   (start :leader-excluded)
+                                   stop
+                                   {:type :info
+                                    :process :nemesis
+                                    :f :start-packet
+                                    :value {:status :bogus
+                                            :mode :slow
+                                            :target-role :leader-included}}
+                                   stop
+                                   recovered]
+                                  {})]
+        (is (false? (:valid? result)))
+        (is (= 1 (:malformed-outcomes result)))
+        (is (empty? (:missing-target-roles result)))))))
 
 (deftest rejects-unknown-packet-modes
   (is (thrown-with-msg? clojure.lang.ExceptionInfo

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -912,7 +912,17 @@
     (let [result (checker/check subject {} unrecovered-history {})]
       (is (false? (:valid? result)))
       (is (empty? (:missing-modes result)))
-      (is (= :degraded (:cluster-state result))))))
+      (is (= :degraded (:cluster-state result))))
+    (let [result (checker/check subject
+                                {}
+                                [{:f :kill-process
+                                  :value (installed {})}
+                                 {:f :await-recovery
+                                  :value (installed {:leader "n1"})}]
+                                {})]
+      (is (false? (:valid? result)))
+      (is (= 1 (:malformed-outcomes result)))
+      (is (empty? (:observed-modes result))))))
 
 (defn- process-kill-value
   ([configs nodes]

--- a/jepsen/test/jepsen/openraft/nemesis_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis_test.clj
@@ -89,7 +89,7 @@
             :await-recovery]
            (mapv :f (:final-generator package))))))
 
-(deftest requires-each-composed-fault-class-to-execute
+(deftest reports-composed-fault-class-coverage-without-requiring-it
   (let [failure-state (harness/failure-state)
         database (db/db {})
         all-voters (set (:nodes test-config))
@@ -161,15 +161,72 @@
         (is (true? (get-in result
                            [:membership :fault-class-executed?])))))
 
-    (testing "a skipped fault does not count as execution"
+    (testing "a skipped fault is reported, not a composed-run failure"
       (let [result (check (mapv #(if (= :pause-process (:f %))
                                    (assoc % :value
                                           {:status :skipped
                                            :reason :no-supported-leader})
                                    %)
                                 history))]
+        (is (:valid? result))
+        (is (false? (get-in result [:pause :fault-class-executed?])))
+        (is (= [:random] (get-in result [:pause :missing-modes])))))
+
+    (testing "an installed outcome the class cannot read stays a failure"
+      (let [result (check (mapv #(if (= :start-partition (:f %))
+                                   (assoc % :value {:status :installed})
+                                   %)
+                                history))]
         (is (false? (:valid? result)))
-        (is (false? (get-in result [:pause :fault-class-executed?])))))))
+        (is (false? (get-in result [:partition :fault-class-executed?])))
+        (is (= 1 (get-in result [:partition :malformed-outcomes])))
+        (is (= :intact (get-in result [:partition :cluster-state])))))
+
+    (testing "an unknown status stays a failure"
+      (let [result (check (mapv #(if (= :start-partition (:f %))
+                                   (assoc % :value {:status :bogus
+                                                    :mode :leader-in-majority})
+                                   %)
+                                history))]
+        (is (false? (:valid? result)))
+        (is (= 1 (get-in result [:partition :malformed-outcomes])))))
+
+    (testing "one recognized fault satisfies the composed run"
+      (let [installed-partition? #(and (= :start-partition (:f %))
+                                       (= :installed
+                                          (get-in % [:value :status])))
+            skip-others (fn [op]
+                          (if (or (installed-partition? op)
+                                  (#{:stop-partition
+                                     :resume-process
+                                     :stop-packet
+                                     :reset-clock
+                                     :restore-membership
+                                     :await-recovery} (:f op)))
+                            op
+                            (assoc op :value {:status :skipped
+                                              :reason :no-supported-leader})))
+            result (check (mapv skip-others history))]
+        (is (:valid? result))
+        (is (= 1 (:fault-classes-executed result)))
+        (is (true? (get-in result [:partition :fault-class-executed?])))))
+
+    (testing "a run in which every fault class was skipped fails"
+      (let [cleanup-fs #{:stop-partition
+                         :resume-process
+                         :stop-packet
+                         :reset-clock
+                         :restore-membership
+                         :await-recovery}
+            skip-all (fn [op]
+                       (if (cleanup-fs (:f op))
+                         op
+                         (assoc op :value {:status :skipped
+                                           :reason :no-supported-leader})))
+            result (check (mapv skip-all history))]
+        (is (false? (:valid? result)))
+        (is (zero? (:fault-classes-executed result)))
+        (is (zero? (get-in result [:partition :malformed-outcomes])))))))
 
 (defn- teardown-package [package-name events throwable]
   {:name package-name


### PR DESCRIPTION

## Changelog

##### perf: jepsen: probe every node at once in collect-reachable-metrics-from
# Summary

`collect-reachable-metrics-from` in
`jepsen/src/jepsen/openraft/cluster.clj` now fetches every node's metrics
through `jepsen.util/real-pmap` instead of one node after another.

# Details

A paused OpenRaft process completes the TCP handshake but answers no
request, so its probe ends at `client/metrics!`'s five-second request
timeout. The scan was sequential, so the wait was five seconds per paused
node. In job 98796102286 of run 33155165510 one `start-packet` scan held
the Nemesis thread for 20.0 seconds with four nodes paused, and three
later scans held it for 10.0 seconds each: 50 of the 60 seconds the fault
schedule had.

One thread runs every fault class and every cleanup, so that wait also
delayed the `resume-process` queued behind it, and the Pause outage lasted
as long as the scan. The scan now costs one timeout no matter how many
nodes are paused.

`real-pmap` reports an interrupt by throwing out of `Thread/join`, which
leaves the flag cleared on the calling thread, so the new outer catch
restores it the way `node-metrics!` does for a probe of its own.

- Ref: #2056


##### test: jepsen: stop failing a chaos run on a fault class that never installed
# Summary

`fault-class-checker` in `jepsen/src/jepsen/openraft/nemesis.clj` no longer
turns `:fault-class-executed? false` into `:valid? false`. It now reports
`:fault-class-executed?` next to the `:missing-modes`,
`:missing-target-roles` and `:missing-changes` entries it used to delete.

# Details

The chaos profile draws partition, process, pause, membership, packet and
clock faults from one 60-second random schedule, so whether a class ever
meets a quorum-supported leader depends on wall-clock timing rather than
on OpenRaft. Four of the last six `Jepsen (chaos)` jobs on main failed on
`:packet {:valid? false, :observed-target-roles [], :fault-class-executed?
false}` while linearizability, final reads and writes, recovery and crash
checks all passed. Run 33155165510 is one of them.

Coverage is still a hard requirement where it is deterministic: the
`jepsen.yml` matrix runs membership, partition, pause, process,
packet-slow, packet-flaky and clock one at a time, and a focused run keeps
the package's own checker, which fails on its missing modes, target roles
or changes.

A chaos run keeps every other verdict of each class: a positive
`:error-count`, a membership run that did not restore or recover, and a
`:cluster-state` other than `:intact` all still reject the run.

- Ref: #2056

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2068)
<!-- Reviewable:end -->
