### PR TITLE
test: jepsen: add partial-network liveness test

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -126,3 +126,44 @@ jobs:
       - name: Cleanup | Docker
         if: always()
         run: make -C jepsen down
+
+  liveness:
+    name: Jepsen Liveness
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v4
+
+      - name: Test | Liveness
+        run: make -C jepsen jepsen LIVENESS=1
+
+      - name: Debug | Docker logs
+        if: failure()
+        run: |
+          docker compose -f jepsen/docker/docker-compose.yml logs --no-color \
+            | tee jepsen/docker-compose.log
+
+      - name: Results | Upload Liveness results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jepsen-results-liveness
+          path: jepsen/store/**/results.edn
+          if-no-files-found: ignore
+
+      - name: Debug | Upload Liveness diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jepsen-debug-liveness
+          path: |
+            jepsen/store/
+            jepsen/docker-compose.log
+          if-no-files-found: ignore
+
+      - name: Cleanup | Docker
+        if: always()
+        run: make -C jepsen down

--- a/jepsen/Makefile
+++ b/jepsen/Makefile
@@ -18,6 +18,10 @@ ifneq ($(PACKET_MODE),)
 override ARGS += --packet-mode $(PACKET_MODE)
 endif
 
+ifeq ($(LIVENESS),1)
+override ARGS += --liveness
+endif
+
 app-lint:
 	cargo fmt --check --manifest-path $(APP_MANIFEST)
 	cargo clippy --no-deps --manifest-path $(APP_MANIFEST) --all-targets -- -D warnings

--- a/jepsen/README.md
+++ b/jepsen/README.md
@@ -157,6 +157,16 @@ linearizable reads, writes, and compare-and-set operations across independent
 registers with Knossos. `NEMESIS` accepts a comma-separated subset when a
 narrower combination is needed.
 
+## Safety tests
+
+Safety runs check linearizable reads, writes, and compare-and-set operations
+under process, network, membership, and clock faults. They include focused
+single-Nemesis runs and the default Chaos composition described below. Focused
+runs also enforce their fault-specific progress and coverage requirements;
+all runs require cleanup and final recovery. The separate Liveness scenario
+below retains these common safety checks while testing progress under a fixed
+network topology.
+
 ### Nemesis Design
 
 Target policies are specific to each fault class. Network Partition and Packet
@@ -348,13 +358,74 @@ This wait has no node-local deadline: Jepsen's shared readiness check provides
 the external 60-second recovery bound, reports a recovery timeout, and leaves
 the process alive for diagnosis and teardown.
 
-### Results and Stored Evidence
+## Liveness tests
+
+### Partial network: old leader connected through a bridge
+
+From the repository root, run `make -C jepsen jepsen LIVENESS=1` (or
+`make -C jepsen test LIVENESS=1` with freshly built, running containers). This
+uses the same five data nodes (`n1` through `n5`) plus the control container as
+the normal safety tests. This is a fixed five-voter Jepsen scenario, not a
+random Chaos combination. It uses the normal Jepsen client, History, linearizability,
+panic, harness-error and final workload checks, plus a phase-specific liveness
+checker. CI runs it in a separate `Jepsen Liveness` job alongside the existing
+Jepsen scenarios on pushes to main and manual workflow dispatches. Pull requests
+run lint and unit tests only. Liveness failures fail the job; they are not
+treated as expected successes. Results and failure diagnostics are uploaded,
+and Docker cleanup runs regardless of the test result.
+
+The test chooses the established leader and waits for all logs to be applied.
+All five voters stay running throughout; no Kill or Restart is injected. Quorum
+is three votes. Three nodes stay mutually connected; the old leader stays
+connected to only one of them (the bridge). The fifth voter is isolated from
+all other voters. Only Raft-port traffic is filtered, not SSH or client HTTP.
+
+The installed topology is:
+
+```text
+       a -------- b             isolated
+        \        /
+         \      /
+          bridge
+             |
+         old leader
+```
+
+Lines represent retained bidirectional Raft connections; all other Raft
+connections are cut. In particular, the old leader cannot reach `a` or `b`,
+and the isolated voter cannot reach any peer. These are roles assigned at
+runtime, not fixed node names. All five processes remain running and remain
+voters, so the connected group `{a, bridge, b}` needs all three votes for a
+quorum. The bridge can still receive heartbeats from the old leader, which is
+the condition this test exercises.
+
+Client operations begin 600 ms after installation, allowing the old leader's
+initial quorum lease to expire before a client can follow a redirect to it.
+The liveness deadline still starts at installation. This prevents an early
+uncommitted write from independently making the bridge's log newer.
+
+The test observes the original topology for ten seconds and requires a new
+write to complete within 1.5 seconds (five configured maximum election timeouts
+of 300 ms). This is an engineering bound, not a Raft timing theorem. Leader and
+Vote metrics are retained for diagnosis, not used as a stability requirement.
+One successful write proves progress, not sustained availability. The topology remains
+unchanged throughout the observation period. Final cleanup heals the network
+and waits for recovery before the final read/write checks. Success during or
+after cleanup cannot excuse failure in the fault observation period.
+
+The existing implementation is expected to report `:nemesis :valid? false`,
+with no progress under `:original-topology`: the old leader keeps the bridge's lease alive.
+This is a failing liveness regression, not a harness success criterion inverted
+to make the test green. A command failure, missing phase or missing recovery
+also fails rather than masquerading as the intended liveness observation.
+
+## Results and Stored Evidence
 
 [Jepsen error-handling semantics](error-handling-semantics.md) defines the
 Outcome and Harness-failure contract. The sections below explain how to read
 the resulting checker verdicts and stored artifacts.
 
-#### Checker Verdicts
+### Checker Verdicts
 
 Checkers turn the collected evidence into separate verdicts. Property checkers
 decide whether OpenRaft satisfies a property: for example, the linearizability
@@ -381,7 +452,7 @@ The top-level `:valid?` combines these independent verdicts and answers only
 whether the entire run can be accepted. It does not by itself identify an
 OpenRaft property violation or the state of the Harness.
 
-#### Stored Evidence
+### Stored Evidence
 
 A run normally stores its artifacts under
 `jepsen/store/<test-name>/<timestamp>/`:
@@ -424,7 +495,8 @@ three possible values:
   report `:unknown`; locate the nested checker with that validity for its
   diagnostic fields.
 
-The test name begins with `openraft linearizable registers`, which also names
+Safety test names begin with `openraft linearizable registers`; the Liveness
+test is named `openraft partial-network liveness`. Each name also identifies
 its directory under `jepsen/store`. The independent linearizability checker
 lists failing keys at `[:workload :linearizable :failures]` and stores each
 key's result at `[:workload :linearizable :results <key>]`. Per-key histories
@@ -463,3 +535,9 @@ of the fault schedule; the seed is only an aid for rerunning similar conditions.
 - [x] Add a read, write, and compare-and-set workload.
 - [x] Add linearizability checking with Knossos.
 - [x] Exercise snapshot construction during ordinary workloads.
+- [x] Add a five-voter partial-network liveness regression that checks timely
+  successful writes while the old leader remains connected through a bridge.
+
+
+## References
+[Raft does not Guarantee Liveness in the face of Network Faults](https://decentralizedthoughts.github.io/2020-12-12-raft-liveness-full-omission/)

--- a/jepsen/src/jepsen/openraft/cli.clj
+++ b/jepsen/src/jepsen/openraft/cli.clj
@@ -10,6 +10,7 @@
              [db :as openraft-db]
              [generator :as openraft-generator]
              [harness :as harness]
+             [liveness :as liveness]
              [nemesis :as openraft-nemesis]
              [worker :as worker]
              [workload :as workload]]
@@ -58,7 +59,8 @@
                  :chaos)))
 
 (def cli-opts
-  [[nil "--api-port PORT" "OpenRaft application HTTP port."
+  [[nil "--liveness" "Run the fixed five-voter partial-network liveness test."]
+   [nil "--api-port PORT" "OpenRaft application HTTP port."
     :default 21001
     :parse-fn parse-long]
 
@@ -134,48 +136,64 @@
   (let [failure-state (harness/failure-state)
         database (openraft-db/db opts)
         workload (workload/workload opts)
+        roles (atom nil)
+        _ (when (and (:liveness opts)
+                     (not (= 5 (count (:nodes opts)) (count (set (:nodes opts))))))
+            (throw (ex-info "--liveness requires five distinct nodes" {})))
         nemesis-types (normalize-nemeses (:nemesis opts))
-        nemesis-package
-        (openraft-nemesis/compose-packages
-         failure-state
-         (mapv (fn [nemesis-type]
-                 (case nemesis-type
-                   :partition
-                   (partition/partition-package)
+        mode-config
+        (if (:liveness opts)
+          {:name "openraft partial-network liveness"
+           :nemesis-package (liveness/package roles)
+           :client (:client workload)
+           :generator (liveness/generator workload)}
+          (let [nemesis-package
+                (openraft-nemesis/compose-packages
+                 failure-state
+                 (mapv (fn [nemesis-type]
+                         (case nemesis-type
+                           :partition
+                           (partition/partition-package)
 
-                   :process
-                   (process/process-package database)
+                           :process
+                           (process/process-package database)
 
-                   :pause
-                   (process/pause-package database)
+                           :pause
+                           (process/pause-package database)
 
-                   :membership
-                   (membership/membership-package database opts)
+                           :membership
+                           (membership/membership-package database opts)
 
-                   :clock
-                   (clock/clock-package)
+                           :clock
+                           (clock/clock-package)
 
-                   :packet
-                   (let [packet-mode (:packet-mode opts)]
-                     (when (and (= [:packet] nemesis-types)
-                                (nil? packet-mode))
-                       (throw (ex-info
-                               "--packet-mode is required for Packet Nemesis"
-                               {:nemesis nemesis-types})))
-                     (packet/packet-package database packet-mode))))
-               nemesis-types))]
+                           :packet
+                           (let [packet-mode (:packet-mode opts)]
+                             (when (and (= [:packet] nemesis-types)
+                                        (nil? packet-mode))
+                               (throw (ex-info
+                                       "--packet-mode is required for Packet Nemesis"
+                                       {:nemesis nemesis-types})))
+                             (packet/packet-package database packet-mode))))
+                       nemesis-types))]
+            {:name (str "openraft linearizable registers "
+                        (str/join "," (map name nemesis-types)))
+             :nemesis-package nemesis-package
+             :client (:client workload)
+             :generator (lifecycle-generator failure-state
+                                             (:time-limit opts)
+                                             workload
+                                             nemesis-package)}))
+        nemesis-package (:nemesis-package mode-config)]
     (merge tests/noop-test
            opts
-           {:name (str "openraft linearizable registers "
-                       (str/join "," (map name nemesis-types)))
+           {:name (:name mode-config)
             :db database
-            :client (worker/wrap-client failure-state (:client workload))
+            :client (worker/wrap-client failure-state
+                                        (:client mode-config))
             :nemesis (worker/wrap-nemesis failure-state
                                           (:nemesis nemesis-package))
-            :generator (lifecycle-generator failure-state
-                                            (:time-limit opts)
-                                            workload
-                                            nemesis-package)
+            :generator (:generator mode-config)
             :checker (openraft-checker/reject-checker-exceptions
                       (openraft-checker/reject-harness-failures
                        failure-state

--- a/jepsen/src/jepsen/openraft/liveness.clj
+++ b/jepsen/src/jepsen/openraft/liveness.clj
@@ -1,0 +1,177 @@
+(ns jepsen.openraft.liveness
+  "Fixed partial-connectivity liveness test, separate from random Chaos."
+  (:require [jepsen [checker :as checker]
+             [control :as c]
+             [generator :as gen]
+             [nemesis :as nemesis]]
+            [jepsen.openraft.await :as await]
+            [jepsen.openraft.client :as http]
+            [jepsen.openraft.cluster :as cluster]))
+
+(def observation-seconds 10)
+(def deadline-nanos 1500000000)
+
+;; Installed topology: five voters, quorum = 3. All links are bidirectional.
+;;
+;;       a -------- b       isolated
+;;        \        /
+;;         \      /
+;;          bridge
+;;             |
+;;          leader
+;;
+;; Cut links: leader --X-- a, leader --X-- b.
+;; The isolated voter has no Raft links; all five processes remain running.
+;; a and b can campaign to replace the old leader. With the bridge, they form
+;; a connected quorum. The bridge still receives the old leader's heartbeats.
+(defn topology [nodes leader]
+  (when-not (and (= 5 (count nodes) (count (set nodes)))
+                 (some #{leader} nodes))
+    (throw (ex-info "Partial-network liveness requires five distinct nodes including the leader" {})))
+  (let [[bridge a b isolated] (remove #{leader} (sort nodes))]
+    {:leader leader :bridge bridge :majority [bridge a b]
+     :cut [a b] :isolated isolated}))
+
+(defn- metric-snapshot! [test nodes]
+  (into {} (map (fn [node] [node (cluster/node-metrics! test node)]) nodes)))
+
+(defn- cut! [test leader nodes]
+  (c/on leader
+        (c/su
+         (doseq [node nodes
+                 :let [ip (.getHostAddress (java.net.InetAddress/getByName
+                                            (http/node-host node)))]]
+           (c/exec :iptables :-A :OR_LIVE :-s ip :-p :tcp
+                   :-m :multiport :--ports (:raft-port test 22001) :-j :DROP)
+           (c/exec :iptables :-A :OR_LIVE :-d ip :-p :tcp
+                   :-m :multiport :--ports (:raft-port test 22001) :-j :DROP)))))
+
+(defn- heal! [roles]
+  (doseq [node (keep #(get @roles %) [:leader :isolated])]
+    (c/on node
+          (c/su
+           (c/exec :bash :-c
+                   (str "if iptables -S OR_LIVE >/dev/null 2>&1; then "
+                        "while iptables -C INPUT -j OR_LIVE 2>/dev/null; do "
+                        "iptables -D INPUT -j OR_LIVE || exit; done; "
+                        "while iptables -C OUTPUT -j OR_LIVE 2>/dev/null; do "
+                        "iptables -D OUTPUT -j OR_LIVE || exit; done; "
+                        "iptables -F OR_LIVE && iptables -X OR_LIVE; fi"))))))
+
+(defrecord PartialNetwork [roles]
+  nemesis/Nemesis
+  (setup! [this _] this)
+  (invoke! [_ test op]
+    (case (:f op)
+      :start-liveness
+      (let [{:keys [leader]} (cluster/await-ready! test)
+            {:keys [cut isolated] :as plan} (topology (:nodes test) leader)]
+        ;; No workload runs during this phase: equal logs exclude freshness as
+        ;; an independent reason to reject candidates after partitioning.
+        (await/until!
+         :equal-logs
+         #(let [ms (metric-snapshot! test (:nodes test))]
+            (if (and (apply = (map :last_applied (vals ms)))
+                     (every? (fn [m] (= (:last_log_index m)
+                                        (get-in m [:last_applied :index])))
+                             (vals ms)))
+              ms
+              (await/retry! :equal-logs {})))
+         {:timeout 10000})
+        (reset! roles plan)
+        (doseq [node [leader isolated]]
+          (c/on node
+                (c/su
+                 (c/exec :iptables :-N :OR_LIVE)
+                 (c/exec :iptables :-I :INPUT :-j :OR_LIVE)
+                 (c/exec :iptables :-I :OUTPUT :-j :OR_LIVE))))
+        (cut! test isolated (remove #{isolated} (:nodes test)))
+        (cut! test leader cut)
+        (assoc op :value (assoc plan :status :installed)))
+
+      :sample-liveness
+      (assoc op :value {:status :observed
+                        :metrics (metric-snapshot! test (:nodes test))})
+
+      :stop-liveness
+      (do (heal! roles)
+          (assoc op :value (assoc (cluster/await-ready! test) :status :recovered)))))
+  (teardown! [_ _] (heal! roles))
+  nemesis/Reflection
+  (fs [_] #{:start-liveness :sample-liveness :stop-liveness}))
+
+(defn- matching-nemesis-events [history f status]
+  (filter #(and (= :nemesis (:process %)) (= f (:f %))
+                (= status (get-in % [:value :status]))) history))
+
+(defn- find-successful-writes [history start end]
+  (:writes
+   (reduce (fn [{:keys [pending] :as acc} op]
+             (cond
+               (= :invoke (:type op)) (assoc-in acc [:pending (:process op)] op)
+               (#{:ok :fail :info} (:type op))
+               (let [invocation (get pending (:process op))]
+                 (cond-> (update acc :pending dissoc (:process op))
+                   (and invocation (= :ok (:type op)) (= :write (:f op))
+                        (<= start (:time invocation) (:time op))
+                        (< (:time op) end))
+                   (update :writes conj op)))
+               :else acc))
+           {:pending {} :writes []} history)))
+
+(defn liveness-checker []
+  (reify checker/Checker
+    (check [_ test history _]
+      (let [start (first (matching-nemesis-events history :start-liveness :installed))
+            stop (first (filter #(and (= :nemesis (:process %))
+                                      (= :stop-liveness (:f %))) history))
+            recovered (first (matching-nemesis-events history :stop-liveness :recovered))
+            bounds? (and start stop recovered
+                         (< (:time start) (:time stop)))
+            samples (matching-nemesis-events history :sample-liveness :observed)
+            majority (get-in start [:value :majority])
+            expected-nodes (set (conj majority (get-in start [:value :leader])
+                                      (get-in start [:value :isolated])))
+            complete-samples? (and (seq samples) (= 5 (count expected-nodes))
+                                   (every? #(= expected-nodes
+                                               (set (keys (get-in % [:value :metrics]))))
+                                           samples))
+            phase (fn [from to]
+                    (let [writes (find-successful-writes history from to)]
+                      {:successful-writes (count writes)
+                       :first-success-ms (some-> (first writes) :time (- from) (/ 1e6))
+                       :within-deadline? (boolean
+                                          (some #(< (:time %) (+ from deadline-nanos))
+                                                writes))}))
+            original (when bounds? (phase (:time start) (:time stop)))
+            configs (for [op (matching-nemesis-events history :sample-liveness :observed)
+                          m (vals (get-in op [:value :metrics]))]
+                      (get-in m [:membership_config :membership :configs]))
+            five-voters? (and (= 5 (count (:nodes test)) (count (set (:nodes test))))
+                              (seq configs)
+                              (every? #(= [(set (map http/node-host (:nodes test)))]
+                                          (mapv set %)) configs))]
+        {:valid? (boolean (and bounds? five-voters? complete-samples?
+                               (:within-deadline? original)))
+         :original-topology original
+         :five-voters? (boolean five-voters?) :recovered? (boolean recovered)}))))
+
+(defn package [roles]
+  {:nemesis (PartialNetwork. roles)
+   :checker (liveness-checker)})
+
+(defn generator [workload]
+  (let [samples #(gen/time-limit observation-seconds
+                                 (gen/stagger 0.2
+                                              (repeat {:type :info :f :sample-liveness})))]
+    (gen/phases
+     (gen/nemesis {:type :info :f :start-liveness})
+     (gen/shortest-any
+      (gen/nemesis (samples))
+      ;; Let the old leader's initial quorum lease expire before the normal
+      ;; client follows any redirect to it. Otherwise an early uncommitted
+      ;; write makes the bridge's log newer and confounds the lease experiment.
+      ;; The liveness deadline still starts at installation, not after this wait.
+      (gen/phases (gen/sleep 0.6) (:generator workload)))
+     (gen/nemesis {:type :info :f :stop-liveness})
+     (:final-generator workload))))

--- a/jepsen/test/jepsen/openraft/liveness_test.clj
+++ b/jepsen/test/jepsen/openraft/liveness_test.clj
@@ -1,0 +1,92 @@
+(ns jepsen.openraft.liveness-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [jepsen.checker :as checker]
+            [jepsen.openraft.liveness :as liveness]))
+
+(def nodes ["n1" "n2" "n3" "n4" "n5"])
+
+(defn event [f time status]
+  {:process :nemesis :type :info :f f :time time :value {:status status}})
+
+(defn writes [start finish]
+  [{:process 0 :type :invoke :f :write :time start :value ["k" "v"]}
+   {:process 0 :type :ok :f :write :time finish :value ["k" "v"]}])
+
+(def base-history
+  [(update (event :start-liveness 0 :installed) :value assoc
+           :majority ["n1" "n2" "n3"] :leader "n4" :isolated "n5")
+   (assoc-in (event :sample-liveness 100000000 :observed)
+             [:value :metrics]
+             (zipmap nodes
+                     (repeat {:membership_config {:membership {:configs [nodes]}}})))
+   {:process :nemesis :type :info :f :stop-liveness :time 10000000000}
+   (event :stop-liveness 11000000000 :recovered)])
+
+(defn verdict [history]
+  (checker/check (liveness/liveness-checker) {:nodes nodes}
+                 (sort-by :time history) {}))
+
+(def passing-history
+  (concat base-history (writes 100000000 200000000)))
+
+(deftest topology-test
+  (is (= {:leader "n4" :bridge "n1" :majority ["n1" "n2" "n3"]
+          :cut ["n2" "n3"] :isolated "n5"}
+         (liveness/topology nodes "n4")))
+  (doseq [leader nodes]
+    (let [{:keys [majority bridge cut isolated] :as plan} (liveness/topology nodes leader)]
+      (is (= leader (:leader plan)))
+      (is (= (frequencies nodes) (frequencies (concat majority [leader isolated]))))
+      (is (= 3 (count majority)))
+      (is (some #{bridge} majority))
+      (is (= (set (remove #{bridge} majority)) (set cut)))))
+  (doseq [invalid [(vec (butlast nodes)) (conj nodes "n6")
+                   ["n1" "n2" "n3" "n4" "n4"]]]
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (liveness/topology invalid "n1"))))
+  (is (thrown? clojure.lang.ExceptionInfo
+               (liveness/topology nodes "n6"))))
+
+(deftest phase-boundaries-test
+  (testing "writes during and after recovery cannot hide the fault-period stall"
+    (let [result (verdict (concat base-history
+                                  (writes 10100000000 10200000000)
+                                  (writes 12000000000 12100000000)))]
+      (is (false? (:valid? result)))
+      (is (zero? (get-in result [:original-topology :successful-writes])))))
+  (testing "timely writes pass without leader stability evidence"
+    (is (true? (:valid? (verdict passing-history)))))
+  (testing "an invocation before installation does not count"
+    (is (zero? (get-in (verdict (concat base-history (writes -1 100000000)))
+                       [:original-topology :successful-writes]))))
+  (testing "a four-voter membership cannot pass the five-node scenario"
+    (let [result (verdict
+                  (map #(if (= :sample-liveness (:f %))
+                          (update-in % [:value :metrics]
+                                     (fn [metrics]
+                                       (into {} (for [[node m] metrics]
+                                                  [node (assoc-in m [:membership_config :membership :configs]
+                                                                  [(vec (butlast nodes))])]))))
+                          %)
+                       passing-history))]
+      (is (false? (:five-voters? result)))
+      (is (false? (:valid? result)))))
+  (testing "missing old-leader or isolated-voter observations cannot pass"
+    (doseq [node ["n4" "n5"]]
+      (is (false?
+           (:valid?
+            (verdict
+             (map #(if (= :sample-liveness (:f %))
+                     (update-in % [:value :metrics] dissoc node) %)
+                  passing-history)))) node)))
+  (testing "success after the deadline is reported but fails the bound"
+    (let [result (verdict (concat base-history
+                                  (writes 1600000000 1700000000)))]
+      (is (= 1 (get-in result [:original-topology :successful-writes])))
+      (is (false? (get-in result [:original-topology :within-deadline?])))
+      (is (false? (:valid? result)))))
+  (testing "missing recovery alone prevents success"
+    (is (false? (:valid? (verdict (remove #(= :recovered (get-in % [:value :status]))
+                                          passing-history))))))
+  (testing "empty history fails closed"
+    (is (false? (:valid? (verdict []))))))


### PR DESCRIPTION
## Purpose

Add a dedicated Jepsen liveness regression, separate from the existing random
Chaos safety tests. Linearizability alone does not establish progress: a
cluster that never completes a write can still have no safety violation.
This test asks whether a connected voter quorum can complete a new write
while a specific partial-network fault remains in place.

CLOSES #2078

## Network topology

All five nodes stay running and remain voters, so a quorum is three votes.
The test discovers the current leader and assigns the other roles at runtime.

```text
       a -------- b             isolated
        \        /
         \      /
          bridge
             |
         old leader
```

Lines are retained bidirectional Raft connections. All other Raft connections
are cut: the old leader cannot reach `a` or `b`, and the isolated voter cannot
reach any peer. The group `{a, bridge, b}` is fully connected and constitutes
a quorum. Only Raft-port traffic is filtered; SSH, metrics, and client HTTP
remain reachable. No process Kill or Restart is involved.

## The liveness problem this exercises

The old leader can reach only itself and the bridge, which is insufficient
for a quorum. Once its quorum lease expires, it cannot accept new writes,
but it continues sending heartbeats to the bridge.

Those heartbeats renew the bridge's follower-side leader lease. While that
lease remains valid, the bridge rejects election requests from `a` and `b`.
Even if `a` and `b` vote for the same candidate, they have only two votes and
need the bridge's vote to elect a replacement.

Without the quorum-loss heartbeat gate, this can leave the old leader
unable to commit and the connected majority unable to elect a leader that
can commit. The Jepsen test application enables the gate with
`quorum_loss_probe_interval: Some(700)` for #2080. It lets the bridge's
lease expire so the connected quorum can elect a leader and complete a write.
The regression checks progress, not which node wins the election. It does
not enable PreVote.

## Test procedure and oracle

1. Wait for a ready cluster and equal, applied logs, then install the topology.
2. Use the normal KVClient and read/write/CAS workload. Delay client operations
   by 600 ms after installation so an early uncommitted write does not
   independently make the bridge's log newer. The deadline still starts at
   installation, not after that delay.
3. Observe the unchanged topology for ten seconds. Require at least one write
   invoked after installation to complete successfully within 1.5 seconds of
   installation: five configured maximum election timeouts of 300 ms. This
   is an engineering bound, not a Raft timing guarantee.
4. Record all-node metrics in history for diagnosis and membership evidence.
   Do not require a separate interval of Leader stability: one successful
   write establishes progress, not sustained availability.
5. Heal the network, await recovery, and run the normal final read/write
   checks. Writes during or after cleanup cannot satisfy fault-period liveness.

The ordinary linearizability, panic, harness-error, and final-workload checks
remain in place. Missing evidence or failed recovery also rejects the run.
There is no diagnostic control phase that disconnects the old leader from
the bridge to force recovery during observation.

## Running and scope

```bash
make -C jepsen jepsen LIVENESS=1
# Or, with freshly built and running containers:
make -C jepsen test LIVENESS=1
```

Default Chaos runs are unchanged. A separate `Jepsen Liveness` job runs with
those scenarios on pushes to main and manual Jepsen workflow dispatches.
Ordinary pull-request events still run only lint and unit tests. The new job
runs `make -C jepsen jepsen LIVENESS=1`, uploads results and failure diagnostics,
and always attempts Docker cleanup. It does not use `continue-on-error` or
invert the test verdict: a liveness failure fails the job and workflow.
The test app enables the #2080 heartbeat gate. The scenario is expected
to pass; a liveness failure indicates a regression of #2080.

The README separates Safety and Liveness, documents the topology and verdict,
and retains the implemented-coverage checklist. Unit tests exercise topology
assignment and checker boundaries, including late writes, writes invoked
before installation, missing observations, and missing recovery.

## Validation

- `make clojure-lint`: passed.
- `lein -o test`: 217 tests, 1958 assertions, zero failures or errors.
- Repository `make verify`: passed.

The reviewer ran `make -C jepsen test LIVENESS=1` locally with Docker:
9 of 9 runs passed, with the first successful write 618–942 ms after fault
installation. A control run with `quorum_loss_probe_interval: None` failed
with `:successful-writes 0`. Partition, pause, clock, and chaos scenarios
also passed locally with the gate enabled.

## Reference

[Raft does not Guarantee Liveness in the face of Network Faults](https://decentralizedthoughts.github.io/2020-12-12-raft-liveness-full-omission/)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2079)
<!-- Reviewable:end -->

