### PR TITLE
fix: jepsen: stabilize coverage reporting

### DIFF
--- a/jepsen/src/jepsen/openraft/nemesis/clock.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/clock.clj
@@ -365,7 +365,7 @@
                                recovered?))
          :bump-installed (boolean bump?)
          :strobe-installed (boolean strobe?)
-         :observed-modes observed-modes
+         :observed-modes (vec (sort observed-modes))
          :observed-target-categories
          (vec (sort observed-target-categories))
          :rate-directions (vec (sort rate-directions))

--- a/jepsen/src/jepsen/openraft/nemesis/outcome.clj
+++ b/jepsen/src/jepsen/openraft/nemesis/outcome.clj
@@ -1,6 +1,11 @@
 (ns jepsen.openraft.nemesis.outcome)
 
-(defn target-category [node-count target-count]
+(defn target-category
+  "Classifies targets as :one, :minority, :majority, or :all.
+
+  :one takes precedence over :all; :minority means target-count is no greater
+  than (quot (dec node-count) 2)."
+  [node-count target-count]
   (cond
     (= 1 target-count) :one
     (= node-count target-count) :all

--- a/jepsen/test/jepsen/openraft/nemesis/clock_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/clock_test.clj
@@ -110,6 +110,8 @@
                  (installed :reset-clock {})]
                 {})]
     (is (:valid? result))
+    (is (= [:bump :rate :strobe]
+           (:observed-modes result)))
     (is (= [:all :minority :one]
            (:observed-target-categories result)))))
 

--- a/jepsen/test/jepsen/openraft/nemesis/outcome_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/outcome_test.clj
@@ -1,0 +1,9 @@
+(ns jepsen.openraft.nemesis.outcome-test
+  (:require [clojure.test :refer [deftest is]]
+            [jepsen.openraft.nemesis.outcome :as outcome]))
+
+(deftest categorizes-target-scale
+  (is (= [:one :minority :majority :majority :all]
+         (mapv (partial outcome/target-category 5)
+               (range 1 6))))
+  (is (= :one (outcome/target-category 1 1))))

--- a/jepsen/test/jepsen/openraft/nemesis/process_test.clj
+++ b/jepsen/test/jepsen/openraft/nemesis/process_test.clj
@@ -151,11 +151,6 @@
         (is (= [[:kill selected]]
                (mapv (juxt :f :value) @invocations)))))))
 
-(deftest categorizes-target-scale
-  (is (= [:one :minority :majority :majority :all]
-         (mapv (partial outcome/target-category 5)
-               (range 1 6)))))
-
 (deftest process-generator-repeats-random-kill-episodes
   (let [invocations (atom [])]
     (gen-test/simulate


### PR DESCRIPTION
## Summary

- sort Clock observed modes for deterministic coverage output
- move the shared target-category test into outcome_test.clj
- document target-category precedence and its minority boundary
- cover the single-node classification boundary without adding a single-node Jepsen scenario

The outcome namespace import remains in process_test.clj because the pause coverage test also calls target-category.

## Testing

- make -C jepsen unit-test
- make -C jepsen lint
- make verify

CLOSES #2069

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2081)
<!-- Reviewable:end -->
