### PR TITLE
feat: prototype hinted conflict search

### DIFF
--- a/examples/raft-kv-memstore-grpc/proto/raft.proto
+++ b/examples/raft-kv-memstore-grpc/proto/raft.proto
@@ -88,6 +88,11 @@ message AppendEntriesRequest {
   LogId leader_commit = 4;
 }
 
+message ConflictHint {
+  LogId last_log_id = 1;
+  LogId committed_log_id = 2;
+}
+
 message AppendEntriesResponse {
   // If not None, the follower rejected the AppendEntries request due to having a higher vote.
   // All other fields are valid only when this field is None
@@ -107,6 +112,9 @@ message AppendEntriesResponse {
   //
   // If `conflict = true` in StreamAppend, this is the conflict log id.
   LogId last_log_id = 3;
+
+  // Optional follower bounds for conflict recovery.
+  ConflictHint conflict_hint = 4;
 }
 
 // The first chunk of snapshot transmission, which contains the snapshot meta.

--- a/examples/raft-kv-memstore-grpc/src/network/mod.rs
+++ b/examples/raft-kv-memstore-grpc/src/network/mod.rs
@@ -10,6 +10,7 @@ use openraft::OptionalSend;
 use openraft::RaftNetworkFactory;
 use openraft::base::BoxFuture;
 use openraft::base::BoxStream;
+use openraft::errors::ConflictingLogId;
 use openraft::errors::NetworkError;
 use openraft::errors::ReplicationClosed;
 use openraft::errors::Unreachable;
@@ -20,6 +21,7 @@ use openraft::network::NetStreamAppend;
 use openraft::network::NetTransferLeader;
 use openraft::network::NetVote;
 use openraft::network::RPCOption;
+use openraft::raft::ConflictHint;
 use openraft::raft::StreamAppendError;
 use openraft::raft::StreamAppendResult;
 use openraft::raft::TransferLeaderRequest;
@@ -88,7 +90,15 @@ impl NetworkConnection {
                     "Missing `last_log_id` in conflict stream-append response",
                 )))
             })?;
-            return Ok(Err(StreamAppendError::Conflict(conflict_log_id.into())));
+            let hint = resp.conflict_hint.map(|hint| ConflictHint {
+                last_log_id: hint.last_log_id.map(Into::into),
+                committed_log_id: hint.committed_log_id.map(Into::into),
+            });
+            return Ok(Err(StreamAppendError::Conflict(ConflictingLogId {
+                expect: conflict_log_id.into(),
+                local: None,
+                hint,
+            })));
         }
 
         Ok(Ok(resp.last_log_id.map(Into::into)))

--- a/examples/raft-kv-memstore-grpc/src/pb_impl/impl_append_entries_response.rs
+++ b/examples/raft-kv-memstore-grpc/src/pb_impl/impl_append_entries_response.rs
@@ -1,3 +1,4 @@
+use openraft::raft::ConflictHint;
 use openraft::raft::StreamAppendError;
 
 use crate::pb;
@@ -11,7 +12,13 @@ impl From<pb::AppendEntriesResponse> for AppendEntriesResponse {
         }
 
         if r.conflict {
-            return AppendEntriesResponse::Conflict;
+            return match r.conflict_hint {
+                None => AppendEntriesResponse::Conflict,
+                Some(hint) => AppendEntriesResponse::ConflictWithHint(ConflictHint {
+                    last_log_id: hint.last_log_id.map(Into::into),
+                    committed_log_id: hint.committed_log_id.map(Into::into),
+                }),
+            };
         }
 
         if let Some(log_id) = r.last_log_id {
@@ -29,21 +36,34 @@ impl From<AppendEntriesResponse> for pb::AppendEntriesResponse {
                 rejected_by: None,
                 conflict: false,
                 last_log_id: None,
+                conflict_hint: None,
             },
             AppendEntriesResponse::PartialSuccess(p) => pb::AppendEntriesResponse {
                 rejected_by: None,
                 conflict: false,
                 last_log_id: p.map(|log_id| log_id.into()),
+                conflict_hint: None,
             },
             AppendEntriesResponse::Conflict => pb::AppendEntriesResponse {
                 rejected_by: None,
                 conflict: true,
                 last_log_id: None,
+                conflict_hint: None,
+            },
+            AppendEntriesResponse::ConflictWithHint(hint) => pb::AppendEntriesResponse {
+                rejected_by: None,
+                conflict: true,
+                last_log_id: None,
+                conflict_hint: Some(pb::ConflictHint {
+                    last_log_id: hint.last_log_id.map(Into::into),
+                    committed_log_id: hint.committed_log_id.map(Into::into),
+                }),
             },
             AppendEntriesResponse::HigherVote(v) => pb::AppendEntriesResponse {
                 rejected_by: Some(v),
                 conflict: false,
                 last_log_id: None,
+                conflict_hint: None,
             },
         }
     }
@@ -56,22 +76,71 @@ impl From<StreamAppendResult> for pb::AppendEntriesResponse {
                 rejected_by: None,
                 conflict: false,
                 last_log_id: Some(log_id.into()),
+                conflict_hint: None,
             },
             Ok(None) => pb::AppendEntriesResponse {
                 rejected_by: None,
                 conflict: false,
                 last_log_id: None,
+                conflict_hint: None,
             },
-            Err(StreamAppendError::Conflict(log_id)) => pb::AppendEntriesResponse {
-                rejected_by: None,
-                conflict: true,
-                last_log_id: Some(log_id.into()),
-            },
+            Err(StreamAppendError::Conflict(conflict)) => {
+                let hint = conflict.hint.map(|hint| pb::ConflictHint {
+                    last_log_id: hint.last_log_id.map(Into::into),
+                    committed_log_id: hint.committed_log_id.map(Into::into),
+                });
+                pb::AppendEntriesResponse {
+                    rejected_by: None,
+                    conflict: true,
+                    last_log_id: Some(conflict.expect.into()),
+                    conflict_hint: hint,
+                }
+            }
             Err(StreamAppendError::HigherVote(vote)) => pb::AppendEntriesResponse {
                 rejected_by: Some(vote),
                 conflict: false,
                 last_log_id: None,
+                conflict_hint: None,
             },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conflict_hint_message_presence_distinguishes_legacy_from_empty_follower() {
+        tracing::info!("decode a legacy conflict without a hint");
+        {
+            let response = pb::AppendEntriesResponse {
+                rejected_by: None,
+                conflict: true,
+                last_log_id: None,
+                conflict_hint: None,
+            };
+            assert_eq!(AppendEntriesResponse::Conflict, response.into());
+        }
+
+        tracing::info!("decode an explicit hint from an empty follower");
+        {
+            let response = pb::AppendEntriesResponse {
+                rejected_by: None,
+                conflict: true,
+                last_log_id: None,
+                conflict_hint: Some(pb::ConflictHint {
+                    last_log_id: None,
+                    committed_log_id: None,
+                }),
+            };
+            assert_eq!(
+                AppendEntriesResponse::ConflictWithHint(ConflictHint {
+                    last_log_id: None,
+                    committed_log_id: None,
+                }),
+                response.into()
+            );
         }
     }
 }

--- a/openraft/src/core/heartbeat/worker.rs
+++ b/openraft/src/core/heartbeat/worker.rs
@@ -163,18 +163,15 @@ where
                 self.send_notification(noti, "Seeing higher Vote").await?;
                 // Higher vote means leadership is not granted, don't send HeartbeatProgress
             }
-            Err(StreamAppendError::Conflict(_conflict_log_id)) => {
-                // The follower does not have `matching` log id.
-                // Use `matching` (which may be None) as the conflict point.
-                //
-                // Safe unwrap(): a None never conflict
-                let conflict_log_id = heartbeat.matching.clone().unwrap();
+            Err(StreamAppendError::Conflict(mut conflict)) => {
+                // Restore details omitted by legacy transports.
+                conflict.expect = heartbeat.matching.clone().unwrap();
 
                 let noti = Notification::ReplicationProgress {
                     stream_id: self.stream_id,
                     progress: Progress {
                         target: self.target.clone(),
-                        result: Ok(ReplicationResult(Err(conflict_log_id))),
+                        result: Ok(ReplicationResult(Err(conflict))),
                     },
                     inflight_id: None,
                 };

--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -2324,7 +2324,6 @@ where
         let last_log_id = entries.last().unwrap().log_id();
         let last_log_index = last_log_id.index();
         tracing::debug!("AppendEntries: {}", entries.as_ref().display_n(10));
-
         let entry_count = entries.len() as u64;
 
         // Record to internal histogram

--- a/openraft/src/docs/protocol/log_replication.md
+++ b/openraft/src/docs/protocol/log_replication.md
@@ -140,7 +140,8 @@ When a Leader is established, it does not know which log entries are present on
 Followers and Learners. Therefore, it must determine the last matching log ID on
 each Follower before sending append-entries.
 
-This process uses a binary search:
+This process starts with an optimistic probe and falls back to a bounded binary
+search:
 
 The Leader uses a span `[matching_log_id, first_conflict_index]` to search:
 - The left bound is the last known matching log ID.
@@ -155,6 +156,8 @@ pub(crate) struct ProgressEntry<C> {
     pub(crate) matching: Option<LogId<C::NodeId>>,
     // Right bound
     pub(crate) searching_end: u64,
+    // Initial optimistic probe.
+    pub(crate) initial_probe_index: Option<u64>,
 }
 ```
 
@@ -163,6 +166,21 @@ pub(crate) struct ProgressEntry<C> {
 - The Leader initializes the span as `[None, leader_last_log_index + 1]`.
   Because the Leader is assumed to have all committed logs. Any logs after
   `leader_last_log_index` are uncommitted and can be safely deleted.
+
+- The Leader first sends entries beginning at the first log entry proposed by
+  its current leadership. If the Follower accepts the preceding log ID, the
+  response establishes a matching prefix and normal streaming continues.
+
+- If the Follower rejects the probe, it may return its `last_log_id` and
+  `committed_log_id` as a conflict hint:
+
+  - If the complete follower `last_log_id` exists in the Leader's log, the
+    Follower is an exact prefix. The Leader sets `matching` to that tail and
+    continues from the following entry.
+  - Otherwise, the divergent tail is an upper bound. If the complete committed
+    log ID also matches the Leader, it is a lower bound. The Leader binary
+    searches only between those bounds.
+  - A legacy response without a hint falls back to the original binary search.
 
 - The Leader sends the log entry at the midpoint of `[ProgressEntry.matching.next_index(), ProgressEntry.searching_end]` to the Follower.
 

--- a/openraft/src/engine/handler/following_handler/mod.rs
+++ b/openraft/src/engine/handler/following_handler/mod.rs
@@ -19,6 +19,7 @@ use crate::entry::raft_entry_ext::RaftEntryExt;
 use crate::errors::ConflictingLogId;
 use crate::errors::RejectAppendEntries;
 use crate::log_id::option_raft_log_id_ext::OptionRaftLogIdExt;
+use crate::raft::ConflictHint;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
 use crate::raft_state::io_state::log_io_id::LogIOId;
@@ -125,12 +126,17 @@ where
             && !self.state.has_log_id(prev)
         {
             let local = self.state.get_log_id(prev.index());
+            let hint = ConflictHint::new(
+                self.state.last_log_id().cloned(),
+                self.state.local_committed().cloned(),
+            );
             tracing::debug!("prev_log_id mismatch, local: {}", local.display());
 
             self.truncate_logs(prev.index());
             return Err(RejectAppendEntries::ConflictingLogId(ConflictingLogId {
                 local,
                 expect: prev.clone(),
+                hint: Some(hint),
             }));
         }
 

--- a/openraft/src/engine/handler/leader_handler/append_entries_test.rs
+++ b/openraft/src/engine/handler/leader_handler/append_entries_test.rs
@@ -157,11 +157,17 @@ fn test_leader_append_entries_normal() -> anyhow::Result<()> {
             },
             Command::Replicate {
                 target: 2,
-                req: Replicate::new_logs(LogIdRange::new(None, Some(log_id(3, 1, 6))), InflightId::new(1)),
+                req: Replicate::new_logs(
+                    LogIdRange::new(Some(log_id(2, 1, 3)), Some(log_id(3, 1, 6))),
+                    InflightId::new(1),
+                ),
             },
             Command::Replicate {
                 target: 3,
-                req: Replicate::new_logs(LogIdRange::new(None, Some(log_id(3, 1, 6))), InflightId::new(2)),
+                req: Replicate::new_logs(
+                    LogIdRange::new(Some(log_id(2, 1, 3)), Some(log_id(3, 1, 6))),
+                    InflightId::new(2),
+                ),
             },
         ],
         eng.output.take_commands()
@@ -290,13 +296,16 @@ fn test_leader_append_entries_with_membership_log() -> anyhow::Result<()> {
                 targets: vec![TargetProgress {
                     target: 2,
                     target_node: (),
-                    progress: ProgressEntry::empty(2, StreamId::new(5), 7),
+                    progress: ProgressEntry::empty(2, StreamId::new(5), 7).with_initial_probe(4),
                 }],
                 close_old_streams: false,
             },
             Command::Replicate {
                 target: 2,
-                req: Replicate::new_logs(LogIdRange::new(None, Some(log_id(3, 1, 6))), InflightId::new(1))
+                req: Replicate::new_logs(
+                    LogIdRange::new(Some(log_id(2, 1, 3)), Some(log_id(3, 1, 6))),
+                    InflightId::new(1),
+                )
             },
         ],
         eng.output.take_commands()

--- a/openraft/src/engine/handler/replication_handler/append_membership_test.rs
+++ b/openraft/src/engine/handler/replication_handler/append_membership_test.rs
@@ -92,12 +92,12 @@ fn test_leader_append_membership_for_leader() -> anyhow::Result<()> {
                     TargetProgress {
                         target: 3,
                         target_node: (),
-                        progress: ProgressEntry::empty(3, StreamId::new(2), 0),
+                        progress: ProgressEntry::empty(3, StreamId::new(2), 0).with_initial_probe(0),
                     },
                     TargetProgress {
                         target: 4,
                         target_node: (),
-                        progress: ProgressEntry::empty(4, StreamId::new(3), 0),
+                        progress: ProgressEntry::empty(4, StreamId::new(3), 0).with_initial_probe(0),
                     }
                 ], /* node-2 is leader,
                     * won't be removed */
@@ -149,11 +149,11 @@ fn test_leader_append_membership_update_learner_process() -> anyhow::Result<()> 
 
     if let Some(l) = &mut eng.leader.as_mut() {
         assert_eq!(
-            Some(&ProgressEntry::empty(4, StreamId::new(3), 11)),
+            Some(&ProgressEntry::empty(4, StreamId::new(3), 11).with_initial_probe(11)),
             l.progress.try_get(&4)
         );
         assert_eq!(
-            Some(&ProgressEntry::empty(5, StreamId::new(4), 11)),
+            Some(&ProgressEntry::empty(5, StreamId::new(4), 11).with_initial_probe(11)),
             l.progress.try_get(&5)
         );
 

--- a/openraft/src/engine/handler/replication_handler/mod.rs
+++ b/openraft/src/engine/handler/replication_handler/mod.rs
@@ -16,6 +16,7 @@ use crate::engine::EngineConfig;
 use crate::engine::EngineOutput;
 use crate::engine::TargetProgress;
 use crate::engine::handler::log_handler::LogHandler;
+use crate::errors::ConflictingLogId;
 use crate::errors::NodeNotFound;
 use crate::errors::Operation;
 use crate::progress;
@@ -129,13 +130,14 @@ where
 
         {
             let end = self.state.last_log_id().next_index();
+            let initial_probe_index = self.leader.noop_log_id().index();
 
             let old_progress = self.leader.progress.clone();
 
             let id_gen = self.state.progress_id_gen.clone();
             let default_entry = |id| {
                 let progress_id = StreamId::new(id_gen.next_id());
-                ProgressEntry::empty(id, progress_id, end)
+                ProgressEntry::empty(id, progress_id, end).with_initial_probe(initial_probe_index)
             };
 
             self.leader.progress = Valid::new(old_progress.into_inner().upgrade_quorum_set(
@@ -274,13 +276,60 @@ where
     pub(crate) fn update_conflicting(
         &mut self,
         target: C::NodeId,
-        conflict: LogIdOf<C>,
+        conflict: ConflictingLogId<C>,
         inflight_id: Option<InflightId>,
     ) {
+        let Some(progress) = self.leader.progress.try_get(&target) else {
+            return;
+        };
+
+        let may_apply_initial_hint = progress.matching().is_none();
+        let mut searching_end = conflict.expect.index();
+        let mut hinted_matching = None;
+
+        if may_apply_initial_hint
+            && let Some(hint) = conflict.hint
+        {
+            let tail_matches = match hint.last_log_id.as_ref() {
+                None => true,
+                Some(last) => self.state.get_log_id(last.index()).as_ref() == Some(last),
+            };
+
+            if tail_matches {
+                // Resume after a matching follower tail.
+                searching_end = hint.last_log_id.next_index();
+                hinted_matching = hint.last_log_id;
+            } else {
+                // Tighten the upper bound with the divergent tail.
+                if let Some(last) = hint.last_log_id {
+                    searching_end = std::cmp::min(searching_end, last.index());
+                }
+
+                // Leader Completeness makes this a valid lower bound.
+                if let Some(committed) = hint.committed_log_id {
+                    debug_assert!(
+                        self.state.has_log_id(&committed),
+                        "follower committed log must exist on the leader: {committed}"
+                    );
+
+                    if committed.index() < searching_end {
+                        hinted_matching = Some(committed);
+                    }
+                }
+            }
+        }
+
+        let mut conflict_accepted = false;
         self.leader.progress.reset_entry_with(&target, |entry| {
             let mut updater = Updater::new(&*self.config, entry);
-            updater.update_conflicting(conflict.index(), inflight_id);
+            conflict_accepted = updater.update_conflicting(searching_end, inflight_id);
         });
+
+        if conflict_accepted
+            && let Some(matching) = hinted_matching
+        {
+            self.update_matching(target, Some(matching), None);
+        }
     }
 
     /// Enable one-time replication reset for a specific node upon log reversion detection.

--- a/openraft/src/engine/handler/replication_handler/update_conflicting_test.rs
+++ b/openraft/src/engine/handler/replication_handler/update_conflicting_test.rs
@@ -8,11 +8,15 @@ use crate::Membership;
 use crate::MembershipState;
 use crate::Vote;
 use crate::engine::Engine;
+use crate::engine::LogIdList;
 use crate::engine::testing::UTConfig;
 use crate::engine::testing::log_id;
+use crate::errors::ConflictingLogId;
 use crate::progress::Inflight;
 use crate::progress::entry::ProgressEntry;
 use crate::progress::inflight_id::InflightId;
+use crate::progress::stream_id::StreamId;
+use crate::raft::ConflictHint;
 use crate::type_config::TypeConfigExt;
 use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::StoredMembershipOf;
@@ -64,6 +68,14 @@ fn quorum_accepted(eng: &Engine<UTConfig>) -> Option<LogIdOf<UTConfig>> {
     *leader.progress.quorum_accepted()
 }
 
+fn conflict_at(expect: LogIdOf<UTConfig>) -> ConflictingLogId<UTConfig> {
+    ConflictingLogId {
+        expect,
+        local: None,
+        hint: None,
+    }
+}
+
 #[test]
 fn test_update_conflicting_response_identity() -> anyhow::Result<()> {
     let mut eng = eng();
@@ -85,7 +97,7 @@ fn test_update_conflicting_response_identity() -> anyhow::Result<()> {
         expected.data.inflight = Inflight::None;
         expected.data.searching_end = 7;
 
-        eng.replication_handler().update_conflicting(2, log_id(2, 1, 7), Some(first_id));
+        eng.replication_handler().update_conflicting(2, conflict_at(log_id(2, 1, 7)), Some(first_id));
 
         let actual = entry(&eng, 2);
         assert_eq!(expected, actual);
@@ -109,7 +121,7 @@ fn test_update_conflicting_response_identity() -> anyhow::Result<()> {
         let expected_entries = entries(&eng);
         let expected_quorum = quorum_accepted(&eng);
 
-        eng.replication_handler().update_conflicting(2, log_id(2, 1, 7), Some(first_id));
+        eng.replication_handler().update_conflicting(2, conflict_at(log_id(2, 1, 7)), Some(first_id));
 
         let actual_entry = entry(&eng, 2);
         let actual_entries = entries(&eng);
@@ -124,7 +136,7 @@ fn test_update_conflicting_response_identity() -> anyhow::Result<()> {
         let mut expected = entry(&eng, 2);
         expected.data.searching_end = 6;
 
-        eng.replication_handler().update_conflicting(2, log_id(2, 1, 6), None);
+        eng.replication_handler().update_conflicting(2, conflict_at(log_id(2, 1, 6)), None);
 
         let actual = entry(&eng, 2);
         assert_eq!(expected, actual);
@@ -135,7 +147,7 @@ fn test_update_conflicting_response_identity() -> anyhow::Result<()> {
         let expected_entries = entries(&eng);
         let expected_quorum = quorum_accepted(&eng);
 
-        eng.replication_handler().update_conflicting(99, log_id(2, 1, 0), Some(first_id));
+        eng.replication_handler().update_conflicting(99, conflict_at(log_id(2, 1, 0)), Some(first_id));
 
         let actual_entries = entries(&eng);
         let actual_quorum = quorum_accepted(&eng);
@@ -144,6 +156,99 @@ fn test_update_conflicting_response_identity() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[test]
+fn test_update_conflicting_uses_matching_tail_hint() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.state.log_ids = LogIdList::new(None, [log_id(1, 1, 5), log_id(2, 1, 10)]);
+
+    update_entry(&mut eng, 2, |entry| {
+        *entry = ProgressEntry::empty(2, StreamId::new(2), 11)
+            .with_inflight(Inflight::logs(Some(log_id(2, 1, 9)), Some(log_id(2, 1, 10)), InflightId::new(7)));
+    });
+
+    eng.replication_handler().update_conflicting(
+        2,
+        ConflictingLogId {
+            expect: log_id(2, 1, 9),
+            local: None,
+            hint: Some(ConflictHint {
+                last_log_id: Some(log_id(1, 1, 5)),
+                committed_log_id: Some(log_id(1, 1, 3)),
+            }),
+        },
+        Some(InflightId::new(7)),
+    );
+
+    let progress = entry(&eng, 2);
+    assert_eq!(Some(&log_id(1, 1, 5)), progress.matching());
+    assert_eq!(6, progress.data.searching_end);
+    assert_eq!(Inflight::None, progress.data.inflight);
+
+    Ok(())
+}
+
+#[test]
+fn test_update_conflicting_uses_committed_hint_as_binary_search_lower_bound() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.state.log_ids = LogIdList::new(None, [log_id(1, 1, 5), log_id(2, 1, 10)]);
+
+    update_entry(&mut eng, 2, |entry| {
+        *entry = ProgressEntry::empty(2, StreamId::new(2), 11)
+            .with_inflight(Inflight::logs(Some(log_id(2, 1, 9)), Some(log_id(2, 1, 10)), InflightId::new(7)));
+    });
+
+    eng.replication_handler().update_conflicting(
+        2,
+        ConflictingLogId {
+            expect: log_id(2, 1, 9),
+            local: Some(log_id(3, 2, 9)),
+            hint: Some(ConflictHint {
+                last_log_id: Some(log_id(3, 2, 8)),
+                committed_log_id: Some(log_id(1, 1, 5)),
+            }),
+        },
+        Some(InflightId::new(7)),
+    );
+
+    let progress = entry(&eng, 2);
+    assert_eq!(Some(&log_id(1, 1, 5)), progress.matching());
+    assert_eq!(8, progress.data.searching_end);
+    assert_eq!(Inflight::None, progress.data.inflight);
+
+    Ok(())
+}
+
+#[test]
+#[should_panic(expected = "follower committed log must exist on the leader")]
+fn test_update_conflicting_asserts_committed_hint_matches_leader() {
+    let mut eng = eng();
+    eng.state.log_ids = LogIdList::new(None, [log_id(1, 1, 5), log_id(2, 1, 10)]);
+
+    tracing::info!(target = 2, "reject a committed hint that violates Leader Completeness");
+    {
+        update_entry(&mut eng, 2, |entry| {
+            *entry = ProgressEntry::empty(2, StreamId::new(2), 11).with_inflight(Inflight::logs(
+                Some(log_id(2, 1, 9)),
+                Some(log_id(2, 1, 10)),
+                InflightId::new(7),
+            ));
+        });
+
+        eng.replication_handler().update_conflicting(
+            2,
+            ConflictingLogId {
+                expect: log_id(2, 1, 9),
+                local: Some(log_id(3, 2, 9)),
+                hint: Some(ConflictHint {
+                    last_log_id: Some(log_id(3, 2, 8)),
+                    committed_log_id: Some(log_id(3, 2, 5)),
+                }),
+            },
+            Some(InflightId::new(7)),
+        );
+    }
 }
 
 #[test]
@@ -189,7 +294,7 @@ fn test_update_conflicting_reversion() -> anyhow::Result<()> {
         expected.data.inflight = Inflight::None;
         expected.data.searching_end = 8;
 
-        eng.replication_handler().update_conflicting(1, log_id(2, 1, 8), Some(first_id));
+        eng.replication_handler().update_conflicting(1, conflict_at(log_id(2, 1, 8)), Some(first_id));
 
         let actual = entry(&eng, 1);
         assert_eq!(expected, actual);
@@ -218,7 +323,7 @@ fn test_update_conflicting_reversion() -> anyhow::Result<()> {
         expected.data.searching_end = 6;
         expected.data.allow_log_reversion = false;
 
-        eng.replication_handler().update_conflicting(3, log_id(2, 1, 6), Some(third_id));
+        eng.replication_handler().update_conflicting(3, conflict_at(log_id(2, 1, 6)), Some(third_id));
 
         let actual = entry(&eng, 3);
         assert_eq!(expected, actual);

--- a/openraft/src/engine/handler/vote_handler/become_leader_test.rs
+++ b/openraft/src/engine/handler/vote_handler/become_leader_test.rs
@@ -72,7 +72,7 @@ fn test_become_leader() -> anyhow::Result<()> {
             targets: vec![TargetProgress {
                 target: 0,
                 target_node: (),
-                progress: ProgressEntry::empty(0, StreamId::new(1), 0),
+                progress: ProgressEntry::empty(0, StreamId::new(1), 0).with_initial_probe(0),
             }],
             close_old_streams: true,
         },
@@ -80,12 +80,14 @@ fn test_become_leader() -> anyhow::Result<()> {
             committed_vote: Vote::new(2, 1).to_committed(),
             entries: Batch::of([EntryOf::<UTConfig>::new_blank(log_id(2, 1, 0))])
         },
-        // Pipeline mode: ProgressEntry::empty(0) has matching.next_index()=0 == searching_end=0
+        // Optimistically probe the new leader's first entry.
         Command::Replicate {
             target: 0,
             req: Replicate {
                 inflight_id: InflightId::new(1),
-                payload: Payload::LogsSince { prev: None },
+                payload: Payload::LogIdRange {
+                    log_id_range: crate::log_id_range::LogIdRange::new(None, Some(log_id(2, 1, 0))),
+                },
             }
         }
     ]);

--- a/openraft/src/engine/tests/append_entries_test.rs
+++ b/openraft/src/engine/tests/append_entries_test.rs
@@ -18,6 +18,7 @@ use crate::entry::RaftEntry;
 use crate::errors::ConflictingLogId;
 use crate::errors::RejectAppendEntries;
 use crate::errors::RejectVote;
+use crate::raft::ConflictHint;
 use crate::raft::LogSegment;
 use crate::raft_state::IOId;
 use crate::raft_state::LogStateReader;
@@ -156,6 +157,10 @@ fn test_append_entries_prev_log_id_conflict() -> anyhow::Result<()> {
         Err(RejectAppendEntries::ConflictingLogId(ConflictingLogId {
             expect: log_id(2, 1, 2),
             local: Some(log_id(1, 1, 2)),
+            hint: Some(ConflictHint {
+                last_log_id: Some(log_id(2, 1, 3)),
+                committed_log_id: Some(log_id(0, 1, 0)),
+            }),
         })),
         res
     );
@@ -261,6 +266,10 @@ fn test_append_entries_prev_log_id_not_exists() -> anyhow::Result<()> {
         Err(RejectAppendEntries::ConflictingLogId(ConflictingLogId {
             expect: log_id(2, 1, 4),
             local: None,
+            hint: Some(ConflictHint {
+                last_log_id: Some(log_id(2, 1, 3)),
+                committed_log_id: Some(log_id(0, 1, 0)),
+            }),
         })),
         res
     );

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -217,7 +217,7 @@ fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
                     targets: vec![TargetProgress {
                         target: 2,
                         target_node: (),
-                        progress: ProgressEntry::empty(2, StreamId::new(2), 1),
+                        progress: ProgressEntry::empty(2, StreamId::new(2), 1).with_initial_probe(1),
                     }],
                     close_old_streams: true,
                 },
@@ -230,7 +230,10 @@ fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
                 },
                 Command::Replicate {
                     target: 2,
-                    req: Replicate::new_logs(LogIdRange::new(None, Some(log_id(2, 1, 1))), InflightId::new(1))
+                    req: Replicate::new_logs(
+                        LogIdRange::new(Some(log_id(0, 0, 0)), Some(log_id(2, 1, 1))),
+                        InflightId::new(1),
+                    )
                 },
             ],
             eng.output.take_commands()

--- a/openraft/src/engine/tests/startup_test.rs
+++ b/openraft/src/engine/tests/startup_test.rs
@@ -82,7 +82,7 @@ fn test_startup_as_leader_without_logs() -> anyhow::Result<()> {
                 targets: vec![TargetProgress {
                     target: 3,
                     target_node: (),
-                    progress: ProgressEntry::empty(3, StreamId::new(2), 4),
+                    progress: ProgressEntry::empty(3, StreamId::new(2), 4).with_initial_probe(4),
                 }],
                 close_old_streams: true,
             },
@@ -92,7 +92,10 @@ fn test_startup_as_leader_without_logs() -> anyhow::Result<()> {
             },
             Command::Replicate {
                 target: 3,
-                req: Replicate::new_logs(LogIdRange::new(None, Some(log_id(2, 2, 4))), InflightId::new(1)),
+                req: Replicate::new_logs(
+                    LogIdRange::new(Some(log_id(1, 1, 3)), Some(log_id(2, 2, 4))),
+                    InflightId::new(1),
+                ),
             }
         ],
         eng.output.take_commands()
@@ -136,13 +139,16 @@ fn test_startup_as_leader_with_proposed_logs() -> anyhow::Result<()> {
                 targets: vec![TargetProgress {
                     target: 3,
                     target_node: (),
-                    progress: ProgressEntry::empty(3, StreamId::new(2), 7),
+                    progress: ProgressEntry::empty(3, StreamId::new(2), 7).with_initial_probe(4),
                 }],
                 close_old_streams: true,
             },
             Command::Replicate {
                 target: 3,
-                req: Replicate::new_logs(LogIdRange::new(None, Some(log_id(1, 2, 6))), InflightId::new(1))
+                req: Replicate::new_logs(
+                    LogIdRange::new(Some(log_id(1, 1, 3)), Some(log_id(1, 2, 6))),
+                    InflightId::new(1),
+                )
             }
         ],
         eng.output.take_commands()

--- a/openraft/src/errors/conflicting_log_id.rs
+++ b/openraft/src/errors/conflicting_log_id.rs
@@ -1,14 +1,22 @@
+use openraft_macros::since;
+
 use crate::RaftTypeConfig;
+use crate::raft::ConflictHint;
 use crate::type_config::alias::LogIdOf;
 
 /// The follower's log does not match the leader's at the given index.
 ///
 /// The follower rejects an `AppendEntries` request because `prev_log_id` from the
 /// leader is not present in its local log.
+#[since(version = "0.10.0", change = "added follower conflict hint")]
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-#[error("conflicting log-id: local={local:?} should be: {expect:?}")]
-pub struct ConflictingLogId<C: RaftTypeConfig> {
+#[error("conflicting log-id: local={local:?} should be: {expect:?}; hint={hint:?}")]
+pub struct ConflictingLogId<C>
+where C: RaftTypeConfig
+{
     pub expect: LogIdOf<C>,
     pub local: Option<LogIdOf<C>>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub hint: Option<ConflictHint<C>>,
 }

--- a/openraft/src/errors/reject_append_entries.rs
+++ b/openraft/src/errors/reject_append_entries.rs
@@ -24,7 +24,7 @@ impl<C: RaftTypeConfig> From<RejectAppendEntries<C>> for StreamAppendError<C> {
     fn from(e: RejectAppendEntries<C>) -> Self {
         match e {
             RejectAppendEntries::RejectVote(r) => StreamAppendError::HigherVote(r.higher),
-            RejectAppendEntries::ConflictingLogId(c) => StreamAppendError::Conflict(c.expect),
+            RejectAppendEntries::ConflictingLogId(c) => StreamAppendError::Conflict(c),
         }
     }
 }

--- a/openraft/src/progress/entry/mod.rs
+++ b/openraft/src/progress/entry/mod.rs
@@ -50,6 +50,9 @@ where C: RaftTypeConfig
     /// One plus the max log index on the following node that might match the leader log.
     pub(crate) searching_end: u64,
 
+    /// A one-shot probe at this leader's first entry.
+    pub(crate) initial_probe_index: Option<u64>,
+
     /// If true, reset the progress by setting matching to `None` when the follower's
     /// log is found reverted to an early state.
     ///
@@ -83,6 +86,12 @@ where C: RaftTypeConfig
         }
     }
 
+    /// Try `index` before falling back to the normal binary search.
+    pub(crate) fn with_initial_probe(mut self, index: u64) -> Self {
+        self.data.initial_probe_index = Some(index);
+        self
+    }
+
     pub(crate) fn matching(&self) -> Option<&LogIdOf<C>> {
         self.matching.as_ref()
     }
@@ -109,6 +118,7 @@ where C: RaftTypeConfig
             stream_id,
             inflight: Inflight::None,
             searching_end,
+            initial_probe_index: None,
             allow_log_reversion: false,
         }
     }
@@ -235,6 +245,18 @@ where C: RaftTypeConfig
         if self.data.searching_end < purge_upto_next {
             self.data.inflight = Inflight::snapshot(inflight_id);
             return Ok(&self.data.inflight);
+        }
+
+        // Probe this leader's first entry before binary search.
+        if let Some(probe_index) = self.data.initial_probe_index.take() {
+            let start = std::cmp::max(probe_index, purge_upto_next);
+            let end = std::cmp::min(start + max_entries, last_next);
+            if start < end {
+                let prev = log_state.prev_log_id(start);
+                let last = log_state.prev_log_id(end);
+                self.data.inflight = Inflight::logs(prev, last, inflight_id);
+                return Ok(&self.data.inflight);
+            }
         }
 
         let matching_next = self.matching().next_index();

--- a/openraft/src/progress/entry/tests.rs
+++ b/openraft/src/progress/entry/tests.rs
@@ -417,6 +417,18 @@ fn test_next_send_not_pipeline_without_matching() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_next_send_tries_initial_leader_entry_before_binary_search() -> anyhow::Result<()> {
+    // Probe index 17 instead of the binary-search midpoint 8.
+    let mut pe = ProgressEntry::<UTConfig>::empty(0, StreamId::new(0), 21).with_initial_probe(17);
+
+    let res = pe.next_send(&mut new_raft_state(6, 10, 20), 100);
+    assert_eq!(Ok(&inflight_logs(16, 20).with_id(1)), res);
+    assert_eq!(None, pe.data.initial_probe_index, "the optimistic probe is one-shot");
+
+    Ok(())
+}
+
+#[test]
 fn test_next_send_probe_from_mid_of_search_range() -> anyhow::Result<()> {
     //    matching,end
     //    4               21

--- a/openraft/src/progress/entry/update.rs
+++ b/openraft/src/progress/entry/update.rs
@@ -46,7 +46,7 @@ where C: RaftTypeConfig
     /// by a quorum must never be withdrawn.
     ///
     /// [`Config::allow_log_reversion`]: `crate::config::Config::allow_log_reversion`
-    pub(crate) fn update_conflicting(&mut self, conflict: u64, inflight_id: Option<InflightId>) {
+    pub(crate) fn update_conflicting(&mut self, conflict: u64, inflight_id: Option<InflightId>) -> bool {
         tracing::debug!(
             "update_conflict: current progress_entry: {}; conflict: {}",
             self.entry,
@@ -57,7 +57,7 @@ where C: RaftTypeConfig
         if let Some(inflight_id) = inflight_id {
             let applied = self.entry.data.inflight.conflict(conflict, inflight_id);
             if !applied {
-                return;
+                return false;
             }
         }
 
@@ -67,7 +67,7 @@ where C: RaftTypeConfig
                 conflict,
                 self.entry.data.searching_end
             );
-            return;
+            return true;
         }
 
         self.entry.data.searching_end = conflict;
@@ -110,6 +110,8 @@ where C: RaftTypeConfig
                 conflict
             );
         }
+
+        true
     }
 
     /// Update the matching log id for this follower when replication succeeds.

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -139,7 +139,7 @@ where
 
         let progress = VecProgress::new(quorum_set.clone(), learner_ids.iter().cloned(), |id| {
             let stream_id = StreamId::new(id_gen.next_id());
-            ProgressEntry::empty(id, stream_id, last_log_id.next_index())
+            ProgressEntry::empty(id, stream_id, last_log_id.next_index()).with_initial_probe(noop_log_id.index())
         });
 
         let now = C::now();

--- a/openraft/src/raft/message/append_entries_response.rs
+++ b/openraft/src/raft/message/append_entries_response.rs
@@ -1,8 +1,11 @@
 use std::fmt;
 
 use display_more::DisplayOptionExt;
+use openraft_macros::since;
 
 use crate::RaftTypeConfig;
+use crate::errors::ConflictingLogId;
+use crate::raft::ConflictHint;
 use crate::raft::StreamAppendError;
 use crate::raft::stream_append::StreamAppendResult;
 use crate::type_config::alias::LogIdOf;
@@ -15,10 +18,13 @@ use crate::type_config::alias::VoteOf;
 ///
 /// [`RPCError`]: crate::errors::RPCError
 /// [`RaftNetworkV2::append_entries`]: crate::network::RaftNetworkV2::append_entries
+#[since(version = "0.10.0", change = "added ConflictWithHint response")]
 #[derive(Debug, Clone)]
 #[derive(PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub enum AppendEntriesResponse<C: RaftTypeConfig> {
+pub enum AppendEntriesResponse<C>
+where C: RaftTypeConfig
+{
     /// Successfully replicated all log entries to the target node.
     Success,
 
@@ -47,6 +53,9 @@ pub enum AppendEntriesResponse<C: RaftTypeConfig> {
     /// [`AppendEntriesRequest::prev_log_id`]: crate::raft::AppendEntriesRequest::prev_log_id
     Conflict,
 
+    /// Conflict with follower search bounds.
+    ConflictWithHint(ConflictHint<C>),
+
     /// Seen a vote `v` that does not hold `mine_vote >= v`.
     /// And a leader's vote(committed vote) must be total order with other votes.
     /// Therefore, it has to be a higher vote: `mine_vote < v`
@@ -73,7 +82,7 @@ where C: RaftTypeConfig
 
     /// Returns true if the response indicates a log conflict.
     pub fn is_conflict(&self) -> bool {
-        matches!(*self, AppendEntriesResponse::Conflict)
+        matches!(*self, AppendEntriesResponse::Conflict | AppendEntriesResponse::ConflictWithHint(_))
     }
 
     /// Convert this response to a stream append result.
@@ -89,7 +98,18 @@ where C: RaftTypeConfig
         match self {
             AppendEntriesResponse::Success => Ok(last_log_id),
             AppendEntriesResponse::PartialSuccess(log_id) => Ok(log_id),
-            AppendEntriesResponse::Conflict => Err(StreamAppendError::Conflict(prev_log_id.unwrap())),
+            AppendEntriesResponse::Conflict => Err(StreamAppendError::Conflict(ConflictingLogId {
+                expect: prev_log_id.unwrap(),
+                local: None,
+                hint: None,
+            })),
+            AppendEntriesResponse::ConflictWithHint(hint) => {
+                Err(StreamAppendError::Conflict(ConflictingLogId {
+                    expect: prev_log_id.unwrap(),
+                    local: None,
+                    hint: Some(hint),
+                }))
+            }
             AppendEntriesResponse::HigherVote(vote) => Err(StreamAppendError::HigherVote(vote)),
         }
     }
@@ -99,7 +119,10 @@ impl<C: RaftTypeConfig> From<StreamAppendResult<C>> for AppendEntriesResponse<C>
     fn from(r: StreamAppendResult<C>) -> Self {
         match r {
             Ok(_) => AppendEntriesResponse::Success,
-            Err(StreamAppendError::Conflict(_)) => AppendEntriesResponse::Conflict,
+            Err(StreamAppendError::Conflict(conflict)) => match conflict.hint {
+                Some(hint) => AppendEntriesResponse::ConflictWithHint(hint),
+                None => AppendEntriesResponse::Conflict,
+            },
             Err(StreamAppendError::HigherVote(v)) => AppendEntriesResponse::HigherVote(v),
         }
     }
@@ -116,6 +139,7 @@ where C: RaftTypeConfig
             }
             AppendEntriesResponse::HigherVote(vote) => write!(f, "Higher vote, {}", vote),
             AppendEntriesResponse::Conflict => write!(f, "Conflict"),
+            AppendEntriesResponse::ConflictWithHint(hint) => write!(f, "ConflictWithHint({hint:?})"),
         }
     }
 }

--- a/openraft/src/raft/message/conflict_hint.rs
+++ b/openraft/src/raft/message/conflict_hint.rs
@@ -1,0 +1,30 @@
+use openraft_macros::since;
+
+use crate::RaftTypeConfig;
+use crate::type_config::alias::LogIdOf;
+
+/// Follower log bounds returned with an AppendEntries conflict.
+#[since(version = "0.10.0", change = "added follower conflict recovery bounds")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
+pub struct ConflictHint<C>
+where C: RaftTypeConfig
+{
+    /// The follower's last log ID before it handled the conflicting request.
+    pub last_log_id: Option<LogIdOf<C>>,
+
+    /// The last log ID known to be locally committed on the follower.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub committed_log_id: Option<LogIdOf<C>>,
+}
+
+impl<C> ConflictHint<C>
+where C: RaftTypeConfig
+{
+    pub(crate) fn new(last_log_id: Option<LogIdOf<C>>, committed_log_id: Option<LogIdOf<C>>) -> Self {
+        Self {
+            last_log_id,
+            committed_log_id,
+        }
+    }
+}

--- a/openraft/src/raft/message/mod.rs
+++ b/openraft/src/raft/message/mod.rs
@@ -7,6 +7,7 @@ mod append_entries_request;
 mod append_entries_response;
 mod change_membership;
 mod change_membership_request;
+mod conflict_hint;
 mod install_snapshot;
 mod log_segment;
 mod precondition;
@@ -22,6 +23,7 @@ pub use append_entries_request::AppendEntriesRequest;
 pub use append_entries_response::AppendEntriesResponse;
 pub use change_membership::ChangeMembershipOutcome;
 pub use change_membership_request::ChangeMembershipRequest;
+pub use conflict_hint::ConflictHint;
 pub use client_write::ClientWriteResponse;
 pub use client_write::ClientWriteResult;
 #[allow(deprecated)]

--- a/openraft/src/raft/message/stream_append_error.rs
+++ b/openraft/src/raft/message/stream_append_error.rs
@@ -1,23 +1,24 @@
 use std::fmt;
 
+use openraft_macros::since;
 use peel_off::Peel;
 
 use crate::RaftTypeConfig;
 use crate::errors::ConflictingLogId;
 use crate::errors::RejectVote;
-use crate::type_config::alias::LogIdOf;
 use crate::type_config::alias::VoteOf;
 
 /// Error type for stream append entries.
 ///
 /// When this error is returned, the stream is terminated.
+#[since(version = "0.10.0", change = "Conflict carries follower conflict details")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
-pub enum StreamAppendError<C: RaftTypeConfig> {
-    /// Log conflict at the given prev_log_id.
-    ///
-    /// The follower's log at this position does not match the leader's.
-    Conflict(LogIdOf<C>),
+pub enum StreamAppendError<C>
+where C: RaftTypeConfig
+{
+    /// The follower's log does not match the leader's `prev_log_id`.
+    Conflict(ConflictingLogId<C>),
 
     /// The follower has a higher vote than the sender's.
     HigherVote(VoteOf<C>),
@@ -28,8 +29,8 @@ where C: RaftTypeConfig
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            StreamAppendError::Conflict(log_id) => {
-                write!(f, "Conflict({})", log_id)
+            StreamAppendError::Conflict(conflict) => {
+                write!(f, "Conflict({})", conflict)
             }
             StreamAppendError::HigherVote(vote) => {
                 write!(f, "HigherVote({})", vote)
@@ -46,10 +47,7 @@ impl<C: RaftTypeConfig> Peel for StreamAppendError<C> {
     fn peel(self) -> Result<ConflictingLogId<C>, RejectVote<C>> {
         match self {
             StreamAppendError::HigherVote(vote) => Err(RejectVote { higher: vote }),
-            StreamAppendError::Conflict(log_id) => Ok(ConflictingLogId {
-                expect: log_id,
-                local: None,
-            }),
+            StreamAppendError::Conflict(conflict) => Ok(conflict),
         }
     }
 }

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -44,6 +44,7 @@ pub use message::AppendEntriesRequest;
 pub use message::AppendEntriesResponse;
 pub use message::ChangeMembershipOutcome;
 pub use message::ChangeMembershipRequest;
+pub use message::ConflictHint;
 pub use message::ClientWriteResponse;
 pub use message::ClientWriteResult;
 #[allow(deprecated)]

--- a/openraft/src/replication/mod.rs
+++ b/openraft/src/replication/mod.rs
@@ -397,8 +397,8 @@ where
                 }
                 Err(append_err) => {
                     match append_err {
-                        StreamAppendError::Conflict(conflict_log_id) => {
-                            self.notify_progress(ReplicationResult(Err(conflict_log_id))).await;
+                        StreamAppendError::Conflict(conflict) => {
+                            self.notify_progress(ReplicationResult(Err(conflict))).await;
                         }
                         StreamAppendError::HigherVote(higher) => {
                             self.replication_context

--- a/openraft/src/replication/response.rs
+++ b/openraft/src/replication/response.rs
@@ -4,6 +4,7 @@ use display_more::DisplayOptionExt;
 use display_more::DisplayResultExt;
 
 use crate::RaftTypeConfig;
+use crate::errors::ConflictingLogId;
 use crate::type_config::alias::LogIdOf;
 
 /// The response of replication command.
@@ -45,7 +46,9 @@ where C: RaftTypeConfig
 ///
 /// Ok for matching, Err for conflict.
 #[derive(Clone, Debug)]
-pub(crate) struct ReplicationResult<C: RaftTypeConfig>(pub(crate) Result<Option<LogIdOf<C>>, LogIdOf<C>>);
+pub(crate) struct ReplicationResult<C: RaftTypeConfig>(
+    pub(crate) Result<Option<LogIdOf<C>>, ConflictingLogId<C>>,
+);
 
 impl<C> fmt::Display for ReplicationResult<C>
 where C: RaftTypeConfig
@@ -70,8 +73,15 @@ mod tests {
         let want = format!("(Match:{})", log_id(1, 2, 3));
         assert!(result.to_string().ends_with(&want), "{}", result.to_string());
 
-        let result = ReplicationResult::<UTConfig>(Err(log_id(1, 2, 3)));
-        let want = format!("(Conflict:{})", log_id(1, 2, 3));
-        assert!(result.to_string().ends_with(&want), "{}", result.to_string());
+        let result = ReplicationResult::<UTConfig>(Err(crate::errors::ConflictingLogId {
+            expect: log_id(1, 2, 3),
+            local: None,
+            hint: None,
+        }));
+        assert!(
+            result.to_string().contains("Conflict:conflicting log-id:"),
+            "{}",
+            result.to_string()
+        );
     }
 }

--- a/tests/tests/append_entries/t10_stream_append.rs
+++ b/tests/tests/append_entries/t10_stream_append.rs
@@ -121,7 +121,14 @@ async fn stream_append_conflict() -> Result<()> {
     let results: Vec<_> = output_stream.collect().await;
     assert_eq!(results, vec![
         Ok(Ok(Some(log_id(1, 1, 1)))),
-        Ok(Err(StreamAppendError::Conflict(log_id(1, 1, 5)))),
+        Ok(Err(StreamAppendError::Conflict(openraft::error::ConflictingLogId {
+            expect: log_id(1, 1, 5),
+            local: None,
+            hint: Some(openraft::raft::ConflictHint {
+                last_log_id: Some(log_id(1, 1, 1)),
+                committed_log_id: None,
+            }),
+        }))),
     ]);
 
     Ok(())


### PR DESCRIPTION
<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->

This is a prototype implementation for the scheme as proposed in https://github.com/databendlabs/openraft/issues/2073#issuecomment-5533429697 

It shrinks down the divergence discovery such that:

1. Without lag, the first AppendEntries will be accepted and replication continues
2. With lag, the continuation point is immediately discovered via a term match on the follower's last_log_id
3. With actual divergence, binary search is used

Because 3 requires a partition to occur, it should be very rare, so the optimization converges the matching id very quickly in a majority of cases.


**Checklist**

- [x] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2076)
<!-- Reviewable:end -->
