### PR TITLE
fix: suppress automatic heartbeat after quorum-ack lease expires to break leader-lease election deadlock

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -432,8 +432,11 @@ where
             return;
         }
 
+        // A ReadIndex read confirms leadership by its own heartbeat round: it is a
+        // client-driven, explicit quorum check, not automatic lease maintenance, so
+        // it bypasses the heartbeat suppression.
         if linearizer_option.heartbeat_if_quorum_ack_stale {
-            lh.send_heartbeat(true);
+            lh.force_send_heartbeat(true);
         }
 
         let deadline = now + wait_timeout;
@@ -680,8 +683,11 @@ where
     }
 
     /// Send a heartbeat message to every follower/learners.
+    ///
+    /// An explicitly requested heartbeat bypasses the quorum-ack lease gate: it is
+    /// the recovery channel for a leader whose lease has expired.
     #[tracing::instrument(level = "debug", skip_all, fields(id = display(&self.id)))]
-    pub(crate) fn send_heartbeat(&mut self, emitter: impl fmt::Display) -> bool {
+    pub(crate) fn send_heartbeat(&mut self, emitter: impl fmt::Display, force: bool) -> bool {
         tracing::debug!("send heartbeat, now: {}", C::now().display());
 
         let Some(mut lh) = self.engine.try_leader_handler().ok() else {
@@ -702,7 +708,16 @@ where
             return false;
         }
 
-        lh.send_heartbeat(false);
+        let sent = if force {
+            lh.force_send_heartbeat(false);
+            true
+        } else {
+            lh.send_heartbeat(false)
+        };
+
+        if !sent {
+            return false;
+        }
 
         // Record heartbeat to external metrics recorder
         if let Some(r) = &self.metrics_recorder {
@@ -1838,7 +1853,7 @@ where
                 }
             }
             ExternalCommand::Heartbeat => {
-                self.send_heartbeat("ExternalCommand");
+                self.send_heartbeat("ExternalCommand", true);
             }
             ExternalCommand::Snapshot => {
                 self.trigger_snapshot();
@@ -2019,7 +2034,7 @@ where
             && now >= t
         {
             if self.runtime_config.enable_heartbeat.load(Ordering::Relaxed) {
-                self.send_heartbeat("tick");
+                self.send_heartbeat("tick", false);
             }
 
             // Install next heartbeat

--- a/openraft/src/docs/protocol/check_quorum.md
+++ b/openraft/src/docs/protocol/check_quorum.md
@@ -26,12 +26,43 @@ request back to the same leader. The lease duration is
 
 [`ForwardToLeader`]: crate::errors::ForwardToLeader
 
+## Heartbeats
+
+Automatic heartbeat broadcast stops only after the quorum lease has been
+expired continuously for one extra `leader_lease`:
+
+```text
+now >= last_quorum_acked + leader_lease + leader_lease
+```
+
+A heartbeat renews the followers' leader leases, and a follower whose lease is
+fresh rejects vote requests. A leader that keeps broadcasting heartbeats after
+long losing quorum support would indefinitely renew the leases of still
+reachable followers, and a connected quorum that keeps hearing such an old
+leader could never elect a new leader. Suppressing heartbeats only after a
+full extra lease keeps the normal case intact: a transient lapse shorter than
+one lease is healed by the next heartbeat round, without an election. A leader
+with no quorum acknowledgement at all, such as a newly established leader,
+never suppresses heartbeats.
+See: [Raft does not Guarantee Liveness in the face of Network
+Faults](https://decentralizedthoughts.github.io/2020-12-12-raft-liveness-full-omission/).
+
+An explicitly requested heartbeat is not suppressed: `Trigger::heartbeat()` and
+the heartbeat round of a ReadIndex read are client- or operator-driven quorum
+checks, and a successful acknowledgement renews the lease and restores
+heartbeat broadcast.
+
+Replication of already accepted log entries is not gated: that traffic is
+bounded, because no new entry can be proposed while the lease is expired, and
+it provides the recovery channel once quorum communication is restored.
+
 ## Recovery
 
 Lease expiry does not change the leader's committed vote or
-[`ServerState`][]. The leader continues sending heartbeats and replicating
-existing logs. A later quorum acknowledgement renews the lease, and the leader
-automatically resumes accepting proposals.
+[`ServerState`][]. The leader stops broadcasting automatic heartbeats once the
+lease has been expired for one extra `leader_lease` and continues replicating
+existing logs. A later quorum acknowledgement renews the lease, heartbeat
+broadcast resumes, and the leader automatically resumes accepting proposals.
 
 If another leader has already been elected, quorum intersection prevents the
 old leader from renewing its lease. A voter in the new leader's quorum rejects
@@ -69,8 +100,8 @@ from the leader's current authority to accept new proposals:
 
 | Behavior | Conventional CheckQuorum | OpenRaft |
 |----------|--------------------------|----------|
-| Lease expires | Become follower | Reject new proposals |
-| Heartbeats and replication | Stop | Continue |
+| Lease expires | Become follower | Reject new proposals; stop automatic heartbeats after one extra lease |
+| Heartbeats and replication | Stop | Backlog replication continues; explicit heartbeat triggers still work |
 | Pending requests | Usually failed | Remain pending |
 | Quorum communication recovers | Run a new election | Renew the lease |
 

--- a/openraft/src/engine/handler/leader_handler/mod.rs
+++ b/openraft/src/engine/handler/leader_handler/mod.rs
@@ -126,8 +126,43 @@ where
         Some(log_ids)
     }
 
+    /// Send a heartbeat to every follower/learner, unless heartbeat broadcast is
+    /// suppressed.
+    ///
+    /// Heartbeats keep the followers' leader leases alive, and a follower whose
+    /// lease is fresh rejects vote requests. Once this Leader has been without
+    /// quorum acknowledgement for more than one extra `leader_lease`, broadcasting
+    /// heartbeats would indefinitely renew the leases of still reachable followers
+    /// and block a connected quorum from electing a new leader (issue #2080).
+    /// See: [`Leader::should_suppress_heartbeat`].
+    ///
+    /// Replication of the pending log backlog is not gated: it is finite, and it
+    /// provides the recovery channel once quorum communication is restored.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) fn send_heartbeat(&mut self, bypass_min_interval: bool) {
+    pub(crate) fn send_heartbeat(&mut self, bypass_min_interval: bool) -> bool {
+        if self.leader.should_suppress_heartbeat(self.config.timer_config.leader_lease) {
+            tracing::info!(
+                "skip broadcasting heartbeat: quorum-ack lease expired for more than one leader_lease: vote: {}, last_quorum_acked: {:?}",
+                self.leader.committed_vote_ref(),
+                self.leader.last_quorum_acked_time(),
+            );
+            return false;
+        }
+
+        self.force_send_heartbeat(bypass_min_interval);
+        true
+    }
+
+    /// Broadcast a heartbeat unconditionally, even when the quorum-ack lease has
+    /// expired.
+    ///
+    /// This is the escape hatch for an explicitly requested heartbeat, such as
+    /// [`Trigger::heartbeat()`]: a successful ack renews the quorum-ack lease and
+    /// restores the ability to propose and to broadcast heartbeats.
+    ///
+    /// [`Trigger::heartbeat()`]: crate::raft::trigger::Trigger::heartbeat
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) fn force_send_heartbeat(&mut self, bypass_min_interval: bool) {
         let membership_log_id = self.state.membership_state.effective().log_id();
         let session_id = ReplicationSessionId::new(self.leader.committed_vote.clone(), membership_log_id.clone());
 

--- a/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
+++ b/openraft/src/engine/handler/leader_handler/send_heartbeat_test.rs
@@ -51,6 +51,10 @@ fn eng() -> Engine<UTConfig> {
 #[test]
 fn test_leader_send_heartbeat() -> anyhow::Result<()> {
     let mut eng = eng();
+    let now = UTConfig::<()>::now();
+    eng.leader.as_mut().unwrap().update_clock(&2, now);
+    eng.leader.as_mut().unwrap().update_clock(&3, now);
+
     eng.output.take_commands();
 
     // A heartbeat is a normal AppendEntries RPC if there are pending data to send.
@@ -83,6 +87,48 @@ fn test_leader_send_heartbeat() -> anyhow::Result<()> {
             eng.output.take_commands()
         );
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_leader_send_heartbeat_suppressed_by_expired_quorum_ack_lease() -> anyhow::Result<()> {
+    // A leader that has been without quorum acknowledgement for more than one
+    // extra leader_lease must not broadcast heartbeats.
+    let mut eng = eng();
+    let lease = eng.config.timer_config.leader_lease;
+    let stale_ack = UTConfig::<()>::now() - lease - lease - Duration::from_millis(1);
+    let leader = eng.leader.as_mut().unwrap();
+    for node_id in [2, 3] {
+        leader.clock_progress.update_entry_with(&node_id, |entry| entry.val = Some(stale_ack));
+    }
+    eng.output.take_commands();
+
+    let sent = eng.try_leader_handler()?.send_heartbeat(false);
+
+    assert!(!sent);
+    assert_eq!(0, eng.output.take_commands().len());
+
+    Ok(())
+}
+
+#[test]
+fn test_leader_send_heartbeat_not_suppressed_within_one_extra_lease() -> anyhow::Result<()> {
+    // A transient lease lapse shorter than one extra leader_lease is healed by the
+    // next heartbeat round: the heartbeat is not suppressed.
+    let mut eng = eng();
+    let lease = eng.config.timer_config.leader_lease;
+    let stale_ack = UTConfig::<()>::now() - lease;
+    let leader = eng.leader.as_mut().unwrap();
+    for node_id in [2, 3] {
+        leader.clock_progress.update_entry_with(&node_id, |entry| entry.val = Some(stale_ack));
+    }
+    eng.output.take_commands();
+
+    let sent = eng.try_leader_handler()?.send_heartbeat(false);
+
+    assert!(sent);
+    assert_eq!(1, eng.output.take_commands().len());
 
     Ok(())
 }

--- a/openraft/src/engine/mod.rs
+++ b/openraft/src/engine/mod.rs
@@ -54,6 +54,7 @@ mod tests {
     mod handle_vote_resp_test;
     mod initialize_test;
     mod install_full_snapshot_test;
+    mod leader_lease_deadlock_test;
     mod pre_elect_test;
     mod refresh_server_state_test;
     mod startup_test;

--- a/openraft/src/engine/tests/leader_lease_deadlock_test.rs
+++ b/openraft/src/engine/tests/leader_lease_deadlock_test.rs
@@ -1,0 +1,188 @@
+//! Engine-level reproduction of issue #2080: liveness deadlock under a partial
+//! network failure.
+//!
+//! Five voters with a three-way connectivity split:
+//!
+//! ```text
+//!        a -------- b            isolated
+//!         \        /
+//!          \      /
+//!           bridge  <-- old leader heartbeats
+//! ```
+//!
+//! The old Leader reaches only the `bridge`; the quorum {a, bridge, b} stays
+//! connected. Two engines stand in for the two decisive nodes:
+//!
+//! - node-1 `bridge`: still hears the old Leader's heartbeat; every heartbeat renews its
+//!   follower-side leader lease via `Leased::touch`;
+//! - node-3: the old Leader; its quorum-ack lease is dead (2 acks < quorum 3) yet it keeps
+//!   broadcasting heartbeats.
+//!
+//! Node-0 `a`'s election is simulated with a term-2 `VoteRequest` sent to the
+//! bridge.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use maplit::btreeset;
+use pretty_assertions::assert_eq;
+
+use crate::Membership;
+use crate::MembershipState;
+use crate::core::ServerState;
+use crate::engine::Engine;
+use crate::engine::testing::UTConfig;
+use crate::engine::testing::log_id;
+use crate::impls::Vote;
+use crate::raft::LogSegment;
+use crate::raft::VoteRequest;
+use crate::raft::VoteResponse;
+use crate::type_config::TypeConfigExt;
+use crate::type_config::alias::LogIdOf;
+use crate::type_config::alias::StoredMembershipOf;
+use crate::type_config::alias::VoteOf;
+use crate::utime::Leased;
+
+fn m01234() -> Membership<u64, ()> {
+    Membership::<u64, ()>::new_with_defaults(vec![btreeset! {0, 1, 2, 3, 4}], [])
+}
+
+fn membership_state() -> MembershipState<crate::engine::testing::UtClid, u64, ()> {
+    MembershipState::new(
+        Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 3, 0)), m01234())),
+        Arc::new(StoredMembershipOf::<UTConfig>::new(Some(log_id(1, 3, 0)), m01234())),
+    )
+}
+
+/// Node ids follow the issue topology: 0 = `a`, 1 = `bridge`, 3 = the old Leader.
+fn bridge() -> Engine<UTConfig> {
+    let mut eng = Engine::testing_default(1);
+    eng.state.enable_validation(false);
+
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        eng.config.timer_config.leader_lease,
+        Vote::new_committed(1, 3),
+    );
+    eng.state.log_ids.append(log_id(1, 3, 0));
+    eng.state.membership_state = membership_state();
+    eng.state.server_state = eng.calc_server_state();
+
+    assert_eq!(ServerState::Follower, eng.state.server_state);
+    eng
+}
+
+fn old_leader() -> Engine<UTConfig> {
+    let mut eng = Engine::testing_default(3);
+    eng.state.enable_validation(false);
+
+    // A Leader never renews the lease on its own `state.vote`; the live lease is
+    // the quorum-ack lease tracked by `Leader`.
+    eng.state.vote = Leased::new(
+        UTConfig::<()>::now(),
+        Duration::from_millis(0),
+        Vote::new_committed(1, 3),
+    );
+    eng.state.log_ids.append(log_id(1, 3, 0));
+    eng.state.membership_state = membership_state();
+    eng.state.server_state = eng.calc_server_state();
+    eng.testing_new_leader();
+
+    assert_eq!(ServerState::Leader, eng.state.server_state);
+    eng
+}
+
+/// One heartbeat from the old Leader: an AppendEntries with the Leader's
+/// committed vote and no entries.
+fn heartbeat(
+    bridge: &mut Engine<UTConfig>,
+    leader_vote: VoteOf<UTConfig>,
+    leader_last: LogIdOf<UTConfig>,
+) -> LogIdOf<UTConfig> {
+    let acked = bridge
+        .append_entries(&leader_vote, LogSegment::new(Some(leader_last), vec![]))
+        .expect("the bridge accepts the old Leader's heartbeat");
+
+    assert!(
+        !bridge.state.vote.is_expired(UTConfig::<()>::now(), Duration::from_millis(0)),
+        "the heartbeat renewed the bridge's leader lease"
+    );
+    assert_eq!(leader_vote, *bridge.state.vote_ref());
+
+    acked.expect("an empty segment acks prev_log_id")
+}
+
+#[test]
+fn test_2080_old_leader_heartbeat_blocks_connected_quorum() -> anyhow::Result<()> {
+    let mut bridge = bridge();
+    let mut old_leader = old_leader();
+    let leader_vote = Vote::new_committed(1, 3);
+    let leader_last = log_id(1, 3, 0);
+
+    // Phase: the old Leader's heartbeat renews the bridge's follower-side lease.
+    {
+        tracing::info!("old leader heartbeats the bridge: lease renewed by touch, vote unchanged");
+        heartbeat(&mut bridge, leader_vote, leader_last);
+    }
+
+    // Phase: the connected quorum campaigns; the bridge rejects while its lease is fresh.
+    {
+        tracing::info!("node-a campaigns at term-2; bridge rejects by follower-side leader lease");
+        let resp = bridge.handle_vote_req(VoteRequest {
+            vote: Vote::new(2, 0),
+            last_log_id: Some(leader_last),
+            leadership_transfer: false,
+        });
+        assert_eq!(VoteResponse::new(leader_vote, Some(leader_last), false), resp);
+    }
+
+    // Phase: the old Leader hears acks only from the bridge: no quorum, quorum-ack lease dead.
+    //
+    // The last quorum acknowledgement happened at `stale_ack` (election time: the
+    // leader itself and two followers acked the blank-entry replication). Since
+    // then only the bridge acks, which is not a quorum, so `quorum_accepted` stays
+    // at the stale value.
+    {
+        tracing::info!("old leader: no quorum acks since election: quorum-ack lease expired, it cannot commit");
+        let lease = old_leader.config.timer_config.leader_lease;
+        let stale_ack = UTConfig::<()>::now() - lease - lease;
+        let leader = old_leader.leader.as_mut().unwrap();
+        for node_id in [0, 1, 2] {
+            leader.clock_progress.update_entry_with(&node_id, |entry| entry.val = Some(stale_ack));
+        }
+
+        assert_eq!(Some(stale_ack), leader.last_quorum_acked_time());
+        assert!(!leader.is_lease_valid(lease));
+        assert!(
+            leader.should_suppress_heartbeat(lease),
+            "the lease has been expired for more than one leader_lease"
+        );
+    }
+
+    // Phase: the old Leader must not broadcast heartbeats once the quorum-ack lease is dead.
+    {
+        tracing::info!("quorum-ack lease expired: send_heartbeat is gated and emits no command");
+
+        let sent = old_leader.try_leader_handler()?.send_heartbeat(false);
+
+        assert!(!sent, "heartbeat must be suppressed by the expired quorum-ack lease");
+        assert_eq!(0, old_leader.output.take_commands().len());
+    }
+
+    // Phase: the cycle never ends: each heartbeat renews the bridge, each renewed
+    // lease rejects the quorum's election, and the old Leader can never commit.
+    {
+        tracing::info!("heartbeat renews the bridge again; the term-2 election is rejected again");
+
+        heartbeat(&mut bridge, leader_vote, leader_last);
+
+        let resp = bridge.handle_vote_req(VoteRequest {
+            vote: Vote::new(2, 0),
+            last_log_id: Some(leader_last),
+            leadership_transfer: false,
+        });
+        assert_eq!(VoteResponse::new(leader_vote, Some(leader_last), false), resp);
+    }
+
+    Ok(())
+}

--- a/openraft/src/proposer/leader.rs
+++ b/openraft/src/proposer/leader.rs
@@ -260,6 +260,29 @@ where
         self.last_quorum_acked_time().is_some_and(|acked| now < acked + leader_lease)
     }
 
+    /// Return whether heartbeat broadcast must be suppressed.
+    ///
+    /// Heartbeats renew the followers' leader leases, and a follower whose lease is
+    /// fresh rejects vote requests. A leader that has not been acknowledged by a
+    /// quorum for more than one extra `leader_lease` beyond the lease expiry has
+    /// long lost quorum support: broadcasting heartbeats then would indefinitely
+    /// renew the leases of still reachable followers and block a connected quorum
+    /// from electing a new leader.
+    ///
+    /// Suppressing heartbeats only after the lease has been expired for a full
+    /// `leader_lease` keeps the normal-case behavior: a transient lapse shorter
+    /// than one lease is healed by the next heartbeat round, without an election.
+    /// A leader with no quorum acknowledgement at all, such as a newly established
+    /// leader, never suppresses heartbeats.
+    pub(crate) fn should_suppress_heartbeat(&self, leader_lease: Duration) -> bool {
+        if self.is_self_quorum() {
+            return false;
+        }
+
+        let now = C::now();
+        self.last_quorum_acked_time().is_some_and(|acked| now >= acked + leader_lease + leader_lease)
+    }
+
     /// Return whether this leader alone constitutes a quorum.
     pub(crate) fn is_self_quorum(&self) -> bool {
         if self.clock_progress.voter_count() != 1 {


### PR DESCRIPTION
fix: suppress automatic heartbeat after quorum-ack lease expires to break leader-lease election deadlock

## Summary

  Fixes #2080.

  Under a partial network partition, a leader that has lost quorum support
  keeps broadcasting heartbeats to the followers it can still reach. Each
  heartbeat renews the follower-side leader lease, and a follower with a
  fresh lease rejects vote requests. A connected majority that keeps
  hearing such an old leader can therefore never elect a new leader: the
  old leader cannot obtain a quorum, yet its heartbeats prevent the
  reachable quorum from replacing it — a liveness deadlock.

  This PR breaks the cycle. A leader stops broadcasting **automatic**
  heartbeats once its quorum-ack lease has been expired continuously for
  one extra `leader_lease`:

  ```text
  now >= last_quorum_acked + leader_lease + leader_lease
  ```

  Without fresh heartbeats, the follower's leader lease expires one lease
  later, and the connected majority can proceed with an election.

  ## The deadlock (#2080)

  Five voters, quorum = 3:

  ```text
         a -------- b             isolated
          \        /
           \      /
            bridge
               |
           old leader
  ```

  - `a`, `bridge`, `b` are mutually connected and form a quorum.
  - The old leader can communicate only with the bridge.
  - One voter is isolated but remains in the membership.

  Two independent leases interact:

  1. The old leader reaches only 2 of 3 voters, so its quorum-ack lease
     expires and it rejects new proposals — but it does not step down and
     keeps sending heartbeats to the bridge.
  2. The bridge's follower-side leader lease is renewed by every
     heartbeat and stays fresh, so the bridge rejects vote requests from
     `a` and `b`. This lease check happens before adopting the
     candidate's higher term.
  3. `a` and `b` only have two votes; they need the bridge's vote.

  ## Root cause

  OpenRaft's CheckQuorum variant intentionally lets a leader reject new
  proposals after lease expiry while continuing to send heartbeats and
  replicate logs. The consequence, described in [Raft does not Guarantee
  Liveness in the face of Network Faults](https://decentralizedthoughts.github.io/2020-12-12-raft-liveness-full-omission/),
  is that the expired leader keeps renewing the leases that block the
  only viable election.

  ## The fix

  - `Leader::should_suppress_heartbeat()` returns true only when the
    quorum-ack lease has been expired for a full extra `leader_lease`.
  - `LeaderHandler::send_heartbeat()` is now gated by that check and
    emits no command when suppressed; `force_send_heartbeat()` keeps the
    old unconditional behavior as an escape hatch.
  - `RaftCore` routes heartbeats accordingly:
    - tick-driven automatic heartbeat: gated (`force = false`);
    - explicitly requested heartbeat (`Trigger::heartbeat()`, and the
      heartbeat round of a ReadIndex read with
      `heartbeat_if_quorum_ack_stale`): forced (`force = true`).

  Design choices:

  - **One extra lease of grace**: a transient lapse shorter than one
    lease is healed by the next heartbeat round, without an election.
    Only a leader that has been unable to reach a quorum for two full
    leases stops broadcasting.
  - **A leader that never got a quorum ack** (e.g. newly established)
    never suppresses heartbeats: it needs them to establish its lease.
  - **Single-node quorum** never suppresses heartbeats.
  - **Explicit heartbeats are never suppressed**: a successful one
    renews the quorum-ack lease and restores normal broadcast, so the
    operator/client-driven quorum check remains a recovery channel.
  - **Backlog replication is not gated**: that traffic is bounded (no new
    entry can be proposed while the lease is expired) and provides the
    recovery channel once quorum communication is restored.

  ## Behavior change

  | Behavior | Before | After |
  |----------|--------|-------|
  | Quorum-ack lease expired | Leader keeps broadcasting heartbeats | Automatic heartbeats stop after one extra `leader_lease` |
  | Explicit heartbeat (`Trigger::heartbeat()`, ReadIndex round) | Same as automatic | Not suppressed; renews the lease on quorum ack |
  | Backlog replication | Continues | Unchanged |
  | Lease expiry semantics (vote, ServerState, pending requests) | Unchanged | Unchanged |



**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [x] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [x] Unittest is a friend:)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2083)
<!-- Reviewable:end -->
