### PR TITLE
fix: log peer-unreachable RPC failures at WARN instead of ERROR

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -1507,7 +1507,7 @@ where
                             target: target.clone(),
                             timeout: ttl,
                         };
-                        tracing::error!("timeout while requesting {}: {}", kind.as_str(), timeout_err);
+                        tracing::warn!("timeout while requesting {}: {}", kind.as_str(), timeout_err);
                         return;
                     }
                 };
@@ -1534,7 +1534,7 @@ where
                     // `pre_vote` returns `Ok(granted)` from the default impl, so Pre-Vote
                     // degrades to a no-op rather than relying on this.
                     Err(err) => {
-                        tracing::error!("while requesting {}, error: {}, target: {}", kind.as_str(), err, target)
+                        tracing::warn!("while requesting {}, error: {}, target: {}", kind.as_str(), err, target)
                     }
                 }
             }
@@ -1562,14 +1562,14 @@ where
                 let res = match tm_res {
                     Ok(res) => res,
                     Err(timeout) => {
-                        tracing::error!("timeout sending transfer_leader: {}, target: {}", timeout, target);
+                        tracing::warn!("timeout sending transfer_leader: {}, target: {}", timeout, target);
                         return;
                     }
                 };
 
                 match res {
                     Err(e) => {
-                        tracing::error!("error sending transfer_leader: {}, target: {}", e, target);
+                        tracing::warn!("error sending transfer_leader: {}, target: {}", e, target);
                     }
                     Ok(resp) => {
                         tracing::info!("Done transfer_leader sent to {}, resp: {:?}", target, resp);

--- a/openraft/src/replication/snapshot_transmitter.rs
+++ b/openraft/src/replication/snapshot_transmitter.rs
@@ -113,8 +113,6 @@ where
                 }
             };
 
-            tracing::error!("ReplicationError while sending snapshot: {}", error);
-
             match error {
                 ReplicationError::Closed(closed) => {
                     tracing::info!("snapshot transmission canceled: {}", closed);


### PR DESCRIPTION
An unreachable peer in an otherwise healthy cluster is expected, recoverable degraded-mode operation, but four callsites still log it at ERROR while the equivalent heartbeat and log-replication failures log at WARN (since 8e0cca52). ERROR is the top `tracing` level, so a downstream `EnvFilter` can only drop these events, not demote them, and monitoring that alerts on ERROR lines treats N-1 operation as a continuous incident.

### Changes

- `raft_core.rs`: vote/pre-vote and transfer-leader RPC timeout/error now log at WARN, matching the heartbeat worker and `ReplicationCore::send_progress_error`. Transfer-leader broadcasts to every voter and is also triggered automatically by the step-down path, so a single down bystander logged an ERROR even when the transfer succeeded.
- `SnapshotTransmitter::stream_snapshot`: drop the blanket ERROR that fired for every `ReplicationError` variant ahead of the match, double-logging the benign ones, and log the retried `RPCError` case at WARN in its own arm. Each variant now logs exactly once: `Closed` and `HigherVote` at INFO, `StorageError` at ERROR, `RPCError` at WARN.

Note: `RemoteError` is uninhabited (`E = Infallible`) at every touched site, so no genuine remote application error is demoted.

`make verify` passes. No message text changed at the re-leveled callsites.

**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- nothing to do: no public API or documented behavior change -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:) <!-- log-level-only change; no log-capture test machinery exists in the repo -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2070)
<!-- Reviewable:end -->
