### PR TITLE
fix: Handle overflow when trigerring snapshots

### DIFF
--- a/openraft/src/config/config.rs
+++ b/openraft/src/config/config.rs
@@ -126,7 +126,7 @@ impl SnapshotPolicy {
                 let committed_next = state.committed().next_index();
                 let base_log_id = last_tried_at.max(state.snapshot_last_log_id());
 
-                if committed_next >= base_log_id.next_index() + threshold {
+                if committed_next >= base_log_id.next_index().saturating_add(*threshold) {
                     state.committed().cloned()
                 } else {
                     None


### PR DESCRIPTION
When the snapshot policy is set to `SnapshotPolicy::LogsSinceLast`, the logic for determing whether to snapshot or not is roughly the following

  next_log_index >= last_snapshot_log_index + snapshot_threshold

Snapshot threshold is a user supplied config value with no validation. If the user sets this value to something very high, like u64::MAX, then the addition will overflow to a very small value, which is guaranteed to be less than next_log_index. We know that
  last_snapshot_log_index < next_log_index
because we can't snapshot a log that doesn't exist. The largest possible value we can wrap around to is last_snapshot_log_index. So when overflow happens, this check will always return true, meaning we'll take a snapshot on every log entry.

This commit fixes the above issue by using `saturating_add` instead of `+`.

An existing potential issue is that when `next_log_index` increases to `u64::MAX`, then we'll take a snapshot regardless of what the `snapshot_threshold` is set to. This is not a real issue, because if you've run out of log indexes then you're already in a lot of trouble and it's not a realistic scenario.

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2075)
<!-- Reviewable:end -->
