### PR TITLE
feat: errors: expose forwarding reason

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -67,6 +67,7 @@ use crate::entry::RaftPayload;
 use crate::errors::AllowNextRevertError;
 use crate::errors::ClientWriteError;
 use crate::errors::Fatal;
+use crate::errors::ForwardReason;
 use crate::errors::ForwardToLeader;
 use crate::errors::Infallible;
 use crate::errors::InitializeError;
@@ -595,7 +596,8 @@ where
 
         // If the leader is transferring leadership, forward requests to the new leader.
         if let Some(to) = lh.leader.get_transfer_to() {
-            return Err(lh.state.new_forward_to_leader(to.clone()));
+            let forward = lh.state.new_forward_to_leader(to.clone());
+            return Err(forward.with_reason(ForwardReason::LeadershipTransfer));
         }
 
         Ok(lh)
@@ -606,7 +608,7 @@ where
         let lh = self.ensure_leader_handler()?;
 
         if !lh.is_lease_valid() {
-            return Err(ForwardToLeader::empty());
+            return Err(ForwardToLeader::empty().with_reason(ForwardReason::LeaseExpired));
         }
 
         Ok(lh)
@@ -2407,6 +2409,7 @@ where
             tx.on_complete(Err(ClientWriteError::ForwardToLeader(ForwardToLeader {
                 leader_id: leader_id.clone(),
                 leader_node: leader_node.clone(),
+                reason: ForwardReason::NotLeader,
             })));
             tracing::debug!("sent ForwardToLeader for purged log_index: {}", log_index);
         }
@@ -2428,6 +2431,7 @@ where
             tx.on_complete(Err(ClientWriteError::ForwardToLeader(ForwardToLeader {
                 leader_id: leader_id.clone(),
                 leader_node: leader_node.clone(),
+                reason: ForwardReason::NotLeader,
             })));
 
             tracing::debug!("sent ForwardToLeader for log_index: {}", log_index);

--- a/openraft/src/docs/feature_flags/feature-flags.md
+++ b/openraft/src/docs/feature_flags/feature-flags.md
@@ -127,6 +127,10 @@ each stage transition.
 Derives `serde::Serialize, serde::Deserialize` for type that are used
 in storage and network, such as `Vote` or `AppendEntriesRequest`.
 
+These derives do not provide a stable wire or storage format. OpenRaft does not
+guarantee that serialized data remains compatible across versions. Applications
+that require compatibility must version or migrate their data.
+
 ## feature-flag `singlethreaded` (removed)
 
 This feature flag has been renamed to `single-threaded` since `0.10.0`.

--- a/openraft/src/errors/mod.rs
+++ b/openraft/src/errors/mod.rs
@@ -423,6 +423,10 @@ where C: RaftTypeConfig
     ///
     /// For [`ForwardReason::LeadershipTransfer`], `leader_id` and `leader_node` identify the
     /// transfer target, which may not have established leadership yet.
+    ///
+    /// Adding this field is not backward compatible with Serde formats that encode structs
+    /// positionally, such as bincode and postcard. Formats that encode structs by field name can
+    /// deserialize older data because a missing field defaults to [`ForwardReason::NotLeader`].
     #[since(version = "0.10.0")]
     #[cfg_attr(feature = "serde", serde(default))]
     pub reason: ForwardReason,

--- a/openraft/src/errors/mod.rs
+++ b/openraft/src/errors/mod.rs
@@ -391,7 +391,24 @@ pub struct Timeout<C: RaftTypeConfig> {
     pub timeout: Duration,
 }
 
-/// Error indicating that the request should be forwarded to the leader.
+/// Why a request must be forwarded or retried.
+#[since(version = "0.10.0")]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum ForwardReason {
+    /// The receiving node is not the leader.
+    #[default]
+    NotLeader,
+
+    /// The receiving leader is transferring leadership to another node.
+    LeadershipTransfer,
+
+    /// The receiving leader's quorum lease has expired.
+    LeaseExpired,
+}
+
+/// Error indicating that the request should be forwarded to the leader or retried.
+#[since(version = "0.10.0", change = "added `reason`")]
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize), serde(bound = ""))]
 #[error("has to forward request to: {leader_id:?}, {leader_node:?}")]
@@ -402,6 +419,13 @@ where C: RaftTypeConfig
     pub leader_id: Option<C::NodeId>,
     /// The node information of the current leader, if known.
     pub leader_node: Option<C::Node>,
+    /// Why the request was rejected.
+    ///
+    /// For [`ForwardReason::LeadershipTransfer`], `leader_id` and `leader_node` identify the
+    /// transfer target, which may not have established leadership yet.
+    #[since(version = "0.10.0")]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub reason: ForwardReason,
 }
 
 impl<C> ForwardToLeader<C>
@@ -412,6 +436,7 @@ where C: RaftTypeConfig
         Self {
             leader_id: None,
             leader_node: None,
+            reason: ForwardReason::NotLeader,
         }
     }
 
@@ -420,7 +445,16 @@ where C: RaftTypeConfig
         Self {
             leader_id: Some(leader_id),
             leader_node: Some(node),
+            reason: ForwardReason::NotLeader,
         }
+    }
+
+    /// Set why the request was rejected.
+    #[since(version = "0.10.0")]
+    #[must_use]
+    pub const fn with_reason(mut self, reason: ForwardReason) -> Self {
+        self.reason = reason;
+        self
     }
 }
 

--- a/openraft/src/raft/mod.rs
+++ b/openraft/src/raft/mod.rs
@@ -116,6 +116,7 @@ use crate::engine::EngineConfig;
 use crate::entry::RaftPayload;
 use crate::errors::ClientWriteError;
 use crate::errors::Fatal;
+use crate::errors::ForwardReason;
 use crate::errors::ForwardToLeader;
 use crate::errors::InitializeError;
 use crate::errors::LinearizableReadError;
@@ -783,6 +784,7 @@ where
             Err(ForwardToLeader {
                 leader_id: Some(node_id.clone()),
                 leader_node: node,
+                reason: ForwardReason::NotLeader,
             })
         }
     }

--- a/tests/tests/client_api/t10_client_write_quorum_lease.rs
+++ b/tests/tests/client_api/t10_client_write_quorum_lease.rs
@@ -7,7 +7,7 @@ use openraft::Config;
 use openraft::ServerState;
 use openraft::async_runtime::WatchReceiver;
 use openraft::errors::ClientWriteError;
-use openraft::errors::ForwardToLeader;
+use openraft::errors::ForwardReason;
 use openraft::errors::RaftError;
 use openraft::impls::ProgressResponder;
 use openraft::type_config::TypeConfigExt;
@@ -59,10 +59,10 @@ async fn client_write_requires_valid_quorum_lease() -> Result<()> {
     .expect("an expired leader lease rejects a new write")
     .unwrap_err();
 
-    assert_eq!(
-        RaftError::APIError(ClientWriteError::ForwardToLeader(ForwardToLeader::empty())),
-        rejected
-    );
+    let RaftError::APIError(ClientWriteError::ForwardToLeader(forward)) = rejected else {
+        panic!("expected ForwardToLeader");
+    };
+    assert_eq!(ForwardReason::LeaseExpired, forward.reason);
 
     let metrics = n0.metrics().borrow_watched().clone();
     assert_eq!(ServerState::Leader, metrics.state);

--- a/tests/tests/client_api/t10_client_writes.rs
+++ b/tests/tests/client_api/t10_client_writes.rs
@@ -223,6 +223,7 @@ async fn write_with_leader() -> Result<()> {
     };
     // Check the error content: leader_id should point to node 0
     assert_eq!(Some(0), forward.leader_id);
+    assert_eq!(openraft::errors::ForwardReason::NotLeader, forward.reason);
 
     // Test 3: Write without leader check should succeed
     let (responder, complete_rx) = ProgressResponder::complete_only();

--- a/tests/tests/client_api/t14_transfer_leader.rs
+++ b/tests/tests/client_api/t14_transfer_leader.rs
@@ -6,10 +6,14 @@ use openraft::Config;
 use openraft::ReadPolicy;
 use openraft::ServerState;
 use openraft::async_runtime::WatchReceiver;
+use openraft::errors::ClientWriteError;
+use openraft::errors::ForwardReason;
 use openraft::errors::LinearizableReadError;
 use openraft::raft::TransferLeaderError;
 use openraft::raft::TransferLeaderRequest;
 use openraft::type_config::TypeConfigExt;
+use openraft_memstore::ClientRequest;
+use openraft_memstore::IntoMemClientRequest;
 use openraft_memstore::TypeConfig;
 
 use crate::fixtures::RaftRouter;
@@ -198,6 +202,7 @@ async fn transfer_leader_with_dead_target_does_not_block_election() -> anyhow::R
             if let Err(e) = &res
                 && let Some(LinearizableReadError::ForwardToLeader(fwd)) = e.api_error()
                 && fwd.leader_id == Some(1)
+                && fwd.reason == ForwardReason::LeadershipTransfer
             {
                 got = true;
                 break;
@@ -279,6 +284,7 @@ async fn transfer_leader_blocks_lease_read() -> anyhow::Result<()> {
         if let Err(e) = &res
             && let Some(LinearizableReadError::ForwardToLeader(fwd)) = e.api_error()
             && fwd.leader_id == Some(1)
+            && fwd.reason == ForwardReason::LeadershipTransfer
         {
             got = true;
             break;
@@ -287,8 +293,21 @@ async fn transfer_leader_blocks_lease_read() -> anyhow::Result<()> {
     }
     assert!(
         got,
-        "expected ForwardToLeader(1) for LeaseRead within 200ms after transfer"
+        "expected a leadership-transfer ForwardToLeader(1) for LeaseRead within 200ms after transfer"
     );
+
+    tracing::info!("--- a write on n0 must identify leadership transfer as the rejection reason");
+    {
+        let err = router
+            .send_client_request(0, ClientRequest::make_request("transfer", 1))
+            .await
+            .expect_err("write must be rejected during leadership transfer");
+        let ClientWriteError::ForwardToLeader(fwd) = err.into_api_error().expect("write returns an API error") else {
+            panic!("expected ForwardToLeader");
+        };
+        assert_eq!(Some(1), fwd.leader_id);
+        assert_eq!(ForwardReason::LeadershipTransfer, fwd.reason);
+    }
 
     Ok(())
 }

--- a/tests/tests/client_api/t51_write_when_leader_quit.rs
+++ b/tests/tests/client_api/t51_write_when_leader_quit.rs
@@ -7,6 +7,7 @@ use openraft::Config;
 use openraft::Vote;
 use openraft::async_runtime::OneshotSender;
 use openraft::errors::ClientWriteError;
+use openraft::errors::ForwardReason;
 use openraft::errors::ForwardToLeader;
 use openraft::errors::RaftError;
 use openraft::raft::AppendEntriesRequest;
@@ -88,6 +89,7 @@ async fn write_when_leader_quit_and_log_revert() -> Result<()> {
         RaftError::APIError(ClientWriteError::ForwardToLeader(ForwardToLeader {
             leader_id: Some(1),
             leader_node: Some(()),
+            reason: ForwardReason::NotLeader,
         }))
     );
 

--- a/tests/tests/client_api/t90_issue_1761_purge_stranded_responder.rs
+++ b/tests/tests/client_api/t90_issue_1761_purge_stranded_responder.rs
@@ -7,6 +7,7 @@ use openraft::Config;
 use openraft::Vote;
 use openraft::async_runtime::OneshotSender;
 use openraft::errors::ClientWriteError;
+use openraft::errors::ForwardReason;
 use openraft::errors::ForwardToLeader;
 use openraft::errors::RaftError;
 use openraft::raft::AppendEntriesRequest;
@@ -125,6 +126,7 @@ async fn write_then_superseded_by_snapshot_install() -> Result<()> {
         RaftError::APIError(ClientWriteError::ForwardToLeader(ForwardToLeader {
             leader_id: Some(1),
             leader_node: Some(()),
+            reason: ForwardReason::NotLeader,
         }))
     );
 


### PR DESCRIPTION
## Why

`ForwardToLeader` currently does not tell a client why its request was rejected. In particular, a request sent to an ordinary follower and a request rejected by a leader during `transfer_leader` look the same.

That distinction affects retry behavior: for an ordinary follower, the client should follow the reported leader immediately. During leadership transfer, however, the reported node is only the transfer target and may not have established leadership yet, so the client may prefer to wait for the transfer to finish before retrying. An expired leader lease similarly calls for retrying instead of forwarding to a different node.

## What changed

- Add a public `ForwardReason` enum with `NotLeader`, `LeadershipTransfer`, and `LeaseExpired`.
- Add `reason` to `ForwardToLeader` while preserving its existing `Display` output.
- Require callers of `ForwardToLeader::empty()` and `ForwardToLeader::new()` to provide the reason explicitly.
- Return `LeadershipTransfer` for reads and writes rejected by the transfer gate.
- Return `LeaseExpired` when a leader rejects a write because its quorum lease expired.
- Return `NotLeader` for ordinary forwarding and stale-leader cases.
- Default a missing serialized reason to `NotLeader` for compatibility with older self-describing payloads.

## Testing

- `make verify`
- `make test-examples`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/databendlabs/openraft/2090)
<!-- Reviewable:end -->
