### PR TITLE
fix: engine: apply smaller-log election backoff only while still behind

### DIFF
--- a/openraft/src/engine/engine_impl.rs
+++ b/openraft/src/engine/engine_impl.rs
@@ -79,11 +79,12 @@ where
     pub(crate) state: Valid<RaftState<C>>,
 
     // TODO: add a Voting state as a container.
-    /// Whether a greater log id is seen during election.
+    /// The greatest last-log-id reported by a peer that rejected a (pre-)vote.
     ///
-    /// If it is true, then this node **may** not become a leader therefore the election timeout
-    /// should be greater.
-    pub(crate) seen_greater_log: bool,
+    /// Extra election delay applies only while this node's last log is still smaller than this
+    /// id. Following a leader long enough to catch up clears the delay without an explicit
+    /// reset. `None` means no such log has been seen, or it was cleared when starting an election.
+    pub(crate) seen_greater_log: Option<LogIdOf<C>>,
 
     /// Represents the Leader state.
     pub(crate) leader: LeaderState<C>,
@@ -116,7 +117,7 @@ where
         Self {
             config,
             state: Valid::new(init_state),
-            seen_greater_log: false,
+            seen_greater_log: None,
             leader: None,
             candidate: None,
             pre_candidate: None,
@@ -545,7 +546,7 @@ where
                 func_name!(),
                 resp.last_log_id.display()
             );
-            self.set_greater_log();
+            self.set_greater_log(resp.last_log_id.clone());
         }
 
         // When vote request is rejected, only update to the non-committed version of the vote.
@@ -611,7 +612,7 @@ where
                 func_name!(),
                 resp.last_log_id.display()
             );
-            self.set_greater_log();
+            self.set_greater_log(resp.last_log_id.clone());
         }
 
         // Adopt the responder's higher term, same as handle_vote_resp does on reject.
@@ -986,20 +987,28 @@ where
         }
     }
 
-    pub(crate) fn is_there_greater_log(&self) -> bool {
-        self.seen_greater_log
-    }
-
-    /// Set that there is greater last log id found.
+    /// Whether a previously observed peer last-log-id is still greater than the local last log.
     ///
-    /// In such a case, this node should not try to elect aggressively.
-    pub(crate) fn set_greater_log(&mut self) {
-        self.seen_greater_log = true;
+    /// Used to extend the next election timeout so a shorter-log node does not campaign
+    /// aggressively. Becomes false once the local log catches up, even if the stored id is not
+    /// cleared.
+    pub(crate) fn is_there_greater_log(&self) -> bool {
+        self.seen_greater_log.as_ref() > self.state.last_log_id()
     }
 
-    /// Clear the flag of that there is greater last log id.
+    /// Record a peer last-log-id that is greater than this node's.
+    ///
+    /// Keeps the maximum id seen so far. This node should not try to elect aggressively until
+    /// its last log is no longer smaller than that id.
+    pub(crate) fn set_greater_log(&mut self, log_id: Option<LogIdOf<C>>) {
+        if log_id.as_ref() > self.seen_greater_log.as_ref() {
+            self.seen_greater_log = log_id;
+        }
+    }
+
+    /// Clear the recorded greater last-log-id.
     pub(crate) fn reset_greater_log(&mut self) {
-        self.seen_greater_log = false;
+        self.seen_greater_log = None;
     }
 
     // Only used by tests

--- a/openraft/src/engine/tests/handle_pre_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_pre_vote_resp_test.rs
@@ -140,6 +140,37 @@ fn test_handle_pre_vote_resp_reject_keeps_waiting() -> anyhow::Result<()> {
     assert!(eng.candidate_ref().is_none(), "no real election started");
     assert_eq!(vote_before, *eng.state.vote_ref());
     assert_eq!(0, eng.output.take_commands().len());
+    assert!(
+        !eng.is_there_greater_log(),
+        "equal last_log_id does not trigger election backoff"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_handle_pre_vote_resp_reject_seen_greater_log() -> anyhow::Result<()> {
+    let mut eng = eng();
+
+    eng.new_pre_candidate(Vote::new(1, 1));
+    eng.pre_candidate_mut().unwrap().grant_by(&1);
+    eng.output.take_commands();
+
+    tracing::info!("--- pre-vote reject with a greater last_log_id records it for election backoff");
+    {
+        eng.handle_pre_vote_resp(2, VoteResponse::new(Vote::new(0, 0), Some(log_id(2, 1, 5)), false));
+
+        assert_eq!(Some(log_id(2, 1, 5)), eng.seen_greater_log);
+        assert!(eng.is_there_greater_log());
+        assert!(eng.pre_candidate_ref().is_some());
+    }
+
+    tracing::info!("--- catching up to that log id clears the extra delay");
+    {
+        eng.state.log_ids = LogIdList::new(None, [log_id(2, 1, 5)]);
+
+        assert!(!eng.is_there_greater_log());
+    }
 
     Ok(())
 }

--- a/openraft/src/engine/tests/handle_vote_resp_test.rs
+++ b/openraft/src/engine/tests/handle_vote_resp_test.rs
@@ -98,6 +98,10 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
         assert_eq!(ServerState::Candidate, eng.state.server_state);
 
         assert_eq!(eng.output.take_commands(), vec![]);
+        assert!(
+            eng.is_there_greater_log(),
+            "rejected (or unmatched) vote with a greater last_log_id records a backoff"
+        );
     }
 
     // TODO: when seeing a higher vote, keep trying until a majority of higher votes are seen.
@@ -135,6 +139,10 @@ fn test_handle_vote_resp() -> anyhow::Result<()> {
                 Command::CloseReplicationStreams,
             ],
             "no SaveVote because the higher vote is not yet granted by this node"
+        );
+        assert!(
+            !eng.is_there_greater_log(),
+            "responder last_log_id is smaller than local; no election backoff"
         );
     }
 
@@ -234,6 +242,53 @@ fn test_handle_vote_resp_equal_vote() -> anyhow::Result<()> {
                 },
             ],
             eng.output.take_commands()
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_handle_vote_resp_seen_greater_log_until_caught_up() -> anyhow::Result<()> {
+    let mut eng = eng();
+    eng.config.id = 1;
+    eng.state.vote = Leased::new(UTConfig::<()>::now(), Duration::from_millis(500), Vote::new(2, 1));
+    eng.state.membership_state.set_effective(Arc::new(StoredMembershipOf::<UTConfig>::new(
+        Some(log_id(1, 1, 1)),
+        m12(),
+    )));
+    let voting = eng.new_candidate(*eng.state.vote_ref());
+    voting.grant_by(&1);
+    eng.state.server_state = ServerState::Candidate;
+    eng.output.take_commands();
+
+    assert!(!eng.is_there_greater_log());
+
+    tracing::info!("--- reject with a greater last_log_id records it for election backoff");
+    {
+        eng.handle_vote_resp(2, VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 5)), false));
+
+        assert_eq!(Some(log_id(2, 1, 5)), eng.seen_greater_log);
+        assert!(eng.is_there_greater_log());
+        assert_eq!(ServerState::Candidate, eng.state.server_state);
+    }
+
+    tracing::info!("--- a later reject with a smaller last_log_id does not shrink the stored id");
+    {
+        eng.handle_vote_resp(2, VoteResponse::new(Vote::new(2, 1), Some(log_id(2, 1, 2)), false));
+
+        assert_eq!(Some(log_id(2, 1, 5)), eng.seen_greater_log);
+        assert!(eng.is_there_greater_log());
+    }
+
+    tracing::info!("--- catching up to that log id clears the extra delay without reset");
+    {
+        eng.state.log_ids = LogIdList::new(None, [log_id(2, 1, 5)]);
+
+        assert_eq!(Some(log_id(2, 1, 5)), eng.seen_greater_log);
+        assert!(
+            !eng.is_there_greater_log(),
+            "local last log is no longer smaller; a later election uses the normal timeout"
         );
     }
 


### PR DESCRIPTION
## Summary
- Replace the sticky `seen_greater_log` bool with the peer last-log-id from a rejected (pre-)vote.
- Extra `smaller_log_timeout` applies only while this node's last log is still smaller than that id, so catching up as a follower does not delay a later election.
- Keep the maximum id seen; starting an election still clears it.

## Test plan
- [x] Engine unit tests for vote and pre-vote rejects that record a greater log, keep the max id, and drop the backoff after catch-up
- [x] `make verify`


Made with [Cursor](https://cursor.com)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2087)
<!-- Reviewable:end -->
