### PR TITLE
test: jepsen: fix flaky probe-thread liveness assertion

### DIFF
--- a/jepsen/test/jepsen/openraft/cluster_test.clj
+++ b/jepsen/test/jepsen/openraft/cluster_test.clj
@@ -230,7 +230,14 @@
                    t))]
     (is (identical? failure thrown))
     (is (= (count (:nodes test-config)) (count @threads)))
-    (is (every? #(not (.isAlive ^Thread %)) @threads))))
+    ;; `awaitTermination` returns once the pool's worker count reaches zero,
+    ;; and each worker decrements that count before it leaves `run`, so a
+    ;; drained thread can still be alive here. The join separates a thread
+    ;; that is exiting from one idling out the cached pool's 60-second
+    ;; keep-alive.
+    (doseq [^Thread thread @threads]
+      (.join thread 10000)
+      (is (not (.isAlive thread))))))
 
 (deftest distinguishes-modeled-metrics-failures-from-harness-errors
   (testing "recognized SUT observations make a node unavailable"


### PR DESCRIPTION

## Changelog

##### test: jepsen: fix flaky probe-thread liveness assertion
# Summary

`rethrows-a-probe-assertion-error-after-draining` in
`jepsen/test/jepsen/openraft/cluster_test.clj` now joins each probe
thread with a 10-second bound before asserting that it is dead. The
assertion failed on main in Jepsen runs 33739726570 and 34131975635
with the production code unchanged.

# Details

`ThreadPoolExecutor.awaitTermination` returns once the pool's worker
count reaches zero, and each worker decrements that count before it
leaves `run`, so `drain-probes!` can return while a drained thread is
still alive for a few stack frames. The unchanged test failed 181 of
3000 local runs on an idle machine.

The bound still separates a drained thread from a leaked one: a drained
thread exits within microseconds, while a thread the scan failed to
drain idles out the cached pool's 60-second keep-alive. Mutating the
scan's `catch Throwable` to `catch Exception` still fails the test.

---

- Improvement
- Build/Testing/CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2082)
<!-- Reviewable:end -->
