### PR TITLE
fix: cargo: compat feature requires serde

### DIFF
--- a/openraft/Cargo.toml
+++ b/openraft/Cargo.toml
@@ -95,7 +95,7 @@ single-term-leader = []
 type-alias = []
 
 # Provide basic compatible types
-compat = []
+compat = ["serde"]
 
 # DEPRECATED: This feature is removed since 0.10.0.
 #

--- a/openraft/src/docs/feature_flags/feature-flags.md
+++ b/openraft/src/docs/feature_flags/feature-flags.md
@@ -54,7 +54,7 @@ let config = Config {
 ## feature-flag `compat`
 
 Enables compatibility supporting types.
-
+Implies `serde`, since these types are serialization shims.
 
 ## feature-flag `loosen-follower-log-revert` (removed)
 


### PR DESCRIPTION
`--features compat` on its own doesn't build:

    cargo check --manifest-path openraft/Cargo.toml --features compat
    error[E0433]: cannot find module or crate `serde`

compat/upgrade.rs derives serde unconditionally. CI only ever builds
compat together with serde, so this never showed up.

Also added a line to feature-flags.md noting the implication.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2084)
<!-- Reviewable:end -->
