### PR TITLE
perf: cap matching-point probes at 8 entries

### DIFF
--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -212,7 +212,7 @@ fn test_leader_append_membership_update_learner_process() -> anyhow::Result<()> 
         // matching.next_index()=0 != searching_end=11, so NOT pipeline mode
         let expected = ProgressEntry::empty(6, StreamId::new(5), 11).with_inflight(Inflight::logs(
             None,
-            Some(log_id(5, 1, 10)),
+            Some(log_id(1, 1, 7)),
             InflightId::new(4),
         ));
         assert_eq!(

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -46,6 +46,10 @@ mod update_conflicting_test;
 #[cfg(test)]
 mod update_matching_test;
 
+/// Bounds replication attached to each matching-point probe, avoiding large fragmented ranges
+/// while retaining batching for small follower gaps.
+const MAX_ENTRIES_PER_PROBE: u64 = 8;
+
 /// Handle replication operations.
 ///
 /// - Writing local log store;
@@ -400,7 +404,7 @@ where
             }
 
             let target = item.id.clone();
-            let t = item.next_send(self.state, self.config.max_payload_entries);
+            let t = item.next_send(self.state, MAX_ENTRIES_PER_PROBE);
             tracing::debug!("next send: target: {}, send: {:?}", target, t);
 
             match t {


### PR DESCRIPTION
## Summary
- Keep the existing `ProgressEntry::next_send(log_state, max_entries)` API.
- Pass `8` for matching-point probes instead of `config.max_payload_entries`.
- Leave `Inflight::LogsSince` pipeline replication and its normal `max_payload_entries` batching unchanged.

## Motivation
After leadership transfer, OpenRaft resets follower `matching` and rediscovers the match point via binary search. Using `max_payload_entries` (500 in the observed deployment) made each midpoint probe carry a large range that storage byte limits fragmented into many AppendEntries RPCs. This delayed matching discovery and the current-term no-op commit.

A cap of 8 retains the small-gap optimization—several nearby entries can still be covered by one probe—while bounding the amount of extra replication attached to each midpoint.

## Test plan
- [x] `cargo test -p openraft` (579 passed)
- [x] `cargo test -p tests t11_append_inconsistent_log`
- [x] `cargo test -p tests t61_allow_follower_log_revert`
- [x] `cargo test -p tests t14_transfer_leader`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2074)
<!-- Reviewable:end -->
